### PR TITLE
feat(mobile): add share extension link handoff

### DIFF
--- a/apps/mobile/ShareExtension.tsx
+++ b/apps/mobile/ShareExtension.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Text, close, openHostApp, type InitialProps } from 'expo-share-extension';
+
+const FALLBACK_MESSAGE = 'No valid URL found in this share.';
+
+const isValidUrl = (value: string) => {
+  if (!value || value.trim().length === 0) return false;
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export default function ShareExtension({ url, text }: InitialProps) {
+  const sharedUrl = useMemo(() => {
+    const candidate = url ?? text ?? '';
+    const normalized = candidate.trim();
+    return isValidUrl(normalized) ? normalized : '';
+  }, [text, url]);
+
+  const handleAdd = () => {
+    if (!sharedUrl) return;
+    openHostApp(`add-link?url=${encodeURIComponent(sharedUrl)}`);
+    close();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Save to Zine</Text>
+      {sharedUrl ? (
+        <Text style={styles.url} numberOfLines={3}>
+          {sharedUrl}
+        </Text>
+      ) : (
+        <Text style={styles.message}>{FALLBACK_MESSAGE}</Text>
+      )}
+      <View style={styles.actions}>
+        <Pressable
+          onPress={handleAdd}
+          disabled={!sharedUrl}
+          style={({ pressed }) => [
+            styles.button,
+            styles.primaryButton,
+            !sharedUrl && styles.buttonDisabled,
+            pressed && sharedUrl && styles.buttonPressed,
+          ]}
+          accessibilityLabel="Add to Zine"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !sharedUrl }}
+        >
+          <Text style={styles.primaryButtonText}>Add to Zine</Text>
+        </Pressable>
+        <Pressable
+          onPress={close}
+          style={({ pressed }) => [
+            styles.button,
+            styles.secondaryButton,
+            pressed && styles.secondaryButtonPressed,
+          ]}
+          accessibilityLabel="Cancel"
+          accessibilityRole="button"
+        >
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+    paddingHorizontal: 18,
+    paddingVertical: 20,
+    justifyContent: 'center',
+    gap: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0F172A',
+  },
+  url: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#0F172A',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+  },
+  message: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#64748B',
+  },
+  actions: {
+    gap: 12,
+  },
+  button: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  primaryButton: {
+    backgroundColor: '#0F172A',
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    backgroundColor: '#E2E8F0',
+  },
+  secondaryButtonText: {
+    color: '#0F172A',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  buttonDisabled: {
+    backgroundColor: '#CBD5F5',
+  },
+  buttonPressed: {
+    opacity: 0.9,
+  },
+  secondaryButtonPressed: {
+    opacity: 0.85,
+  },
+});

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -40,6 +40,21 @@
       "expo-router",
       "expo-secure-store",
       [
+        "expo-share-extension",
+        {
+          "activationRules": [
+            {
+              "type": "url",
+              "max": 1
+            },
+            {
+              "type": "text",
+              "max": 1
+            }
+          ]
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,0 +1,1 @@
+import 'expo-router/entry';

--- a/apps/mobile/index.share.js
+++ b/apps/mobile/index.share.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+
+import ShareExtension from './ShareExtension';
+
+AppRegistry.registerComponent('shareExtension', () => ShareExtension);

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,7 +1,10 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const { withShareExtension } = require('expo-share-extension/metro');
 const { withUniwindConfig } = require('uniwind/metro');
 
-const config = getDefaultConfig(__dirname);
+const config = withShareExtension(getDefaultConfig(__dirname), {
+  isCSSEnabled: true,
+});
 
 module.exports = withUniwindConfig(config, {
   cssEntryFile: './global.css',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zine/mobile",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "scripts": {
     "dev": "EXPO_HOSTNAME=100.92.242.50 expo start -c --port ${METRO_PORT:-8081}",
@@ -39,6 +39,7 @@
     "expo-linear-gradient": "^15.0.8",
     "expo-linking": "^8.0.11",
     "expo-router": "~6.0.21",
+    "expo-share-extension": "^5.0.5",
     "expo-secure-store": "^15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "expo-linking": "^8.0.11",
         "expo-router": "~6.0.21",
         "expo-secure-store": "^15.0.8",
+        "expo-share-extension": "^5.0.5",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
@@ -1559,6 +1560,8 @@
 
     "expo-server": ["expo-server@1.0.5", "", {}, "sha512-IGR++flYH70rhLyeXF0Phle56/k4cee87WeQ4mamS+MkVAVP+dDlOHf2nN06Z9Y2KhU0Gp1k+y61KkghF7HdhA=="],
 
+    "expo-share-extension": ["expo-share-extension@5.0.5", "", { "dependencies": { "semver": "^7.7.2", "valibot": "^1.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-F8QIs4TPFmfeACTn9YRbzmnlAdwC1sSa2oUcN7WdYnqwuRV4A7jcGAMEoIAF14U37Vpzl0/kTuMquDJSmpT5CQ=="],
+
     "expo-splash-screen": ["expo-splash-screen@31.0.13", "", { "dependencies": { "@expo/prebuild-config": "^54.0.8" }, "peerDependencies": { "expo": "*" } }, "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA=="],
 
     "expo-status-bar": ["expo-status-bar@3.0.9", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw=="],
@@ -2730,6 +2733,8 @@
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+
+    "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 


### PR DESCRIPTION
## Summary
- add a share extension entrypoint and UI for handing off shared URLs
- configure Expo share extension plugin and Metro integration for dual entrypoints
- prefill the add-link screen from share extension query params

## Testing
- not run (not requested)

## Issue
- Closes #70