### PR TITLE
feat(auth): add token reconnection UX for expired OAuth connections

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 apps/mobile/expo-env.d.ts
+apps/mobile/ios/
 .opencode/

--- a/apps/mobile/app/subscriptions/connect/spotify.tsx
+++ b/apps/mobile/app/subscriptions/connect/spotify.tsx
@@ -22,6 +22,7 @@ import { Colors, Typography, Spacing, Radius, ProviderColors } from '@/constants
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { OAuthErrorBoundary } from '@/components/oauth-error-boundary';
 import { connectProvider } from '@/lib/oauth';
+import { trpc } from '@/lib/trpc';
 
 // Spotify brand color
 const SPOTIFY_GREEN = ProviderColors.spotify;
@@ -60,6 +61,7 @@ function SpotifyConnectContent() {
   const router = useRouter();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const utils = trpc.useUtils();
 
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -70,6 +72,8 @@ function SpotifyConnectContent() {
 
     try {
       await connectProvider('SPOTIFY');
+      // Invalidate connections cache so UI shows updated state immediately
+      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
       // On success, navigate back to subscriptions screen
       // TODO: Navigate to /subscriptions/discover/spotify when discover screen is implemented
       router.replace('/subscriptions' as never);
@@ -84,7 +88,7 @@ function SpotifyConnectContent() {
     } finally {
       setIsConnecting(false);
     }
-  }, [router]);
+  }, [router, utils]);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>

--- a/apps/mobile/app/subscriptions/connect/youtube.tsx
+++ b/apps/mobile/app/subscriptions/connect/youtube.tsx
@@ -23,6 +23,7 @@ import { Colors, Spacing, Radius, Typography, Shadows } from '@/constants/theme'
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { OAuthErrorBoundary } from '@/components/oauth-error-boundary';
 import { connectProvider } from '@/lib/oauth';
+import { trpc } from '@/lib/trpc';
 
 // YouTube brand color
 const YOUTUBE_RED = '#EA4335';
