### PR TITLE
Fix auth button text contrast on sign-in/sign-up

### DIFF
--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -172,7 +172,7 @@ export default function SignInScreen() {
             disabled={isLoading || !email || !password}
           >
             {isLoading ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={colors.buttonPrimaryText} />
             ) : (
               <Text style={styles.primaryButtonText}>Sign In</Text>
             )}
@@ -281,7 +281,7 @@ function createStyles(colors: typeof Colors.light) {
       color: colors.text,
     },
     primaryButton: {
-      backgroundColor: colors.primary,
+      backgroundColor: colors.buttonPrimary,
       borderRadius: Radius.md,
       paddingVertical: Spacing.lg,
       alignItems: 'center',
@@ -293,7 +293,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     primaryButtonText: {
       ...Typography.titleMedium,
-      color: '#FFFFFF',
+      color: colors.buttonPrimaryText,
     },
     divider: {
       flexDirection: 'row',

--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -182,7 +182,7 @@ export default function SignUpScreen() {
               disabled={isLoading || verificationCode.length < 6}
             >
               {isLoading ? (
-                <ActivityIndicator color="#FFFFFF" />
+                <ActivityIndicator color={colors.buttonPrimaryText} />
               ) : (
                 <Text style={styles.primaryButtonText}>Verify Email</Text>
               )}
@@ -263,7 +263,7 @@ export default function SignUpScreen() {
             disabled={isLoading || !email || password.length < 8}
           >
             {isLoading ? (
-              <ActivityIndicator color="#FFFFFF" />
+              <ActivityIndicator color={colors.buttonPrimaryText} />
             ) : (
               <Text style={styles.primaryButtonText}>Create Account</Text>
             )}
@@ -377,7 +377,7 @@ function createStyles(colors: typeof Colors.light) {
       marginTop: Spacing.xs,
     },
     primaryButton: {
-      backgroundColor: colors.primary,
+      backgroundColor: colors.buttonPrimary,
       borderRadius: Radius.md,
       paddingVertical: Spacing.lg,
       alignItems: 'center',
@@ -389,7 +389,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     primaryButtonText: {
       ...Typography.titleMedium,
-      color: '#FFFFFF',
+      color: colors.buttonPrimaryText,
     },
     secondaryButton: {
       backgroundColor: 'transparent',


### PR DESCRIPTION
## Summary
- switch auth primary button background from `colors.primary` to `colors.buttonPrimary`
- switch auth primary button text/loading spinner color from hardcoded white to `colors.buttonPrimaryText`
- apply fix to both sign-in and sign-up screens for consistent contrast

## Testing
- not run locally in this environment (Expo CLI not installed)