### PR TITLE
chore: add .env.preview to mobile gitignore

### DIFF
--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -32,6 +32,7 @@ yarn-error.*
 
 # local env files
 .env*.local
+.env.preview
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- Adds `.env.preview` to the mobile app's `.gitignore` to prevent preview environment secrets from being committed