### PR TITLE
feat: Add X/Twitter post support using FxTwitter API

### DIFF
--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -37,7 +37,8 @@ export const ProviderColors = {
   youtube: '#FF0000',
   spotify: '#1DB954',
   substack: '#FF6719',
-  twitter: '#1DA1F2',
+  twitter: '#1DA1F2', // Keep for backward compatibility
+  x: '#1DA1F2', // X (same as twitter)
   pocket: '#EF4154',
 };
 

--- a/apps/mobile/hooks/use-bookmarks.ts
+++ b/apps/mobile/hooks/use-bookmarks.ts
@@ -27,13 +27,16 @@ export interface LinkPreview {
   thumbnailUrl: string | null;
   duration: number | null;
   canonicalUrl: string;
-  source: 'provider_api' | 'oembed' | 'opengraph' | 'fallback' | 'article_extractor';
+  source: 'provider_api' | 'oembed' | 'opengraph' | 'fallback' | 'article_extractor' | 'fxtwitter';
   description?: string;
   // Article-specific fields
   siteName?: string;
   wordCount?: number;
   readingTimeMinutes?: number;
   hasArticleContent?: boolean;
+  // X/Twitter-specific fields
+  publishedAt?: string;
+  rawMetadata?: string;
 }
 
 /**
@@ -64,6 +67,9 @@ export interface SaveBookmarkInput {
   wordCount?: number;
   readingTimeMinutes?: number;
   hasArticleContent?: boolean;
+  // X/Twitter-specific fields
+  publishedAt?: string;
+  rawMetadata?: string;
 }
 
 // ============================================================================
@@ -259,6 +265,9 @@ export function useSaveBookmark() {
       wordCount: preview.wordCount,
       readingTimeMinutes: preview.readingTimeMinutes,
       hasArticleContent: preview.hasArticleContent,
+      // X/Twitter-specific fields
+      publishedAt: preview.publishedAt,
+      rawMetadata: preview.rawMetadata,
     });
   };
 
@@ -292,6 +301,9 @@ export function useSaveBookmark() {
       wordCount: preview.wordCount,
       readingTimeMinutes: preview.readingTimeMinutes,
       hasArticleContent: preview.hasArticleContent,
+      // X/Twitter-specific fields
+      publishedAt: preview.publishedAt,
+      rawMetadata: preview.rawMetadata,
     });
   };
 

--- a/apps/mobile/lib/content-utils.ts
+++ b/apps/mobile/lib/content-utils.ts
@@ -27,12 +27,12 @@ export type UIContentType = 'video' | 'podcast' | 'article' | 'post';
 /**
  * API provider types (uppercase, from backend)
  */
-export type Provider = 'YOUTUBE' | 'SPOTIFY' | 'RSS' | 'SUBSTACK' | 'WEB';
+export type Provider = 'YOUTUBE' | 'SPOTIFY' | 'RSS' | 'SUBSTACK' | 'WEB' | 'X';
 
 /**
  * UI provider types (lowercase, for display/styling)
  */
-export type UIProvider = 'youtube' | 'spotify' | 'rss' | 'substack' | 'web';
+export type UIProvider = 'youtube' | 'spotify' | 'rss' | 'substack' | 'web' | 'x';
 
 // ============================================================================
 // Type Mapping
