### PR TITLE
Creator latest content opens internal items

### DIFF
--- a/apps/mobile/components/creator/CreatorLatestContent.tsx
+++ b/apps/mobile/components/creator/CreatorLatestContent.tsx
@@ -280,6 +280,7 @@ export function CreatorLatestContent({ creatorId, provider }: CreatorLatestConte
     duration: item.duration,
     publishedAt: item.publishedAt ? new Date(item.publishedAt).toISOString() : null,
     url: item.externalUrl,
+    itemId: item.itemId ?? null,
     isBookmarked: false, // TODO: Cross-reference with bookmarks when needed
   }));
 

--- a/apps/mobile/hooks/use-creator.ts
+++ b/apps/mobile/hooks/use-creator.ts
@@ -44,6 +44,7 @@ export interface CreatorContentItem {
   duration: number | null;
   publishedAt: number | null;
   externalUrl: string;
+  itemId?: string | null;
 }
 
 /**

--- a/apps/mobile/lib/analytics.test.ts
+++ b/apps/mobile/lib/analytics.test.ts
@@ -121,6 +121,8 @@ describe('analytics.track', () => {
         creatorId: 'creator-123',
         contentType: 'bookmark',
         provider: 'YOUTUBE',
+        destination: 'internal',
+        itemId: 'item-123',
       });
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
@@ -136,6 +138,8 @@ describe('analytics.track', () => {
         creatorId: 'creator-123',
         contentType: 'latest',
         provider: 'YOUTUBE',
+        destination: 'external',
+        itemId: null,
         externalUrl: 'https://youtube.com/watch?v=abc123',
       });
 

--- a/apps/mobile/lib/analytics.ts
+++ b/apps/mobile/lib/analytics.ts
@@ -44,6 +44,11 @@ export type ConnectionPromptReason = 'NOT_CONNECTED' | 'TOKEN_EXPIRED';
 export type CreatorContentType = 'bookmark' | 'latest';
 
 /**
+ * Destination of content navigation
+ */
+export type CreatorContentDestination = 'internal' | 'external';
+
+/**
  * Analytics event definitions
  */
 export interface AnalyticsEvents {
@@ -84,6 +89,8 @@ export interface AnalyticsEvents {
     creatorId: string;
     contentType: CreatorContentType;
     provider: string;
+    destination: CreatorContentDestination;
+    itemId?: string | null;
     externalUrl?: string;
   };
 

--- a/apps/worker/src/trpc/routers/creators.test.ts
+++ b/apps/worker/src/trpc/routers/creators.test.ts
@@ -133,6 +133,7 @@ interface MockContentItem {
   publishedAt: number;
   externalUrl: string;
   duration: number | null;
+  itemId?: string | null;
   isBookmarked: boolean;
 }
 
@@ -854,6 +855,7 @@ describe('Creators Router', () => {
           publishedAt: Date.now() - 86400000,
           externalUrl: 'https://www.youtube.com/watch?v=video_123',
           duration: 600,
+          itemId: 'item_123',
           isBookmarked: false,
         },
         {
@@ -864,6 +866,7 @@ describe('Creators Router', () => {
           publishedAt: Date.now() - 172800000,
           externalUrl: 'https://www.youtube.com/watch?v=video_456',
           duration: 1200,
+          itemId: null,
           isBookmarked: true,
         },
       ];
@@ -883,8 +886,10 @@ describe('Creators Router', () => {
       expect(result.items[0].id).toBe('video_123');
       expect(result.items[0].title).toBe('Test Video');
       expect(result.items[0].isBookmarked).toBe(false);
+      expect(result.items[0].itemId).toBe('item_123');
       expect(result.items[1].id).toBe('video_456');
       expect(result.items[1].isBookmarked).toBe(true);
+      expect(result.items[1].itemId).toBeNull();
     });
 
     it('should return content items for Spotify creator when connected', async () => {
@@ -1044,6 +1049,7 @@ describe('Creators Router', () => {
           publishedAt: Date.now(),
           externalUrl: 'https://www.youtube.com/watch?v=video_123',
           duration: 600,
+          itemId: 'item_456',
           isBookmarked: false,
         },
       ];
@@ -1072,6 +1078,7 @@ describe('Creators Router', () => {
       expect(item).toHaveProperty('publishedAt');
       expect(item).toHaveProperty('externalUrl');
       expect(item).toHaveProperty('duration');
+      expect(item).toHaveProperty('itemId');
       expect(item).toHaveProperty('isBookmarked');
     });
 


### PR DESCRIPTION
## Summary
- include `itemId` on latest creator content responses
- route creator latest content taps to internal item pages when available, falling back to external URLs
- record navigation destination and `itemId` in analytics with tests updated

## Testing
- `bun run test` (apps/mobile)
- `bun run test:run` (apps/worker)
- `bun run lint` (apps/mobile)
- `bun run lint` (apps/worker)
- iOS simulator: opened creator profile from a bookmarked item; tapping a latest-content row without an internal item opened Safari; tapping a row with an internal ID navigated internally but the item was missing in local data ("Item … not found")

Fixes #62