### PR TITLE
feat(home): add jump back in collection

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -121,6 +121,18 @@ export default function HomeScreen() {
   const { data: libraryData } = useLibraryItems();
 
   // Transform to ItemCardData format for use with ItemCard component
+  const jumpBackInItems = useMemo((): ItemCardData[] => {
+    return (homeData?.jumpBackIn ?? []).slice(0, 10).map((item) => ({
+      id: item.id,
+      title: item.title,
+      creator: item.publisher ?? item.creator,
+      thumbnailUrl: item.thumbnailUrl ?? null,
+      contentType: mapContentType(item.contentType) as ContentType,
+      provider: mapProvider(item.provider) as Provider,
+      duration: item.duration ?? null,
+    }));
+  }, [homeData?.jumpBackIn]);
+
   const recentlyBookmarked = useMemo((): ItemCardData[] => {
     return (homeData?.recentBookmarks ?? []).slice(0, 6).map((item) => ({
       id: item.id,
@@ -210,9 +222,30 @@ export default function HomeScreen() {
             </View>
           ) : (
             <>
+              {/* Jump Back In - Recently Opened Bookmarks */}
+              {jumpBackInItems.length >= 4 && (
+                <Animated.View entering={FadeInDown.delay(100).duration(400)}>
+                  <SectionHeader
+                    title="Jump Back In"
+                    count={jumpBackInItems.length}
+                    colors={colors}
+                  />
+                  <FlatList
+                    horizontal
+                    data={jumpBackInItems}
+                    renderItem={({ item, index }) => (
+                      <ItemCard item={item} variant="horizontal" index={index} />
+                    )}
+                    keyExtractor={(item) => item.id}
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={styles.horizontalList}
+                  />
+                </Animated.View>
+              )}
+
               {/* Recently Bookmarked - Horizontal Cards */}
               {recentlyBookmarked.length > 0 && (
-                <Animated.View entering={FadeInDown.delay(100).duration(400)}>
+                <Animated.View entering={FadeInDown.delay(200).duration(400)}>
                   <SectionHeader
                     title="Recently Bookmarked"
                     count={recentlyBookmarked.length}
@@ -234,7 +267,7 @@ export default function HomeScreen() {
               {/* Inbox Section - Condensed List using compact ItemCard */}
               {inboxItems.length > 0 && (
                 <Animated.View
-                  entering={FadeInDown.delay(200).duration(400)}
+                  entering={FadeInDown.delay(300).duration(400)}
                   style={styles.section}
                 >
                   <SectionHeader
@@ -255,7 +288,7 @@ export default function HomeScreen() {
 
               {/* Category Collection - Large Cards with overlay */}
               {podcasts.length > 0 && (
-                <Animated.View entering={FadeInDown.delay(300).duration(400)}>
+                <Animated.View entering={FadeInDown.delay(400).duration(400)}>
                   <SectionHeader title="Podcasts" count={podcasts.length} colors={colors} />
                   <FlatList
                     horizontal
@@ -271,7 +304,7 @@ export default function HomeScreen() {
               )}
 
               {/* Categories */}
-              <Animated.View entering={FadeInDown.delay(400).duration(400)} style={styles.section}>
+              <Animated.View entering={FadeInDown.delay(500).duration(400)} style={styles.section}>
                 <SectionHeader title="Categories" colors={colors} />
                 <ScrollView
                   horizontal
@@ -311,7 +344,7 @@ export default function HomeScreen() {
 
               {/* Videos - Horizontal Cards */}
               {videos.length > 0 && (
-                <Animated.View entering={FadeInDown.delay(500).duration(400)}>
+                <Animated.View entering={FadeInDown.delay(600).duration(400)}>
                   <SectionHeader title="Videos" count={videos.length} colors={colors} />
                   <FlatList
                     horizontal

--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -37,6 +37,7 @@ import {
   useBookmarkItem,
   useUnbookmarkItem,
   useToggleFinished,
+  useMarkItemOpened,
   UserItemState,
   ContentType,
 } from '@/hooks/use-items-trpc';
@@ -552,6 +553,7 @@ export default function ItemDetailScreen() {
   const bookmarkMutation = useBookmarkItem();
   const unbookmarkMutation = useUnbookmarkItem();
   const toggleFinishedMutation = useToggleFinished();
+  const markOpenedMutation = useMarkItemOpened();
 
   // Fetch creator data for description (when creatorId is available)
   const { creator: creatorData } = useCreator(item?.creatorId ?? '');
@@ -583,6 +585,9 @@ export default function ItemDetailScreen() {
       const supported = await Linking.canOpenURL(item.canonicalUrl);
       if (supported) {
         await Linking.openURL(item.canonicalUrl);
+        if (item.state === UserItemState.BOOKMARKED) {
+          markOpenedMutation.mutate({ id: item.id });
+        }
       }
     } catch (err) {
       logger.error('Failed to open URL', { error: err });

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -323,7 +323,7 @@ export function useLibraryItems(options?: {
  *
  * Returns curated sections for the home screen:
  * - recentBookmarks: Latest bookmarked items
- * - jumpBackIn: Items with playback progress
+ * - jumpBackIn: Recently opened bookmarks
  * - byContentType: Items grouped by video/podcast/article
  *
  * @returns tRPC query result with home data sections
@@ -626,14 +626,28 @@ export function useToggleFinished() {
 }
 
 /**
+ * Hook for marking a bookmarked item as opened
+ *
+ * Used to power the "Jump Back In" section on home.
+ */
+export function useMarkItemOpened() {
+  const utils = trpc.useUtils();
+
+  return trpc.items.markOpened.useMutation({
+    onSettled: (_data, _err, { id }) => {
+      utils.items.home.invalidate();
+      utils.items.get.invalidate({ id });
+    },
+  });
+}
+
+/**
  * Hook for updating playback/reading progress
  *
  * Updates the progress position for video/podcast/article consumption.
- * Used for "Jump Back In" feature on home screen.
  *
  * No optimistic update is performed since progress updates are typically
  * fire-and-forget operations that don't need immediate UI feedback.
- * Invalidates home data on completion to refresh "Jump Back In" section.
  *
  * @returns tRPC mutation with mutate/mutateAsync functions
  *
@@ -657,7 +671,6 @@ export function useUpdateProgress() {
 
   return trpc.items.updateProgress.useMutation({
     onSettled: () => {
-      // Invalidate home data to refresh "Jump Back In" section
       utils.items.home.invalidate();
     },
   });

--- a/apps/worker/src/db/migrations/0001_add_user_items_last_opened_at.sql
+++ b/apps/worker/src/db/migrations/0001_add_user_items_last_opened_at.sql
@@ -1,0 +1,7 @@
+-- Created: 2026-01-24
+-- Add last_opened_at tracking for recently opened bookmarks
+
+ALTER TABLE `user_items` ADD COLUMN `last_opened_at` text;
+
+CREATE INDEX `user_items_recent_opened_idx`
+  ON `user_items` (`user_id`, `state`, `last_opened_at`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1737295200000,
       "tag": "0000_initial_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1769282819000,
+      "tag": "0001_add_user_items_last_opened_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -82,6 +82,7 @@ export const userItems = sqliteTable(
     ingestedAt: text('ingested_at').notNull(), // ISO8601 (legacy)
     bookmarkedAt: text('bookmarked_at'), // ISO8601 (legacy)
     archivedAt: text('archived_at'), // ISO8601 (legacy)
+    lastOpenedAt: text('last_opened_at'), // ISO8601 (legacy)
 
     // Progress tracking
     progressPosition: integer('progress_position'), // Seconds
@@ -105,6 +106,9 @@ export const userItems = sqliteTable(
 
     // Fast library queries: WHERE userId = ? AND state = 'BOOKMARKED' ORDER BY bookmarkedAt DESC
     index('user_items_library_idx').on(table.userId, table.state, table.bookmarkedAt),
+
+    // Fast recently opened queries: WHERE userId = ? AND state = 'BOOKMARKED' ORDER BY lastOpenedAt DESC
+    index('user_items_recent_opened_idx').on(table.userId, table.state, table.lastOpenedAt),
   ]
 );
 

--- a/apps/worker/src/trpc/mock-data.ts
+++ b/apps/worker/src/trpc/mock-data.ts
@@ -39,6 +39,7 @@ export type ItemView = {
   state: UserItemState;
   ingestedAt: string;
   bookmarkedAt: string | null;
+  lastOpenedAt: string | null;
   progress: { position: number; duration: number; percent: number } | null;
   /** Whether user has finished/consumed this item */
   isFinished: boolean;
@@ -75,6 +76,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.INBOX,
     ingestedAt: '2024-12-10T08:30:00Z',
     bookmarkedAt: null,
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -100,6 +102,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.INBOX,
     ingestedAt: '2024-12-12T09:00:00Z',
     bookmarkedAt: null,
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -125,6 +128,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.INBOX,
     ingestedAt: '2024-12-11T14:00:00Z',
     bookmarkedAt: null,
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -150,6 +154,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.INBOX,
     ingestedAt: '2024-12-12T18:00:00Z',
     bookmarkedAt: null,
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -179,6 +184,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-12-08T14:00:00Z',
     bookmarkedAt: '2024-12-09T09:15:00Z',
+    lastOpenedAt: '2024-12-22T09:30:00Z',
     progress: {
       position: 2400,
       duration: 7200,
@@ -208,6 +214,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-11-16T10:00:00Z',
     bookmarkedAt: '2024-11-17T08:30:00Z',
+    lastOpenedAt: '2024-12-21T14:05:00Z',
     progress: {
       position: 1200,
       duration: 2700,
@@ -237,6 +244,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-10-21T12:00:00Z',
     bookmarkedAt: '2024-10-22T15:00:00Z',
+    lastOpenedAt: '2024-12-20T11:45:00Z',
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -262,6 +270,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-09-11T08:00:00Z',
     bookmarkedAt: '2024-09-12T19:00:00Z',
+    lastOpenedAt: '2024-12-19T07:20:00Z',
     progress: {
       position: 4500,
       duration: 5400,
@@ -291,6 +300,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-11-02T07:00:00Z',
     bookmarkedAt: '2024-11-03T11:00:00Z',
+    lastOpenedAt: '2024-12-18T18:10:00Z',
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -316,6 +326,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-08-16T09:00:00Z',
     bookmarkedAt: '2024-08-17T20:00:00Z',
+    lastOpenedAt: null,
     progress: {
       position: 7200,
       duration: 14400,
@@ -345,6 +356,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-12-02T08:00:00Z',
     bookmarkedAt: '2024-12-03T10:00:00Z',
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -370,6 +382,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.BOOKMARKED,
     ingestedAt: '2024-11-26T09:00:00Z',
     bookmarkedAt: '2024-11-27T14:00:00Z',
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -399,6 +412,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.ARCHIVED,
     ingestedAt: '2024-06-02T08:00:00Z',
     bookmarkedAt: '2024-06-03T09:00:00Z',
+    lastOpenedAt: null,
     progress: {
       position: 1200,
       duration: 1200,
@@ -428,6 +442,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.ARCHIVED,
     ingestedAt: '2024-07-21T10:00:00Z',
     bookmarkedAt: '2024-07-22T08:00:00Z',
+    lastOpenedAt: null,
     progress: {
       position: 3600,
       duration: 3600,
@@ -457,6 +472,7 @@ export const MOCK_ITEMS: ItemView[] = [
     state: UserItemState.ARCHIVED,
     ingestedAt: '2024-05-16T12:00:00Z',
     bookmarkedAt: '2024-05-17T10:00:00Z',
+    lastOpenedAt: null,
     progress: null,
     isFinished: false,
     finishedAt: null,
@@ -495,8 +511,11 @@ export function getMockHomeData() {
     /** Most recently bookmarked items */
     recentBookmarks: bookmarked.slice(0, 5),
 
-    /** Items with progress (for "Jump Back In" feature) */
-    jumpBackIn: bookmarked.filter((item) => item.progress !== null).slice(0, 5),
+    /** Recently opened bookmarks ("Jump Back In") */
+    jumpBackIn: bookmarked
+      .filter((item) => item.lastOpenedAt !== null)
+      .sort((a, b) => (b.lastOpenedAt ?? '').localeCompare(a.lastOpenedAt ?? ''))
+      .slice(0, 10),
 
     /** Items grouped by content type */
     byContentType: {


### PR DESCRIPTION
## Summary
- add last-opened tracking and mark-opened mutation for bookmarked items
- surface a Jump Back In home section when 4+ items exist
- refresh home mocks/tests and add D1 migration for `last_opened_at`

## Testing
- `prettier --check "**/*.{ts,tsx,js,jsx,json,md}"`
- `turbo run typecheck`
- `vitest run "--exclude=**/user-do.test.ts" "--exclude=**/scheduler.test.ts"`