@@ -99,6 +100,7 @@ function YouTubeConnectContent() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const router = useRouter();
+  const utils = trpc.useUtils();
 
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -109,6 +111,8 @@ function YouTubeConnectContent() {
 
     try {
       await connectProvider('YOUTUBE');
+      // Invalidate connections cache so UI shows updated state immediately
+      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
       // On success, navigate to subscriptions discover screen
       router.replace('/subscriptions/discover/youtube' as const);
     } catch (err) {
@@ -120,7 +124,7 @@ function YouTubeConnectContent() {
     } finally {
       setIsConnecting(false);
     }
-  }, [router]);
+  }, [router, utils]);
 
   const handleRetry = useCallback(() => {
     setError(null);

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -15,6 +15,7 @@ import { Colors, Spacing, Radius, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useConnections } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
+import { getStatusDisplay, type ConnectionStatus } from '@/lib/connection-status';
 
 // ============================================================================
 // Icons
@@ -47,9 +48,6 @@ function ChevronRightIcon({ size = 20, color = '#6A6A6A' }: { size?: number; col
 // ============================================================================
 // Types
 // ============================================================================
-
-/** Connection status from the API */
-type ConnectionStatus = 'ACTIVE' | 'EXPIRED' | 'REVOKED' | null;
 
 interface ProviderCardProps {
   provider: 'YOUTUBE' | 'SPOTIFY';
@@ -85,35 +83,8 @@ function ProviderCard({
 
   const Icon = config.icon;
 
-  // Determine display state based on connection status
-  const getStatusDisplay = () => {
-    switch (connectionStatus) {
-      case 'ACTIVE':
-        return {
-          dotColor: colors.success,
-          text: 'Connected',
-          textColor: colors.textSecondary,
-          showCount: true,
-        };
-      case 'EXPIRED':
-      case 'REVOKED':
-        return {
-          dotColor: colors.warning,
-          text: 'Reconnect required',
-          textColor: colors.warning,
-          showCount: false,
-        };
-      default:
-        return {
-          dotColor: colors.textTertiary,
-          text: 'Not connected',
-          textColor: colors.textTertiary,
-          showCount: false,
-        };
-    }
-  };
-
-  const statusDisplay = getStatusDisplay();
+  // Get display state based on connection status
+  const statusDisplay = getStatusDisplay(connectionStatus, colors);
 
   return (
     <Pressable

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -48,9 +48,12 @@ function ChevronRightIcon({ size = 20, color = '#6A6A6A' }: { size?: number; col
 // Types
 // ============================================================================
 
+/** Connection status from the API */
+type ConnectionStatus = 'ACTIVE' | 'EXPIRED' | 'REVOKED' | null;
+
 interface ProviderCardProps {
   provider: 'YOUTUBE' | 'SPOTIFY';
-  isConnected: boolean;
+  connectionStatus: ConnectionStatus;
   subscriptionCount: number;
   onPress: () => void;
   colors: typeof Colors.dark;
@@ -62,7 +65,7 @@ interface ProviderCardProps {
 
 function ProviderCard({
   provider,
-  isConnected,
+  connectionStatus,
   subscriptionCount,
   onPress,
   colors,
@@ -82,6 +85,36 @@ function ProviderCard({
 
   const Icon = config.icon;
 
+  // Determine display state based on connection status
+  const getStatusDisplay = () => {
+    switch (connectionStatus) {
+      case 'ACTIVE':
+        return {
+          dotColor: colors.success,
+          text: 'Connected',
+          textColor: colors.textSecondary,
+          showCount: true,
+        };
+      case 'EXPIRED':
+      case 'REVOKED':
+        return {
+          dotColor: colors.warning,
+          text: 'Reconnect required',
+          textColor: colors.warning,
+          showCount: false,
+        };
+      default:
+        return {
+          dotColor: colors.textTertiary,
+          text: 'Not connected',
+          textColor: colors.textTertiary,
+          showCount: false,
+        };
+    }
+  };
+
+  const statusDisplay = getStatusDisplay();
+
   return (
     <Pressable
       onPress={onPress}
@@ -93,26 +126,15 @@ function ProviderCard({
       <View style={styles.providerContent}>
         <Text style={[styles.providerName, { color: colors.text }]}>{config.name}</Text>
         <View style={styles.providerStatusRow}>
-          {isConnected ? (
-            <>
-              <View style={[styles.statusDot, { backgroundColor: colors.success }]} />
-              <Text style={[styles.providerStatus, { color: colors.textSecondary }]}>
-                Connected
-              </Text>
-              {subscriptionCount > 0 && (
-                <Text style={[styles.providerCount, { color: colors.textTertiary }]}>
-                  {' '}
-                  · {subscriptionCount} subscription{subscriptionCount !== 1 ? 's' : ''}
-                </Text>
-              )}
-            </>
-          ) : (
-            <>
-              <View style={[styles.statusDot, { backgroundColor: colors.textTertiary }]} />
-              <Text style={[styles.providerStatus, { color: colors.textTertiary }]}>
-                Not connected
-              </Text>
-            </>
+          <View style={[styles.statusDot, { backgroundColor: statusDisplay.dotColor }]} />
+          <Text style={[styles.providerStatus, { color: statusDisplay.textColor }]}>
+            {statusDisplay.text}
+          </Text>
+          {statusDisplay.showCount && subscriptionCount > 0 && (
+            <Text style={[styles.providerCount, { color: colors.textTertiary }]}>
+              {' '}
+              · {subscriptionCount} subscription{subscriptionCount !== 1 ? 's' : ''}
+            </Text>
           )}
         </View>
       </View>
@@ -143,11 +165,11 @@ export default function SubscriptionsScreen() {
 
   const isLoading = connectionsLoading || subscriptionsLoading;
 
-  // Check connection status
+  // Get connection status for each provider
   const youtubeConnection = connections?.find((c) => c.provider === 'YOUTUBE');
   const spotifyConnection = connections?.find((c) => c.provider === 'SPOTIFY');
-  const isYouTubeConnected = youtubeConnection?.status === 'ACTIVE';
-  const isSpotifyConnected = spotifyConnection?.status === 'ACTIVE';
+  const youtubeStatus = (youtubeConnection?.status as ConnectionStatus) ?? null;
+  const spotifyStatus = (spotifyConnection?.status as ConnectionStatus) ?? null;
 
   // Count subscriptions per provider
   const youtubeCount = subscriptions.filter((s) => s.provider === 'YOUTUBE').length;
@@ -175,7 +197,7 @@ export default function SubscriptionsScreen() {
         <Animated.View entering={FadeInDown.delay(100).duration(400)}>
           <ProviderCard
             provider="YOUTUBE"
-            isConnected={isYouTubeConnected}
+            connectionStatus={youtubeStatus}
             subscriptionCount={youtubeCount}
             onPress={() => handleProviderPress('YOUTUBE')}
             colors={colors}
@@ -185,7 +207,7 @@ export default function SubscriptionsScreen() {
         <Animated.View entering={FadeInDown.delay(200).duration(400)}>
           <ProviderCard
             provider="SPOTIFY"
-            isConnected={isSpotifyConnected}
+            connectionStatus={spotifyStatus}
             subscriptionCount={spotifyCount}
             onPress={() => handleProviderPress('SPOTIFY')}
             colors={colors}

--- a/apps/mobile/lib/connection-status.test.ts
+++ b/apps/mobile/lib/connection-status.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for lib/connection-status.ts
+ *
+ * Tests the getStatusDisplay function which determines how to render
+ * OAuth connection status in the ProviderCard component.
+ *
+ * Test cases cover all four status states:
+ * - ACTIVE: Green "Connected" state
+ * - EXPIRED: Amber "Reconnect required" state
+ * - REVOKED: Amber "Reconnect required" state
+ * - null: Gray "Not connected" state
+ *
+ * @see Issue zine-rvo: Frontend: Add tests for connection status display
+ */
+
+import { getStatusDisplay, type ConnectionStatus } from './connection-status';
+import { Colors } from '@/constants/theme';
+
+describe('getStatusDisplay', () => {
+  // Use dark theme colors (the app uses dark-only theme)
+  const colors = Colors.dark;
+
+  describe('ACTIVE status', () => {
+    it('returns green Connected state', () => {
+      const result = getStatusDisplay('ACTIVE', colors);
+
+      expect(result.dotColor).toBe(colors.success);
+      expect(result.text).toBe('Connected');
+      expect(result.textColor).toBe(colors.textSecondary);
+      expect(result.showCount).toBe(true);
+    });
+
+    it('uses success color for the status dot', () => {
+      const result = getStatusDisplay('ACTIVE', colors);
+
+      // Verify the success color is the expected green
+      expect(result.dotColor).toBe('#10B981');
+    });
+  });
+
+  describe('EXPIRED status', () => {
+    it('returns amber Reconnect required state', () => {
+      const result = getStatusDisplay('EXPIRED', colors);
+
+      expect(result.dotColor).toBe(colors.warning);
+      expect(result.text).toBe('Reconnect required');
+      expect(result.textColor).toBe(colors.warning);
+      expect(result.showCount).toBe(false);
+    });
+
+    it('uses warning color for both dot and text', () => {
+      const result = getStatusDisplay('EXPIRED', colors);
+
+      // Verify the warning color is the expected amber
+      expect(result.dotColor).toBe('#F59E0B');
+      expect(result.textColor).toBe('#F59E0B');
+    });
+
+    it('hides subscription count', () => {
+      const result = getStatusDisplay('EXPIRED', colors);
+
+      expect(result.showCount).toBe(false);
+    });
+  });
+
+  describe('REVOKED status', () => {
+    it('returns amber Reconnect required state', () => {
+      const result = getStatusDisplay('REVOKED', colors);
+
+      expect(result.dotColor).toBe(colors.warning);
+      expect(result.text).toBe('Reconnect required');
+      expect(result.textColor).toBe(colors.warning);
+      expect(result.showCount).toBe(false);
+    });
+
+    it('has same display as EXPIRED status', () => {
+      const expiredResult = getStatusDisplay('EXPIRED', colors);
+      const revokedResult = getStatusDisplay('REVOKED', colors);
+
+      expect(revokedResult.dotColor).toBe(expiredResult.dotColor);
+      expect(revokedResult.text).toBe(expiredResult.text);
+      expect(revokedResult.textColor).toBe(expiredResult.textColor);
+      expect(revokedResult.showCount).toBe(expiredResult.showCount);
+    });
+
+    it('hides subscription count', () => {
+      const result = getStatusDisplay('REVOKED', colors);
+
+      expect(result.showCount).toBe(false);
+    });
+  });
+
+  describe('null status (not connected)', () => {
+    it('returns gray Not connected state', () => {
+      const result = getStatusDisplay(null, colors);
+
+      expect(result.dotColor).toBe(colors.textTertiary);
+      expect(result.text).toBe('Not connected');
+      expect(result.textColor).toBe(colors.textTertiary);
+      expect(result.showCount).toBe(false);
+    });
+
+    it('uses textTertiary color for muted appearance', () => {
+      const result = getStatusDisplay(null, colors);
+
+      // Verify the tertiary color is the expected gray
+      expect(result.dotColor).toBe('#6A6A6A');
+      expect(result.textColor).toBe('#6A6A6A');
+    });
+
+    it('hides subscription count', () => {
+      const result = getStatusDisplay(null, colors);
+
+      expect(result.showCount).toBe(false);
+    });
+  });
+
+  describe('subscription count visibility', () => {
+    it('only shows count for ACTIVE status', () => {
+      const statuses: ConnectionStatus[] = ['ACTIVE', 'EXPIRED', 'REVOKED', null];
+
+      const results = statuses.map((status) => ({
+        status,
+        showCount: getStatusDisplay(status, colors).showCount,
+      }));
+
+      // Only ACTIVE should show count
+      expect(results.find((r) => r.status === 'ACTIVE')?.showCount).toBe(true);
+      expect(results.find((r) => r.status === 'EXPIRED')?.showCount).toBe(false);
+      expect(results.find((r) => r.status === 'REVOKED')?.showCount).toBe(false);
+      expect(results.find((r) => r.status === null)?.showCount).toBe(false);
+    });
+  });
+
+  describe('return type', () => {
+    it('returns StatusDisplay object with all required properties', () => {
+      const result = getStatusDisplay('ACTIVE', colors);
+
+      // Type check - ensure all properties exist
+      expect(result).toHaveProperty('dotColor');
+      expect(result).toHaveProperty('text');
+      expect(result).toHaveProperty('textColor');
+      expect(result).toHaveProperty('showCount');
+
+      // Type check - ensure correct types
+      expect(typeof result.dotColor).toBe('string');
+      expect(typeof result.text).toBe('string');
+      expect(typeof result.textColor).toBe('string');
+      expect(typeof result.showCount).toBe('boolean');
+    });
+  });
+
+  describe('theme compatibility', () => {
+    it('works with light theme colors', () => {
+      const lightColors = Colors.light;
+      const result = getStatusDisplay('ACTIVE', lightColors);
+
+      expect(result.dotColor).toBe(lightColors.success);
+      expect(result.textColor).toBe(lightColors.textSecondary);
+    });
+
+    it('uses theme colors consistently across all statuses', () => {
+      const statuses: ConnectionStatus[] = ['ACTIVE', 'EXPIRED', 'REVOKED', null];
+
+      // Each status should use colors from the theme object
+      for (const status of statuses) {
+        const result = getStatusDisplay(status, colors);
+
+        // All colors should be hex strings
+        expect(result.dotColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        expect(result.textColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      }
+    });
+  });
+});

--- a/apps/mobile/lib/connection-status.ts
+++ b/apps/mobile/lib/connection-status.ts
@@ -1,0 +1,74 @@
+/**
+ * Connection Status Display Utilities
+ *
+ * Functions for determining how to display OAuth connection status
+ * in the UI. Used by ProviderCard component on the subscriptions screen.
+ */
+
+import type { Colors } from '@/constants/theme';
+
+/**
+ * Connection status from the API.
+ * - ACTIVE: Connection is valid and working
+ * - EXPIRED: Token expired and refresh failed
+ * - REVOKED: User revoked access in the provider
+ * - null: No connection exists
+ */
+export type ConnectionStatus = 'ACTIVE' | 'EXPIRED' | 'REVOKED' | null;
+
+/**
+ * Display configuration for a connection status.
+ * Used to render the visual state in ProviderCard.
+ */
+export interface StatusDisplay {
+  /** Color for the status indicator dot */
+  dotColor: string;
+  /** Text to display (e.g., "Connected", "Reconnect required") */
+  text: string;
+  /** Color for the status text */
+  textColor: string;
+  /** Whether to show subscription count */
+  showCount: boolean;
+}
+
+/**
+ * Returns the display configuration for a given connection status.
+ *
+ * Status mapping:
+ * - ACTIVE: Green dot, "Connected" text, shows subscription count
+ * - EXPIRED/REVOKED: Amber dot, "Reconnect required" text, hides count
+ * - null (no connection): Gray dot, "Not connected" text, hides count
+ *
+ * @param connectionStatus - The connection status from the API
+ * @param colors - Theme colors object (Colors.dark or Colors.light)
+ * @returns Display configuration for the status
+ */
+export function getStatusDisplay(
+  connectionStatus: ConnectionStatus,
+  colors: typeof Colors.dark
+): StatusDisplay {
+  switch (connectionStatus) {
+    case 'ACTIVE':
+      return {
+        dotColor: colors.success,
+        text: 'Connected',
+        textColor: colors.textSecondary,
+        showCount: true,
+      };
+    case 'EXPIRED':
+    case 'REVOKED':
+      return {
+        dotColor: colors.warning,
+        text: 'Reconnect required',
+        textColor: colors.warning,
+        showCount: false,
+      };
+    default:
+      return {
+        dotColor: colors.textTertiary,
+        text: 'Not connected',
+        textColor: colors.textTertiary,
+        showCount: false,
+      };
+  }
+}

--- a/apps/mobile/lib/oauth.ts
+++ b/apps/mobile/lib/oauth.ts
@@ -144,7 +144,7 @@ export function getRedirectUri(provider?: OAuthProvider): string {
 
   // For Spotify and fallback, use our custom scheme
   if (__DEV__) {
-    const uri = AuthSession.makeRedirectUri({ scheme: 'zine' });
+    const uri = AuthSession.makeRedirectUri({ scheme: 'zine', path: 'oauth/callback' });
     console.log('[OAuth] Dev redirect URI:', uri);
     return uri;
   }

--- a/apps/worker/src/lib/token-refresh.test.ts
+++ b/apps/worker/src/lib/token-refresh.test.ts
@@ -691,7 +691,7 @@ describe('error handling', () => {
     });
   });
 
-  it('should include provider error details in REFRESH_FAILED', async () => {
+  it('should detect permanent errors (invalid_grant) and return REFRESH_FAILED_PERMANENT', async () => {
     const connection = createMockConnection({
       tokenExpiresAt: MOCK_NOW - 1000,
     });
@@ -708,7 +708,7 @@ describe('error handling', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(TokenRefreshError);
       const tokenError = error as TokenRefreshError;
-      expect(tokenError.code).toBe('REFRESH_FAILED');
+      expect(tokenError.code).toBe('REFRESH_FAILED_PERMANENT');
       expect(tokenError.details).toContain('invalid_grant');
     }
   });

--- a/apps/worker/src/lib/token-refresh.test.ts
+++ b/apps/worker/src/lib/token-refresh.test.ts
@@ -12,7 +12,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ProviderConnection, TokenRefreshEnv } from './token-refresh';
-import { getValidAccessToken, TokenRefreshError } from './token-refresh';
+import {
+  getValidAccessToken,
+  TokenRefreshError,
+  isPermanentRefreshError,
+  persistConnectionExpired,
+} from './token-refresh';
 
 // ============================================================================
 // Mocks
@@ -830,6 +835,62 @@ describe('integration scenarios', () => {
     expect(setCall.refreshToken).toBe('encrypted:rotated-spotify-refresh-token');
   });
 
+  it('should mark connection EXPIRED when provider returns invalid_grant', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"error":"invalid_grant"}'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify connection status was updated to EXPIRED
+    expect(mockDbUpdate).toHaveBeenCalled();
+    const updateCalls = mockDbUpdate.mock.results;
+    // The last update call should be the status update to EXPIRED
+    const lastUpdateCall = updateCalls[updateCalls.length - 1].value;
+    const setCall = lastUpdateCall.set.mock.calls[0][0];
+    expect(setCall.status).toBe('EXPIRED');
+  });
+
+  it('should NOT mark connection EXPIRED for transient 500 error', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('Internal server error'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify update was NOT called (no status update for transient errors)
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should NOT mark connection EXPIRED for 429 rate limit error', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: vi.fn().mockResolvedValue('Rate limit exceeded'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify update was NOT called (no status update for rate limit errors)
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
   // Skip: vi.advanceTimersByTimeAsync not compatible with Workers vitest pool
   it.skip('should handle multiple rapid refresh requests with locking', async () => {
     const connection = createMockConnection({
@@ -860,5 +921,244 @@ describe('integration scenarios', () => {
     await vi.advanceTimersByTimeAsync(2500);
     const result2 = await resultPromise2;
     expect(result2).toBe('concurrent-refreshed-token');
+  });
+});
+
+// ============================================================================
+// isPermanentRefreshError Unit Tests
+// ============================================================================
+
+describe('isPermanentRefreshError', () => {
+  it('should return true for invalid_grant error with 400 status', () => {
+    expect(isPermanentRefreshError(400, '{"error":"invalid_grant"}')).toBe(true);
+  });
+
+  it('should return true for invalid_grant error with 401 status', () => {
+    expect(isPermanentRefreshError(401, '{"error":"invalid_grant"}')).toBe(true);
+  });
+
+  it('should return true for unauthorized_client error', () => {
+    expect(isPermanentRefreshError(400, '{"error":"unauthorized_client"}')).toBe(true);
+  });
+
+  it('should return true for invalid_client error', () => {
+    expect(isPermanentRefreshError(400, '{"error":"invalid_client"}')).toBe(true);
+  });
+
+  it('should return true for "Token has been expired or revoked" message', () => {
+    expect(isPermanentRefreshError(400, 'Token has been expired or revoked')).toBe(true);
+  });
+
+  it('should return true for revoked token message containing invalid_grant', () => {
+    expect(isPermanentRefreshError(400, 'Error: invalid_grant - Token has been revoked')).toBe(
+      true
+    );
+  });
+
+  it('should return false for 5xx server errors', () => {
+    expect(isPermanentRefreshError(500, 'Internal server error')).toBe(false);
+    expect(isPermanentRefreshError(502, 'Bad Gateway')).toBe(false);
+    expect(isPermanentRefreshError(503, 'Service Unavailable')).toBe(false);
+  });
+
+  it('should return false for 429 rate limit errors', () => {
+    expect(isPermanentRefreshError(429, 'Rate limit exceeded')).toBe(false);
+  });
+
+  it('should return false for network-like errors (status 0)', () => {
+    expect(isPermanentRefreshError(0, '')).toBe(false);
+  });
+
+  it('should return false for 403 Forbidden (not 400/401)', () => {
+    // 403 is not treated as permanent in the current implementation
+    expect(isPermanentRefreshError(403, 'Access denied')).toBe(false);
+  });
+
+  it('should return false for 400 with non-permanent error code', () => {
+    expect(isPermanentRefreshError(400, '{"error":"invalid_request"}')).toBe(false);
+    expect(isPermanentRefreshError(400, '{"error":"server_error"}')).toBe(false);
+  });
+
+  it('should return false for 400 with malformed JSON', () => {
+    expect(isPermanentRefreshError(400, 'Not a JSON response')).toBe(false);
+  });
+
+  it('should return false for empty error body', () => {
+    expect(isPermanentRefreshError(400, '')).toBe(false);
+  });
+
+  it('should handle JSON with additional fields', () => {
+    const errorBody = JSON.stringify({
+      error: 'invalid_grant',
+      error_description: 'Token has been revoked',
+    });
+    expect(isPermanentRefreshError(400, errorBody)).toBe(true);
+  });
+});
+
+// ============================================================================
+// persistConnectionExpired Unit Tests
+// ============================================================================
+
+describe('persistConnectionExpired', () => {
+  it('should update connection status to EXPIRED', async () => {
+    const env = createMockEnv();
+
+    await persistConnectionExpired('test-connection-id', env);
+
+    // Verify update was called
+    expect(mockDbUpdate).toHaveBeenCalled();
+
+    // Verify the status was set to EXPIRED
+    const updateCall = mockDbUpdate.mock.results[0].value;
+    const setCall = updateCall.set.mock.calls[0][0];
+    expect(setCall.status).toBe('EXPIRED');
+  });
+
+  it('should update the correct connection by ID', async () => {
+    const env = createMockEnv();
+    const connectionId = 'specific-connection-123';
+
+    await persistConnectionExpired(connectionId, env);
+
+    // Verify where clause was called with correct ID
+    const updateCall = mockDbUpdate.mock.results[0].value;
+    const setResult = updateCall.set.mock.results[0].value;
+    const whereCall = setResult.where.mock.calls[0][0];
+    expect(whereCall.val).toBe(connectionId);
+  });
+});
+
+// ============================================================================
+// Integration Tests for Expired Token Flow
+// ============================================================================
+
+describe('expired token flow integration', () => {
+  it('should mark connection EXPIRED and throw REFRESH_FAILED_PERMANENT for invalid_grant', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"error":"invalid_grant"}'),
+    });
+
+    try {
+      await getValidAccessToken(connection, env);
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TokenRefreshError);
+      const tokenError = error as TokenRefreshError;
+      expect(tokenError.code).toBe('REFRESH_FAILED_PERMANENT');
+    }
+
+    // Verify connection was marked as EXPIRED
+    expect(mockDbUpdate).toHaveBeenCalled();
+    const updateCalls = mockDbUpdate.mock.results;
+    const lastUpdateCall = updateCalls[updateCalls.length - 1].value;
+    const setCall = lastUpdateCall.set.mock.calls[0][0];
+    expect(setCall.status).toBe('EXPIRED');
+  });
+
+  it('should mark connection EXPIRED for unauthorized_client error', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"error":"unauthorized_client"}'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify connection was marked as EXPIRED
+    const updateCalls = mockDbUpdate.mock.results;
+    const lastUpdateCall = updateCalls[updateCalls.length - 1].value;
+    const setCall = lastUpdateCall.set.mock.calls[0][0];
+    expect(setCall.status).toBe('EXPIRED');
+  });
+
+  it('should mark connection EXPIRED for Google "Token has been expired or revoked" message', async () => {
+    const connection = createMockConnection({
+      provider: 'YOUTUBE',
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('Token has been expired or revoked'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify connection was marked as EXPIRED
+    const updateCalls = mockDbUpdate.mock.results;
+    const lastUpdateCall = updateCalls[updateCalls.length - 1].value;
+    const setCall = lastUpdateCall.set.mock.calls[0][0];
+    expect(setCall.status).toBe('EXPIRED');
+  });
+
+  it('should NOT mark connection EXPIRED for temporary server errors', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: vi.fn().mockResolvedValue('Service temporarily unavailable'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify no DB update was made for transient errors
+    expect(mockDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should release lock even after marking connection as EXPIRED', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"error":"invalid_grant"}'),
+    });
+
+    await expect(getValidAccessToken(connection, env)).rejects.toThrow(TokenRefreshError);
+
+    // Verify lock was released
+    expect(mockReleaseLock).toHaveBeenCalledWith(env.OAUTH_STATE_KV, 'token:refresh:conn-123');
+  });
+
+  it('should return REFRESH_FAILED (not PERMANENT) for 400 with unknown error', async () => {
+    const connection = createMockConnection({
+      tokenExpiresAt: MOCK_NOW - 1000,
+    });
+    const env = createMockEnv();
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: vi.fn().mockResolvedValue('{"error":"temporarily_unavailable"}'),
+    });
+
+    try {
+      await getValidAccessToken(connection, env);
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TokenRefreshError);
+      const tokenError = error as TokenRefreshError;
+      // Should be regular REFRESH_FAILED, not PERMANENT
+      expect(tokenError.code).toBe('REFRESH_FAILED');
+    }
+
+    // Should NOT update connection status
+    expect(mockDbUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/lib/token-refresh.ts
+++ b/apps/worker/src/lib/token-refresh.ts
@@ -371,7 +371,7 @@ function sleep(ms: number): Promise<void> {
  *
  * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
  */
-function isPermanentRefreshError(status: number, errorBody: string): boolean {
+export function isPermanentRefreshError(status: number, errorBody: string): boolean {
   // 400 or 401 with specific error codes indicate permanent failure
   if (status !== 400 && status !== 401) {
     return false;
@@ -405,7 +405,10 @@ function isPermanentRefreshError(status: number, errorBody: string): boolean {
  * Called when a refresh token is permanently rejected by the provider,
  * indicating the user needs to reconnect (re-authenticate).
  */
-async function persistConnectionExpired(connectionId: string, env: TokenRefreshEnv): Promise<void> {
+export async function persistConnectionExpired(
+  connectionId: string,
+  env: TokenRefreshEnv
+): Promise<void> {
   const db = drizzle(env.DB);
 
   await db


### PR DESCRIPTION
## Summary
- Add token reconnection UX that prompts users to re-authenticate when OAuth tokens expire
- Implement connection status tracking to detect expired/needs reconnection states
- Add comprehensive tests for expired token flow and connection status display
- Invalidate TRPC connections cache after OAuth connect for immediate UI updates
- Ignore iOS build artifacts in Prettier to fix CI formatting checks

## Test plan
- [x] Unit tests for connection status detection
- [x] Integration tests for expired token flow  
- [x] Manual testing of reconnection prompts in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)