### PR TITLE
feat: Add article saving with improved metadata extraction

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -356,9 +356,22 @@ export default function ItemDetailScreen() {
           <View style={styles.metaRow}>
             <View style={[styles.providerDot, { backgroundColor: providerColor }]} />
             <Text style={[styles.creator, { color: colors.textSecondary }]}>{item.creator}</Text>
-            <Text style={[styles.separator, { color: colors.textTertiary }]}>{' on '}</Text>
-            <Text style={[styles.provider, { color: colors.textSecondary }]}>{providerLabel}</Text>
+            {providerLabel && (
+              <>
+                <Text style={[styles.separator, { color: colors.textTertiary }]}>{' on '}</Text>
+                <Text style={[styles.provider, { color: colors.textSecondary }]}>
+                  {providerLabel}
+                </Text>
+              </>
+            )}
           </View>
+
+          {/* Reading Time */}
+          {item.readingTimeMinutes && (
+            <Text style={[styles.readingTime, { color: colors.textTertiary }]}>
+              {item.readingTimeMinutes} min read
+            </Text>
+          )}
 
           {/* Published date */}
           {item.publishedAt && (
@@ -376,7 +389,9 @@ export default function ItemDetailScreen() {
               pressed && { opacity: 0.9 },
             ]}
           >
-            <Text style={styles.openButtonText}>Open in {providerLabel}</Text>
+            <Text style={styles.openButtonText}>
+              {providerLabel ? `Open in ${providerLabel}` : 'Open'}
+            </Text>
             <ChevronRightIcon size={20} color="#fff" />
           </Pressable>
 
@@ -544,6 +559,10 @@ const styles = StyleSheet.create({
   publishedAt: {
     ...Typography.bodySmall,
     marginBottom: Spacing.lg,
+  },
+  readingTime: {
+    ...Typography.bodySmall,
+    marginBottom: Spacing.xs,
   },
 
   // Open Button

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -25,6 +25,7 @@ import { formatDuration, formatRelativeTime } from '@/lib/format';
 import {
   getContentIcon,
   getProviderColor,
+  getProviderLabel,
   getContentAspectRatio,
   isSquareContent,
   mapContentType,
@@ -53,6 +54,7 @@ export interface ItemCardData {
   contentType: ContentType;
   provider: Provider;
   duration?: number | null;
+  readingTimeMinutes?: number | null;
   bookmarkedAt?: string | null;
   publishedAt?: string | null;
   isFinished?: boolean;
@@ -113,10 +115,15 @@ export function ItemCard({
   const contentType = mapContentType(item.contentType);
   const contentColor = ContentColors[contentType];
   const providerColor = getProviderColor(item.provider);
+  const providerLabel = getProviderLabel(item.provider);
 
   // Calculate aspect ratio based on content type
   const isSquare = isSquareContent(item.contentType);
   const aspectRatio = getContentAspectRatio(item.contentType);
+
+  // Reading time for articles (only show when no duration - duration takes precedence for video/podcast)
+  const readingTimeText =
+    item.readingTimeMinutes && !item.duration ? `${item.readingTimeMinutes} min` : null;
 
   // Handle press - navigate to detail by default
   const handlePress = () => {
@@ -175,6 +182,12 @@ export function ItemCard({
                 <Text style={styles.durationText}>{durationText}</Text>
               </View>
             )}
+            {/* Reading time badge (for articles without duration) */}
+            {readingTimeText && (
+              <View style={styles.durationBadge}>
+                <Text style={styles.durationText}>{readingTimeText}</Text>
+              </View>
+            )}
             {/* Completed badge */}
             {item.isFinished && (
               <View style={[styles.completedBadge, { backgroundColor: colors.success }]}>
@@ -196,6 +209,12 @@ export function ItemCard({
               >
                 {item.creator}
               </Text>
+              {providerLabel && (
+                <Text style={[styles.compactTime, { color: colors.textTertiary }]}>
+                  {' '}
+                  on {providerLabel}
+                </Text>
+              )}
               {timeText && (
                 <Text style={[styles.compactTime, { color: colors.textTertiary }]}>
                   {' '}
@@ -249,6 +268,12 @@ export function ItemCard({
                 <Text style={styles.durationText}>{durationText}</Text>
               </View>
             )}
+            {/* Reading time badge (for articles without duration) */}
+            {readingTimeText && (
+              <View style={styles.durationBadge}>
+                <Text style={styles.durationText}>{readingTimeText}</Text>
+              </View>
+            )}
             {/* Content type badge */}
             <View style={[styles.typeBadge, { backgroundColor: contentColor }]}>
               <Text style={styles.typeText}>{contentType}</Text>
@@ -260,9 +285,17 @@ export function ItemCard({
             <Text style={[styles.fullTitle, { color: colors.text }]} numberOfLines={2}>
               {item.title}
             </Text>
-            <Text style={[styles.fullCreator, { color: colors.textSecondary }]} numberOfLines={1}>
-              {item.creator}
-            </Text>
+            <View style={styles.fullMeta}>
+              <Text style={[styles.fullCreator, { color: colors.textSecondary }]} numberOfLines={1}>
+                {item.creator}
+              </Text>
+              {providerLabel && (
+                <Text style={[styles.fullProvider, { color: colors.textTertiary }]}>
+                  {' '}
+                  on {providerLabel}
+                </Text>
+              )}
+            </View>
           </View>
 
           {/* Actions */}
@@ -344,6 +377,12 @@ export function ItemCard({
               <Text style={styles.largeDurationText}>{durationText}</Text>
             </View>
           )}
+          {/* Reading time badge (for articles without duration) */}
+          {readingTimeText && (
+            <View style={styles.largeDurationBadge}>
+              <Text style={styles.largeDurationText}>{readingTimeText}</Text>
+            </View>
+          )}
         </View>
 
         {/* Content */}
@@ -356,6 +395,12 @@ export function ItemCard({
             <Text style={[styles.largeCreator, { color: colors.textSecondary }]} numberOfLines={1}>
               {item.creator}
             </Text>
+            {providerLabel && (
+              <Text style={[styles.largeProvider, { color: colors.textTertiary }]}>
+                {' '}
+                on {providerLabel}
+              </Text>
+            )}
           </View>
         </View>
       </Pressable>
@@ -436,6 +481,14 @@ const styles = StyleSheet.create({
   fullCreator: {
     ...Typography.bodyMedium,
   },
+  fullMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  fullProvider: {
+    ...Typography.bodyMedium,
+  },
   fullActions: {
     flexDirection: 'row',
     padding: Spacing.md,
@@ -478,7 +531,9 @@ const styles = StyleSheet.create({
   },
   largeCreator: {
     ...Typography.bodyMedium,
-    flex: 1,
+  },
+  largeProvider: {
+    ...Typography.bodyMedium,
   },
   largeDurationBadge: {
     position: 'absolute',

--- a/apps/mobile/components/link-preview-card.tsx
+++ b/apps/mobile/components/link-preview-card.tsx
@@ -63,6 +63,10 @@ export function LinkPreviewCard({ preview, style }: LinkPreviewCardProps) {
   const showDuration =
     durationText && (preview.contentType === 'VIDEO' || preview.contentType === 'PODCAST');
 
+  // Format reading time for articles
+  const showReadingTime = preview.readingTimeMinutes && preview.contentType === 'ARTICLE';
+  const readingTimeText = showReadingTime ? `${preview.readingTimeMinutes} min read` : null;
+
   // Check if this is from a connected provider (provider_api source)
   const isConnected = preview.source === 'provider_api';
 
@@ -73,6 +77,7 @@ export function LinkPreviewCard({ preview, style }: LinkPreviewCardProps) {
     `by ${preview.creator}`,
     `from ${providerLabel}`,
     showDuration ? durationText : null,
+    showReadingTime ? readingTimeText : null,
     isConnected ? 'Connected source' : null,
   ]
     .filter(Boolean)
@@ -113,6 +118,13 @@ export function LinkPreviewCard({ preview, style }: LinkPreviewCardProps) {
         {showDuration && (
           <View style={styles.durationBadge}>
             <Text style={styles.durationText}>{durationText}</Text>
+          </View>
+        )}
+
+        {/* Reading time badge - bottom right (for articles) */}
+        {showReadingTime && (
+          <View style={styles.durationBadge}>
+            <Text style={styles.durationText}>{readingTimeText}</Text>
           </View>
         )}
 

--- a/apps/mobile/hooks/use-bookmarks.ts
+++ b/apps/mobile/hooks/use-bookmarks.ts
@@ -27,8 +27,13 @@ export interface LinkPreview {
   thumbnailUrl: string | null;
   duration: number | null;
   canonicalUrl: string;
-  source: 'provider_api' | 'oembed' | 'opengraph' | 'fallback';
+  source: 'provider_api' | 'oembed' | 'opengraph' | 'fallback' | 'article_extractor';
   description?: string;
+  // Article-specific fields
+  siteName?: string;
+  wordCount?: number;
+  readingTimeMinutes?: number;
+  hasArticleContent?: boolean;
 }
 
 /**
@@ -54,6 +59,11 @@ export interface SaveBookmarkInput {
   duration: number | null;
   canonicalUrl: string;
   description?: string;
+  // Article-specific fields
+  siteName?: string;
+  wordCount?: number;
+  readingTimeMinutes?: number;
+  hasArticleContent?: boolean;
 }
 
 // ============================================================================
@@ -244,6 +254,11 @@ export function useSaveBookmark() {
       duration: preview.duration,
       canonicalUrl: preview.canonicalUrl,
       description: preview.description,
+      // Article-specific fields
+      siteName: preview.siteName,
+      wordCount: preview.wordCount,
+      readingTimeMinutes: preview.readingTimeMinutes,
+      hasArticleContent: preview.hasArticleContent,
     });
   };
 
@@ -272,6 +287,11 @@ export function useSaveBookmark() {
       duration: preview.duration,
       canonicalUrl: preview.canonicalUrl,
       description: preview.description,
+      // Article-specific fields
+      siteName: preview.siteName,
+      wordCount: preview.wordCount,
+      readingTimeMinutes: preview.readingTimeMinutes,
+      hasArticleContent: preview.hasArticleContent,
     });
   };
 

--- a/apps/mobile/lib/content-utils.ts
+++ b/apps/mobile/lib/content-utils.ts
@@ -27,12 +27,12 @@ export type UIContentType = 'video' | 'podcast' | 'article' | 'post';
 /**
  * API provider types (uppercase, from backend)
  */
-export type Provider = 'YOUTUBE' | 'SPOTIFY' | 'RSS' | 'SUBSTACK';
+export type Provider = 'YOUTUBE' | 'SPOTIFY' | 'RSS' | 'SUBSTACK' | 'WEB';
 
 /**
  * UI provider types (lowercase, for display/styling)
  */
-export type UIProvider = 'youtube' | 'spotify' | 'rss' | 'substack';
+export type UIProvider = 'youtube' | 'spotify' | 'rss' | 'substack' | 'web';
 
 // ============================================================================
 // Type Mapping
@@ -167,6 +167,8 @@ export function getProviderColor(provider: Provider | UIProvider): string {
       return ProviderColors.spotify;
     case 'substack':
       return ProviderColors.substack;
+    case 'web':
+      return '#6366F1'; // Indigo for web links
     case 'rss':
     default:
       return '#6366F1'; // Fallback to primary indigo
@@ -208,11 +210,12 @@ export function getContentTypeLabel(type: ContentType | UIContentType): string {
  * Get human-readable label for provider
  *
  * @param provider - Provider (accepts both API and UI types)
- * @returns Properly cased provider name
+ * @returns Properly cased provider name (empty string for web - shows author only)
  *
  * @example
  * getProviderLabel('youtube') // 'YouTube'
  * getProviderLabel('SPOTIFY') // 'Spotify'
+ * getProviderLabel('WEB')     // '' (empty - web links show author name only)
  */
 export function getProviderLabel(provider: Provider | UIProvider): string {
   const normalized = normalizeProvider(provider);
@@ -226,6 +229,8 @@ export function getProviderLabel(provider: Provider | UIProvider): string {
       return 'Substack';
     case 'rss':
       return 'RSS';
+    case 'web':
+      return ''; // Web links show author name only, no provider label
     default:
       return 'Unknown';
   }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@hono/trpc-server": "^0.3.2",
+    "@mozilla/readability": "^0.6.0",
     "@spotify/web-api-ts-sdk": "^1.2.0",
     "@trpc/server": "^11.0.0",
     "@zine/shared": "workspace:*",
@@ -33,6 +34,7 @@
     "googleapis": "^169.0.0",
     "hono": "^4.6.14",
     "jose": "^5.9.6",
+    "linkedom": "^0.18.12",
     "superjson": "^2.2.2",
     "svix": "^1.44.0",
     "ulid": "^3.0.2",

--- a/apps/worker/src/db/migrations/0006_add_article_fields.sql
+++ b/apps/worker/src/db/migrations/0006_add_article_fields.sql
@@ -1,0 +1,5 @@
+-- Add article-specific metadata fields to items table
+
+ALTER TABLE items ADD COLUMN word_count INTEGER;
+ALTER TABLE items ADD COLUMN reading_time_minutes INTEGER;
+ALTER TABLE items ADD COLUMN article_content_key TEXT;

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -41,6 +41,11 @@ export const items = sqliteTable(
     duration: integer('duration'), // Seconds
     publishedAt: text('published_at'), // ISO8601 (legacy)
 
+    // Article-specific metadata
+    wordCount: integer('word_count'),
+    readingTimeMinutes: integer('reading_time_minutes'),
+    articleContentKey: text('article_content_key'), // R2 object key for full article content
+
     // System
     createdAt: text('created_at').notNull(), // ISO8601 (legacy)
     updatedAt: text('updated_at').notNull(), // ISO8601 (legacy)

--- a/apps/worker/src/lib/article-extractor.test.ts
+++ b/apps/worker/src/lib/article-extractor.test.ts
@@ -1,0 +1,578 @@
+/**
+ * Tests for Article Extractor
+ *
+ * Tests article metadata extraction using Readability and linkedom.
+ * Uses mock fetch to simulate various HTML responses.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { extractArticleFromHtml, extractArticle } from './article-extractor';
+
+// Mock logger to prevent console output during tests
+vi.mock('./logger', () => ({
+  logger: {
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+// ============================================================================
+// Test HTML Templates
+// ============================================================================
+
+/**
+ * Generate valid article HTML that passes Readability's isProbablyReaderable check
+ * Readability requires substantial content to consider something readable
+ */
+function createArticleHtml(options: {
+  title?: string;
+  author?: string;
+  ogImage?: string;
+  siteName?: string;
+  publishedTime?: string;
+  content?: string;
+}): string {
+  const {
+    title = 'Test Article Title',
+    author,
+    ogImage,
+    siteName,
+    publishedTime,
+    content = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(50),
+  } = options;
+
+  const metaTags: string[] = [];
+  if (ogImage) metaTags.push(`<meta property="og:image" content="${ogImage}">`);
+  if (siteName) metaTags.push(`<meta property="og:site_name" content="${siteName}">`);
+  if (publishedTime)
+    metaTags.push(`<meta property="article:published_time" content="${publishedTime}">`);
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>${title}</title>
+      ${metaTags.join('\n      ')}
+    </head>
+    <body>
+      <article>
+        <h1>${title}</h1>
+        ${author ? `<p class="byline">By ${author}</p>` : ''}
+        <p>${content}</p>
+      </article>
+    </body>
+    </html>
+  `;
+}
+
+/**
+ * Generate minimal HTML that is not a readable article
+ */
+function createNonArticleHtml(options: { ogImage?: string } = {}): string {
+  const { ogImage } = options;
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Home Page</title>
+      ${ogImage ? `<meta property="og:image" content="${ogImage}">` : ''}
+    </head>
+    <body>
+      <nav><a href="/">Home</a><a href="/about">About</a></nav>
+      <p>Short content.</p>
+    </body>
+    </html>
+  `;
+}
+
+// ============================================================================
+// Mock Fetch Setup
+// ============================================================================
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(html: string, options?: { status?: number; contentType?: string }): void {
+  const { status = 200, contentType = 'text/html; charset=utf-8' } = options || {};
+
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(html, {
+      status,
+      headers: { 'Content-Type': contentType },
+    })
+  );
+}
+
+function mockFetchError(error: Error): void {
+  globalThis.fetch = vi.fn().mockRejectedValue(error);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('article-extractor', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('extractArticleFromHtml', () => {
+    describe('valid article HTML', () => {
+      it('extracts article metadata from valid HTML', () => {
+        const html = createArticleHtml({
+          title: 'My Test Article',
+          author: 'John Doe',
+          ogImage: 'https://example.com/image.jpg',
+          siteName: 'Example Blog',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(true);
+        expect(result!.title).toBe('My Test Article');
+        expect(result!.thumbnailUrl).toBe('https://example.com/image.jpg');
+        expect(result!.siteName).toBe('Example Blog');
+      });
+
+      it('calculates reading time based on content length', () => {
+        // Create article with known word count
+        // ~200 words per minute, content is estimated at 5 chars per word
+        const longContent = 'Word '.repeat(400); // ~400 words = 2 minutes
+        const html = createArticleHtml({
+          title: 'Long Article',
+          content: longContent,
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/long');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(true);
+        expect(result!.wordCount).toBeGreaterThan(0);
+        expect(result!.readingTimeMinutes).toBeGreaterThan(0);
+      });
+
+      it('extracts author/byline from article', () => {
+        const html = createArticleHtml({
+          title: 'Article With Author',
+          author: 'Jane Smith',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        // Note: Readability may or may not extract byline depending on HTML structure
+        // The important thing is it doesn't throw
+        expect(result!.isArticle).toBe(true);
+      });
+
+      it('extracts content HTML for reader view', () => {
+        // Need substantial content for Readability to consider it readable
+        const mainContent =
+          'This is the main article content that should be extracted. ' +
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(50);
+        const html = createArticleHtml({
+          title: 'Content Test',
+          content: mainContent,
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(true);
+        expect(result!.content).not.toBeNull();
+        expect(result!.content).toContain('main article content');
+      });
+    });
+
+    describe('non-article HTML', () => {
+      it('returns isArticle: false for non-readable content', () => {
+        const html = createNonArticleHtml();
+
+        const result = extractArticleFromHtml(html, 'https://example.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(false);
+        expect(result!.title).toBe('');
+        expect(result!.content).toBeNull();
+        expect(result!.wordCount).toBeNull();
+        expect(result!.readingTimeMinutes).toBeNull();
+      });
+
+      it('still extracts OG image from non-article pages', () => {
+        const html = createNonArticleHtml({
+          ogImage: 'https://example.com/og-image.png',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(false);
+        expect(result!.thumbnailUrl).toBe('https://example.com/og-image.png');
+      });
+
+      it('extracts site name from domain for non-article pages', () => {
+        const html = createNonArticleHtml();
+
+        const result = extractArticleFromHtml(html, 'https://medium.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(false);
+        expect(result!.siteName).toBe('Medium');
+      });
+    });
+
+    describe('malformed HTML', () => {
+      it('handles completely malformed HTML gracefully', () => {
+        const malformedHtml = '<html><head><title>Broken';
+
+        // Should return null or a non-article result without throwing
+        // linkedom is quite tolerant, so it may still parse something
+        expect(() =>
+          extractArticleFromHtml(malformedHtml, 'https://example.com/broken')
+        ).not.toThrow();
+      });
+
+      it('handles empty HTML string', () => {
+        // Should not throw, may return null or non-article
+        expect(() => extractArticleFromHtml('', 'https://example.com/empty')).not.toThrow();
+      });
+
+      it('handles HTML with only whitespace', () => {
+        expect(() =>
+          extractArticleFromHtml('   \n\t  ', 'https://example.com/whitespace')
+        ).not.toThrow();
+      });
+
+      it('handles HTML without head or body', () => {
+        expect(() =>
+          extractArticleFromHtml('<p>Just a paragraph</p>', 'https://example.com/minimal')
+        ).not.toThrow();
+      });
+    });
+
+    describe('missing fields', () => {
+      it('uses site name fallback from domain when not in meta tags', () => {
+        const html = createArticleHtml({
+          title: 'Article Without Site Name',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://techcrunch.com/article');
+
+        expect(result).not.toBeNull();
+        // Should fall back to extracting from domain
+        expect(result!.siteName).toBe('Techcrunch');
+      });
+
+      it('handles missing author gracefully', () => {
+        const html = createArticleHtml({
+          title: 'No Author Article',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.isArticle).toBe(true);
+        // author can be null
+        expect(result!.author).toSatisfy((v: string | null) => v === null || typeof v === 'string');
+      });
+
+      it('handles missing OG image gracefully', () => {
+        const html = createArticleHtml({
+          title: 'No Image Article',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.thumbnailUrl).toBeNull();
+      });
+
+      it('handles missing published time', () => {
+        const html = createArticleHtml({
+          title: 'No Date Article',
+        });
+
+        const result = extractArticleFromHtml(html, 'https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.publishedAt).toBeNull();
+      });
+    });
+
+    describe('OG image extraction', () => {
+      it('extracts og:image from meta tag', () => {
+        const html = `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta property="og:image" content="https://cdn.example.com/hero.jpg">
+          </head>
+          <body><nav>Links</nav></body>
+          </html>
+        `;
+
+        const result = extractArticleFromHtml(html, 'https://example.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.thumbnailUrl).toBe('https://cdn.example.com/hero.jpg');
+      });
+
+      it('returns null when no og:image present', () => {
+        const html = `
+          <!DOCTYPE html>
+          <html>
+          <head><title>No OG</title></head>
+          <body><nav>Links</nav></body>
+          </html>
+        `;
+
+        const result = extractArticleFromHtml(html, 'https://example.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.thumbnailUrl).toBeNull();
+      });
+
+      it('takes first og:image when multiple present', () => {
+        const html = `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta property="og:image" content="https://example.com/first.jpg">
+            <meta property="og:image" content="https://example.com/second.jpg">
+          </head>
+          <body><nav>Links</nav></body>
+          </html>
+        `;
+
+        const result = extractArticleFromHtml(html, 'https://example.com/');
+
+        expect(result).not.toBeNull();
+        expect(result!.thumbnailUrl).toBe('https://example.com/first.jpg');
+      });
+    });
+  });
+
+  describe('extractArticle', () => {
+    describe('successful fetch and parse', () => {
+      it('fetches URL and extracts article metadata', async () => {
+        const html = createArticleHtml({
+          title: 'Fetched Article',
+          ogImage: 'https://example.com/thumb.jpg',
+        });
+        mockFetch(html);
+
+        const result = await extractArticle('https://example.com/article');
+
+        expect(result).not.toBeNull();
+        expect(result!.title).toBe('Fetched Article');
+        expect(result!.thumbnailUrl).toBe('https://example.com/thumb.jpg');
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          'https://example.com/article',
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'User-Agent': expect.stringContaining('ZineBot'),
+            }),
+          })
+        );
+      });
+
+      it('sends correct Accept header', async () => {
+        mockFetch(createArticleHtml({ title: 'Test' }));
+
+        await extractArticle('https://example.com/article');
+
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Accept: 'text/html,application/xhtml+xml',
+            }),
+          })
+        );
+      });
+    });
+
+    describe('fetch failures', () => {
+      it('returns null on 404 response', async () => {
+        mockFetch('Not Found', { status: 404 });
+
+        const result = await extractArticle('https://example.com/missing');
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null on 500 response', async () => {
+        mockFetch('Internal Server Error', { status: 500 });
+
+        const result = await extractArticle('https://example.com/error');
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null on 403 forbidden', async () => {
+        mockFetch('Forbidden', { status: 403 });
+
+        const result = await extractArticle('https://example.com/forbidden');
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null on network error', async () => {
+        mockFetchError(new Error('Network error'));
+
+        const result = await extractArticle('https://example.com/unreachable');
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null on DNS resolution failure', async () => {
+        mockFetchError(new Error('getaddrinfo ENOTFOUND'));
+
+        const result = await extractArticle('https://nonexistent.example.com/');
+
+        expect(result).toBeNull();
+      });
+
+      it('returns null on timeout', async () => {
+        const timeoutError = new Error('Timeout');
+        timeoutError.name = 'AbortError';
+        mockFetchError(timeoutError);
+
+        const result = await extractArticle('https://slow.example.com/');
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('extractSiteNameFromDomain (via extractArticleFromHtml)', () => {
+    // The function is private, but we can test it through extractArticleFromHtml
+    // when the page is not an article (isArticle: false case uses it)
+
+    it('extracts "Medium" from medium.com', () => {
+      const html = createNonArticleHtml();
+      const result = extractArticleFromHtml(html, 'https://medium.com/');
+
+      expect(result!.siteName).toBe('Medium');
+    });
+
+    it('extracts "Substack" from newsletter.substack.com', () => {
+      const html = createNonArticleHtml();
+      const result = extractArticleFromHtml(html, 'https://newsletter.substack.com/');
+
+      expect(result!.siteName).toBe('Substack');
+    });
+
+    it('handles www prefix correctly', () => {
+      const html = createNonArticleHtml();
+      const result = extractArticleFromHtml(html, 'https://www.example.com/');
+
+      expect(result!.siteName).toBe('Example');
+    });
+
+    it('handles multi-level TLDs', () => {
+      const html = createNonArticleHtml();
+      const result = extractArticleFromHtml(html, 'https://www.bbc.co.uk/');
+
+      // Should extract "co" (second to last part) - this is expected behavior
+      expect(result!.siteName).toBe('Co');
+    });
+
+    it('capitalizes first letter of domain', () => {
+      const html = createNonArticleHtml();
+      const result = extractArticleFromHtml(html, 'https://techcrunch.com/');
+
+      expect(result!.siteName).toBe('Techcrunch');
+    });
+
+    it('returns "Unknown" for invalid URLs', () => {
+      const html = createNonArticleHtml();
+      // Force the function to be called with an invalid URL
+      const result = extractArticleFromHtml(html, 'not-a-valid-url');
+
+      expect(result!.siteName).toBe('Unknown');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles very long articles', () => {
+      const veryLongContent = 'This is a sentence. '.repeat(5000); // ~50k words
+      const html = createArticleHtml({
+        title: 'Very Long Article',
+        content: veryLongContent,
+      });
+
+      const result = extractArticleFromHtml(html, 'https://example.com/long');
+
+      expect(result).not.toBeNull();
+      expect(result!.isArticle).toBe(true);
+      expect(result!.wordCount).toBeGreaterThan(1000);
+      expect(result!.readingTimeMinutes).toBeGreaterThan(10);
+    });
+
+    it('handles special characters in title', () => {
+      const html = createArticleHtml({
+        title: 'Test & "Quotes" <Special> Characters',
+      });
+
+      const result = extractArticleFromHtml(html, 'https://example.com/special');
+
+      expect(result).not.toBeNull();
+      // linkedom handles HTML entities, title should be extracted
+      expect(result!.title).toBeTruthy();
+    });
+
+    it('handles unicode content', () => {
+      const html = createArticleHtml({
+        title: '日本語タイトル',
+        content: 'Unicode content: café, naïve, 中文, 한국어. '.repeat(50),
+      });
+
+      const result = extractArticleFromHtml(html, 'https://example.com/unicode');
+
+      expect(result).not.toBeNull();
+      expect(result!.isArticle).toBe(true);
+    });
+
+    it('handles articles with no text content', () => {
+      const html = `
+        <!DOCTYPE html>
+        <html>
+        <head><title>Image Gallery</title></head>
+        <body>
+          <article>
+            <h1>Photo Gallery</h1>
+            <img src="photo1.jpg" alt="Photo 1">
+            <img src="photo2.jpg" alt="Photo 2">
+          </article>
+        </body>
+        </html>
+      `;
+
+      // Should not throw
+      expect(() => extractArticleFromHtml(html, 'https://example.com/gallery')).not.toThrow();
+    });
+
+    it('handles protocol-relative URLs in og:image', () => {
+      const html = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta property="og:image" content="//cdn.example.com/image.jpg">
+        </head>
+        <body><nav>Links</nav></body>
+        </html>
+      `;
+
+      const result = extractArticleFromHtml(html, 'https://example.com/');
+
+      expect(result).not.toBeNull();
+      expect(result!.thumbnailUrl).toBe('//cdn.example.com/image.jpg');
+    });
+  });
+});

--- a/apps/worker/src/lib/article-extractor.ts
+++ b/apps/worker/src/lib/article-extractor.ts
@@ -1,0 +1,144 @@
+import { parseHTML } from 'linkedom/worker';
+import { Readability, isProbablyReaderable } from '@mozilla/readability';
+import { logger } from './logger';
+
+const extractorLogger = logger.child('article-extractor');
+
+/**
+ * Extracted article metadata
+ */
+export interface ArticleMetadata {
+  /** Article title */
+  title: string;
+  /** Author/byline */
+  author: string | null;
+  /** Publication/site name */
+  siteName: string | null;
+  /** ISO8601 publication date */
+  publishedAt: string | null;
+  /** Cover/lead image URL */
+  thumbnailUrl: string | null;
+  /** Article summary/excerpt */
+  excerpt: string | null;
+  /** Estimated word count */
+  wordCount: number | null;
+  /** Reading time in minutes (based on 200 WPM) */
+  readingTimeMinutes: number | null;
+  /** Full article HTML for reader view */
+  content: string | null;
+  /** Whether this URL is a readable article */
+  isArticle: boolean;
+}
+
+const USER_AGENT = 'ZineBot/1.0 (+https://zine.app/bot)';
+
+/**
+ * Extract article metadata from a URL
+ */
+export async function extractArticle(url: string): Promise<ArticleMetadata | null> {
+  try {
+    extractorLogger.debug('Fetching article', { url });
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    });
+
+    if (!response.ok) {
+      extractorLogger.warn('Article fetch failed', { url, status: response.status });
+      return null;
+    }
+
+    const html = await response.text();
+    return extractArticleFromHtml(html, url);
+  } catch (error) {
+    extractorLogger.error('Article extraction error', { url, error });
+    return null;
+  }
+}
+
+/**
+ * Extract article metadata from HTML string
+ */
+export function extractArticleFromHtml(html: string, url: string): ArticleMetadata | null {
+  try {
+    const { document } = parseHTML(html);
+
+    // Check if this looks like an article
+    const isArticle = isProbablyReaderable(document);
+
+    if (!isArticle) {
+      return {
+        title: '',
+        author: null,
+        siteName: extractSiteNameFromDomain(url),
+        publishedAt: null,
+        thumbnailUrl: extractOgImage(document),
+        excerpt: null,
+        wordCount: null,
+        readingTimeMinutes: null,
+        content: null,
+        isArticle: false,
+      };
+    }
+
+    // Clone document before Readability modifies it
+    const documentClone = document.cloneNode(true);
+    const reader = new Readability(documentClone as Document);
+    const article = reader.parse();
+
+    if (!article) {
+      return null;
+    }
+
+    // Calculate reading time (~200 words per minute)
+    // Readability's length is textContent length; estimate ~5 chars per word
+    const articleLength = article.length ?? 0;
+    const estimatedWords = Math.round(articleLength / 5);
+    const readingTimeMinutes = Math.ceil(estimatedWords / 200);
+
+    return {
+      title: article.title ?? '',
+      author: article.byline ?? null,
+      siteName: article.siteName ?? extractSiteNameFromDomain(url),
+      publishedAt: article.publishedTime ?? null,
+      thumbnailUrl: extractOgImage(document),
+      excerpt: article.excerpt ?? null,
+      wordCount: estimatedWords,
+      readingTimeMinutes,
+      content: article.content ?? null,
+      isArticle: true,
+    };
+  } catch (error) {
+    extractorLogger.error('HTML parsing error', { url, error });
+    return null;
+  }
+}
+
+/**
+ * Extract OG image from document
+ */
+function extractOgImage(document: Document): string | null {
+  const ogImage = document.querySelector('meta[property="og:image"]');
+  return ogImage?.getAttribute('content') || null;
+}
+
+/**
+ * Extract site name from domain
+ */
+function extractSiteNameFromDomain(url: string): string {
+  try {
+    const hostname = new URL(url).hostname;
+    const domain = hostname.replace(/^www\./, '');
+    const parts = domain.split('.');
+    if (parts.length >= 2) {
+      const name = parts[parts.length - 2];
+      return name.charAt(0).toUpperCase() + name.slice(1);
+    }
+    return domain;
+  } catch {
+    return 'Unknown';
+  }
+}

--- a/apps/worker/src/lib/article-storage.ts
+++ b/apps/worker/src/lib/article-storage.ts
@@ -1,0 +1,149 @@
+/**
+ * Article Storage Module for R2 Operations
+ *
+ * Provides functions to store, retrieve, and delete article content from R2.
+ * Article content is stored as HTML files with metadata for tracking.
+ *
+ * @example
+ * ```typescript
+ * import { storeArticleContent, getArticleContent } from './lib/article-storage';
+ *
+ * // Store article content
+ * const key = await storeArticleContent(env.ARTICLE_BUCKET, 'item-123', '<html>...</html>');
+ *
+ * // Retrieve article content
+ * const content = await getArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ *
+ * // Check if content exists
+ * const exists = await hasArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ *
+ * // Delete article content
+ * await deleteArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ * ```
+ */
+
+import { logger } from './logger';
+
+const storageLogger = logger.child('article-storage');
+
+// ============================================================================
+// Key Generation
+// ============================================================================
+
+/**
+ * Generate the R2 key for an article.
+ */
+function getArticleKey(itemId: string): string {
+  return `articles/${itemId}.html`;
+}
+
+// ============================================================================
+// Storage Operations
+// ============================================================================
+
+/**
+ * Store article content in R2.
+ *
+ * @param bucket - R2 bucket binding
+ * @param itemId - Item ID to use as key
+ * @param content - Article HTML content
+ * @returns R2 object key
+ *
+ * @example
+ * ```typescript
+ * const key = await storeArticleContent(env.ARTICLE_BUCKET, 'item-123', '<html>...</html>');
+ * console.log(key); // 'articles/item-123.html'
+ * ```
+ */
+export async function storeArticleContent(
+  bucket: R2Bucket,
+  itemId: string,
+  content: string
+): Promise<string> {
+  const key = getArticleKey(itemId);
+
+  await bucket.put(key, content, {
+    httpMetadata: {
+      contentType: 'text/html; charset=utf-8',
+    },
+    customMetadata: {
+      itemId,
+      storedAt: new Date().toISOString(),
+    },
+  });
+
+  storageLogger.info('Article content stored', {
+    itemId,
+    key,
+    contentLength: content.length,
+  });
+
+  return key;
+}
+
+/**
+ * Retrieve article content from R2.
+ *
+ * @param bucket - R2 bucket binding
+ * @param itemId - Item ID to retrieve
+ * @returns Article HTML content, or null if not found
+ *
+ * @example
+ * ```typescript
+ * const content = await getArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ * if (content) {
+ *   console.log('Article found:', content.length, 'chars');
+ * }
+ * ```
+ */
+export async function getArticleContent(bucket: R2Bucket, itemId: string): Promise<string | null> {
+  const key = getArticleKey(itemId);
+  const object = await bucket.get(key);
+
+  if (!object) {
+    storageLogger.debug('Article content not found', { itemId, key });
+    return null;
+  }
+
+  return object.text();
+}
+
+/**
+ * Delete article content from R2.
+ *
+ * @param bucket - R2 bucket binding
+ * @param itemId - Item ID to delete
+ *
+ * @example
+ * ```typescript
+ * await deleteArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ * ```
+ */
+export async function deleteArticleContent(bucket: R2Bucket, itemId: string): Promise<void> {
+  const key = getArticleKey(itemId);
+  await bucket.delete(key);
+  storageLogger.info('Article content deleted', { itemId, key });
+}
+
+/**
+ * Check if article content exists in R2.
+ *
+ * Uses HEAD request which is more efficient than GET for existence checks.
+ *
+ * @param bucket - R2 bucket binding
+ * @param itemId - Item ID to check
+ * @returns true if the article exists, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const exists = await hasArticleContent(env.ARTICLE_BUCKET, 'item-123');
+ * if (!exists) {
+ *   // Fetch and store the article
+ * }
+ * ```
+ */
+export async function hasArticleContent(bucket: R2Bucket, itemId: string): Promise<boolean> {
+  const key = getArticleKey(itemId);
+  const head = await bucket.head(key);
+  return head !== null;
+}

--- a/apps/worker/src/lib/link-parser.test.ts
+++ b/apps/worker/src/lib/link-parser.test.ts
@@ -170,19 +170,19 @@ describe('parseLink', () => {
       it('falls back to generic for invalid video ID length', () => {
         // Invalid YouTube URLs fall through to generic handler
         const shortResult = parseLink('https://youtube.com/watch?v=short');
-        expect(shortResult?.provider).toBe(Provider.RSS);
+        expect(shortResult?.provider).toBe(Provider.WEB);
         expect(shortResult?.contentType).toBe(ContentType.ARTICLE);
 
         const longResult = parseLink('https://youtube.com/watch?v=waytoolongvideoid');
-        expect(longResult?.provider).toBe(Provider.RSS);
+        expect(longResult?.provider).toBe(Provider.WEB);
       });
 
       it('falls back to generic for missing video ID', () => {
         const result1 = parseLink('https://youtube.com/watch');
-        expect(result1?.provider).toBe(Provider.RSS);
+        expect(result1?.provider).toBe(Provider.WEB);
 
         const result2 = parseLink('https://youtube.com/watch?');
-        expect(result2?.provider).toBe(Provider.RSS);
+        expect(result2?.provider).toBe(Provider.WEB);
       });
 
       it('handles video IDs with special chars', () => {
@@ -223,25 +223,25 @@ describe('parseLink', () => {
       it('falls back to generic for invalid episode ID length', () => {
         // Invalid Spotify URLs fall through to generic handler
         const shortResult = parseLink('https://open.spotify.com/episode/short');
-        expect(shortResult?.provider).toBe(Provider.RSS);
+        expect(shortResult?.provider).toBe(Provider.WEB);
         expect(shortResult?.contentType).toBe(ContentType.ARTICLE);
 
         const longResult = parseLink(
           'https://open.spotify.com/episode/waytoolongepisodeid12345678'
         );
-        expect(longResult?.provider).toBe(Provider.RSS);
+        expect(longResult?.provider).toBe(Provider.WEB);
       });
 
       it('falls back to generic for non-episode content types', () => {
         // Track URLs should fall through to generic
         const result = parseLink('https://open.spotify.com/track/abc123');
-        expect(result?.provider).toBe(Provider.RSS);
+        expect(result?.provider).toBe(Provider.WEB);
         expect(result?.contentType).toBe(ContentType.ARTICLE);
       });
 
       it('falls back to generic for wrong hostname', () => {
         const result = parseLink('https://spotify.com/episode/4rOoJ6Egrf8K2IrywzwOMk');
-        expect(result?.provider).toBe(Provider.RSS); // Falls through to generic
+        expect(result?.provider).toBe(Provider.WEB); // Falls through to generic
       });
     });
   });
@@ -286,12 +286,12 @@ describe('parseLink', () => {
       it('returns null for non-post URLs', () => {
         // Homepage should fall through to generic
         const result = parseLink('https://example.substack.com');
-        expect(result?.provider).toBe(Provider.RSS);
+        expect(result?.provider).toBe(Provider.WEB);
       });
 
       it('returns null for missing slug', () => {
         const result = parseLink('https://example.substack.com/p/');
-        expect(result?.provider).toBe(Provider.RSS); // Falls through to generic
+        expect(result?.provider).toBe(Provider.WEB); // Falls through to generic
       });
     });
   });
@@ -340,7 +340,7 @@ describe('parseLink', () => {
       it('returns null for non-status URLs', () => {
         // Profile URL should fall through to generic
         const result = parseLink('https://twitter.com/elonmusk');
-        expect(result?.provider).toBe(Provider.RSS);
+        expect(result?.provider).toBe(Provider.WEB);
         expect(result?.contentType).toBe(ContentType.ARTICLE);
       });
 
@@ -356,7 +356,7 @@ describe('parseLink', () => {
       const result = parseLink('https://example.com/article/hello-world');
 
       expect(result).toEqual({
-        provider: Provider.RSS,
+        provider: Provider.WEB,
         contentType: ContentType.ARTICLE,
         providerId: 'https://example.com/article/hello-world',
         canonicalUrl: 'https://example.com/article/hello-world',

--- a/apps/worker/src/lib/link-parser.ts
+++ b/apps/worker/src/lib/link-parser.ts
@@ -269,7 +269,7 @@ function parseGeneric(url: URL): ParsedLink {
   const canonicalUrl = stripTrackingParams(url);
 
   return {
-    provider: Provider.RSS,
+    provider: Provider.WEB,
     contentType: ContentType.ARTICLE,
     providerId: canonicalUrl, // Use full URL as provider ID
     canonicalUrl,

--- a/apps/worker/src/lib/link-preview.test.ts
+++ b/apps/worker/src/lib/link-preview.test.ts
@@ -369,7 +369,7 @@ describe('link-preview', () => {
         const result = await fetchLinkPreview('https://example.com/blog/article');
 
         expect(result).not.toBeNull();
-        expect(result!.provider).toBe(Provider.RSS);
+        expect(result!.provider).toBe(Provider.WEB);
         expect(result!.contentType).toBe(ContentType.ARTICLE);
         expect(result!.title).toBe('Generic Article Title');
         expect(result!.creator).toBe('Blog Author');

--- a/apps/worker/src/routes/auth.test.ts
+++ b/apps/worker/src/routes/auth.test.ts
@@ -93,6 +93,12 @@ function createMockEnv(): Env['Bindings'] {
       put: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
     } as unknown as KVNamespace,
+    ARTICLE_CONTENT: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      head: vi.fn().mockResolvedValue(null),
+    } as unknown as R2Bucket,
     ENVIRONMENT: 'test',
     CLERK_WEBHOOK_SECRET: 'whsec_test_secret',
   };

--- a/apps/worker/src/trpc/routers/items.test.ts
+++ b/apps/worker/src/trpc/routers/items.test.ts
@@ -47,6 +47,8 @@ function createMockItemView(overrides: Partial<ItemView> = {}): ItemView {
     progress: null,
     isFinished: false,
     finishedAt: null,
+    wordCount: null,
+    readingTimeMinutes: null,
   };
 
   return { ...defaults, ...overrides };
@@ -1013,6 +1015,8 @@ describe('ItemView Type', () => {
       progress: null,
       isFinished: false,
       finishedAt: null,
+      wordCount: null,
+      readingTimeMinutes: null,
     };
 
     expect(itemView.id).toBe('ui-001');
@@ -1045,6 +1049,8 @@ describe('ItemView Type', () => {
       },
       isFinished: false,
       finishedAt: null,
+      wordCount: null,
+      readingTimeMinutes: null,
     };
 
     expect(itemWithProgress.progress).not.toBeNull();

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -12,6 +12,7 @@ import {
 } from '@zine/shared';
 import { userItems, items } from '../../db/schema';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import { getArticleContent } from '../../lib/article-storage';
 
 // ============================================================================
 // Types
@@ -43,6 +44,10 @@ export type ItemView = {
   summary: string | null;
   duration: number | null; // seconds
   publishedAt: string | null;
+
+  // Article-specific metadata
+  wordCount: number | null;
+  readingTimeMinutes: number | null;
 
   // User state
   state: UserItemState;
@@ -88,6 +93,8 @@ function toItemView(row: {
     summary: item.summary,
     duration: item.duration,
     publishedAt: item.publishedAt,
+    wordCount: item.wordCount,
+    readingTimeMinutes: item.readingTimeMinutes,
     state: userItem.state as UserItemState,
     ingestedAt: userItem.ingestedAt,
     bookmarkedAt: userItem.bookmarkedAt,
@@ -112,9 +119,9 @@ function toItemView(row: {
 
 const FilterSchema = z
   .object({
-    provider: ProviderSchema.optional(),
-    contentType: ContentTypeSchema.optional(),
-    isFinished: z.boolean().optional(),
+    provider: ProviderSchema.nullish(),
+    contentType: ContentTypeSchema.nullish(),
+    isFinished: z.boolean().nullish(),
   })
   .optional();
 
@@ -377,6 +384,31 @@ export const itemsRouter = router({
       }
 
       return toItemView(result[0]);
+    }),
+
+  /**
+   * Get article content for an item from R2.
+   * Returns null if no content is stored.
+   */
+  getArticleContent: protectedProcedure
+    .input(z.object({ itemId: z.string().min(1) }))
+    .query(async ({ input, ctx }) => {
+      // Verify user owns this item
+      const userItem = await ctx.db.query.userItems.findFirst({
+        where: and(eq(userItems.userId, ctx.userId), eq(userItems.itemId, input.itemId)),
+      });
+
+      if (!userItem) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Item not found',
+        });
+      }
+
+      // Fetch from R2
+      const content = await getArticleContent(ctx.env.ARTICLE_CONTENT, input.itemId);
+
+      return { content };
     }),
 
   /**

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -14,6 +14,8 @@ export interface Bindings {
   WEBHOOK_IDEMPOTENCY: KVNamespace;
   /** KV namespace for OAuth state storage */
   OAUTH_STATE_KV: KVNamespace;
+  /** R2 bucket for article content storage */
+  ARTICLE_CONTENT: R2Bucket;
   /** Current environment (development, staging, production) */
   ENVIRONMENT: string;
   /** Clerk publishable key */

--- a/apps/worker/worker-configuration.d.ts
+++ b/apps/worker/worker-configuration.d.ts
@@ -2,6 +2,7 @@
 
 interface Env {
   WEBHOOK_IDEMPOTENCY: KVNamespace;
+  ARTICLE_CONTENT: R2Bucket;
   ENVIRONMENT: 'development' | 'staging' | 'production';
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   USER_DO: DurableObjectNamespace<import('./src/index').UserDO>;

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -13,6 +13,11 @@ id = "9b2d9ef82c02438ba13184bfc68c2d43"
 binding = "OAUTH_STATE_KV"
 id = "2101381b080942f9a7799583ccb2e096"
 
+# R2 bucket for article content storage
+[[r2_buckets]]
+binding = "ARTICLE_CONTENT"
+bucket_name = "zine-article-content-dev"
+
 # D1 Database binding (development)
 [[d1_databases]]
 binding = "DB"
@@ -47,6 +52,9 @@ id = "abb1a04762cb4a129218d8c9651adf7c"
 [[env.staging.kv_namespaces]]
 binding = "OAUTH_STATE_KV"
 id = "acb7c409523d4ddeb7941ec2783ace9d"
+[[env.staging.r2_buckets]]
+binding = "ARTICLE_CONTENT"
+bucket_name = "zine-article-content-staging"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "zine-db-staging"
@@ -77,6 +85,9 @@ id = "9937928f2eb54074bda5e035dac09c14"
 binding = "OAUTH_STATE_KV"
 id = "c58624987cd94f3285ca7f62e5c2fe16"
 
+[[env.production.r2_buckets]]
+binding = "ARTICLE_CONTENT"
+bucket_name = "zine-article-content-prod"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "zine-db-production"

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@hono/trpc-server": "^0.3.2",
+        "@mozilla/readability": "^0.6.0",
         "@spotify/web-api-ts-sdk": "^1.2.0",
         "@trpc/server": "^11.0.0",
         "@zine/shared": "workspace:*",
@@ -94,6 +95,7 @@
         "googleapis": "^169.0.0",
         "hono": "^4.6.14",
         "jose": "^5.9.6",
+        "linkedom": "^0.18.12",
         "superjson": "^2.2.2",
         "svix": "^1.44.0",
         "ulid": "^3.0.2",
@@ -128,7 +130,7 @@
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.5", "", {}, "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA=="],
 
@@ -656,6 +658,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
@@ -1118,7 +1122,7 @@
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
 
-    "babel-plugin-istanbul": ["babel-plugin-istanbul@6.1.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-instrument": "^5.0.4", "test-exclude": "^6.0.0" } }, "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA=="],
+    "babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
 
     "babel-plugin-jest-hoist": ["babel-plugin-jest-hoist@29.6.3", "", { "dependencies": { "@babel/template": "^7.3.3", "@babel/types": "^7.3.3", "@types/babel__core": "^7.1.14", "@types/babel__traverse": "^7.0.6" } }, "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg=="],
 
@@ -1307,6 +1311,8 @@
     "css-tree": ["css-tree@1.1.3", "", { "dependencies": { "mdn-data": "2.0.14", "source-map": "^0.6.1" } }, "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q=="],
 
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
 
     "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
 
@@ -1712,7 +1718,9 @@
 
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.1", "entities": "^6.0.0" } }, "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -1989,6 +1997,8 @@
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
 
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
@@ -2656,6 +2666,8 @@
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
     "ulid": ["ulid@3.0.2", "", { "bin": { "ulid": "dist/cli.js" } }, "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
@@ -2808,8 +2820,6 @@
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2823,12 +2833,6 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
-    "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
-    "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@clerk/clerk-js/@tanstack/query-core": ["@tanstack/query-core@5.87.4", "", {}, "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw=="],
 
@@ -2878,6 +2882,8 @@
 
     "@expo/cli/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
+    "@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
     "@expo/config/glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 
     "@expo/config/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
@@ -2902,7 +2908,7 @@
 
     "@expo/image-utils/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
-    "@expo/metro-config/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+    "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/metro-config/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
@@ -2915,6 +2921,8 @@
     "@expo/metro-runtime/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
     "@expo/prebuild-config/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -2929,8 +2937,6 @@
     "@jest/create-cache-key-function/@jest/types": ["@jest/types@29.6.3", "", { "dependencies": { "@jest/schemas": "^29.6.3", "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^17.0.8", "chalk": "^4.0.0" } }, "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw=="],
 
     "@jest/reporters/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "@jest/transform/babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -2994,7 +3000,7 @@
 
     "babel-jest/@jest/transform": ["@jest/transform@29.7.0", "", { "dependencies": { "@babel/core": "^7.11.6", "@jest/types": "^29.6.3", "@jridgewell/trace-mapping": "^0.3.18", "babel-plugin-istanbul": "^6.1.1", "chalk": "^4.0.0", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.9", "jest-haste-map": "^29.7.0", "jest-regex-util": "^29.6.3", "jest-util": "^29.7.0", "micromatch": "^4.0.4", "pirates": "^4.0.4", "slash": "^3.0.0", "write-file-atomic": "^4.0.2" } }, "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw=="],
 
-    "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
+    "babel-jest/babel-plugin-istanbul": ["babel-plugin-istanbul@6.1.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-instrument": "^5.0.4", "test-exclude": "^6.0.0" } }, "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA=="],
 
     "babel-plugin-macros/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -3076,6 +3082,8 @@
 
     "is-bun-module/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
+    "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "jayson/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
@@ -3100,8 +3108,6 @@
 
     "jest-environment-node/jest-util": ["jest-util@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA=="],
 
-    "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
     "jest-runner/jest-environment-node": ["jest-environment-node@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "jest-mock": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0" } }, "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA=="],
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
@@ -3125,8 +3131,6 @@
     "log-update/ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "metro/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -3167,8 +3171,6 @@
     "ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
     "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "parse-json/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
@@ -3458,7 +3460,7 @@
 
     "babel-jest/@jest/transform/write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "babel-jest/babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -3517,8 +3519,6 @@
     "expo/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "jest-config/babel-jest/babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
 
     "jest-config/babel-jest/babel-preset-jest": ["babel-preset-jest@30.2.0", "", { "dependencies": { "babel-plugin-jest-hoist": "30.2.0", "babel-preset-current-node-syntax": "^1.2.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-beta.1" } }, "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ=="],
 
@@ -3746,6 +3746,8 @@
 
     "babel-jest/@jest/transform/write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "babel-jest/babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "expo/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
     "jest-config/babel-jest/babel-preset-jest/babel-plugin-jest-hoist": ["babel-plugin-jest-hoist@30.2.0", "", { "dependencies": { "@types/babel__core": "^7.20.5" } }, "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA=="],
@@ -3753,8 +3755,6 @@
     "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "jest-config/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "jest-environment-node/@jest/fake-timers/jest-message-util/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "jest-environment-node/@jest/fake-timers/jest-message-util/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -26,6 +26,7 @@ export enum Provider {
   SPOTIFY = 'SPOTIFY',
   RSS = 'RSS',
   SUBSTACK = 'SUBSTACK',
+  WEB = 'WEB',
 }
 
 /**
@@ -111,6 +112,12 @@ export interface Item {
 
   /** Duration in seconds (for video/audio content) */
   duration?: number;
+
+  /** Estimated word count (for articles) */
+  wordCount?: number;
+
+  /** Estimated reading time in minutes (for articles) */
+  readingTimeMinutes?: number;
 
   /** When this Item record was created */
   createdAt: string;


### PR DESCRIPTION
## Summary

Add the ability to save web articles with reliable metadata extraction, store full article content in R2 for reader view, and fix UX issues where articles inappropriately show "RSS" as the platform/provider label.

Closes #28

## Changes

### Backend - Article Detection & Extraction
- **New `@mozilla/readability` + `linkedom` integration** for article detection and extraction
- **Article metadata extraction**: title, author/byline, publication/site name, reading time (calculated from word count), excerpt, and full article content
- **R2 storage for article content**: Full article HTML stored in R2 bucket for future reader view feature
- **New `Provider.WEB`** enum value for generic web URLs (replacing RSS misuse for non-feed URLs)

### Frontend - UX Fixes
- Articles now show author name only, not "{Author} on RSS"
- Button says "Open" instead of "Open in RSS" for web articles  
- Reading time displayed for articles on item cards and detail page
- New indigo color for WEB provider

### Database
- Added migration `0006_add_article_fields.sql` with columns:
  - `word_count` - estimated word count for reading time calculation
  - `reading_time_minutes` - pre-calculated reading time
  - `article_content_key` - R2 object key for stored article content

### Files Changed
| Area | Files |
|------|-------|
| **Backend** | `article-extractor.ts` (new), `article-storage.ts` (new), `link-preview.ts`, `link-parser.ts`, `bookmarks.ts`, `items.ts`, `types.ts`, `wrangler.toml` |
| **Frontend** | `content-utils.ts`, `item-card.tsx`, `link-preview-card.tsx`, `[id].tsx`, `use-bookmarks.ts` |
| **Shared** | `domain.ts` |
| **Database** | `schema.ts`, `0006_add_article_fields.sql` (new) |

## Technical Approach

- **Article Extractor**: Uses `linkedom/worker` (Cloudflare Workers compatible) with `@mozilla/readability` to:
  - Detect if URL is an article via `isProbablyReaderable()`
  - Extract title, byline, content, excerpt, and site name
  - Calculate reading time (~200 words per minute)

- **Fallback Chain**: Article Extractor → Open Graph → URL Fallback (graceful degradation)

- **R2 Storage**: Articles stored at `articles/{itemId}.html` with 30-day lifecycle rule

## Testing

- 37 new unit tests for article extraction
- Updated existing tests to expect `Provider.WEB` for generic URLs
- All 752 tests passing