### PR TITLE
feat: Add pull-to-refresh on Inbox screen with full provider sync (#19)

### DIFF
--- a/apps/mobile/hooks/use-sync-all.test.ts
+++ b/apps/mobile/hooks/use-sync-all.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Tests for hooks/use-sync-all.ts
+ *
+ * Tests the useSyncAll hook including:
+ * - Initial state
+ * - syncAll mutation trigger
+ * - Success message formatting (items found, all caught up, with errors)
+ * - Cooldown management
+ * - Rate limit error handling
+ * - Inbox invalidation on success
+ * - Cooldown prevents multiple calls
+ *
+ * @see features/subscriptions/frontend-spec.md
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+
+// ============================================================================
+// Module-level Mocks
+// ============================================================================
+
+const mockMutate = jest.fn();
+const mockInvalidate = jest.fn();
+let mockOnSuccess:
+  | ((data: { synced: number; itemsFound: number; errors: string[] }) => void)
+  | undefined;
+let mockOnError: ((error: { data?: { code?: string }; message?: string }) => void) | undefined;
+let mockIsPending = false;
+
+jest.mock('../lib/trpc', () => ({
+  trpc: {
+    subscriptions: {
+      syncAll: {
+        useMutation: (options: {
+          onSuccess?: (data: { synced: number; itemsFound: number; errors: string[] }) => void;
+          onError?: (error: { data?: { code?: string }; message?: string }) => void;
+        }) => {
+          mockOnSuccess = options.onSuccess;
+          mockOnError = options.onError;
+          return {
+            mutate: mockMutate,
+            isPending: mockIsPending,
+          };
+        },
+      },
+    },
+    useUtils: () => ({
+      items: {
+        inbox: {
+          invalidate: mockInvalidate,
+        },
+      },
+    }),
+  },
+}));
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+import { useSyncAll } from './use-sync-all';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  mockIsPending = false;
+  mockOnSuccess = undefined;
+  mockOnError = undefined;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useSyncAll', () => {
+  describe('initial state', () => {
+    it('should return initial state correctly', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.cooldownSeconds).toBe(0);
+      expect(result.current.lastResult).toBeNull();
+      expect(typeof result.current.syncAll).toBe('function');
+    });
+  });
+
+  describe('syncAll mutation', () => {
+    it('should trigger mutation when syncAll called', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+      });
+
+      expect(mockMutate).toHaveBeenCalled();
+    });
+
+    it('should not trigger mutation while loading', () => {
+      mockIsPending = true;
+
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success message formatting', () => {
+    it('should format success message for found items (singular)', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 1,
+          errors: [],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('Found 1 new item');
+      expect(result.current.lastResult?.success).toBe(true);
+    });
+
+    it('should format success message for found items (plural)', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 3,
+          errors: [],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('Found 3 new items');
+      expect(result.current.lastResult?.success).toBe(true);
+    });
+
+    it('should format success message for all caught up', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 0,
+          errors: [],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('All caught up!');
+      expect(result.current.lastResult?.success).toBe(true);
+    });
+
+    it('should format success message when no subscriptions to sync', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 0,
+          itemsFound: 0,
+          errors: [],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('No subscriptions to sync');
+      expect(result.current.lastResult?.success).toBe(true);
+    });
+
+    it('should format success message with errors (singular)', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 3,
+          itemsFound: 2,
+          errors: ['YouTube: Channel1'],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('Found 2 new items (1 failed)');
+      expect(result.current.lastResult?.success).toBe(true);
+      expect(result.current.lastResult?.errors).toEqual(['YouTube: Channel1']);
+    });
+
+    it('should format success message with multiple errors', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 3,
+          itemsFound: 0,
+          errors: ['YouTube: Channel1', 'Spotify: Show1', 'YouTube: Channel2'],
+        });
+      });
+
+      expect(result.current.lastResult?.message).toBe('All caught up! (3 failed)');
+      expect(result.current.lastResult?.errors).toHaveLength(3);
+    });
+
+    it('should store full result data on success', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 3,
+          errors: ['YouTube: Test'],
+        });
+      });
+
+      expect(result.current.lastResult).toEqual({
+        success: true,
+        synced: 5,
+        itemsFound: 3,
+        errors: ['YouTube: Test'],
+        message: 'Found 3 new items (1 failed)',
+      });
+    });
+  });
+
+  describe('cooldown management', () => {
+    it('should set cooldown after success', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 3,
+          errors: [],
+        });
+      });
+
+      expect(result.current.cooldownSeconds).toBe(120);
+    });
+
+    it('should countdown cooldown over time', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 1,
+          itemsFound: 0,
+          errors: [],
+        });
+      });
+
+      expect(result.current.cooldownSeconds).toBe(120);
+
+      // Advance time by 1 second
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.cooldownSeconds).toBe(119);
+
+      // Advance time by 10 more seconds
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+
+      expect(result.current.cooldownSeconds).toBe(109);
+    });
+
+    it('should reach zero and stop countdown', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 1,
+          itemsFound: 0,
+          errors: [],
+        });
+      });
+
+      // Advance past the full cooldown
+      act(() => {
+        jest.advanceTimersByTime(121000);
+      });
+
+      expect(result.current.cooldownSeconds).toBe(0);
+    });
+
+    it('should not trigger syncAll during cooldown', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      // First call
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 1,
+          itemsFound: 1,
+          errors: [],
+        });
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+
+      // Clear mock to track second call
+      mockMutate.mockClear();
+
+      // Try to call again while in cooldown
+      act(() => {
+        result.current.syncAll();
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+    });
+
+    it('should allow syncAll after cooldown expires', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      // First call
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 1,
+          itemsFound: 1,
+          errors: [],
+        });
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      mockMutate.mockClear();
+
+      // Wait for cooldown to expire
+      act(() => {
+        jest.advanceTimersByTime(121000);
+      });
+
+      expect(result.current.cooldownSeconds).toBe(0);
+
+      // Should work again
+      act(() => {
+        result.current.syncAll();
+      });
+
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('rate limit error handling', () => {
+    it('should handle rate limit error with code', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'TOO_MANY_REQUESTS' },
+          message: 'Please wait 2 minutes between full syncs',
+        });
+      });
+
+      expect(result.current.lastResult?.success).toBe(false);
+      expect(result.current.cooldownSeconds).toBe(120);
+      expect(result.current.lastResult?.message).toBe('Try again in 2 minutes');
+    });
+
+    it('should parse cooldown from error message (minutes)', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'TOO_MANY_REQUESTS' },
+          message: 'Please wait 5 minutes between syncs',
+        });
+      });
+
+      expect(result.current.cooldownSeconds).toBe(300); // 5 * 60
+    });
+
+    it('should parse cooldown from error message (seconds)', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'TOO_MANY_REQUESTS' },
+          message: 'Please wait 30 seconds',
+        });
+      });
+
+      expect(result.current.cooldownSeconds).toBe(30);
+    });
+
+    it('should use default cooldown if cannot parse from message', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'TOO_MANY_REQUESTS' },
+          message: 'Rate limited',
+        });
+      });
+
+      expect(result.current.cooldownSeconds).toBe(120);
+    });
+
+    it('should handle non-rate-limit errors', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'INTERNAL_SERVER_ERROR' },
+          message: 'Something went wrong',
+        });
+      });
+
+      expect(result.current.lastResult?.success).toBe(false);
+      expect(result.current.lastResult?.message).toBe('Something went wrong');
+      expect(result.current.cooldownSeconds).toBe(0); // No cooldown for non-rate-limit errors
+    });
+
+    it('should handle error with no message', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'INTERNAL_SERVER_ERROR' },
+        });
+      });
+
+      expect(result.current.lastResult?.success).toBe(false);
+      expect(result.current.lastResult?.message).toBe('Sync failed');
+    });
+  });
+
+  describe('inbox invalidation', () => {
+    it('should invalidate inbox on success', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 1,
+          itemsFound: 1,
+          errors: [],
+        });
+      });
+
+      expect(mockInvalidate).toHaveBeenCalled();
+    });
+
+    it('should invalidate inbox even when no new items found', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnSuccess?.({
+          synced: 5,
+          itemsFound: 0,
+          errors: [],
+        });
+      });
+
+      expect(mockInvalidate).toHaveBeenCalled();
+    });
+
+    it('should not invalidate inbox on error', () => {
+      const { result } = renderHook(() => useSyncAll());
+
+      act(() => {
+        result.current.syncAll();
+        mockOnError?.({
+          data: { code: 'INTERNAL_SERVER_ERROR' },
+          message: 'Error',
+        });
+      });
+
+      expect(mockInvalidate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isLoading state', () => {
+    it('should expose isPending as isLoading', () => {
+      mockIsPending = true;
+      const { result } = renderHook(() => useSyncAll());
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+});

--- a/apps/mobile/hooks/use-sync-all.ts
+++ b/apps/mobile/hooks/use-sync-all.ts
@@ -1,0 +1,141 @@
+/**
+ * useSyncAll Hook
+ *
+ * Triggers sync across all active subscriptions.
+ * Handles rate limiting (2-minute cooldown) and provides aggregated feedback.
+ *
+ * Designed for pull-to-refresh on Inbox screen where users want to
+ * check ALL their subscriptions for new content at once.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { trpc } from '../lib/trpc';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+const DEFAULT_COOLDOWN_SECONDS = 120; // 2 minutes (matches backend)
+
+export interface SyncAllResult {
+  success: boolean;
+  synced: number;
+  itemsFound: number;
+  errors: string[];
+  message: string;
+}
+
+export interface UseSyncAllReturn {
+  syncAll: () => void;
+  isLoading: boolean;
+  cooldownSeconds: number;
+  lastResult: SyncAllResult | null;
+}
+
+// ============================================================================
+// Hook Implementation
+// ============================================================================
+
+export function useSyncAll(): UseSyncAllReturn {
+  const utils = trpc.useUtils();
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+  const [lastResult, setLastResult] = useState<SyncAllResult | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // NOTE: Using type assertion since syncAll mutation is added in zine-6m2.4
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mutation = (trpc as any).subscriptions.syncAll.useMutation({
+    onSuccess: (data: { synced: number; itemsFound: number; errors: string[] }) => {
+      // Format user-friendly message
+      let message: string;
+      if (data.itemsFound > 0) {
+        message = `Found ${data.itemsFound} new item${data.itemsFound === 1 ? '' : 's'}`;
+      } else if (data.synced > 0) {
+        message = 'All caught up!';
+      } else {
+        message = 'No subscriptions to sync';
+      }
+
+      if (data.errors.length > 0) {
+        message = `${message} (${data.errors.length} failed)`;
+      }
+
+      setLastResult({
+        success: true,
+        synced: data.synced,
+        itemsFound: data.itemsFound,
+        errors: data.errors,
+        message,
+      });
+
+      setCooldownSeconds(DEFAULT_COOLDOWN_SECONDS);
+
+      // Invalidate inbox cache to show new items
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (utils as any).items.inbox.invalidate();
+    },
+    onError: (error: { data?: { code?: string }; message?: string }) => {
+      if (error.data?.code === 'TOO_MANY_REQUESTS') {
+        const match = error.message?.match(/(\d+)\s*(minutes?|seconds?)/i);
+        let seconds = DEFAULT_COOLDOWN_SECONDS;
+        if (match) {
+          const value = parseInt(match[1], 10);
+          seconds = match[2].toLowerCase().startsWith('minute') ? value * 60 : value;
+        }
+
+        setCooldownSeconds(seconds);
+        setLastResult({
+          success: false,
+          synced: 0,
+          itemsFound: 0,
+          errors: [],
+          message: `Try again in ${Math.ceil(seconds / 60)} minute${Math.ceil(seconds / 60) === 1 ? '' : 's'}`,
+        });
+      } else {
+        setLastResult({
+          success: false,
+          synced: 0,
+          itemsFound: 0,
+          errors: [error.message || 'Unknown error'],
+          message: error.message || 'Sync failed',
+        });
+      }
+    },
+  });
+
+  // Countdown timer for cooldown
+  useEffect(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    if (cooldownSeconds <= 0) return;
+
+    intervalRef.current = setInterval(() => {
+      setCooldownSeconds((prev) => {
+        if (prev <= 1) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [cooldownSeconds > 0]);
+
+  const syncAll = useCallback(() => {
+    if (cooldownSeconds > 0 || mutation.isPending) return;
+    mutation.mutate();
+  }, [cooldownSeconds, mutation]);
+
+  return {
+    syncAll,
+    isLoading: mutation.isPending,
+    cooldownSeconds,
+    lastResult,
+  };
+}


### PR DESCRIPTION
## Summary

- Add pull-to-refresh (PTR) gesture to the Inbox screen using FlatList's native `onRefresh`/`refreshing` props
- Create `useSyncAll` hook for triggering bulk sync of all subscriptions at once
- Wire `syncNow` mutation to actual YouTube/Spotify polling functions
- Add new `syncAll` mutation with 2-minute rate limiting per user

## Key Changes

### Backend (`apps/worker`)
- **syncNow mutation**: Now calls actual `pollSingleYouTubeSubscription` and `pollSingleSpotifySubscription` functions instead of returning placeholder `itemsFound: 0`
- **syncAll mutation**: New endpoint that syncs all active subscriptions for a user with:
  - 2-minute rate limiting per user
  - Partial failure handling (continues on individual subscription errors)
  - Aggregated results: `{ synced, itemsFound, errors }`

### Frontend (`apps/mobile`)
- **useSyncAll hook**: 
  - Calls syncAll tRPC mutation
  - Manages 2-minute cooldown timer
  - Formats user-friendly success/error messages
  - Invalidates inbox cache on success
- **Inbox integration**:
  - PTR gesture using FlatList's native props
  - Empty state support with `ListEmptyComponent`
  - Offline detection with error toast
  - Success/error toasts for sync results

## Testing
- Added 22 frontend tests for `useSyncAll` hook
- Added 11 backend tests for `syncAll` mutation
- All 557+ worker tests passing

## UX Behavior

| Scenario | Behavior |
|----------|----------|
| Pull to refresh (online) | Spinner shows, sync runs, toast appears |
| Pull to refresh (offline) | Error toast "Cannot sync while offline" |
| Found new items | Success toast "Found 3 new items" |
| No new items | Success toast "All caught up!" |
| Partial failure | Success toast "Found 2 items (1 failed)" |
| Rate limited | Error toast "Try again in 2 minutes" |

Closes #19