@@ -169,6 +169,8 @@ export function getProviderColor(provider: Provider | UIProvider): string {
       return ProviderColors.substack;
     case 'web':
       return '#6366F1'; // Indigo for web links
+    case 'x':
+      return ProviderColors.x;
     case 'rss':
     default:
       return '#6366F1'; // Fallback to primary indigo
@@ -227,6 +229,8 @@ export function getProviderLabel(provider: Provider | UIProvider): string {
       return 'Spotify';
     case 'substack':
       return 'Substack';
+    case 'x':
+      return 'X';
     case 'rss':
       return 'RSS';
     case 'web':

--- a/apps/worker/src/db/migrations/0007_add_raw_metadata.sql
+++ b/apps/worker/src/db/migrations/0007_add_raw_metadata.sql
@@ -1,0 +1,11 @@
+-- Migration: Add raw_metadata column to items table
+-- Purpose: Store complete provider API responses for future feature development
+-- 
+-- Use cases:
+-- - FxTwitter: engagement metrics, polls, quote tweets, media arrays
+-- - YouTube: full video details, channel info
+-- - Spotify: episode details, show info
+--
+-- This column is nullable and stores JSON as TEXT.
+
+ALTER TABLE `items` ADD `raw_metadata` text;

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -24,7 +24,7 @@ export const items = sqliteTable(
 
     // Classification - values stored as UPPERCASE to match existing enums
     contentType: text('content_type').notNull(), // VIDEO | PODCAST | ARTICLE | POST
-    provider: text('provider').notNull(), // YOUTUBE | SPOTIFY | SUBSTACK | RSS
+    provider: text('provider').notNull(), // YOUTUBE | SPOTIFY | SUBSTACK | RSS | X
     providerId: text('provider_id').notNull(), // External ID
     canonicalUrl: text('canonical_url').notNull(),
 
@@ -40,6 +40,7 @@ export const items = sqliteTable(
     summary: text('summary'),
     duration: integer('duration'), // Seconds
     publishedAt: text('published_at'), // ISO8601 (legacy)
+    rawMetadata: text('raw_metadata'), // JSON string of provider API response
 
     // Article-specific metadata
     wordCount: integer('word_count'),

--- a/apps/worker/src/lib/fxtwitter.test.ts
+++ b/apps/worker/src/lib/fxtwitter.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  fetchFxTwitter,
+  fetchFxTwitterByUrl,
+  parseTwitterUrl,
+  FXTWITTER_API_BASE,
+} from './fxtwitter';
+import type { FxTwitterResponse } from './fxtwitter';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock logger to prevent console output during tests
+vi.mock('./logger', () => ({
+  logger: {
+    child: () => ({
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+describe('fxtwitter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // parseTwitterUrl
+  // ==========================================================================
+  describe('parseTwitterUrl', () => {
+    it('parses valid x.com URL', () => {
+      const result = parseTwitterUrl('https://x.com/user/status/12345');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('parses valid twitter.com URL', () => {
+      const result = parseTwitterUrl('https://twitter.com/user/status/12345');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('parses URL with www prefix', () => {
+      const result = parseTwitterUrl('https://www.x.com/user/status/12345');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('parses URL with query params', () => {
+      const result = parseTwitterUrl('https://x.com/user/status/12345?s=20');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('returns null for invalid domain', () => {
+      const result = parseTwitterUrl('https://google.com');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for missing status path', () => {
+      const result = parseTwitterUrl('https://x.com/user/likes');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for non-numeric tweet ID', () => {
+      const result = parseTwitterUrl('https://x.com/user/status/abc');
+      expect(result).toBeNull();
+    });
+
+    it('parses URL with http protocol', () => {
+      const result = parseTwitterUrl('http://x.com/user/status/12345');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('parses URL with www prefix on twitter.com', () => {
+      const result = parseTwitterUrl('https://www.twitter.com/user/status/12345');
+      expect(result).toEqual({ username: 'user', tweetId: '12345' });
+    });
+
+    it('handles complex usernames', () => {
+      const result = parseTwitterUrl('https://x.com/user_name123/status/12345');
+      expect(result).toEqual({ username: 'user_name123', tweetId: '12345' });
+    });
+
+    it('handles long tweet IDs', () => {
+      const result = parseTwitterUrl('https://x.com/user/status/1234567890123456789');
+      expect(result).toEqual({ username: 'user', tweetId: '1234567890123456789' });
+    });
+  });
+
+  // ==========================================================================
+  // fetchFxTwitter
+  // ==========================================================================
+  describe('fetchFxTwitter', () => {
+    const mockTweetResponse: FxTwitterResponse = {
+      code: 200,
+      message: 'OK',
+      tweet: {
+        id: '12345',
+        url: 'https://twitter.com/user/status/12345',
+        text: 'Hello world!',
+        created_at: '2024-01-01T00:00:00.000Z',
+        created_timestamp: 1704067200,
+        author: {
+          name: 'Test User',
+          screen_name: 'user',
+          avatar_url: 'https://pbs.twimg.com/profile_images/123/avatar.jpg',
+        },
+        likes: 100,
+        retweets: 50,
+        replies: 25,
+        views: 1000,
+        lang: 'en',
+        source: 'Twitter Web App',
+      },
+    };
+
+    it('returns tweet data on successful response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      const result = await fetchFxTwitter('user', '12345');
+
+      expect(result).toEqual(mockTweetResponse);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${FXTWITTER_API_BASE}/user/status/12345`,
+        expect.objectContaining({
+          headers: { Accept: 'application/json' },
+        })
+      );
+    });
+
+    it('returns null on HTTP error (404)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await fetchFxTwitter('user', '12345');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on API error response', async () => {
+      const errorResponse: FxTwitterResponse = {
+        code: 404,
+        message: 'Tweet not found',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(errorResponse),
+      });
+
+      const result = await fetchFxTwitter('user', '12345');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await fetchFxTwitter('user', '12345');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on timeout (AbortError)', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      const result = await fetchFxTwitter('user', '12345');
+
+      expect(result).toBeNull();
+    });
+
+    it('encodes username and tweetId in URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      await fetchFxTwitter('user@name', '12345');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${FXTWITTER_API_BASE}/user%40name/status/12345`,
+        expect.any(Object)
+      );
+    });
+
+    it('passes AbortSignal to fetch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      await fetchFxTwitter('user', '12345');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // fetchFxTwitterByUrl
+  // ==========================================================================
+  describe('fetchFxTwitterByUrl', () => {
+    const mockTweetResponse: FxTwitterResponse = {
+      code: 200,
+      message: 'OK',
+      tweet: {
+        id: '12345',
+        url: 'https://twitter.com/user/status/12345',
+        text: 'Hello world!',
+        created_at: '2024-01-01T00:00:00.000Z',
+        created_timestamp: 1704067200,
+        author: {
+          name: 'Test User',
+          screen_name: 'user',
+          avatar_url: 'https://pbs.twimg.com/profile_images/123/avatar.jpg',
+        },
+        likes: 100,
+        retweets: 50,
+        replies: 25,
+        views: 1000,
+        lang: 'en',
+        source: 'Twitter Web App',
+      },
+    };
+
+    it('calls fetch with correct endpoint for valid URL', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      const result = await fetchFxTwitterByUrl('https://x.com/user/status/12345');
+
+      expect(result).toEqual(mockTweetResponse);
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${FXTWITTER_API_BASE}/user/status/12345`,
+        expect.any(Object)
+      );
+    });
+
+    it('returns null for invalid URL without calling fetch', async () => {
+      const result = await fetchFxTwitterByUrl('https://google.com');
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns null for malformed Twitter URL without calling fetch', async () => {
+      const result = await fetchFxTwitterByUrl('https://x.com/user/likes');
+
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('handles twitter.com URLs', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      await fetchFxTwitterByUrl('https://twitter.com/testuser/status/67890');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${FXTWITTER_API_BASE}/testuser/status/67890`,
+        expect.any(Object)
+      );
+    });
+
+    it('strips query params from URL when parsing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTweetResponse),
+      });
+
+      await fetchFxTwitterByUrl('https://x.com/user/status/12345?s=20&t=abc');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${FXTWITTER_API_BASE}/user/status/12345`,
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/apps/worker/src/lib/fxtwitter.ts
+++ b/apps/worker/src/lib/fxtwitter.ts
@@ -1,0 +1,364 @@
+/**
+ * FxTwitter API Client
+ *
+ * Provides a typed client for the FxTwitter API to fetch full tweet data.
+ * FxTwitter is a free, no-auth API that provides complete tweet information
+ * including full text, media, engagement metrics, and more.
+ *
+ * Why FxTwitter over Twitter's oEmbed?
+ * - Full tweet text (not truncated to 140 chars)
+ * - Thumbnail/image URLs included
+ * - Engagement metrics (likes, retweets, replies, views)
+ * - Media attachments (photos, videos)
+ * - Poll data
+ * - Quote tweets
+ *
+ * @example
+ * ```typescript
+ * import { fetchFxTwitterByUrl } from './lib/fxtwitter';
+ *
+ * const result = await fetchFxTwitterByUrl('https://x.com/elonmusk/status/1234567890');
+ * if (result?.tweet) {
+ *   console.log(result.tweet.text);
+ *   console.log(result.tweet.author.name);
+ * }
+ * ```
+ */
+
+import { logger } from './logger';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Poll choice in a Twitter poll
+ */
+export interface FxTwitterPollChoice {
+  /** Display label for the choice */
+  label: string;
+  /** Number of votes for this choice */
+  count: number;
+  /** Percentage of total votes (0-100) */
+  percentage: number;
+}
+
+/**
+ * Poll attached to a tweet
+ */
+export interface FxTwitterPoll {
+  /** Array of poll choices */
+  choices: FxTwitterPollChoice[];
+  /** Total number of votes across all choices */
+  total_votes: number;
+  /** ISO timestamp when the poll ends */
+  ends_at: string;
+}
+
+/**
+ * Photo attachment
+ */
+export interface FxTwitterPhoto {
+  /** Direct URL to the image */
+  url: string;
+  /** Image width in pixels */
+  width: number;
+  /** Image height in pixels */
+  height: number;
+  /** Alt text for accessibility (optional) */
+  altText?: string;
+}
+
+/**
+ * Video attachment
+ */
+export interface FxTwitterVideo {
+  /** Direct URL to the video file */
+  url: string;
+  /** URL to video thumbnail image */
+  thumbnail_url: string;
+  /** Video width in pixels */
+  width: number;
+  /** Video height in pixels */
+  height: number;
+  /** Duration in seconds */
+  duration: number;
+  /** Video format (e.g., "video/mp4") */
+  format?: string;
+}
+
+/**
+ * Media attachments on a tweet
+ */
+export interface FxTwitterMedia {
+  /** Array of photo attachments */
+  photos?: FxTwitterPhoto[];
+  /** Array of video attachments */
+  videos?: FxTwitterVideo[];
+}
+
+/**
+ * Tweet author information
+ */
+export interface FxTwitterAuthor {
+  /** Display name (e.g., "Elon Musk") */
+  name: string;
+  /** Twitter handle without @ (e.g., "elonmusk") */
+  screen_name: string;
+  /** URL to profile avatar image */
+  avatar_url: string;
+  /** URL to profile banner image (optional) */
+  banner_url?: string;
+  /** Whether the account is verified (optional) */
+  verified?: boolean;
+  /** Twitter user ID (optional) */
+  id?: string;
+}
+
+/**
+ * Full tweet data from FxTwitter
+ */
+export interface FxTwitterTweet {
+  /** Tweet ID */
+  id: string;
+  /** Canonical URL to the tweet */
+  url: string;
+  /** Full tweet text */
+  text: string;
+  /** ISO timestamp when the tweet was created */
+  created_at: string;
+  /** Unix timestamp (seconds) when the tweet was created */
+  created_timestamp: number;
+  /** Tweet author information */
+  author: FxTwitterAuthor;
+  /** Number of likes */
+  likes: number;
+  /** Number of retweets */
+  retweets: number;
+  /** Number of replies */
+  replies: number;
+  /** Number of views (impressions) */
+  views: number;
+  /** Language code (e.g., "en") */
+  lang: string;
+  /** Client used to post the tweet (e.g., "Twitter Web App") */
+  source: string;
+  /** Media attachments (optional) */
+  media?: FxTwitterMedia;
+  /** Poll data (optional) */
+  poll?: FxTwitterPoll;
+  /** Quoted tweet (optional) */
+  quote?: FxTwitterTweet;
+}
+
+/**
+ * FxTwitter API response
+ */
+export interface FxTwitterResponse {
+  /** Response code (200 for success) */
+  code: number;
+  /** Response message */
+  message: string;
+  /** Tweet data (present on success) */
+  tweet?: FxTwitterTweet;
+}
+
+/**
+ * Parsed Twitter URL components
+ */
+export interface ParsedTwitterUrl {
+  /** Twitter username */
+  username: string;
+  /** Tweet ID */
+  tweetId: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** FxTwitter API base URL */
+export const FXTWITTER_API_BASE = 'https://api.fxtwitter.com';
+
+/** Request timeout in milliseconds (10s for Worker environment reliability) */
+const FETCH_TIMEOUT_MS = 10000;
+
+/** Regex pattern for Twitter/X URLs */
+const TWITTER_URL_PATTERN =
+  /^https?:\/\/(?:www\.)?(?:twitter\.com|x\.com)\/([^/]+)\/status\/(\d+)/i;
+
+// ============================================================================
+// Logger
+// ============================================================================
+
+const fxTwitterLogger = logger.child('fxtwitter');
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * Make a fetch request with timeout using AbortController
+ */
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number = FETCH_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+// ============================================================================
+// URL Parsing
+// ============================================================================
+
+/**
+ * Parse a Twitter/X URL to extract username and tweet ID
+ *
+ * Supports both twitter.com and x.com URLs.
+ *
+ * @param url - Full Twitter/X URL (e.g., https://x.com/user/status/123)
+ * @returns Parsed components, or null if URL doesn't match expected pattern
+ *
+ * @example
+ * ```typescript
+ * const parsed = parseTwitterUrl('https://x.com/elonmusk/status/1234567890');
+ * if (parsed) {
+ *   console.log(parsed.username); // "elonmusk"
+ *   console.log(parsed.tweetId); // "1234567890"
+ * }
+ * ```
+ */
+export function parseTwitterUrl(url: string): ParsedTwitterUrl | null {
+  const match = url.match(TWITTER_URL_PATTERN);
+
+  if (!match || !match[1] || !match[2]) {
+    return null;
+  }
+
+  return {
+    username: match[1],
+    tweetId: match[2],
+  };
+}
+
+// ============================================================================
+// API Functions
+// ============================================================================
+
+/**
+ * Fetch tweet data from FxTwitter API
+ *
+ * @param username - Twitter username (without @)
+ * @param tweetId - Tweet ID
+ * @returns FxTwitterResponse with tweet data, or null on failure
+ *
+ * @example
+ * ```typescript
+ * const result = await fetchFxTwitter('elonmusk', '1234567890');
+ * if (result?.tweet) {
+ *   console.log(result.tweet.text);
+ * }
+ * ```
+ */
+export async function fetchFxTwitter(
+  username: string,
+  tweetId: string
+): Promise<FxTwitterResponse | null> {
+  const apiUrl = `${FXTWITTER_API_BASE}/${encodeURIComponent(username)}/status/${encodeURIComponent(tweetId)}`;
+
+  try {
+    const response = await fetchWithTimeout(apiUrl);
+
+    if (!response.ok) {
+      fxTwitterLogger.warn('FxTwitter API request failed', {
+        status: response.status,
+        username,
+        tweetId,
+      });
+      return null;
+    }
+
+    const data = (await response.json()) as FxTwitterResponse;
+
+    // Check for API-level errors
+    if (data.code !== 200) {
+      fxTwitterLogger.warn('FxTwitter API returned error', {
+        code: data.code,
+        message: data.message,
+        username,
+        tweetId,
+      });
+      return null;
+    }
+
+    fxTwitterLogger.debug('FxTwitter API request successful', {
+      username,
+      tweetId,
+      hasMedia: !!data.tweet?.media,
+      hasPoll: !!data.tweet?.poll,
+      hasQuote: !!data.tweet?.quote,
+    });
+
+    return data;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      fxTwitterLogger.warn('FxTwitter API request timed out', {
+        username,
+        tweetId,
+        timeoutMs: FETCH_TIMEOUT_MS,
+        apiUrl,
+      });
+    } else {
+      fxTwitterLogger.error('FxTwitter API request error', {
+        error: error instanceof Error ? error.message : String(error),
+        errorType: error instanceof Error ? error.name : typeof error,
+        username,
+        tweetId,
+        apiUrl,
+      });
+    }
+    return null;
+  }
+}
+
+/**
+ * Fetch tweet data from FxTwitter API using a Twitter/X URL
+ *
+ * Convenience function that parses the URL and fetches the tweet data.
+ *
+ * @param url - Full Twitter/X URL (e.g., https://x.com/user/status/123)
+ * @returns FxTwitterResponse with tweet data, or null on failure
+ *
+ * @example
+ * ```typescript
+ * const result = await fetchFxTwitterByUrl('https://x.com/elonmusk/status/1234567890');
+ * if (result?.tweet) {
+ *   console.log(result.tweet.text);
+ *   console.log(result.tweet.author.name);
+ *   console.log(result.tweet.likes);
+ * }
+ * ```
+ */
+export async function fetchFxTwitterByUrl(url: string): Promise<FxTwitterResponse | null> {
+  const parsed = parseTwitterUrl(url);
+
+  if (!parsed) {
+    fxTwitterLogger.warn('Invalid Twitter URL format', { url });
+    return null;
+  }
+
+  return fetchFxTwitter(parsed.username, parsed.tweetId);
+}

--- a/apps/worker/src/lib/link-parser.test.ts
+++ b/apps/worker/src/lib/link-parser.test.ts
@@ -302,7 +302,7 @@ describe('parseLink', () => {
         const result = parseLink('https://twitter.com/elonmusk/status/1234567890123456789');
 
         expect(result).toEqual({
-          provider: Provider.RSS, // X is not OAuth-connected
+          provider: Provider.X,
           contentType: ContentType.POST,
           providerId: '1234567890123456789',
           canonicalUrl: 'https://x.com/elonmusk/status/1234567890123456789',
@@ -313,7 +313,7 @@ describe('parseLink', () => {
         const result = parseLink('https://x.com/elonmusk/status/1234567890123456789');
 
         expect(result).toEqual({
-          provider: Provider.RSS,
+          provider: Provider.X,
           contentType: ContentType.POST,
           providerId: '1234567890123456789',
           canonicalUrl: 'https://x.com/elonmusk/status/1234567890123456789',
@@ -323,7 +323,7 @@ describe('parseLink', () => {
       it('handles www prefix', () => {
         const result = parseLink('https://www.twitter.com/user/status/1234567890123456789');
 
-        expect(result?.provider).toBe(Provider.RSS);
+        expect(result?.provider).toBe(Provider.X);
         expect(result?.providerId).toBe('1234567890123456789');
       });
     });

--- a/apps/worker/src/lib/link-parser.ts
+++ b/apps/worker/src/lib/link-parser.ts
@@ -225,7 +225,6 @@ function parseSubstack(url: URL): ParsedLink | null {
  * - twitter.com/USERNAME/status/STATUS_ID
  * - x.com/USERNAME/status/STATUS_ID
  *
- * Note: Uses RSS provider since X is not OAuth-connected
  */
 function parseTwitter(url: URL): ParsedLink | null {
   const hostname = url.hostname.toLowerCase().replace('www.', '');
@@ -249,7 +248,7 @@ function parseTwitter(url: URL): ParsedLink | null {
     const canonicalUrl = `https://x.com/${username}/status/${statusId}`;
 
     return {
-      provider: Provider.RSS, // X is not OAuth-connected, use RSS provider
+      provider: Provider.X,
       contentType: ContentType.POST,
       providerId: statusId,
       canonicalUrl,

--- a/apps/worker/src/lib/oembed.test.ts
+++ b/apps/worker/src/lib/oembed.test.ts
@@ -353,8 +353,8 @@ describe('fetchTwitterOEmbed', () => {
     expect(result?.title).toBe('Hello world! This is a test tweet.');
   });
 
-  it('should truncate long tweets to 140 characters', async () => {
-    const longTweetText = 'A'.repeat(200);
+  it('should truncate long tweets to 280 characters', async () => {
+    const longTweetText = 'A'.repeat(300);
     const tweetWithLongText = {
       ...TWITTER_OEMBED_RESPONSE,
       html: `<blockquote><p>${longTweetText}</p></blockquote>`,
@@ -366,8 +366,23 @@ describe('fetchTwitterOEmbed', () => {
 
     const result = await fetchTwitterOEmbed('https://twitter.com/user/status/123');
 
-    expect(result?.title?.length).toBe(140);
+    expect(result?.title?.length).toBe(280);
     expect(result?.title?.endsWith('...')).toBe(true);
+  });
+
+  it('should handle tweets with HTML tags like br and a', async () => {
+    const tweetWithHtml = {
+      ...TWITTER_OEMBED_RESPONSE,
+      html: '<blockquote><p lang="en">First line<br><br>Second line with <a href="https://example.com">@mention</a></p></blockquote>',
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(tweetWithHtml),
+    });
+
+    const result = await fetchTwitterOEmbed('https://twitter.com/user/status/123');
+
+    expect(result?.title).toBe('First line Second line with @mention');
   });
 
   it('should decode HTML entities in tweet text', async () => {

--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -68,6 +68,9 @@ const SaveInputSchema = z.object({
   wordCount: z.number().int().min(0).optional(),
   readingTimeMinutes: z.number().int().min(0).optional(),
   hasArticleContent: z.boolean().optional(),
+  // X/Twitter-specific fields
+  publishedAt: z.string().optional(), // ISO8601 timestamp
+  rawMetadata: z.string().optional(), // JSON string of provider API response
 });
 
 // ============================================================================
@@ -233,10 +236,11 @@ export const bookmarksRouter = router({
         publisher: input.siteName ?? null,
         summary: input.description ?? null,
         duration: input.duration,
-        publishedAt: null,
+        publishedAt: input.publishedAt ?? null,
         wordCount,
         readingTimeMinutes,
         articleContentKey,
+        rawMetadata: input.rawMetadata ?? null,
         createdAt: now,
         updatedAt: now,
       });

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -27,6 +27,7 @@ export enum Provider {
   RSS = 'RSS',
   SUBSTACK = 'SUBSTACK',
   WEB = 'WEB',
+  X = 'X',
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds FxTwitter API client for rich tweet metadata extraction
- Adds `Provider.X` enum value for X/Twitter content
- Adds `rawMetadata` column to items table for storing full API responses
- Updates link parser to use `Provider.X` for Twitter/X URLs
- Updates link preview to use FxTwitter as primary source with oEmbed fallback
- Adds X provider color and content type handling in mobile app

## Changes

### Backend (Worker)
- **New**: `apps/worker/src/lib/fxtwitter.ts` - FxTwitter API client with TypeScript interfaces
- **New**: `apps/worker/src/lib/fxtwitter.test.ts` - Comprehensive test suite (23 tests)
- **New**: `apps/worker/src/db/migrations/0007_add_raw_metadata.sql` - Migration for rawMetadata column
- **Updated**: `apps/worker/src/db/schema.ts` - Added rawMetadata column
- **Updated**: `apps/worker/src/lib/link-parser.ts` - Use Provider.X for Twitter/X URLs
- **Updated**: `apps/worker/src/lib/link-preview.ts` - FxTwitter as primary, oEmbed as fallback
- **Updated**: `apps/worker/src/lib/oembed.ts` - Better HTML handling, 280 char limit
- **Updated**: `apps/worker/src/trpc/routers/bookmarks.ts` - Store rawMetadata when saving

### Shared
- **Updated**: `packages/shared/src/types/domain.ts` - Added `X = 'X'` to Provider enum

### Mobile App
- **Updated**: `apps/mobile/constants/theme.ts` - Added X provider color
- **Updated**: `apps/mobile/lib/content-utils.ts` - Handle X provider in mappers
- **Updated**: `apps/mobile/hooks/use-bookmarks.ts` - Support rawMetadata field

## Testing

All 796 tests pass. New tests added for:
- FxTwitter API client (23 tests covering success, error, and edge cases)
- Updated oEmbed tests for HTML handling

Closes #30