### PR TITLE
fix(worker): ensure last_opened_at column exists

### DIFF
--- a/apps/worker/src/db/index.ts
+++ b/apps/worker/src/db/index.ts
@@ -2,6 +2,47 @@
 import { drizzle } from 'drizzle-orm/d1';
 import * as schema from './schema';
 
+let userItemsLastOpenedAtReady: boolean | null = null;
+let userItemsLastOpenedAtPromise: Promise<void> | null = null;
+
+export async function ensureUserItemsLastOpenedAt(d1: D1Database) {
+  if (!d1 || typeof d1.prepare !== 'function') {
+    return;
+  }
+
+  if (userItemsLastOpenedAtReady) {
+    return;
+  }
+
+  if (userItemsLastOpenedAtPromise) {
+    await userItemsLastOpenedAtPromise;
+    return;
+  }
+
+  userItemsLastOpenedAtPromise = (async () => {
+    const result = await d1.prepare("PRAGMA table_info('user_items')").all();
+    const columns = Array.isArray(result.results) ? result.results : [];
+    const hasColumn = columns.some((column) => column?.name === 'last_opened_at');
+
+    if (!hasColumn) {
+      await d1.prepare('ALTER TABLE user_items ADD COLUMN last_opened_at text').run();
+      await d1
+        .prepare(
+          'CREATE INDEX IF NOT EXISTS user_items_recent_opened_idx ON user_items (user_id, state, last_opened_at)'
+        )
+        .run();
+    }
+
+    userItemsLastOpenedAtReady = true;
+  })().catch((error) => {
+    userItemsLastOpenedAtReady = false;
+    userItemsLastOpenedAtPromise = null;
+    throw error;
+  });
+
+  await userItemsLastOpenedAtPromise;
+}
+
 export function createDb(d1: D1Database) {
   return drizzle(d1, { schema });
 }

--- a/apps/worker/src/trpc/context.ts
+++ b/apps/worker/src/trpc/context.ts
@@ -1,4 +1,4 @@
-import { createDb } from '../db';
+import { createDb, ensureUserItemsLastOpenedAt } from '../db';
 import type { Context } from 'hono';
 import type { Env } from '../types';
 
@@ -12,6 +12,7 @@ import type { Env } from '../types';
  */
 export async function createContext(c: Context<Env>) {
   const userId = c.get('userId');
+  await ensureUserItemsLastOpenedAt(c.env.DB);
   const db = createDb(c.env.DB);
   return { userId, db, env: c.env };
 }


### PR DESCRIPTION
## Summary
- add a runtime D1 schema check to ensure `user_items.last_opened_at` exists
- create the missing column/index when needed to prevent production query errors
- run the check before building the tRPC db context

## Testing
- `bun run lint` (warnings about `no-explicit-any` in existing tests)
- `bun run test:run`
- `prettier --check "**/*.{ts,tsx,js,jsx,json,md}"`
- `turbo run typecheck`
- `vitest run --exclude=**/user-do.test.ts --exclude=**/scheduler.test.ts`