### PR TITLE
Add newsletter fab icons and avatar metadata handling

### DIFF
--- a/apps/mobile/app/item/item-detail-helpers.tsx
+++ b/apps/mobile/app/item/item-detail-helpers.tsx
@@ -25,7 +25,7 @@ export function getFabConfig(provider: string): FabConfig {
       };
     case 'GMAIL':
       return {
-        providerIcon: <Ionicons name="mail-outline" size={22} color="#FFFFFF" />,
+        providerIcon: <Ionicons name="newspaper-outline" size={22} color="#FFFFFF" />,
         backgroundColor: '#1A73E8',
       };
     case 'X':

--- a/apps/mobile/app/item/item-detail-helpers.tsx
+++ b/apps/mobile/app/item/item-detail-helpers.tsx
@@ -23,6 +23,11 @@ export function getFabConfig(provider: string): FabConfig {
         providerIcon: <Ionicons name="logo-youtube" size={22} color="#FFFFFF" />,
         backgroundColor: '#FF0000',
       };
+    case 'GMAIL':
+      return {
+        providerIcon: <Ionicons name="mail-outline" size={22} color="#FFFFFF" />,
+        backgroundColor: '#1A73E8',
+      };
     case 'X':
     case 'TWITTER':
       return {

--- a/apps/mobile/app/onboarding/select-channels.tsx
+++ b/apps/mobile/app/onboarding/select-channels.tsx
@@ -26,7 +26,7 @@ import { showSuccess, showError } from '@/lib/toast-utils';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useSubscriptions, type SubscribePayload } from '@/hooks/use-subscriptions';
 import { trpc } from '@/lib/trpc';
-import { validateAndConvertProvider } from '@/lib/route-validation';
+import { validateAndConvertDiscoverProvider } from '@/lib/route-validation';
 import {
   ChannelSelectionList,
   ChannelSelectionActionBar,
@@ -93,7 +93,7 @@ export default function SelectChannelsScreen() {
   const params = useLocalSearchParams<{ provider: string }>();
 
   // Validate and normalize provider to uppercase
-  const providerValidation = validateAndConvertProvider(params.provider);
+  const providerValidation = validateAndConvertDiscoverProvider(params.provider);
 
   // Use validated provider or default to YOUTUBE for hook consistency
   // (hooks must be called unconditionally)

--- a/apps/mobile/app/settings/connections.tsx
+++ b/apps/mobile/app/settings/connections.tsx
@@ -92,6 +92,12 @@ function ProviderCard({
       color: ProviderColors.spotify,
       description: 'Import podcasts from your Spotify account',
     },
+    GMAIL: {
+      icon: '📬',
+      name: 'Gmail',
+      color: '#1A73E8',
+      description: 'Import newsletters from your Gmail inbox',
+    },
   };
 
   const config = providerConfig[provider];
@@ -206,6 +212,7 @@ export default function ConnectionsScreen() {
   // Get individual provider connections
   const youtubeConnection = connections?.find((c: Connection) => c.provider === 'YOUTUBE');
   const spotifyConnection = connections?.find((c: Connection) => c.provider === 'SPOTIFY');
+  const gmailConnection = connections?.find((c: Connection) => c.provider === 'GMAIL');
 
   // Navigation handlers
   const handleConnectYouTube = useCallback(() => {
@@ -214,6 +221,10 @@ export default function ConnectionsScreen() {
 
   const handleConnectSpotify = useCallback(() => {
     router.push('/subscriptions/connect/spotify' as Href);
+  }, [router]);
+
+  const handleConnectGmail = useCallback(() => {
+    router.push('/subscriptions/connect/gmail' as Href);
   }, [router]);
 
   // Disconnect handlers with confirmation
@@ -247,6 +258,24 @@ export default function ConnectionsScreen() {
           onPress: () => {
             setDisconnectingProvider('SPOTIFY');
             disconnectMutation.mutate({ provider: 'SPOTIFY' });
+          },
+        },
+      ]
+    );
+  }, [disconnectMutation]);
+
+  const handleDisconnectGmail = useCallback(() => {
+    Alert.alert(
+      'Disconnect Gmail',
+      'Are you sure you want to disconnect Gmail? Newsletter sync will stop until you reconnect.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Disconnect',
+          style: 'destructive',
+          onPress: () => {
+            setDisconnectingProvider('GMAIL');
+            disconnectMutation.mutate({ provider: 'GMAIL' });
           },
         },
       ]
@@ -293,6 +322,15 @@ export default function ConnectionsScreen() {
           onConnect={handleConnectSpotify}
           onDisconnect={handleDisconnectSpotify}
           isDisconnecting={disconnectingProvider === 'SPOTIFY'}
+        />
+
+        <ProviderCard
+          provider="GMAIL"
+          connection={gmailConnection}
+          colors={colors}
+          onConnect={handleConnectGmail}
+          onDisconnect={handleDisconnectGmail}
+          isDisconnecting={disconnectingProvider === 'GMAIL'}
         />
 
         {/* Privacy Note */}

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -100,6 +100,7 @@ export default function SettingsScreen() {
   // Extract connection status
   const youtubeConnection = connections?.find((c: Connection) => c.provider === 'YOUTUBE');
   const spotifyConnection = connections?.find((c: Connection) => c.provider === 'SPOTIFY');
+  const gmailConnection = connections?.find((c: Connection) => c.provider === 'GMAIL');
 
   // Get subscription count from items array
   const activeSubscriptionCount = subscriptionsData?.items?.length ?? 0;
@@ -169,6 +170,22 @@ export default function SettingsScreen() {
             }
             onPress={() =>
               router.push({ pathname: '/settings/connections', params: { provider: 'spotify' } })
+            }
+          />
+
+          {/* Gmail */}
+          <SettingsRow
+            icon="📬"
+            title="Gmail"
+            subtitle={
+              gmailConnection?.status === 'ACTIVE'
+                ? gmailConnection.providerUserId || 'Connected'
+                : 'Not connected'
+            }
+            rightText={gmailConnection?.status === 'ACTIVE' ? 'Connected' : 'Add'}
+            rightTextColor={gmailConnection?.status === 'ACTIVE' ? colors.success : colors.textTertiary}
+            onPress={() =>
+              router.push({ pathname: '/settings/connections', params: { provider: 'gmail' } })
             }
           />
         </View>

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -183,7 +183,9 @@ export default function SettingsScreen() {
                 : 'Not connected'
             }
             rightText={gmailConnection?.status === 'ACTIVE' ? 'Connected' : 'Add'}
-            rightTextColor={gmailConnection?.status === 'ACTIVE' ? colors.success : colors.textTertiary}
+            rightTextColor={
+              gmailConnection?.status === 'ACTIVE' ? colors.success : colors.textTertiary
+            }
             onPress={() =>
               router.push({ pathname: '/settings/connections', params: { provider: 'gmail' } })
             }

--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -32,7 +32,7 @@ import { trpc } from '@/lib/trpc';
 import { validateAndConvertProvider } from '@/lib/route-validation';
 import { ErrorState, LoadingState } from '@/components/list-states';
 
-type Provider = 'YOUTUBE' | 'SPOTIFY';
+type Provider = 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
 
 interface UnifiedChannel {
   providerChannelId: string;
@@ -40,6 +40,14 @@ interface UnifiedChannel {
   imageUrl: string | null;
   isAddedToZine: boolean;
   subscriptionId?: string;
+}
+
+interface NewsletterFeed {
+  id: string;
+  displayName: string;
+  fromAddress: string | null;
+  status: 'ACTIVE' | 'HIDDEN' | 'UNSUBSCRIBED';
+  lastSeenAt: number;
 }
 
 // ============================================================================
@@ -58,6 +66,14 @@ function SpotifyIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: 
   return (
     <Svg width={size} height={size} viewBox="0 0 24 24" fill={color}>
       <Path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </Svg>
+  );
+}
+
+function GmailIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill={color}>
+      <Path d="M12 13.4L2 6.75V18h20V6.75L12 13.4zm10-9.4H2l10 6.65L22 4z" />
     </Svg>
   );
 }
@@ -114,6 +130,12 @@ function getProviderConfig(provider: Provider) {
       icon: SpotifyIcon,
       brandColor: '#1DB954',
       contentName: 'podcasts',
+    },
+    GMAIL: {
+      name: 'Gmail',
+      icon: GmailIcon,
+      brandColor: '#1A73E8',
+      contentName: 'newsletters',
     },
   }[provider];
 }
@@ -285,6 +307,76 @@ function ChannelItem({
   );
 }
 
+interface NewsletterItemProps {
+  feed: NewsletterFeed;
+  onToggleStatus: () => void;
+  onUnsubscribe: () => void;
+  isProcessing: boolean;
+  colors: typeof Colors.dark;
+}
+
+function NewsletterItem({
+  feed,
+  onToggleStatus,
+  onUnsubscribe,
+  isProcessing,
+  colors,
+}: NewsletterItemProps) {
+  const isActive = feed.status === 'ACTIVE';
+
+  return (
+    <Animated.View>
+      <View style={styles.channelItem}>
+        <View style={[styles.channelImagePlaceholder, { backgroundColor: colors.backgroundTertiary }]}>
+          <Text style={[styles.channelImagePlaceholderText, { color: colors.textSecondary }]}>✉️</Text>
+        </View>
+        <View style={styles.channelContent}>
+          <Text style={[styles.channelName, { color: colors.text }]} numberOfLines={1}>
+            {feed.displayName}
+          </Text>
+          {feed.fromAddress && (
+            <Text style={[styles.connectionDetail, { color: colors.textSecondary }]} numberOfLines={1}>
+              {feed.fromAddress}
+            </Text>
+          )}
+        </View>
+
+        <View style={styles.newsletterActions}>
+          <Pressable
+            onPress={onToggleStatus}
+            disabled={isProcessing}
+            style={({ pressed }) => [
+              styles.newsletterButton,
+              {
+                backgroundColor: isActive ? colors.backgroundTertiary : colors.success,
+              },
+              pressed && { opacity: 0.8 },
+              isProcessing && { opacity: 0.5 },
+            ]}
+          >
+            {isProcessing ? (
+              <ActivityIndicator size="small" color={isActive ? colors.text : '#FFFFFF'} />
+            ) : (
+              <Text
+                style={[
+                  styles.newsletterButtonText,
+                  { color: isActive ? colors.text : '#FFFFFF' },
+                ]}
+              >
+                {isActive ? 'Hide' : 'Show'}
+              </Text>
+            )}
+          </Pressable>
+
+          <Pressable onPress={onUnsubscribe} disabled={isProcessing}>
+            <Text style={[styles.disconnectText, { color: colors.error }]}>Unsubscribe</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Animated.View>
+  );
+}
+
 interface EmptyChannelsStateProps {
   provider: Provider;
   isConnected: boolean;
@@ -318,6 +410,7 @@ export default function ProviderDetailScreen() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'dark'];
   const params = useLocalSearchParams<{ provider: string }>();
+  const utils = trpc.useUtils() as any;
 
   // Validate provider param
   const providerValidation = validateAndConvertProvider(params.provider);
@@ -344,14 +437,55 @@ export default function ProviderDetailScreen() {
   );
   const isConnected = connection?.status === 'ACTIVE';
 
+  const discoverProvider: 'YOUTUBE' | 'SPOTIFY' =
+    provider === 'SPOTIFY' ? 'SPOTIFY' : 'YOUTUBE';
+
   // Fetch available channels from provider
   const discoverQuery = trpc.subscriptions.discover.available.useQuery(
-    { provider: provider as SharedProvider },
+    { provider: discoverProvider as SharedProvider },
     {
       staleTime: 5 * 60 * 1000,
-      enabled: providerValidation.success && isConnected,
+      enabled: providerValidation.success && isConnected && provider !== 'GMAIL',
     }
   );
+
+  const newslettersQuery = (trpc as any).subscriptions.newsletters.list.useQuery(
+    { limit: 100, search: searchQuery || undefined },
+    {
+      staleTime: 60 * 1000,
+      enabled: providerValidation.success && isConnected && provider === 'GMAIL',
+    }
+  );
+
+  const newslettersSyncMutation = (trpc as any).subscriptions.newsletters.syncNow.useMutation({
+    onSuccess: () => {
+      utils.subscriptions?.newsletters?.list?.invalidate?.();
+      utils.subscriptions?.newsletters?.stats?.invalidate?.();
+    },
+    onError: (error: Error) => {
+      Alert.alert('Sync failed', error.message || 'Failed to sync newsletters. Please try again.');
+    },
+  });
+
+  const updateNewsletterStatusMutation = (trpc as any).subscriptions.newsletters.updateStatus.useMutation({
+    onError: (error: Error) => {
+      Alert.alert('Update failed', error.message || 'Failed to update newsletter status.');
+    },
+    onSuccess: () => {
+      utils.subscriptions?.newsletters?.list?.invalidate?.();
+      utils.subscriptions?.newsletters?.stats?.invalidate?.();
+    },
+  });
+
+  const unsubscribeNewsletterMutation = (trpc as any).subscriptions.newsletters.unsubscribe.useMutation({
+    onError: (error: Error) => {
+      Alert.alert('Unsubscribe failed', error.message || 'Failed to unsubscribe from newsletter.');
+    },
+    onSuccess: () => {
+      utils.subscriptions?.newsletters?.list?.invalidate?.();
+      utils.subscriptions?.newsletters?.stats?.invalidate?.();
+    },
+  });
 
   const disconnectMutation = useDisconnectConnection({
     onError: (error) => {
@@ -367,6 +501,11 @@ export default function ProviderDetailScreen() {
     () => subscriptions.filter((s) => s.provider === provider),
     [subscriptions, provider]
   );
+
+  const newsletterFeeds: NewsletterFeed[] = useMemo(() => {
+    const data = newslettersQuery.data as { items?: NewsletterFeed[] } | undefined;
+    return (data?.items ?? []).filter((feed) => feed.status !== 'UNSUBSCRIBED');
+  }, [newslettersQuery.data]);
 
   // Build unified channel list
   const unifiedChannels: UnifiedChannel[] = useMemo(() => {
@@ -408,6 +547,9 @@ export default function ProviderDetailScreen() {
     return unifiedChannels.filter((c) => c.name.toLowerCase().includes(query));
   }, [unifiedChannels, searchQuery]);
 
+  const subscriptionProvider: 'YOUTUBE' | 'SPOTIFY' =
+    provider === 'SPOTIFY' ? 'SPOTIFY' : 'YOUTUBE';
+
   // Handlers
   const handleConnect = useCallback(() => {
     router.push(`/subscriptions/connect/${provider.toLowerCase()}` as Href);
@@ -431,6 +573,41 @@ export default function ProviderDetailScreen() {
     );
   }, [config.name, provider, disconnectMutation]);
 
+  const handleNewslettersSync = useCallback(() => {
+    newslettersSyncMutation.mutate();
+  }, [newslettersSyncMutation]);
+
+  const handleNewsletterToggleStatus = useCallback(
+    (feed: NewsletterFeed) => {
+      const nextStatus = feed.status === 'ACTIVE' ? 'HIDDEN' : 'ACTIVE';
+      updateNewsletterStatusMutation.mutate({
+        feedId: feed.id,
+        status: nextStatus,
+      });
+    },
+    [updateNewsletterStatusMutation]
+  );
+
+  const handleNewsletterUnsubscribe = useCallback(
+    (feed: NewsletterFeed) => {
+      Alert.alert(
+        `Unsubscribe from ${feed.displayName}?`,
+        'This will mark the newsletter as unsubscribed in Zine.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Unsubscribe',
+            style: 'destructive',
+            onPress: () => {
+              unsubscribeNewsletterMutation.mutate({ feedId: feed.id });
+            },
+          },
+        ]
+      );
+    },
+    [unsubscribeNewsletterMutation]
+  );
+
   const handleAdd = useCallback(
     (channel: UnifiedChannel) => {
       if (processingChannels.has(channel.providerChannelId)) return;
@@ -438,7 +615,7 @@ export default function ProviderDetailScreen() {
       setProcessingChannels((prev) => new Set(prev).add(channel.providerChannelId));
 
       subscribe({
-        provider,
+        provider: subscriptionProvider,
         providerChannelId: channel.providerChannelId,
         name: channel.name,
         imageUrl: channel.imageUrl ?? undefined,
@@ -453,7 +630,7 @@ export default function ProviderDetailScreen() {
         });
       }, 1000);
     },
-    [provider, subscribe, processingChannels]
+    [processingChannels, subscribe, subscriptionProvider]
   );
 
   const handleRemove = useCallback(
@@ -492,6 +669,29 @@ export default function ProviderDetailScreen() {
 
   const keyExtractor = useCallback((item: UnifiedChannel) => item.providerChannelId, []);
 
+  const renderNewsletterItem = useCallback(
+    ({ item }: { item: NewsletterFeed }) => (
+      <NewsletterItem
+        feed={item}
+        onToggleStatus={() => handleNewsletterToggleStatus(item)}
+        onUnsubscribe={() => handleNewsletterUnsubscribe(item)}
+        isProcessing={
+          updateNewsletterStatusMutation.isPending || unsubscribeNewsletterMutation.isPending
+        }
+        colors={colors}
+      />
+    ),
+    [
+      colors,
+      handleNewsletterToggleStatus,
+      handleNewsletterUnsubscribe,
+      unsubscribeNewsletterMutation.isPending,
+      updateNewsletterStatusMutation.isPending,
+    ]
+  );
+
+  const newsletterKeyExtractor = useCallback((item: NewsletterFeed) => item.id, []);
+
   // Invalid provider
   if (!providerValidation.success) {
     return (
@@ -504,7 +704,15 @@ export default function ProviderDetailScreen() {
     );
   }
 
-  const isLoading = connectionsLoading || subscriptionsLoading;
+  const isLoading =
+    connectionsLoading ||
+    subscriptionsLoading ||
+    (provider === 'GMAIL' && isConnected && newslettersQuery.isLoading);
+
+  const isGmailProvider = provider === 'GMAIL';
+  const listData = isGmailProvider ? newsletterFeeds : filteredChannels;
+  const listRenderItem = isGmailProvider ? renderNewsletterItem : renderItem;
+  const listKeyExtractor = isGmailProvider ? newsletterKeyExtractor : keyExtractor;
 
   return (
     <>
@@ -518,9 +726,9 @@ export default function ProviderDetailScreen() {
           <LoadingState />
         ) : (
           <FlatList
-            data={filteredChannels}
-            renderItem={renderItem}
-            keyExtractor={keyExtractor}
+            data={listData}
+            renderItem={listRenderItem as any}
+            keyExtractor={listKeyExtractor as any}
             contentContainerStyle={styles.listContent}
             contentInsetAdjustmentBehavior="automatic"
             showsVerticalScrollIndicator={false}
@@ -537,16 +745,34 @@ export default function ProviderDetailScreen() {
                 />
 
                 {/* Search and count */}
-                {isConnected && unifiedChannels.length > 0 && (
+                {isConnected && (
                   <Animated.View style={styles.searchSection}>
                     <View style={styles.sectionHeader}>
                       <Text style={[styles.sectionTitle, { color: colors.text }]}>
                         {config.contentName.charAt(0).toUpperCase() + config.contentName.slice(1)}
                       </Text>
                       <Text style={[styles.sectionCount, { color: colors.textTertiary }]}>
-                        {unifiedChannels.length}
+                        {isGmailProvider ? newsletterFeeds.length : unifiedChannels.length}
                       </Text>
                     </View>
+                    {isGmailProvider && (
+                      <Pressable
+                        onPress={handleNewslettersSync}
+                        disabled={newslettersSyncMutation.isPending}
+                        style={({ pressed }) => [
+                          styles.syncButton,
+                          { backgroundColor: colors.backgroundTertiary },
+                          pressed && { opacity: 0.8 },
+                          newslettersSyncMutation.isPending && { opacity: 0.5 },
+                        ]}
+                      >
+                        {newslettersSyncMutation.isPending ? (
+                          <ActivityIndicator size="small" color={colors.text} />
+                        ) : (
+                          <Text style={[styles.syncButtonText, { color: colors.text }]}>Sync now</Text>
+                        )}
+                      </Pressable>
+                    )}
                     <View
                       style={[
                         styles.searchBar,
@@ -569,7 +795,7 @@ export default function ProviderDetailScreen() {
               </View>
             }
             ListEmptyComponent={
-              !discoverQuery.isLoading ? (
+              !(isGmailProvider ? newslettersQuery.isLoading : discoverQuery.isLoading) ? (
                 <EmptyChannelsState provider={provider} isConnected={isConnected} colors={colors} />
               ) : (
                 <View style={styles.loadingChannels}>
@@ -677,6 +903,17 @@ const styles = StyleSheet.create({
     ...Typography.bodyMedium,
     marginLeft: Spacing.sm,
   },
+  syncButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radius.md,
+    marginBottom: Spacing.md,
+  },
+  syncButtonText: {
+    ...Typography.labelMedium,
+    fontWeight: '600',
+  },
   searchBar: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -739,6 +976,21 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#FFFFFF',
+  },
+  newsletterActions: {
+    alignItems: 'flex-end',
+    gap: Spacing.sm,
+  },
+  newsletterButton: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radius.full,
+    minWidth: 72,
+    alignItems: 'center',
+  },
+  newsletterButtonText: {
+    ...Typography.labelMedium,
+    fontWeight: '600',
   },
 
   // Empty State

--- a/apps/mobile/app/subscriptions/connect/_layout.tsx
+++ b/apps/mobile/app/subscriptions/connect/_layout.tsx
@@ -2,7 +2,7 @@
  * Layout for OAuth connect screens.
  *
  * Provides a Stack navigator for provider-specific connect screens
- * (YouTube, Spotify) with consistent styling and navigation.
+ * (YouTube, Spotify, Gmail) with consistent styling and navigation.
  */
 
 import { Stack } from 'expo-router';
@@ -39,6 +39,13 @@ export default function ConnectLayout() {
         name="spotify"
         options={{
           title: 'Connect Spotify',
+          presentation: 'card',
+        }}
+      />
+      <Stack.Screen
+        name="gmail"
+        options={{
+          title: 'Connect Gmail',
           presentation: 'card',
         }}
       />

--- a/apps/mobile/app/subscriptions/connect/gmail.tsx
+++ b/apps/mobile/app/subscriptions/connect/gmail.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+
+import { Colors, Typography, Spacing, Radius } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { OAuthErrorBoundary } from '@/components/oauth-error-boundary';
+import { connectProvider } from '@/lib/oauth';
+import { trpc } from '@/lib/trpc';
+
+const GMAIL_BLUE = '#1A73E8';
+
+function PermissionItem({
+  icon,
+  title,
+  description,
+  colors,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  colors: typeof Colors.light;
+}) {
+  return (
+    <View style={styles.permissionItem}>
+      <Text style={styles.permissionIcon}>{icon}</Text>
+      <View style={styles.permissionText}>
+        <Text style={[styles.permissionTitle, { color: colors.text }]}>{title}</Text>
+        <Text style={[styles.permissionDescription, { color: colors.textSecondary }]}>
+          {description}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+function GmailConnectContent() {
+  const router = useRouter();
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const utils = trpc.useUtils();
+
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConnect = useCallback(async () => {
+    setIsConnecting(true);
+    setError(null);
+
+    try {
+      await connectProvider('GMAIL');
+      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
+      await (utils as any).subscriptions?.newsletters?.stats?.invalidate?.();
+      await (utils as any).subscriptions?.newsletters?.list?.invalidate?.();
+      router.replace('/subscriptions/gmail' as const);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Connection failed';
+      if (message.includes('cancelled') || message.includes('cancel')) {
+        setError(null);
+      } else {
+        setError(message);
+      }
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [router, utils]);
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}> 
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <View style={[styles.iconContainer, { backgroundColor: `${GMAIL_BLUE}15` }]}>
+            <Text style={styles.providerIcon}>📬</Text>
+          </View>
+          <Text style={[styles.title, { color: colors.text }]}>Connect Gmail</Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}> 
+            Import newsletters from your inbox into Zine
+          </Text>
+        </View>
+
+        <View
+          style={[
+            styles.permissionsCard,
+            { backgroundColor: colors.card, borderColor: colors.border },
+          ]}
+        >
+          <Text style={[styles.permissionsHeader, { color: colors.textSecondary }]}>WHAT WE&apos;LL ACCESS</Text>
+          <View style={styles.permissionsList}>
+            <PermissionItem
+              icon="📰"
+              title="Newsletter metadata"
+              description="Sender, subject, and list headers used to detect newsletters"
+              colors={colors}
+            />
+            <PermissionItem
+              icon="📥"
+              title="Recent inbox messages"
+              description="Read-only access to identify new newsletter issues"
+              colors={colors}
+            />
+          </View>
+        </View>
+
+        <View style={[styles.permissionsCard, { backgroundColor: colors.card, borderColor: colors.border }]}> 
+          <Text style={[styles.permissionsHeader, { color: colors.textSecondary }]}>WHAT WE WON&apos;T DO</Text>
+          <View style={styles.permissionsList}>
+            <PermissionItem
+              icon="✉️"
+              title="No email sending"
+              description="Zine will never send mail from your account"
+              colors={colors}
+            />
+            <PermissionItem
+              icon="✍️"
+              title="No inbox edits"
+              description="Zine does not delete, archive, or modify your messages"
+              colors={colors}
+            />
+          </View>
+        </View>
+
+        {error && (
+          <View style={[styles.errorContainer, { backgroundColor: `${colors.error}15` }]}> 
+            <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>
+          </View>
+        )}
+
+        <Pressable
+          style={[
+            styles.connectButton,
+            { backgroundColor: GMAIL_BLUE },
+            isConnecting && styles.buttonDisabled,
+          ]}
+          onPress={handleConnect}
+          disabled={isConnecting}
+        >
+          {isConnecting ? (
+            <ActivityIndicator color="#FFFFFF" size="small" />
+          ) : (
+            <>
+              <Text style={styles.gmailIcon}>G</Text>
+              <Text style={styles.connectButtonText}>Connect Gmail</Text>
+            </>
+          )}
+        </Pressable>
+
+        {isConnecting && (
+          <Text style={[styles.loadingText, { color: colors.textSecondary }]}>Opening Gmail authorization...</Text>
+        )}
+
+        <View style={styles.footer}>
+          <Text style={[styles.footerText, { color: colors.textTertiary }]}> 
+            You can disconnect anytime from Connections. Newsletter items render like standard web articles.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+export default function GmailConnectScreen() {
+  const router = useRouter();
+
+  const handleRetry = useCallback(() => {
+    router.replace('/subscriptions/connect/gmail' as never);
+  }, [router]);
+
+  return (
+    <OAuthErrorBoundary provider="GMAIL" onRetry={handleRetry}>
+      <GmailConnectContent />
+    </OAuthErrorBoundary>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: Spacing['2xl'],
+    paddingTop: Spacing['3xl'],
+    paddingBottom: Spacing['2xl'],
+  },
+  header: {
+    alignItems: 'center',
+    marginBottom: Spacing['3xl'],
+  },
+  iconContainer: {
+    width: 80,
+    height: 80,
+    borderRadius: Radius['2xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Spacing.lg,
+  },
+  providerIcon: {
+    fontSize: 40,
+  },
+  title: {
+    ...Typography.headlineMedium,
+    marginBottom: Spacing.sm,
+    textAlign: 'center',
+  },
+  subtitle: {
+    ...Typography.bodyLarge,
+    textAlign: 'center',
+    paddingHorizontal: Spacing.lg,
+  },
+  permissionsCard: {
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    padding: Spacing.lg,
+    marginBottom: Spacing.xl,
+  },
+  permissionsHeader: {
+    ...Typography.labelSmall,
+    marginBottom: Spacing.md,
+  },
+  permissionsList: {
+    gap: Spacing.lg,
+  },
+  permissionItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing.md,
+  },
+  permissionIcon: {
+    fontSize: 24,
+    marginTop: 2,
+  },
+  permissionText: {
+    flex: 1,
+  },
+  permissionTitle: {
+    ...Typography.titleSmall,
+    marginBottom: Spacing.xs,
+  },
+  permissionDescription: {
+    ...Typography.bodySmall,
+  },
+  errorContainer: {
+    borderRadius: Radius.md,
+    padding: Spacing.md,
+    marginBottom: Spacing.lg,
+  },
+  errorText: {
+    ...Typography.bodyMedium,
+    textAlign: 'center',
+  },
+  connectButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing.lg,
+    borderRadius: Radius.lg,
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  gmailIcon: {
+    fontSize: 20,
+    color: '#FFFFFF',
+    fontWeight: '700',
+  },
+  connectButtonText: {
+    ...Typography.titleMedium,
+    color: '#FFFFFF',
+  },
+  loadingText: {
+    ...Typography.bodySmall,
+    textAlign: 'center',
+    marginBottom: Spacing.lg,
+  },
+  footer: {
+    marginTop: 'auto',
+    paddingTop: Spacing.xl,
+  },
+  footerText: {
+    ...Typography.bodySmall,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+});

--- a/apps/mobile/app/subscriptions/discover/[provider].tsx
+++ b/apps/mobile/app/subscriptions/discover/[provider].tsx
@@ -24,7 +24,7 @@ import { Colors, Spacing, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
 import { trpc } from '@/lib/trpc';
-import { validateAndConvertProvider } from '@/lib/route-validation';
+import { validateAndConvertDiscoverProvider } from '@/lib/route-validation';
 import { ErrorState } from '@/components/list-states';
 import { ChannelSelectionList, type Channel, type Provider } from '@/components/subscriptions';
 
@@ -56,7 +56,7 @@ export default function ProviderDiscoverScreen() {
   const params = useLocalSearchParams<{ provider: string }>();
 
   // Validate and normalize provider to uppercase
-  const providerValidation = validateAndConvertProvider(params.provider);
+  const providerValidation = validateAndConvertDiscoverProvider(params.provider);
 
   // Use validated provider or default to YOUTUBE for hook consistency
   // (hooks must be called unconditionally)

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -160,7 +160,9 @@ export default function SubscriptionsScreen() {
   const spotifyConnection = connections?.find(
     (connection: Connection) => connection.provider === 'SPOTIFY'
   );
-  const gmailConnection = connections?.find((connection: Connection) => connection.provider === 'GMAIL');
+  const gmailConnection = connections?.find(
+    (connection: Connection) => connection.provider === 'GMAIL'
+  );
   const youtubeStatus = (youtubeConnection?.status as ConnectionStatus) ?? null;
   const spotifyStatus = (spotifyConnection?.status as ConnectionStatus) ?? null;
   const gmailStatus = (gmailConnection?.status as ConnectionStatus) ?? null;

--- a/apps/mobile/components/badges.tsx
+++ b/apps/mobile/components/badges.tsx
@@ -13,7 +13,7 @@ import { ContentColors, ProviderColors, Typography, Spacing, Radius } from '@/co
 // Types
 // =============================================================================
 
-export type ProviderType = 'YOUTUBE' | 'SPOTIFY' | 'SUBSTACK' | 'X' | 'TWITTER' | 'WEB';
+export type ProviderType = 'YOUTUBE' | 'SPOTIFY' | 'GMAIL' | 'SUBSTACK' | 'X' | 'TWITTER' | 'WEB';
 export type ContentTypeValue = 'VIDEO' | 'PODCAST' | 'ARTICLE' | 'POST';
 
 // =============================================================================
@@ -28,6 +28,7 @@ function getProviderConfig(provider: string): { color: string; label: string } {
   const map: Record<string, { color: string; label: string }> = {
     YOUTUBE: { color: ProviderColors.youtube, label: 'YouTube' },
     SPOTIFY: { color: ProviderColors.spotify, label: 'Spotify' },
+    GMAIL: { color: ProviderColors.gmail, label: 'Gmail' },
     SUBSTACK: { color: ProviderColors.substack, label: 'Substack' },
     X: { color: ProviderColors.x, label: 'X' },
     TWITTER: { color: ProviderColors.x, label: 'X' },

--- a/apps/mobile/components/oauth-error-boundary.tsx
+++ b/apps/mobile/components/oauth-error-boundary.tsx
@@ -21,7 +21,7 @@ import { parseOAuthError, getOAuthErrorDisplay, type OAuthError } from '@/lib/oa
 import { oauthLogger } from '@/lib/logger';
 
 interface OAuthErrorFallbackProps {
-  provider: 'YOUTUBE' | 'SPOTIFY';
+  provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
   error: OAuthError;
   onRetry?: () => void;
 }
@@ -29,8 +29,10 @@ interface OAuthErrorFallbackProps {
 /**
  * Get provider display name for user-facing messages.
  */
-function getProviderName(provider: 'YOUTUBE' | 'SPOTIFY'): string {
-  return provider === 'YOUTUBE' ? 'YouTube' : 'Spotify';
+function getProviderName(provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'): string {
+  if (provider === 'YOUTUBE') return 'YouTube';
+  if (provider === 'SPOTIFY') return 'Spotify';
+  return 'Gmail';
 }
 
 /**
@@ -73,7 +75,7 @@ function OAuthErrorFallback({ provider, error, onRetry }: OAuthErrorFallbackProp
 
 interface OAuthErrorBoundaryProps {
   children: ReactNode;
-  provider: 'YOUTUBE' | 'SPOTIFY';
+  provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
   onRetry?: () => void;
   /** Optional error to display directly (for non-React error flows) */
   error?: Error | string | null;

--- a/apps/mobile/components/subscription-error-boundary.tsx
+++ b/apps/mobile/components/subscription-error-boundary.tsx
@@ -64,7 +64,7 @@ function isAuthError(error: Error | null): boolean {
 }
 
 interface SubscriptionErrorFallbackProps {
-  provider?: 'YOUTUBE' | 'SPOTIFY';
+  provider?: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
   onRetry?: () => void;
 }
 
@@ -81,6 +81,8 @@ function SubscriptionErrorFallback({ provider, onRetry }: SubscriptionErrorFallb
     // Navigate to provider connect screen
     if (provider === 'SPOTIFY') {
       router.push('/subscriptions/connect/spotify');
+    } else if (provider === 'GMAIL') {
+      router.push('/subscriptions/connect/gmail');
     } else {
       router.push('/subscriptions/connect/youtube');
     }
@@ -128,7 +130,7 @@ interface SubscriptionErrorBoundaryProps {
   /** Subscription ID for logging and reset key */
   subscriptionId?: string;
   /** Provider type for reconnection navigation */
-  provider?: 'YOUTUBE' | 'SPOTIFY';
+  provider?: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
   /** Callback when retry is clicked */
   onRetry?: () => void;
 }

--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -36,6 +36,7 @@ export const ContentColors = {
 export const ProviderColors = {
   youtube: '#2A2A2A',
   spotify: '#1A1A1A',
+  gmail: '#1A73E8',
   substack: '#3A3A3A',
   twitter: '#2A2A2A',
   x: '#2A2A2A',

--- a/apps/mobile/hooks/use-connections.ts
+++ b/apps/mobile/hooks/use-connections.ts
@@ -73,6 +73,22 @@ interface ConnectionsListResponse {
   GMAIL: ProviderConnectionData | null;
 }
 
+interface NewslettersListResponse {
+  items: unknown[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+interface NewsletterStatsResponse {
+  total: number;
+  active: number;
+  hidden: number;
+  unsubscribed: number;
+  lastSyncAt: number | null;
+  lastSyncStatus: string;
+  lastSyncError: string | null;
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -216,10 +232,16 @@ export function useDisconnectConnection(options?: {
   onSettled?: () => void;
 }) {
   type DisconnectContext = {
-    previousConnections?: Connection[];
+    previousConnections?: ConnectionsListResponse | Connection[];
     previousSubscriptions?: {
       defaultList?: SubscriptionsResponse;
       limitedList?: SubscriptionsResponse;
+    };
+    previousNewsletters?: {
+      listDefault?: NewslettersListResponse;
+      listNoSearch?: NewslettersListResponse;
+      listUnscoped?: NewslettersListResponse;
+      stats?: NewsletterStatsResponse;
     };
   };
 
@@ -233,16 +255,52 @@ export function useDisconnectConnection(options?: {
       await utils.subscriptions?.connections?.list?.cancel?.();
       await utils.subscriptions?.list?.cancel?.({});
       await utils.subscriptions?.list?.cancel?.({ limit: 50 });
+      if (provider === 'GMAIL') {
+        await utils.subscriptions?.newsletters?.list?.cancel?.({
+          limit: 100,
+          search: undefined,
+        });
+        await utils.subscriptions?.newsletters?.list?.cancel?.({
+          limit: 100,
+        });
+        await utils.subscriptions?.newsletters?.list?.cancel?.(undefined);
+        await utils.subscriptions?.newsletters?.stats?.cancel?.();
+      }
 
       const previousConnections = utils.subscriptions?.connections?.list?.getData?.();
       const previousSubscriptionsDefault = utils.subscriptions?.list?.getData?.({});
       const previousSubscriptionsLimited = utils.subscriptions?.list?.getData?.({ limit: 50 });
+      const previousNewslettersList =
+        provider === 'GMAIL'
+          ? utils.subscriptions?.newsletters?.list?.getData?.({ limit: 100, search: undefined })
+          : undefined;
+      const previousNewslettersListNoSearch =
+        provider === 'GMAIL'
+          ? utils.subscriptions?.newsletters?.list?.getData?.({ limit: 100 })
+          : undefined;
+      const previousNewslettersListDefault =
+        provider === 'GMAIL'
+          ? utils.subscriptions?.newsletters?.list?.getData?.(undefined)
+          : undefined;
+      const previousNewslettersStats =
+        provider === 'GMAIL' ? utils.subscriptions?.newsletters?.stats?.getData?.() : undefined;
 
-      utils.subscriptions?.connections?.list?.setData?.(
-        undefined,
-        (old: Connection[] | undefined) =>
-          old ? old.filter((connection) => connection.provider !== provider) : old
-      );
+      const updateConnections = (
+        old: ConnectionsListResponse | Connection[] | undefined
+      ): ConnectionsListResponse | Connection[] | undefined => {
+        if (!old) return old;
+
+        if (Array.isArray(old)) {
+          return old.filter((connection) => connection.provider !== provider);
+        }
+
+        return {
+          ...old,
+          [provider]: null,
+        };
+      };
+
+      utils.subscriptions?.connections?.list?.setData?.(undefined, updateConnections);
 
       const updateSubscriptions = (old: SubscriptionsResponse | undefined) => {
         if (!old) return old;
@@ -260,11 +318,58 @@ export function useDisconnectConnection(options?: {
       utils.subscriptions?.list?.setData?.({}, updateSubscriptions);
       utils.subscriptions?.list?.setData?.({ limit: 50 }, updateSubscriptions);
 
+      if (provider === 'GMAIL') {
+        utils.subscriptions?.newsletters?.list?.setData?.(
+          { limit: 100, search: undefined },
+          {
+            items: [],
+            nextCursor: null,
+            hasMore: false,
+          }
+        );
+        utils.subscriptions?.newsletters?.list?.setData?.(
+          { limit: 100 },
+          {
+            items: [],
+            nextCursor: null,
+            hasMore: false,
+          }
+        );
+        utils.subscriptions?.newsletters?.list?.setData?.(undefined, {
+          items: [],
+          nextCursor: null,
+          hasMore: false,
+        });
+
+        utils.subscriptions?.newsletters?.stats?.setData?.(
+          undefined,
+          (old: NewsletterStatsResponse | undefined) => {
+            if (!old) return old;
+            return {
+              ...old,
+              total: 0,
+              active: 0,
+              hidden: 0,
+              unsubscribed: 0,
+              lastSyncAt: null,
+              lastSyncStatus: 'IDLE',
+              lastSyncError: null,
+            };
+          }
+        );
+      }
+
       return {
         previousConnections,
         previousSubscriptions: {
           defaultList: previousSubscriptionsDefault,
           limitedList: previousSubscriptionsLimited,
+        },
+        previousNewsletters: {
+          listDefault: previousNewslettersList,
+          listNoSearch: previousNewslettersListNoSearch,
+          listUnscoped: previousNewslettersListDefault,
+          stats: previousNewslettersStats,
         },
       };
     },
@@ -284,11 +389,41 @@ export function useDisconnectConnection(options?: {
         );
       }
 
+      if (context?.previousNewsletters?.listDefault !== undefined) {
+        utils.subscriptions?.newsletters?.list?.setData?.(
+          { limit: 100, search: undefined },
+          context.previousNewsletters.listDefault
+        );
+      }
+      if (context?.previousNewsletters?.listNoSearch !== undefined) {
+        utils.subscriptions?.newsletters?.list?.setData?.(
+          { limit: 100 },
+          context.previousNewsletters.listNoSearch
+        );
+      }
+      if (context?.previousNewsletters?.listUnscoped !== undefined) {
+        utils.subscriptions?.newsletters?.list?.setData?.(
+          undefined,
+          context.previousNewsletters.listUnscoped
+        );
+      }
+
+      if (context?.previousNewsletters?.stats !== undefined) {
+        utils.subscriptions?.newsletters?.stats?.setData?.(
+          undefined,
+          context.previousNewsletters.stats
+        );
+      }
+
       options?.onError?.(error);
     },
-    onSuccess: () => {
+    onSuccess: (_data: unknown, input: DisconnectConnectionInput) => {
       utils.subscriptions?.connections?.list?.invalidate?.();
       utils.subscriptions?.list?.invalidate?.();
+      if (input.provider === 'GMAIL') {
+        utils.subscriptions?.newsletters?.list?.invalidate?.();
+        utils.subscriptions?.newsletters?.stats?.invalidate?.();
+      }
       options?.onSuccess?.();
     },
     onSettled: () => {

--- a/apps/mobile/hooks/use-connections.ts
+++ b/apps/mobile/hooks/use-connections.ts
@@ -25,7 +25,7 @@ export type ConnectionStatus = 'ACTIVE' | 'EXPIRED' | 'REVOKED';
 /**
  * Supported OAuth providers
  */
-export type ConnectionProvider = 'YOUTUBE' | 'SPOTIFY';
+export type ConnectionProvider = 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
 
 /**
  * Connection type returned from the backend.
@@ -70,6 +70,7 @@ interface ProviderConnectionData {
 interface ConnectionsListResponse {
   YOUTUBE: ProviderConnectionData | null;
   SPOTIFY: ProviderConnectionData | null;
+  GMAIL: ProviderConnectionData | null;
 }
 
 // ============================================================================
@@ -111,6 +112,10 @@ function transformConnectionsResponse(response: ConnectionsListResponse): Connec
 
   if (response.SPOTIFY) {
     connections.push(transformConnection('SPOTIFY', response.SPOTIFY));
+  }
+
+  if (response.GMAIL) {
+    connections.push(transformConnection('GMAIL', response.GMAIL));
   }
 
   return connections;

--- a/apps/mobile/lib/oauth-errors.test.ts
+++ b/apps/mobile/lib/oauth-errors.test.ts
@@ -1,0 +1,21 @@
+import { OAuthErrorCode, parseOAuthError } from './oauth-errors';
+
+describe('parseOAuthError', () => {
+  it('classifies Gmail insufficient scope errors correctly', () => {
+    const error = parseOAuthError(
+      'Gmail API request failed (403): Request had insufficient authentication scopes. ACCESS_TOKEN_SCOPE_INSUFFICIENT'
+    );
+
+    expect(error.code).toBe(OAuthErrorCode.INVALID_SCOPE);
+    expect(error.message).toContain('missing required scopes');
+  });
+
+  it('classifies Gmail API disabled errors correctly', () => {
+    const error = parseOAuthError(
+      'Gmail API has not been used in project 123 before or it is disabled. reason=accessNotConfigured'
+    );
+
+    expect(error.code).toBe(OAuthErrorCode.PROVIDER_ERROR);
+    expect(error.message).toContain('Gmail API is not enabled');
+  });
+});

--- a/apps/mobile/lib/oauth-errors.ts
+++ b/apps/mobile/lib/oauth-errors.ts
@@ -260,6 +260,36 @@ export function parseOAuthError(error: unknown): OAuthError {
       };
     }
 
+    // Gmail OAuth granted token is missing required read scope
+    if (
+      errorLower.includes('insufficient authentication scopes') ||
+      errorLower.includes('insufficient permission') ||
+      errorLower.includes('insufficientpermissions') ||
+      errorLower.includes('access_token_scope_insufficient')
+    ) {
+      return {
+        code: OAuthErrorCode.INVALID_SCOPE,
+        message:
+          'Gmail permissions are missing required scopes. Reconnect and allow read-only Gmail access.',
+        recoverable: true,
+        action: 'retry',
+      };
+    }
+
+    // Gmail API not enabled in Google Cloud project
+    if (
+      errorLower.includes('accessnotconfigured') ||
+      errorLower.includes('gmail api has not been used in project')
+    ) {
+      return {
+        code: OAuthErrorCode.PROVIDER_ERROR,
+        message:
+          'Gmail API is not enabled for this app configuration. Enable Gmail API in Google Cloud Console, then try again.',
+        recoverable: true,
+        action: 'retry',
+      };
+    }
+
     // State validation errors
     if (errorLower.includes('state') && errorLower.includes('mismatch')) {
       return {

--- a/apps/mobile/lib/offline-queue.ts
+++ b/apps/mobile/lib/offline-queue.ts
@@ -496,24 +496,30 @@ class OfflineActionQueue {
    */
   private async executeAction(action: OfflineAction): Promise<void> {
     const { getOfflineTRPCClient } = await import('./trpc-offline-client');
-    const client = getOfflineTRPCClient();
+    const client = getOfflineTRPCClient() as any;
 
     // Map action types to tRPC mutations
     // Note: Current router uses 'sources' not 'subscriptions'
     // The action payload structure should match the mutation input
     switch (action.type) {
       case 'SUBSCRIBE':
-        // payload: { provider, feedUrl, name? }
-        await client.sources.add.mutate(
-          action.payload as Parameters<typeof client.sources.add.mutate>[0]
-        );
+        if (client.sources?.add?.mutate) {
+          // Legacy router path
+          await client.sources.add.mutate(action.payload);
+        } else {
+          // Current router path
+          await client.subscriptions.add.mutate(action.payload);
+        }
         break;
 
       case 'UNSUBSCRIBE':
-        // payload: { id }
-        await client.sources.remove.mutate(
-          action.payload as Parameters<typeof client.sources.remove.mutate>[0]
-        );
+        if (client.sources?.remove?.mutate) {
+          // Legacy router path
+          await client.sources.remove.mutate(action.payload);
+        } else {
+          // Current router path
+          await client.subscriptions.remove.mutate(action.payload);
+        }
         break;
     }
   }

--- a/apps/mobile/lib/route-validation.test.ts
+++ b/apps/mobile/lib/route-validation.test.ts
@@ -10,7 +10,9 @@ import {
   toBackendProvider,
   validateProviderRoute,
   validateAndConvertProvider,
+  validateAndConvertDiscoverProvider,
   VALID_PROVIDER_ROUTES,
+  VALID_DISCOVER_PROVIDER_ROUTES,
 } from './route-validation';
 
 describe('route-validation', () => {
@@ -84,16 +86,19 @@ describe('route-validation', () => {
     it('returns true for valid lowercase providers', () => {
       expect(isValidProviderRoute('youtube')).toBe(true);
       expect(isValidProviderRoute('spotify')).toBe(true);
+      expect(isValidProviderRoute('gmail')).toBe(true);
     });
 
     it('returns true for valid uppercase providers (case-insensitive)', () => {
       expect(isValidProviderRoute('YOUTUBE')).toBe(true);
       expect(isValidProviderRoute('SPOTIFY')).toBe(true);
+      expect(isValidProviderRoute('GMAIL')).toBe(true);
     });
 
     it('returns true for mixed case providers', () => {
       expect(isValidProviderRoute('YouTube')).toBe(true);
       expect(isValidProviderRoute('Spotify')).toBe(true);
+      expect(isValidProviderRoute('Gmail')).toBe(true);
     });
 
     it('returns false for invalid providers', () => {
@@ -116,6 +121,7 @@ describe('route-validation', () => {
       expect(normalizeProviderRoute('YouTube')).toBe('youtube');
       expect(normalizeProviderRoute('spotify')).toBe('spotify');
       expect(normalizeProviderRoute('SPOTIFY')).toBe('spotify');
+      expect(normalizeProviderRoute('GMAIL')).toBe('gmail');
     });
 
     it('returns undefined for invalid providers', () => {
@@ -134,6 +140,7 @@ describe('route-validation', () => {
     it('converts lowercase route to uppercase backend format', () => {
       expect(toBackendProvider('youtube')).toBe('YOUTUBE');
       expect(toBackendProvider('spotify')).toBe('SPOTIFY');
+      expect(toBackendProvider('gmail')).toBe('GMAIL');
     });
   });
 
@@ -178,6 +185,12 @@ describe('route-validation', () => {
       if (spotifyResult.success) {
         expect(spotifyResult.data).toBe('SPOTIFY');
       }
+
+      const gmailResult = validateAndConvertProvider('gmail');
+      expect(gmailResult.success).toBe(true);
+      if (gmailResult.success) {
+        expect(gmailResult.data).toBe('GMAIL');
+      }
     });
 
     it('returns error for invalid provider', () => {
@@ -189,11 +202,37 @@ describe('route-validation', () => {
     });
   });
 
+  describe('validateAndConvertDiscoverProvider', () => {
+    it('allows youtube and spotify', () => {
+      expect(validateAndConvertDiscoverProvider('youtube')).toEqual({
+        success: true,
+        data: 'YOUTUBE',
+      });
+      expect(validateAndConvertDiscoverProvider('spotify')).toEqual({
+        success: true,
+        data: 'SPOTIFY',
+      });
+    });
+
+    it('rejects gmail for discovery', () => {
+      const result = validateAndConvertDiscoverProvider('gmail');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.message).toContain('not supported for discovery');
+      }
+    });
+  });
+
   describe('VALID_PROVIDER_ROUTES', () => {
     it('contains expected providers', () => {
       expect(VALID_PROVIDER_ROUTES).toContain('youtube');
       expect(VALID_PROVIDER_ROUTES).toContain('spotify');
-      expect(VALID_PROVIDER_ROUTES.length).toBe(2);
+      expect(VALID_PROVIDER_ROUTES).toContain('gmail');
+      expect(VALID_PROVIDER_ROUTES.length).toBe(3);
+    });
+
+    it('keeps discovery providers limited to youtube/spotify', () => {
+      expect(VALID_DISCOVER_PROVIDER_ROUTES).toEqual(['youtube', 'spotify']);
     });
   });
 });

--- a/apps/worker/src/db/migrations/0004_add_gmail_newsletters.sql
+++ b/apps/worker/src/db/migrations/0004_add_gmail_newsletters.sql
@@ -1,0 +1,84 @@
+-- Created: 2026-02-07
+-- Add Gmail mailbox + newsletter ingestion tables
+
+CREATE TABLE IF NOT EXISTS `gmail_mailboxes` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `provider_connection_id` text NOT NULL REFERENCES `provider_connections`(`id`),
+  `google_sub` text NOT NULL,
+  `email` text NOT NULL,
+  `history_id` text,
+  `watch_expiration_at` integer,
+  `last_sync_at` integer,
+  `last_sync_status` text NOT NULL DEFAULT 'IDLE',
+  `last_sync_error` text,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `gmail_mailboxes_user_connection_idx`
+  ON `gmail_mailboxes` (`user_id`, `provider_connection_id`);
+
+CREATE INDEX IF NOT EXISTS `gmail_mailboxes_sync_idx`
+  ON `gmail_mailboxes` (`last_sync_status`, `updated_at`);
+
+CREATE TABLE IF NOT EXISTS `newsletter_feeds` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `gmail_mailbox_id` text NOT NULL REFERENCES `gmail_mailboxes`(`id`),
+  `canonical_key` text NOT NULL,
+  `list_id` text,
+  `from_address` text,
+  `display_name` text,
+  `unsubscribe_mailto` text,
+  `unsubscribe_url` text,
+  `unsubscribe_post_header` text,
+  `detection_score` real NOT NULL,
+  `status` text NOT NULL DEFAULT 'ACTIVE',
+  `first_seen_at` integer NOT NULL,
+  `last_seen_at` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `newsletter_feeds_user_canonical_key_idx`
+  ON `newsletter_feeds` (`user_id`, `canonical_key`);
+
+CREATE INDEX IF NOT EXISTS `newsletter_feeds_mailbox_status_idx`
+  ON `newsletter_feeds` (`gmail_mailbox_id`, `status`, `last_seen_at`);
+
+CREATE TABLE IF NOT EXISTS `newsletter_feed_messages` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `gmail_mailbox_id` text NOT NULL REFERENCES `gmail_mailboxes`(`id`),
+  `newsletter_feed_id` text NOT NULL REFERENCES `newsletter_feeds`(`id`),
+  `gmail_message_id` text NOT NULL,
+  `gmail_thread_id` text,
+  `item_id` text NOT NULL REFERENCES `items`(`id`),
+  `internal_date` integer,
+  `created_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `newsletter_feed_messages_user_message_idx`
+  ON `newsletter_feed_messages` (`user_id`, `gmail_message_id`);
+
+CREATE INDEX IF NOT EXISTS `newsletter_feed_messages_feed_date_idx`
+  ON `newsletter_feed_messages` (`newsletter_feed_id`, `internal_date`);
+
+CREATE TABLE IF NOT EXISTS `newsletter_unsubscribe_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `newsletter_feed_id` text NOT NULL REFERENCES `newsletter_feeds`(`id`),
+  `method` text NOT NULL,
+  `target` text NOT NULL,
+  `status` text NOT NULL,
+  `error` text,
+  `requested_at` integer NOT NULL,
+  `completed_at` integer
+);
+
+CREATE INDEX IF NOT EXISTS `newsletter_unsubscribe_feed_idx`
+  ON `newsletter_unsubscribe_events` (`newsletter_feed_id`, `requested_at`);
+
+CREATE INDEX IF NOT EXISTS `newsletter_unsubscribe_user_idx`
+  ON `newsletter_unsubscribe_events` (`user_id`, `requested_at`);

--- a/apps/worker/src/db/migrations/0004_newsletter_opt_in_defaults.sql
+++ b/apps/worker/src/db/migrations/0004_newsletter_opt_in_defaults.sql
@@ -1,0 +1,8 @@
+-- Created: 2026-02-08
+-- Make existing newsletter feeds opt-in by default.
+-- Keep this migration data-only to avoid SQLite FK rebuild issues on local D1.
+
+UPDATE `newsletter_feeds`
+SET `status` = 'UNSUBSCRIBED',
+    `updated_at` = CAST(strftime('%s','now') AS INTEGER) * 1000
+WHERE `status` != 'UNSUBSCRIBED';

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1770422401000,
       "tag": "0004_add_gmail_newsletters",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1770519000000,
+      "tag": "0004_newsletter_opt_in_defaults",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770422400000,
       "tag": "0003_add_tags_and_collections",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1770422401000,
+      "tag": "0004_add_gmail_newsletters",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -284,7 +284,7 @@ export const newsletterFeeds = sqliteTable(
     unsubscribeUrl: text('unsubscribe_url'),
     unsubscribePostHeader: text('unsubscribe_post_header'),
     detectionScore: real('detection_score').notNull(),
-    status: text('status').notNull().default('ACTIVE'), // ACTIVE | HIDDEN | UNSUBSCRIBED
+    status: text('status').notNull().default('ACTIVE'), // ACTIVE | HIDDEN | UNSUBSCRIBED (ingestion path sets UNSUBSCRIBED by default)
     firstSeenAt: integer('first_seen_at').notNull(),
     lastSeenAt: integer('last_seen_at').notNull(),
     createdAt: integer('created_at').notNull(),
@@ -292,7 +292,11 @@ export const newsletterFeeds = sqliteTable(
   },
   (table) => [
     uniqueIndex('newsletter_feeds_user_canonical_key_idx').on(table.userId, table.canonicalKey),
-    index('newsletter_feeds_mailbox_status_idx').on(table.gmailMailboxId, table.status, table.lastSeenAt),
+    index('newsletter_feeds_mailbox_status_idx').on(
+      table.gmailMailboxId,
+      table.status,
+      table.lastSeenAt
+    ),
   ]
 );
 

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { sqliteTable, text, integer, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, real, uniqueIndex, index } from 'drizzle-orm/sqlite-core';
 
 // ============================================================================
 // Users
@@ -200,7 +200,7 @@ export const sources = sqliteTable(
 // ============================================================================
 // Provider Connections (OAuth tokens per provider)
 // ============================================================================
-// Stores encrypted OAuth credentials for connected providers (YouTube, Spotify)
+// Stores encrypted OAuth credentials for connected providers (YouTube, Spotify, Gmail)
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
 export const providerConnections = sqliteTable(
   'provider_connections',
@@ -209,7 +209,7 @@ export const providerConnections = sqliteTable(
     userId: text('user_id')
       .notNull()
       .references(() => users.id),
-    provider: text('provider').notNull(), // YOUTUBE | SPOTIFY
+    provider: text('provider').notNull(), // YOUTUBE | SPOTIFY | GMAIL
     providerUserId: text('provider_user_id'), // Provider's user ID
 
     // Encrypted OAuth tokens (AES-256-GCM encrypted)
@@ -227,6 +227,132 @@ export const providerConnections = sqliteTable(
     // One connection per provider per user
     uniqueIndex('provider_connections_user_provider_idx').on(table.userId, table.provider),
     index('provider_connections_status_idx').on(table.status),
+  ]
+);
+
+// ============================================================================
+// Gmail Mailboxes
+// ============================================================================
+// One connected Gmail mailbox per user/provider connection.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const gmailMailboxes = sqliteTable(
+  'gmail_mailboxes',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    providerConnectionId: text('provider_connection_id')
+      .notNull()
+      .references(() => providerConnections.id),
+    googleSub: text('google_sub').notNull(), // Stable Google user ID
+    email: text('email').notNull(),
+    historyId: text('history_id'), // Gmail incremental sync cursor
+    watchExpirationAt: integer('watch_expiration_at'), // Reserved for future watch/push support
+    lastSyncAt: integer('last_sync_at'),
+    lastSyncStatus: text('last_sync_status').notNull().default('IDLE'), // IDLE | RUNNING | SUCCESS | ERROR
+    lastSyncError: text('last_sync_error'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('gmail_mailboxes_user_connection_idx').on(table.userId, table.providerConnectionId),
+    index('gmail_mailboxes_sync_idx').on(table.lastSyncStatus, table.updatedAt),
+  ]
+);
+
+// ============================================================================
+// Newsletter Feeds
+// ============================================================================
+// Canonical newsletter identities detected from Gmail metadata.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const newsletterFeeds = sqliteTable(
+  'newsletter_feeds',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    gmailMailboxId: text('gmail_mailbox_id')
+      .notNull()
+      .references(() => gmailMailboxes.id),
+    canonicalKey: text('canonical_key').notNull(), // Stable identity (list-id/unsub/from fallback)
+    listId: text('list_id'),
+    fromAddress: text('from_address'),
+    displayName: text('display_name'),
+    unsubscribeMailto: text('unsubscribe_mailto'),
+    unsubscribeUrl: text('unsubscribe_url'),
+    unsubscribePostHeader: text('unsubscribe_post_header'),
+    detectionScore: real('detection_score').notNull(),
+    status: text('status').notNull().default('ACTIVE'), // ACTIVE | HIDDEN | UNSUBSCRIBED
+    firstSeenAt: integer('first_seen_at').notNull(),
+    lastSeenAt: integer('last_seen_at').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('newsletter_feeds_user_canonical_key_idx').on(table.userId, table.canonicalKey),
+    index('newsletter_feeds_mailbox_status_idx').on(table.gmailMailboxId, table.status, table.lastSeenAt),
+  ]
+);
+
+// ============================================================================
+// Newsletter Feed Messages
+// ============================================================================
+// Maps Gmail messages to detected newsletter feeds and ingested items.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const newsletterFeedMessages = sqliteTable(
+  'newsletter_feed_messages',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    gmailMailboxId: text('gmail_mailbox_id')
+      .notNull()
+      .references(() => gmailMailboxes.id),
+    newsletterFeedId: text('newsletter_feed_id')
+      .notNull()
+      .references(() => newsletterFeeds.id),
+    gmailMessageId: text('gmail_message_id').notNull(),
+    gmailThreadId: text('gmail_thread_id'),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    internalDate: integer('internal_date'),
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('newsletter_feed_messages_user_message_idx').on(table.userId, table.gmailMessageId),
+    index('newsletter_feed_messages_feed_date_idx').on(table.newsletterFeedId, table.internalDate),
+  ]
+);
+
+// ============================================================================
+// Newsletter Unsubscribe Events
+// ============================================================================
+// Audit trail for unsubscribe attempts from newsletter feeds.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const newsletterUnsubscribeEvents = sqliteTable(
+  'newsletter_unsubscribe_events',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    newsletterFeedId: text('newsletter_feed_id')
+      .notNull()
+      .references(() => newsletterFeeds.id),
+    method: text('method').notNull(), // URL | MAILTO | ONE_CLICK_POST
+    target: text('target').notNull(),
+    status: text('status').notNull(), // REQUESTED | COMPLETED | FAILED
+    error: text('error'),
+    requestedAt: integer('requested_at').notNull(),
+    completedAt: integer('completed_at'),
+  },
+  (table) => [
+    index('newsletter_unsubscribe_feed_idx').on(table.newsletterFeedId, table.requestedAt),
+    index('newsletter_unsubscribe_user_idx').on(table.userId, table.requestedAt),
   ]
 );
 

--- a/apps/worker/src/lib/auth.ts
+++ b/apps/worker/src/lib/auth.ts
@@ -159,6 +159,10 @@ const OAUTH_CONFIG = {
     tokenUrl: 'https://oauth2.googleapis.com/token',
     userInfoUrl: 'https://www.googleapis.com/oauth2/v2/userinfo',
   },
+  GMAIL: {
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    userInfoUrl: 'https://www.googleapis.com/oauth2/v2/userinfo',
+  },
   SPOTIFY: {
     tokenUrl: 'https://accounts.spotify.com/api/token',
     userInfoUrl: 'https://api.spotify.com/v1/me',
@@ -168,13 +172,13 @@ const OAUTH_CONFIG = {
 /**
  * OAuth-enabled providers (subset of all providers)
  */
-type OAuthProvider = Provider.YOUTUBE | Provider.SPOTIFY;
+type OAuthProvider = Provider.YOUTUBE | Provider.SPOTIFY | Provider.GMAIL;
 
 /**
  * Check if a provider supports OAuth
  */
 function isOAuthProvider(provider: Provider): provider is OAuthProvider {
-  return provider === Provider.YOUTUBE || provider === Provider.SPOTIFY;
+  return provider === Provider.YOUTUBE || provider === Provider.SPOTIFY || provider === Provider.GMAIL;
 }
 
 /**
@@ -200,9 +204,9 @@ export async function exchangeCodeForTokens(
   const config = OAUTH_CONFIG[provider];
 
   // Get client credentials from environment
-  const clientId = provider === 'YOUTUBE' ? env.GOOGLE_CLIENT_ID : env.SPOTIFY_CLIENT_ID;
-  const clientSecret =
-    provider === 'YOUTUBE' ? env.GOOGLE_CLIENT_SECRET : env.SPOTIFY_CLIENT_SECRET;
+  const isGoogleProvider = provider === 'YOUTUBE' || provider === 'GMAIL';
+  const clientId = isGoogleProvider ? env.GOOGLE_CLIENT_ID : env.SPOTIFY_CLIENT_ID;
+  const clientSecret = isGoogleProvider ? env.GOOGLE_CLIENT_SECRET : env.SPOTIFY_CLIENT_SECRET;
   const redirectUri = overrideRedirectUri || env.OAUTH_REDIRECT_URI || 'zine://oauth/callback';
 
   if (!clientId) {
@@ -292,7 +296,7 @@ export async function getProviderUserInfo(
   const data = (await response.json()) as Record<string, unknown>;
 
   // Map provider-specific response to common format
-  if (provider === 'YOUTUBE') {
+  if (provider === 'YOUTUBE' || provider === 'GMAIL') {
     return {
       id: data.id as string,
       email: data.email as string | undefined,

--- a/apps/worker/src/lib/auth.ts
+++ b/apps/worker/src/lib/auth.ts
@@ -178,7 +178,9 @@ type OAuthProvider = Provider.YOUTUBE | Provider.SPOTIFY | Provider.GMAIL;
  * Check if a provider supports OAuth
  */
 function isOAuthProvider(provider: Provider): provider is OAuthProvider {
-  return provider === Provider.YOUTUBE || provider === Provider.SPOTIFY || provider === Provider.GMAIL;
+  return (
+    provider === Provider.YOUTUBE || provider === Provider.SPOTIFY || provider === Provider.GMAIL
+  );
 }
 
 /**

--- a/apps/worker/src/lib/token-refresh.ts
+++ b/apps/worker/src/lib/token-refresh.ts
@@ -280,6 +280,7 @@ function getProviderConfig(
 ): { tokenUrl: string; clientId: string; clientSecret?: string } {
   switch (provider) {
     case 'YOUTUBE':
+    case 'GMAIL':
       return {
         tokenUrl: 'https://oauth2.googleapis.com/token',
         clientId: env.GOOGLE_CLIENT_ID,

--- a/apps/worker/src/newsletters/avatar.test.ts
+++ b/apps/worker/src/newsletters/avatar.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildNewsletterAvatarUrl } from './avatar';
+
+describe('newsletter avatar resolver', () => {
+  it('prefers list-id publication domains for Substack newsletters', () => {
+    const avatarUrl = buildNewsletterAvatarUrl({
+      listId: '<lennysnewsletter.substack.com>',
+      fromAddress: 'hello@substack.com',
+      unsubscribeUrl: 'https://substack.com/unsubscribe',
+    });
+
+    expect(avatarUrl).toBe(
+      'https://www.google.com/s2/favicons?domain=lennysnewsletter.substack.com&sz=128'
+    );
+  });
+
+  it('prefers custom unsubscribe hosts over list-id when available', () => {
+    const avatarUrl = buildNewsletterAvatarUrl({
+      listId: '<thorstenball.substack.com>',
+      fromAddress: 'thorstenball@substack.com',
+      unsubscribeUrl:
+        'https://registerspill.thorstenball.com/action/disable_email/disable?token=abc',
+    });
+
+    expect(avatarUrl).toBe(
+      'https://www.google.com/s2/favicons?domain=registerspill.thorstenball.com&sz=128'
+    );
+  });
+
+  it('resolves open.substack canonical URLs to publication subdomains', () => {
+    const avatarUrl = buildNewsletterAvatarUrl({
+      canonicalUrl:
+        'https://open.substack.com/pub/lenny/p/getting-paid-to-vibe-code?utm_source=mail',
+    });
+
+    expect(avatarUrl).toBe('https://www.google.com/s2/favicons?domain=lenny.substack.com&sz=128');
+  });
+
+  it('ignores Gmail-only hosts and uses sender domain fallback', () => {
+    const avatarUrl = buildNewsletterAvatarUrl({
+      canonicalUrl: 'https://mail.google.com/mail/u/0/#inbox/123',
+      fromAddress: 'newsletter@beehiiv.com',
+    });
+
+    expect(avatarUrl).toBe('https://www.google.com/s2/favicons?domain=beehiiv.com&sz=128');
+  });
+
+  it('returns null when no domain identity is available', () => {
+    const avatarUrl = buildNewsletterAvatarUrl({
+      canonicalUrl: 'not-a-url',
+      fromAddress: null,
+      listId: null,
+      unsubscribeUrl: null,
+      creatorHandle: null,
+    });
+
+    expect(avatarUrl).toBeNull();
+  });
+});

--- a/apps/worker/src/newsletters/avatar.ts
+++ b/apps/worker/src/newsletters/avatar.ts
@@ -1,0 +1,105 @@
+const EXCLUDED_AVATAR_HOST_PATTERN =
+  /(^|\.)mail\.google\.com$|(^|\.)accounts\.google\.com$|(^|\.)googleusercontent\.com$/i;
+const OPEN_SUBSTACK_HOST_PATTERN = /(^|\.)open\.substack\.com$/i;
+const BARE_SUBSTACK_HOST_PATTERN = /^substack\.com$/i;
+const LIST_ID_DOMAIN_PATTERN = /[a-z0-9.-]+\.[a-z]{2,}/g;
+
+type NewsletterAvatarIdentity = {
+  canonicalUrl?: string | null;
+  listId?: string | null;
+  fromAddress?: string | null;
+  unsubscribeUrl?: string | null;
+  creatorHandle?: string | null;
+};
+
+function normalizeHostname(hostname: string | null | undefined): string | null {
+  if (!hostname) {
+    return null;
+  }
+
+  const trimmed = hostname.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/^www\./, '');
+}
+
+function extractDomainFromEmail(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const raw = value.trim().toLowerCase();
+  if (!raw || !raw.includes('@')) {
+    return null;
+  }
+
+  const domain = raw.split('@').pop();
+  return normalizeHostname(domain ?? null);
+}
+
+function extractDomainFromListId(listId: string | null | undefined): string | null {
+  if (!listId) {
+    return null;
+  }
+
+  const matches = listId.toLowerCase().match(LIST_ID_DOMAIN_PATTERN);
+  if (!matches || matches.length === 0) {
+    return null;
+  }
+
+  return normalizeHostname(matches[matches.length - 1] ?? null);
+}
+
+function extractDomainFromUrl(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (OPEN_SUBSTACK_HOST_PATTERN.test(url.hostname)) {
+      const segments = url.pathname.split('/').filter(Boolean);
+      if (segments.length >= 2 && segments[0] === 'pub') {
+        const publication = normalizeHostname(segments[1]);
+        if (publication) {
+          return `${publication}.substack.com`;
+        }
+      }
+    }
+    return normalizeHostname(url.hostname);
+  } catch {
+    return null;
+  }
+}
+
+function chooseAvatarDomain(identity: NewsletterAvatarIdentity): string | null {
+  const unsubscribeDomain = extractDomainFromUrl(identity.unsubscribeUrl);
+  const candidates = [
+    // Prefer unsubscribe host when it carries publication branding
+    // (e.g. registerspill.thorstenball.com), but skip bare substack.com.
+    unsubscribeDomain && !BARE_SUBSTACK_HOST_PATTERN.test(unsubscribeDomain)
+      ? unsubscribeDomain
+      : null,
+    extractDomainFromListId(identity.listId),
+    extractDomainFromUrl(identity.canonicalUrl),
+    extractDomainFromEmail(identity.fromAddress),
+    extractDomainFromEmail(identity.creatorHandle),
+    unsubscribeDomain,
+  ];
+
+  return (
+    candidates.find((candidate) => !!candidate && !EXCLUDED_AVATAR_HOST_PATTERN.test(candidate)) ??
+    null
+  );
+}
+
+export function buildNewsletterAvatarUrl(identity: NewsletterAvatarIdentity): string | null {
+  const domain = chooseAvatarDomain(identity);
+  if (!domain) {
+    return null;
+  }
+
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`;
+}

--- a/apps/worker/src/newsletters/gmail.test.ts
+++ b/apps/worker/src/newsletters/gmail.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeNewsletterScore,
+  isLikelyNewsletterFeedIdentity,
+  selectBestNewsletterIssueUrl,
+  shouldUpgradeNewsletterIssueUrl,
+} from './gmail';
+
+describe('gmail newsletter detection', () => {
+  it('classifies Substack digests as newsletters', () => {
+    const detection = computeNewsletterScore({
+      listId: '<newsetter.substack.com>',
+      listUnsubscribe: '<https://substack.com/unsubscribe>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://substack.com/unsubscribe',
+      unsubscribePostHeader: 'List-Unsubscribe=One-Click',
+      fromAddress: 'author@substack.com',
+      fromDisplayName: 'Author Weekly',
+      subject: 'Weekly product digest',
+    });
+
+    expect(detection.isNewsletter).toBe(true);
+    expect(detection.score).toBeGreaterThanOrEqual(0.78);
+  });
+
+  it('rejects transactional notifications even with unsubscribe headers', () => {
+    const githubDetection = computeNewsletterScore({
+      listId: '<repo.github.com>',
+      listUnsubscribe: '<https://github.com/notifications/unsubscribe>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://github.com/notifications/unsubscribe',
+      unsubscribePostHeader: null,
+      fromAddress: 'notifications@github.com',
+      fromDisplayName: 'GitHub Notifications',
+      subject: '[org/repo] You were mentioned in a pull request',
+    });
+
+    const uberDetection = computeNewsletterScore({
+      listId: '<uber.com>',
+      listUnsubscribe: '<https://uber.com/unsubscribe>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://uber.com/unsubscribe',
+      unsubscribePostHeader: null,
+      fromAddress: 'noreply@uber.com',
+      fromDisplayName: 'Uber',
+      subject: 'Your Uber receipt',
+    });
+
+    expect(githubDetection.isNewsletter).toBe(false);
+    expect(uberDetection.isNewsletter).toBe(false);
+  });
+
+  it('filters transactional senders from feed identity list results', () => {
+    const githubIdentity = isLikelyNewsletterFeedIdentity({
+      listId: '<repo.github.com>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://github.com/notifications/unsubscribe',
+      fromAddress: 'notifications@github.com',
+      displayName: 'GitHub Notifications',
+    });
+
+    const uberIdentity = isLikelyNewsletterFeedIdentity({
+      listId: '<ride.uber.com>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://uber.com/unsubscribe',
+      fromAddress: 'uber@uber.com',
+      displayName: 'Uber',
+    });
+
+    const substackIdentity = isLikelyNewsletterFeedIdentity({
+      listId: '<newsetter.substack.com>',
+      unsubscribeMailto: null,
+      unsubscribeUrl: 'https://substack.com/unsubscribe',
+      fromAddress: 'author@substack.com',
+      displayName: 'Author Weekly',
+    });
+
+    expect(githubIdentity).toBe(false);
+    expect(uberIdentity).toBe(false);
+    expect(substackIdentity).toBe(true);
+  });
+
+  it('prefers real content links over unsubscribe/manage links', () => {
+    const bestUrl = selectBestNewsletterIssueUrl({
+      candidates: [
+        {
+          url: 'https://substack.com/account/settings',
+          anchorText: 'Manage preferences',
+          source: 'html_anchor',
+          index: 0,
+        },
+        {
+          url: 'https://lennysnewsletter.substack.com/p/getting-paid-to-vibe-code?utm_source=substack',
+          anchorText: 'Read this issue',
+          source: 'html_anchor',
+          index: 1,
+        },
+        {
+          url: 'https://substack.com/unsubscribe?token=abc',
+          anchorText: 'Unsubscribe',
+          source: 'html_anchor',
+          index: 2,
+        },
+      ],
+      unsubscribeUrl: 'https://substack.com/unsubscribe?token=abc',
+      fromAddress: 'lenny@substack.com',
+      listId: '<lennysnewsletter.substack.com>',
+    });
+
+    expect(bestUrl).toBe('https://lennysnewsletter.substack.com/p/getting-paid-to-vibe-code');
+  });
+
+  it('unwraps redirect links and returns canonical article URL', () => {
+    const bestUrl = selectBestNewsletterIssueUrl({
+      candidates: [
+        {
+          url: 'https://www.google.com/url?q=https%3A%2F%2Fnewsletter.example.com%2Fposts%2F42%3Futm_source%3Dmail&sa=D',
+          anchorText: 'Open article',
+          source: 'html_anchor',
+          index: 0,
+        },
+      ],
+      unsubscribeUrl: null,
+      fromAddress: 'news@newsletter.example.com',
+      listId: '<newsletter.example.com>',
+    });
+
+    expect(bestUrl).toBe('https://newsletter.example.com/posts/42');
+  });
+
+  it('normalizes open.substack share links to publication article URLs', () => {
+    const bestUrl = selectBestNewsletterIssueUrl({
+      candidates: [
+        {
+          url: 'https://open.substack.com/pub/lenny/p/getting-paid-to-vibe-code?redirect=app-store',
+          anchorText: 'Read online',
+          source: 'html_anchor',
+          index: 0,
+        },
+      ],
+      unsubscribeUrl: null,
+      fromAddress: 'lenny@substack.com',
+      listId: '<lenny.substack.com>',
+    });
+
+    expect(bestUrl).toBe('https://lenny.substack.com/p/getting-paid-to-vibe-code');
+  });
+
+  it('returns null when only non-content links are present', () => {
+    const bestUrl = selectBestNewsletterIssueUrl({
+      candidates: [
+        {
+          url: 'https://substack.com/unsubscribe?token=abc',
+          anchorText: 'Unsubscribe',
+          source: 'html_anchor',
+          index: 0,
+        },
+        {
+          url: 'https://substack.com/account/settings',
+          anchorText: 'Account settings',
+          source: 'html_anchor',
+          index: 1,
+        },
+      ],
+      unsubscribeUrl: 'https://substack.com/unsubscribe?token=abc',
+      fromAddress: 'lenny@substack.com',
+      listId: '<lennysnewsletter.substack.com>',
+    });
+
+    expect(bestUrl).toBeNull();
+  });
+
+  it('upgrades legacy Gmail fallback URLs to resolved article URLs', () => {
+    const shouldUpgrade = shouldUpgradeNewsletterIssueUrl(
+      'https://mail.google.com/mail/u/0/#inbox/19c3d745ca305284',
+      'https://newsletter.example.com/posts/42'
+    );
+
+    expect(shouldUpgrade).toBe(true);
+  });
+
+  it('upgrades Substack redirect wrappers to final article URLs', () => {
+    const shouldUpgrade = shouldUpgradeNewsletterIssueUrl(
+      'https://substack.com/redirect/abc123?j=token',
+      'https://newsletter.example.com/posts/42'
+    );
+
+    expect(shouldUpgrade).toBe(true);
+  });
+
+  it('upgrades open.substack wrapper URLs to publication article URLs', () => {
+    const shouldUpgrade = shouldUpgradeNewsletterIssueUrl(
+      'https://open.substack.com/pub/lenny/p/getting-paid-to-vibe-code?redirect=app-store',
+      'https://lenny.substack.com/p/getting-paid-to-vibe-code'
+    );
+
+    expect(shouldUpgrade).toBe(true);
+  });
+
+  it('does not upgrade when URL quality is unchanged', () => {
+    const shouldUpgrade = shouldUpgradeNewsletterIssueUrl(
+      'https://newsletter.example.com/posts/42',
+      'https://newsletter.example.com/posts/42'
+    );
+
+    expect(shouldUpgrade).toBe(false);
+  });
+});

--- a/apps/worker/src/newsletters/gmail.ts
+++ b/apps/worker/src/newsletters/gmail.ts
@@ -1,0 +1,965 @@
+import { and, eq } from 'drizzle-orm';
+import { ulid } from 'ulid';
+import { ContentType, Provider } from '@zine/shared';
+
+import { createDb, type Database } from '../db';
+import { findOrCreateCreator } from '../db/helpers/creators';
+import {
+  gmailMailboxes,
+  newsletterFeeds,
+  newsletterFeedMessages,
+  items,
+  providerConnections,
+  userItems,
+} from '../db/schema';
+import { tryAcquireLock, releaseLock } from '../lib/locks';
+import { logger } from '../lib/logger';
+import type { ProviderConnection, TokenRefreshEnv } from '../lib/token-refresh';
+import { getValidAccessToken } from '../lib/token-refresh';
+import type { Bindings } from '../types';
+
+const gmailLogger = logger.child('gmail-newsletters');
+
+const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+const DEFAULT_INITIAL_DAYS = 30;
+const MAX_INITIAL_PAGES = 2;
+const MAX_INCREMENTAL_PAGES = 3;
+const MESSAGE_FETCH_CONCURRENCY = 5;
+const NEWSLETTER_SCORE_THRESHOLD = 0.55;
+const GMAIL_POLL_LOCK_KEY = 'cron:poll-gmail-newsletters:lock';
+const GMAIL_POLL_LOCK_TTL = 900;
+
+type GmailHeader = {
+  name?: string;
+  value?: string;
+};
+
+type GmailMessageListResponse = {
+  messages?: Array<{ id: string; threadId?: string }>;
+  nextPageToken?: string;
+};
+
+type GmailHistoryResponse = {
+  historyId?: string;
+  history?: Array<{
+    messagesAdded?: Array<{
+      message?: {
+        id?: string;
+      };
+    }>;
+  }>;
+  nextPageToken?: string;
+};
+
+type GmailMessageMetadata = {
+  id: string;
+  threadId?: string;
+  historyId?: string;
+  internalDate?: string;
+  snippet?: string;
+  payload?: {
+    headers?: GmailHeader[];
+  };
+};
+
+type GmailProfile = {
+  historyId?: string;
+  emailAddress?: string;
+};
+
+export type NewsletterFeedStatus = 'ACTIVE' | 'HIDDEN' | 'UNSUBSCRIBED';
+
+export interface GmailSyncResult {
+  mailboxId: string;
+  mode: 'initial' | 'incremental';
+  processedMessages: number;
+  newItems: number;
+  feedsUpserted: number;
+  latestHistoryId: string | null;
+}
+
+export interface GmailPollResult {
+  skipped: boolean;
+  processedMailboxes?: number;
+  newItems?: number;
+  reason?: string;
+}
+
+type NewsletterDetection = {
+  isNewsletter: boolean;
+  score: number;
+};
+
+type ParsedMessage = {
+  messageId: string;
+  threadId: string;
+  internalDateMs: number;
+  historyId: string | null;
+  fromAddress: string;
+  fromDisplayName: string;
+  subject: string;
+  snippet: string;
+  listId: string | null;
+  unsubscribeMailto: string | null;
+  unsubscribeUrl: string | null;
+  unsubscribePostHeader: string | null;
+  detection: NewsletterDetection;
+  canonicalKey: string;
+  issueUrl: string | null;
+};
+
+interface MessageIdFetchResult {
+  mode: 'initial' | 'incremental';
+  ids: string[];
+  latestHistoryId: string | null;
+}
+
+class GmailApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'GmailApiError';
+  }
+}
+
+class StaleHistoryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StaleHistoryError';
+  }
+}
+
+function normalizeHeaderValue(value: string | null | undefined): string {
+  return (value ?? '').trim();
+}
+
+function normalizeKeySegment(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function parseAddress(value: string): { email: string; displayName: string } {
+  const trimmed = value.trim();
+  const bracketMatch = trimmed.match(/^(.*)<([^>]+)>$/);
+
+  if (bracketMatch) {
+    return {
+      displayName: bracketMatch[1].replace(/"/g, '').trim() || bracketMatch[2].trim(),
+      email: bracketMatch[2].trim().toLowerCase(),
+    };
+  }
+
+  return {
+    displayName: trimmed || 'Newsletter',
+    email: trimmed.toLowerCase(),
+  };
+}
+
+function getHeaderValue(headers: GmailHeader[] | undefined, name: string): string | null {
+  if (!headers) return null;
+  const lowerName = name.toLowerCase();
+  const header = headers.find((entry) => entry.name?.toLowerCase() === lowerName);
+  return normalizeHeaderValue(header?.value ?? null) || null;
+}
+
+function parseListUnsubscribe(value: string | null): { mailto: string | null; url: string | null } {
+  if (!value) {
+    return { mailto: null, url: null };
+  }
+
+  const tokens = value
+    .split(',')
+    .map((part) => part.replace(/[<>]/g, '').trim())
+    .filter(Boolean);
+
+  let mailto: string | null = null;
+  let url: string | null = null;
+
+  for (const token of tokens) {
+    if (!mailto && token.toLowerCase().startsWith('mailto:')) {
+      mailto = token;
+      continue;
+    }
+
+    if (!url && /^https?:\/\//i.test(token)) {
+      url = token;
+    }
+  }
+
+  return { mailto, url };
+}
+
+function extractFirstUrl(snippet: string): string | null {
+  const match = snippet.match(/https?:\/\/[^\s)]+/i);
+  return match?.[0] ?? null;
+}
+
+function computeNewsletterScore(params: {
+  listId: string | null;
+  listUnsubscribe: string | null;
+  unsubscribePostHeader: string | null;
+  fromAddress: string;
+  subject: string;
+}): NewsletterDetection {
+  let score = 0;
+
+  if (params.listId) {
+    score += 0.65;
+  }
+
+  if (params.listUnsubscribe) {
+    score += 0.35;
+  }
+
+  if (params.unsubscribePostHeader?.toLowerCase().includes('one-click')) {
+    score += 0.1;
+  }
+
+  if (/newsletter|digest|updates|weekly|daily/i.test(params.fromAddress)) {
+    score += 0.1;
+  }
+
+  if (/receipt|invoice|statement|verification|security|password|order/i.test(params.subject)) {
+    score -= 0.5;
+  }
+
+  const clamped = Math.max(0, Math.min(1, score));
+  return {
+    isNewsletter: clamped >= NEWSLETTER_SCORE_THRESHOLD,
+    score: clamped,
+  };
+}
+
+function buildCanonicalKey(params: {
+  listId: string | null;
+  unsubscribeUrl: string | null;
+  unsubscribeMailto: string | null;
+  fromAddress: string;
+}): string {
+  if (params.listId) {
+    return `list:${normalizeKeySegment(params.listId)}`;
+  }
+
+  if (params.unsubscribeUrl) {
+    return `unsub-url:${normalizeKeySegment(params.unsubscribeUrl)}`;
+  }
+
+  if (params.unsubscribeMailto) {
+    return `unsub-mailto:${normalizeKeySegment(params.unsubscribeMailto)}`;
+  }
+
+  return `from:${normalizeKeySegment(params.fromAddress)}`;
+}
+
+function buildGmailFallbackUrl(threadId: string): string {
+  return `https://mail.google.com/mail/u/0/#inbox/${threadId}`;
+}
+
+async function gmailGet<T>(accessToken: string, path: string): Promise<T> {
+  const response = await fetch(`${GMAIL_API_BASE}/${path}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new GmailApiError(response.status, `Gmail API request failed (${response.status}): ${body}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchMessageIdsInitial(accessToken: string): Promise<MessageIdFetchResult> {
+  const messageIds: string[] = [];
+  let pageToken: string | undefined;
+
+  for (let page = 0; page < MAX_INITIAL_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      maxResults: '100',
+      q: `in:inbox newer_than:${DEFAULT_INITIAL_DAYS}d`,
+    });
+
+    if (pageToken) {
+      params.set('pageToken', pageToken);
+    }
+
+    const response = await gmailGet<GmailMessageListResponse>(
+      accessToken,
+      `messages?${params.toString()}`
+    );
+
+    for (const message of response.messages ?? []) {
+      if (message.id) {
+        messageIds.push(message.id);
+      }
+    }
+
+    if (!response.nextPageToken) {
+      break;
+    }
+
+    pageToken = response.nextPageToken;
+  }
+
+  const profile = await gmailGet<GmailProfile>(accessToken, 'profile');
+
+  return {
+    mode: 'initial',
+    ids: Array.from(new Set(messageIds)),
+    latestHistoryId: profile.historyId ?? null,
+  };
+}
+
+async function fetchMessageIdsIncremental(
+  accessToken: string,
+  historyId: string
+): Promise<MessageIdFetchResult> {
+  const messageIds: string[] = [];
+  let pageToken: string | undefined;
+  let latestHistoryId: string | null = historyId;
+
+  for (let page = 0; page < MAX_INCREMENTAL_PAGES; page += 1) {
+    const params = new URLSearchParams({
+      startHistoryId: historyId,
+      historyTypes: 'messageAdded',
+      maxResults: '100',
+    });
+
+    if (pageToken) {
+      params.set('pageToken', pageToken);
+    }
+
+    let response: GmailHistoryResponse;
+    try {
+      response = await gmailGet<GmailHistoryResponse>(accessToken, `history?${params.toString()}`);
+    } catch (error) {
+      if (error instanceof GmailApiError && error.status === 404) {
+        throw new StaleHistoryError('Stored Gmail history cursor is no longer valid');
+      }
+      throw error;
+    }
+
+    latestHistoryId = response.historyId ?? latestHistoryId;
+
+    for (const historyEntry of response.history ?? []) {
+      for (const added of historyEntry.messagesAdded ?? []) {
+        if (added.message?.id) {
+          messageIds.push(added.message.id);
+        }
+      }
+    }
+
+    if (!response.nextPageToken) {
+      break;
+    }
+
+    pageToken = response.nextPageToken;
+  }
+
+  return {
+    mode: 'incremental',
+    ids: Array.from(new Set(messageIds)),
+    latestHistoryId,
+  };
+}
+
+async function fetchMessageMetadata(
+  accessToken: string,
+  messageId: string
+): Promise<GmailMessageMetadata> {
+  const params = new URLSearchParams({
+    format: 'metadata',
+  });
+
+  const headerNames = ['From', 'Subject', 'List-Id', 'List-Unsubscribe', 'List-Unsubscribe-Post'];
+  for (const name of headerNames) {
+    params.append('metadataHeaders', name);
+  }
+
+  return gmailGet<GmailMessageMetadata>(
+    accessToken,
+    `messages/${encodeURIComponent(messageId)}?${params.toString()}`
+  );
+}
+
+function parseMessage(metadata: GmailMessageMetadata): ParsedMessage | null {
+  if (!metadata.id) {
+    return null;
+  }
+
+  const headers = metadata.payload?.headers;
+  const fromRaw = getHeaderValue(headers, 'From');
+  const subject = getHeaderValue(headers, 'Subject') ?? '(No subject)';
+  const listId = getHeaderValue(headers, 'List-Id');
+  const listUnsubscribe = getHeaderValue(headers, 'List-Unsubscribe');
+  const unsubscribePostHeader = getHeaderValue(headers, 'List-Unsubscribe-Post');
+
+  if (!fromRaw) {
+    return null;
+  }
+
+  const { email: fromAddress, displayName } = parseAddress(fromRaw);
+  const parsedUnsubscribe = parseListUnsubscribe(listUnsubscribe);
+  const detection = computeNewsletterScore({
+    listId,
+    listUnsubscribe,
+    unsubscribePostHeader,
+    fromAddress,
+    subject,
+  });
+
+  const internalDateMs = Number.parseInt(metadata.internalDate ?? '', 10) || Date.now();
+  const snippet = metadata.snippet?.trim() ?? '';
+  const threadId = metadata.threadId ?? metadata.id;
+
+  const issueUrl = extractFirstUrl(snippet);
+
+  return {
+    messageId: metadata.id,
+    threadId,
+    internalDateMs,
+    historyId: metadata.historyId ?? null,
+    fromAddress,
+    fromDisplayName: displayName,
+    subject,
+    snippet,
+    listId,
+    unsubscribeMailto: parsedUnsubscribe.mailto,
+    unsubscribeUrl: parsedUnsubscribe.url,
+    unsubscribePostHeader,
+    detection,
+    canonicalKey: buildCanonicalKey({
+      listId,
+      unsubscribeUrl: parsedUnsubscribe.url,
+      unsubscribeMailto: parsedUnsubscribe.mailto,
+      fromAddress,
+    }),
+    issueUrl,
+  };
+}
+
+async function getGmailConnection(
+  userId: string,
+  db: Database
+): Promise<ProviderConnection | null> {
+  const connection = await db.query.providerConnections.findFirst({
+    where: and(
+      eq(providerConnections.userId, userId),
+      eq(providerConnections.provider, Provider.GMAIL),
+      eq(providerConnections.status, 'ACTIVE')
+    ),
+  });
+
+  return (connection as ProviderConnection | undefined) ?? null;
+}
+
+async function ensureMailboxRecord(
+  db: Database,
+  userId: string,
+  connectionId: string,
+  accessToken: string
+) {
+  const existing = await db.query.gmailMailboxes.findFirst({
+    where: and(
+      eq(gmailMailboxes.userId, userId),
+      eq(gmailMailboxes.providerConnectionId, connectionId)
+    ),
+  });
+
+  const profile = await gmailGet<GmailProfile>(accessToken, 'profile');
+
+  const googleSubResponse = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!googleSubResponse.ok) {
+    const body = await googleSubResponse.text();
+    throw new Error(`Failed to load Google user info: ${googleSubResponse.status} ${body}`);
+  }
+
+  const googleUserInfo = (await googleSubResponse.json()) as { id?: string; email?: string };
+  const googleSub = googleUserInfo.id ?? existing?.googleSub;
+  const email = profile.emailAddress ?? googleUserInfo.email ?? existing?.email;
+
+  if (!googleSub || !email) {
+    throw new Error('Missing Google identity details while initializing Gmail mailbox');
+  }
+
+  const now = Date.now();
+
+  if (existing) {
+    await db
+      .update(gmailMailboxes)
+      .set({
+        googleSub,
+        email,
+        updatedAt: now,
+      })
+      .where(eq(gmailMailboxes.id, existing.id));
+
+    return {
+      ...existing,
+      googleSub,
+      email,
+    };
+  }
+
+  const mailboxId = ulid();
+  await db.insert(gmailMailboxes).values({
+    id: mailboxId,
+    userId,
+    providerConnectionId: connectionId,
+    googleSub,
+    email,
+    historyId: profile.historyId ?? null,
+    watchExpirationAt: null,
+    lastSyncAt: null,
+    lastSyncStatus: 'IDLE',
+    lastSyncError: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return {
+    id: mailboxId,
+    userId,
+    providerConnectionId: connectionId,
+    googleSub,
+    email,
+    historyId: profile.historyId ?? null,
+    watchExpirationAt: null,
+    lastSyncAt: null,
+    lastSyncStatus: 'IDLE',
+    lastSyncError: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function upsertNewsletterFeed(
+  db: Database,
+  userId: string,
+  mailboxId: string,
+  parsed: ParsedMessage
+) {
+  const now = Date.now();
+
+  const existing = await db.query.newsletterFeeds.findFirst({
+    where: and(
+      eq(newsletterFeeds.userId, userId),
+      eq(newsletterFeeds.canonicalKey, parsed.canonicalKey)
+    ),
+  });
+
+  if (existing) {
+    await db
+      .update(newsletterFeeds)
+      .set({
+        listId: parsed.listId,
+        fromAddress: parsed.fromAddress,
+        displayName: parsed.fromDisplayName,
+        unsubscribeMailto: parsed.unsubscribeMailto,
+        unsubscribeUrl: parsed.unsubscribeUrl,
+        unsubscribePostHeader: parsed.unsubscribePostHeader,
+        detectionScore: Math.max(existing.detectionScore, parsed.detection.score),
+        lastSeenAt: parsed.internalDateMs,
+        updatedAt: now,
+      })
+      .where(eq(newsletterFeeds.id, existing.id));
+
+    return {
+      ...existing,
+      status: existing.status as NewsletterFeedStatus,
+    };
+  }
+
+  const feedId = ulid();
+  await db.insert(newsletterFeeds).values({
+    id: feedId,
+    userId,
+    gmailMailboxId: mailboxId,
+    canonicalKey: parsed.canonicalKey,
+    listId: parsed.listId,
+    fromAddress: parsed.fromAddress,
+    displayName: parsed.fromDisplayName,
+    unsubscribeMailto: parsed.unsubscribeMailto,
+    unsubscribeUrl: parsed.unsubscribeUrl,
+    unsubscribePostHeader: parsed.unsubscribePostHeader,
+    detectionScore: parsed.detection.score,
+    status: 'ACTIVE',
+    firstSeenAt: parsed.internalDateMs,
+    lastSeenAt: parsed.internalDateMs,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return {
+    id: feedId,
+    status: 'ACTIVE' as NewsletterFeedStatus,
+  };
+}
+
+async function ingestNewsletterMessage(params: {
+  db: Database;
+  userId: string;
+  mailboxId: string;
+  googleSub: string;
+  parsed: ParsedMessage;
+  feedId: string;
+}): Promise<boolean> {
+  const existingMapping = await params.db.query.newsletterFeedMessages.findFirst({
+    where: and(
+      eq(newsletterFeedMessages.userId, params.userId),
+      eq(newsletterFeedMessages.gmailMessageId, params.parsed.messageId)
+    ),
+    columns: { id: true },
+  });
+
+  if (existingMapping) {
+    return false;
+  }
+
+  const providerId = `${params.googleSub}:${params.parsed.messageId}`;
+  const issueUrl = params.parsed.issueUrl ?? buildGmailFallbackUrl(params.parsed.threadId);
+  const publishedAtIso = new Date(params.parsed.internalDateMs).toISOString();
+  const nowIso = new Date().toISOString();
+
+  const creator = await findOrCreateCreator(
+    { db: params.db },
+    {
+      provider: Provider.GMAIL,
+      providerCreatorId: params.parsed.canonicalKey,
+      name: params.parsed.fromDisplayName,
+      handle: params.parsed.fromAddress,
+      externalUrl: issueUrl,
+    }
+  );
+
+  await params.db
+    .insert(items)
+    .values({
+      id: ulid(),
+      contentType: ContentType.ARTICLE,
+      provider: Provider.GMAIL,
+      providerId,
+      canonicalUrl: issueUrl,
+      title: params.parsed.subject,
+      thumbnailUrl: null,
+      creatorId: creator.id,
+      publisher: params.parsed.fromDisplayName,
+      summary: params.parsed.snippet || null,
+      duration: null,
+      publishedAt: publishedAtIso,
+      rawMetadata: JSON.stringify({
+        messageId: params.parsed.messageId,
+        threadId: params.parsed.threadId,
+        listId: params.parsed.listId,
+        fromAddress: params.parsed.fromAddress,
+        unsubscribeUrl: params.parsed.unsubscribeUrl,
+      }),
+      wordCount: null,
+      readingTimeMinutes: null,
+      articleContentKey: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    })
+    .onConflictDoNothing({
+      target: [items.provider, items.providerId],
+    });
+
+  const canonicalItem = await params.db.query.items.findFirst({
+    where: and(eq(items.provider, Provider.GMAIL), eq(items.providerId, providerId)),
+    columns: { id: true },
+  });
+
+  if (!canonicalItem) {
+    throw new Error(`Failed to load created newsletter item for providerId=${providerId}`);
+  }
+
+  await params.db
+    .insert(userItems)
+    .values({
+      id: ulid(),
+      userId: params.userId,
+      itemId: canonicalItem.id,
+      state: 'INBOX',
+      ingestedAt: nowIso,
+      bookmarkedAt: null,
+      archivedAt: null,
+      lastOpenedAt: null,
+      progressPosition: null,
+      progressDuration: null,
+      progressUpdatedAt: null,
+      isFinished: false,
+      finishedAt: null,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    })
+    .onConflictDoNothing({
+      target: [userItems.userId, userItems.itemId],
+    });
+
+  await params.db
+    .insert(newsletterFeedMessages)
+    .values({
+      id: ulid(),
+      userId: params.userId,
+      gmailMailboxId: params.mailboxId,
+      newsletterFeedId: params.feedId,
+      gmailMessageId: params.parsed.messageId,
+      gmailThreadId: params.parsed.threadId,
+      itemId: canonicalItem.id,
+      internalDate: params.parsed.internalDateMs,
+      createdAt: Date.now(),
+    })
+    .onConflictDoNothing({
+      target: [newsletterFeedMessages.userId, newsletterFeedMessages.gmailMessageId],
+    });
+
+  return true;
+}
+
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results: R[] = [];
+  let index = 0;
+
+  const tasks = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (index < items.length) {
+      const itemIndex = index;
+      index += 1;
+      results[itemIndex] = await worker(items[itemIndex]);
+    }
+  });
+
+  await Promise.all(tasks);
+  return results;
+}
+
+export async function syncGmailNewslettersForUser(
+  userId: string,
+  db: Database,
+  env: TokenRefreshEnv,
+  options?: {
+    forceFull?: boolean;
+    mailboxId?: string;
+  }
+): Promise<GmailSyncResult> {
+  const connection = await getGmailConnection(userId, db);
+  if (!connection) {
+    throw new Error('No active Gmail connection found');
+  }
+
+  const accessToken = await getValidAccessToken(connection, env);
+
+  const mailboxConditions = [
+    eq(gmailMailboxes.userId, userId),
+    eq(gmailMailboxes.providerConnectionId, connection.id),
+  ];
+  if (options?.mailboxId) {
+    mailboxConditions.push(eq(gmailMailboxes.id, options.mailboxId));
+  }
+
+  let mailbox = await db.query.gmailMailboxes.findFirst({
+    where: and(...mailboxConditions),
+  });
+
+  if (!mailbox) {
+    mailbox = await ensureMailboxRecord(db, userId, connection.id, accessToken);
+  }
+
+  const now = Date.now();
+  await db
+    .update(gmailMailboxes)
+    .set({
+      lastSyncStatus: 'RUNNING',
+      lastSyncError: null,
+      updatedAt: now,
+    })
+    .where(eq(gmailMailboxes.id, mailbox.id));
+
+  try {
+    let messageIds: MessageIdFetchResult;
+
+    if (mailbox.historyId && !options?.forceFull) {
+      try {
+        messageIds = await fetchMessageIdsIncremental(accessToken, mailbox.historyId);
+      } catch (error) {
+        if (error instanceof StaleHistoryError) {
+          gmailLogger.warn('History cursor stale, falling back to initial sync', {
+            mailboxId: mailbox.id,
+            userId,
+          });
+          messageIds = await fetchMessageIdsInitial(accessToken);
+        } else {
+          throw error;
+        }
+      }
+    } else {
+      messageIds = await fetchMessageIdsInitial(accessToken);
+    }
+
+    const metadataResults = await runWithConcurrency(
+      messageIds.ids,
+      MESSAGE_FETCH_CONCURRENCY,
+      async (messageId) => {
+        try {
+          return await fetchMessageMetadata(accessToken, messageId);
+        } catch (error) {
+          gmailLogger.warn('Failed to fetch Gmail message metadata', {
+            mailboxId: mailbox.id,
+            messageId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      }
+    );
+
+    let processedMessages = 0;
+    let newItems = 0;
+    let feedsUpserted = 0;
+    let latestHistoryId = messageIds.latestHistoryId;
+
+    for (const metadata of metadataResults) {
+      if (!metadata) {
+        continue;
+      }
+
+      const parsed = parseMessage(metadata);
+      if (!parsed || !parsed.detection.isNewsletter) {
+        continue;
+      }
+
+      processedMessages += 1;
+      if (parsed.historyId) {
+        latestHistoryId = parsed.historyId;
+      }
+
+      const feed = await upsertNewsletterFeed(db, userId, mailbox.id, parsed);
+      feedsUpserted += 1;
+
+      if (feed.status !== 'ACTIVE') {
+        continue;
+      }
+
+      const created = await ingestNewsletterMessage({
+        db,
+        userId,
+        mailboxId: mailbox.id,
+        googleSub: mailbox.googleSub,
+        parsed,
+        feedId: feed.id,
+      });
+
+      if (created) {
+        newItems += 1;
+      }
+    }
+
+    const completedAt = Date.now();
+    await db
+      .update(gmailMailboxes)
+      .set({
+        historyId: latestHistoryId ?? mailbox.historyId,
+        lastSyncAt: completedAt,
+        lastSyncStatus: 'SUCCESS',
+        lastSyncError: null,
+        updatedAt: completedAt,
+      })
+      .where(eq(gmailMailboxes.id, mailbox.id));
+
+    return {
+      mailboxId: mailbox.id,
+      mode: messageIds.mode,
+      processedMessages,
+      newItems,
+      feedsUpserted,
+      latestHistoryId: latestHistoryId ?? null,
+    };
+  } catch (error) {
+    const failedAt = Date.now();
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    await db
+      .update(gmailMailboxes)
+      .set({
+        lastSyncStatus: 'ERROR',
+        lastSyncError: errorMessage,
+        updatedAt: failedAt,
+      })
+      .where(eq(gmailMailboxes.id, mailbox.id));
+
+    throw error;
+  }
+}
+
+export async function ensureGmailMailboxForConnection(params: {
+  db: Database;
+  userId: string;
+  connection: ProviderConnection;
+  env: TokenRefreshEnv;
+}) {
+  const accessToken = await getValidAccessToken(params.connection, params.env);
+  return ensureMailboxRecord(params.db, params.userId, params.connection.id, accessToken);
+}
+
+export async function pollGmailNewsletters(
+  env: Bindings,
+  _ctx: ExecutionContext
+): Promise<GmailPollResult> {
+  const lockAcquired = await tryAcquireLock(env.OAUTH_STATE_KV, GMAIL_POLL_LOCK_KEY, GMAIL_POLL_LOCK_TTL);
+  if (!lockAcquired) {
+    gmailLogger.info('Skipped Gmail newsletter polling: lock held');
+    return { skipped: true, reason: 'lock_held' };
+  }
+
+  try {
+    const db = createDb(env.DB);
+    const mailboxes = await db.query.gmailMailboxes.findMany({
+      limit: 25,
+    });
+
+    if (mailboxes.length === 0) {
+      return { skipped: false, processedMailboxes: 0, newItems: 0, reason: 'no_mailboxes' };
+    }
+
+    let processedMailboxes = 0;
+    let newItems = 0;
+
+    for (const mailbox of mailboxes) {
+      try {
+        const result = await syncGmailNewslettersForUser(mailbox.userId, db, env as TokenRefreshEnv, {
+          mailboxId: mailbox.id,
+        });
+        processedMailboxes += 1;
+        newItems += result.newItems;
+      } catch (error) {
+        gmailLogger.error('Failed polling Gmail mailbox', {
+          mailboxId: mailbox.id,
+          userId: mailbox.userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return {
+      skipped: false,
+      processedMailboxes,
+      newItems,
+    };
+  } finally {
+    await releaseLock(env.OAUTH_STATE_KV, GMAIL_POLL_LOCK_KEY);
+  }
+}

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -3,6 +3,7 @@ import { router } from './trpc';
 import { itemsRouter } from './routers/items';
 import { subscriptionsRouter } from './routers/subscriptions';
 import { connectionsRouter } from './routers/connections';
+import { newslettersRouter } from './routers/newsletters';
 import { bookmarksRouter } from './routers/bookmarks';
 import { creatorsRouter } from './routers/creators';
 import { adminRouter } from './routers/admin';
@@ -53,6 +54,7 @@ export const appRouter = router({
     syncStatus: subscriptionsRouter.syncStatus,
     activeSyncJob: subscriptionsRouter.activeSyncJob,
     discover: subscriptionsRouter.discover,
+    newsletters: newslettersRouter,
   }),
   // Admin operations (data repair, diagnostics)
   admin: adminRouter,

--- a/apps/worker/src/trpc/routers/connections.test.ts
+++ b/apps/worker/src/trpc/routers/connections.test.ts
@@ -103,7 +103,7 @@ function createMockContext(userId: string | null = TEST_USER_ID) {
  */
 function createMockConnectionsCaller(ctx: ReturnType<typeof createMockContext>) {
   return {
-    registerState: async (input: { provider: 'YOUTUBE' | 'SPOTIFY'; state: string }) => {
+    registerState: async (input: { provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'; state: string }) => {
       if (!ctx.userId) {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
       }
@@ -120,7 +120,7 @@ function createMockConnectionsCaller(ctx: ReturnType<typeof createMockContext>) 
     },
 
     callback: async (input: {
-      provider: 'YOUTUBE' | 'SPOTIFY';
+      provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL';
       code: string;
       state: string;
       codeVerifier: string;
@@ -187,10 +187,11 @@ function createMockConnectionsCaller(ctx: ReturnType<typeof createMockContext>) 
       return {
         YOUTUBE: connections?.find((c: { provider: string }) => c.provider === 'YOUTUBE') ?? null,
         SPOTIFY: connections?.find((c: { provider: string }) => c.provider === 'SPOTIFY') ?? null,
+        GMAIL: connections?.find((c: { provider: string }) => c.provider === 'GMAIL') ?? null,
       };
     },
 
-    disconnect: async (_input: { provider: 'YOUTUBE' | 'SPOTIFY' }) => {
+    disconnect: async (_input: { provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL' }) => {
       if (!ctx.userId) {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
       }
@@ -581,6 +582,7 @@ describe('Connections Router', () => {
       expect(result).toEqual({
         YOUTUBE: null,
         SPOTIFY: null,
+        GMAIL: null,
       });
     });
 
@@ -603,6 +605,7 @@ describe('Connections Router', () => {
       expect(result.YOUTUBE?.provider).toBe('YOUTUBE');
       expect(result.YOUTUBE?.status).toBe('ACTIVE');
       expect(result.SPOTIFY).toBeNull();
+      expect(result.GMAIL).toBeNull();
     });
 
     it('should return connection info for both providers', async () => {
@@ -623,6 +626,7 @@ describe('Connections Router', () => {
       expect(result.SPOTIFY).not.toBeNull();
       expect(result.YOUTUBE?.provider).toBe('YOUTUBE');
       expect(result.SPOTIFY?.provider).toBe('SPOTIFY');
+      expect(result.GMAIL).toBeNull();
     });
 
     it('should return EXPIRED status for expired connections', async () => {

--- a/apps/worker/src/trpc/routers/newsletters.ts
+++ b/apps/worker/src/trpc/routers/newsletters.ts
@@ -1,12 +1,24 @@
 import { TRPCError } from '@trpc/server';
-import { and, desc, eq, like, lt } from 'drizzle-orm';
+import { and, desc, eq, inArray, like, lt } from 'drizzle-orm';
 import { z } from 'zod';
 import { ulid } from 'ulid';
 
-import { newsletterFeeds, newsletterUnsubscribeEvents, gmailMailboxes } from '../../db/schema';
-import { syncGmailNewslettersForUser } from '../../newsletters/gmail';
+import {
+  newsletterFeeds,
+  newsletterUnsubscribeEvents,
+  gmailMailboxes,
+  newsletterFeedMessages,
+  items,
+  providerConnections,
+} from '../../db/schema';
+import {
+  syncGmailNewslettersForUser,
+  isLikelyNewsletterFeedIdentity,
+  seedLatestNewsletterItemForFeed,
+} from '../../newsletters/gmail';
 import type { TokenRefreshEnv } from '../../lib/token-refresh';
 import { protectedProcedure, router } from '../trpc';
+import type { Database } from '../../db';
 
 const NewsletterFeedStatusSchema = z.enum(['ACTIVE', 'HIDDEN', 'UNSUBSCRIBED']);
 
@@ -26,57 +38,185 @@ const UnsubscribeInputSchema = z.object({
   feedId: z.string().min(1),
 });
 
+type ActiveGmailMailbox = {
+  id: string;
+  lastSyncAt: number | null;
+  lastSyncStatus: string;
+  lastSyncError: string | null;
+  updatedAt: number;
+};
+
+async function getActiveGmailMailboxes(
+  db: Database,
+  userId: string
+): Promise<ActiveGmailMailbox[]> {
+  const connection = await db.query.providerConnections.findFirst({
+    where: and(
+      eq(providerConnections.userId, userId),
+      eq(providerConnections.provider, 'GMAIL'),
+      eq(providerConnections.status, 'ACTIVE')
+    ),
+    columns: {
+      id: true,
+    },
+  });
+
+  if (!connection) {
+    return [];
+  }
+
+  return db.query.gmailMailboxes.findMany({
+    where: and(
+      eq(gmailMailboxes.userId, userId),
+      eq(gmailMailboxes.providerConnectionId, connection.id)
+    ),
+    columns: {
+      id: true,
+      lastSyncAt: true,
+      lastSyncStatus: true,
+      lastSyncError: true,
+      updatedAt: true,
+    },
+  });
+}
+
 export const newslettersRouter = router({
-  list: protectedProcedure.input(ListNewslettersInputSchema.optional()).query(async ({ ctx, input }) => {
-    const limit = input?.limit ?? 50;
-    const conditions = [eq(newsletterFeeds.userId, ctx.userId)];
+  list: protectedProcedure
+    .input(ListNewslettersInputSchema.optional())
+    .query(async ({ ctx, input }) => {
+      const limit = input?.limit ?? 50;
+      const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+      const mailboxIds = activeMailboxes.map((row) => row.id);
 
-    if (input?.status) {
-      conditions.push(eq(newsletterFeeds.status, input.status));
-    }
+      if (mailboxIds.length === 0) {
+        return {
+          items: [],
+          nextCursor: null,
+          hasMore: false,
+        };
+      }
 
-    if (input?.search) {
-      const term = `%${input.search.toLowerCase()}%`;
-      conditions.push(
-        like(newsletterFeeds.displayName, term)
+      const conditions = [
+        eq(newsletterFeeds.userId, ctx.userId),
+        inArray(newsletterFeeds.gmailMailboxId, mailboxIds),
+      ];
+
+      if (input?.status) {
+        conditions.push(eq(newsletterFeeds.status, input.status));
+      }
+
+      if (input?.search) {
+        const term = `%${input.search.toLowerCase()}%`;
+        conditions.push(like(newsletterFeeds.displayName, term));
+      }
+
+      if (input?.cursor) {
+        conditions.push(lt(newsletterFeeds.id, input.cursor));
+      }
+
+      const rows = await ctx.db.query.newsletterFeeds.findMany({
+        where: and(...conditions),
+        orderBy: [desc(newsletterFeeds.lastSeenAt), desc(newsletterFeeds.id)],
+        limit: limit + 1,
+      });
+
+      const hasMore = rows.length > limit;
+      const visibleRows = (hasMore ? rows.slice(0, limit) : rows).filter((row) =>
+        isLikelyNewsletterFeedIdentity({
+          listId: row.listId,
+          unsubscribeMailto: row.unsubscribeMailto,
+          unsubscribeUrl: row.unsubscribeUrl,
+          fromAddress: row.fromAddress,
+          displayName: row.displayName,
+        })
       );
-    }
 
-    if (input?.cursor) {
-      conditions.push(lt(newsletterFeeds.id, input.cursor));
-    }
+      const latestThumbnailByFeedId = new Map<string, string | null>();
+      const visibleFeedIds = visibleRows.map((row) => row.id);
 
-    const rows = await ctx.db.query.newsletterFeeds.findMany({
-      where: and(...conditions),
-      orderBy: [desc(newsletterFeeds.lastSeenAt), desc(newsletterFeeds.id)],
-      limit: limit + 1,
-    });
+      if (visibleFeedIds.length > 0) {
+        const messageRows = await ctx.db.query.newsletterFeedMessages.findMany({
+          where: and(
+            eq(newsletterFeedMessages.userId, ctx.userId),
+            inArray(newsletterFeedMessages.newsletterFeedId, visibleFeedIds)
+          ),
+          columns: {
+            newsletterFeedId: true,
+            itemId: true,
+            internalDate: true,
+            createdAt: true,
+          },
+          orderBy: [
+            desc(newsletterFeedMessages.internalDate),
+            desc(newsletterFeedMessages.createdAt),
+          ],
+        });
 
-    const hasMore = rows.length > limit;
-    const items = hasMore ? rows.slice(0, limit) : rows;
+        const latestItemIdByFeedId = new Map<string, string>();
+        for (const row of messageRows) {
+          if (!latestItemIdByFeedId.has(row.newsletterFeedId)) {
+            latestItemIdByFeedId.set(row.newsletterFeedId, row.itemId);
+          }
+        }
 
-    return {
-      items: items.map((row) => ({
-        id: row.id,
-        displayName: row.displayName ?? row.fromAddress ?? 'Newsletter',
-        fromAddress: row.fromAddress,
-        status: row.status,
-        detectionScore: row.detectionScore,
-        lastSeenAt: row.lastSeenAt,
-        firstSeenAt: row.firstSeenAt,
-        unsubscribeUrl: row.unsubscribeUrl,
-        unsubscribeMailto: row.unsubscribeMailto,
-      })),
-      nextCursor: hasMore && items.length > 0 ? items[items.length - 1].id : null,
-      hasMore,
-    };
-  }),
+        const latestItemIds = Array.from(new Set(latestItemIdByFeedId.values()));
+        if (latestItemIds.length > 0) {
+          const latestItems = await ctx.db.query.items.findMany({
+            where: inArray(items.id, latestItemIds),
+            columns: {
+              id: true,
+              thumbnailUrl: true,
+            },
+          });
+
+          const thumbnailByItemId = new Map(
+            latestItems.map((item) => [item.id, item.thumbnailUrl])
+          );
+
+          for (const [feedId, itemId] of latestItemIdByFeedId.entries()) {
+            latestThumbnailByFeedId.set(feedId, thumbnailByItemId.get(itemId) ?? null);
+          }
+        }
+      }
+
+      return {
+        items: visibleRows.map((row) => ({
+          id: row.id,
+          displayName: row.displayName ?? row.fromAddress ?? 'Newsletter',
+          fromAddress: row.fromAddress,
+          listId: row.listId,
+          imageUrl: latestThumbnailByFeedId.get(row.id) ?? null,
+          status: row.status,
+          detectionScore: row.detectionScore,
+          lastSeenAt: row.lastSeenAt,
+          firstSeenAt: row.firstSeenAt,
+          unsubscribeUrl: row.unsubscribeUrl,
+          unsubscribeMailto: row.unsubscribeMailto,
+        })),
+        nextCursor: hasMore ? (rows[rows.length - 1]?.id ?? null) : null,
+        hasMore,
+      };
+    }),
 
   updateStatus: protectedProcedure
     .input(UpdateStatusInputSchema)
     .mutation(async ({ ctx, input }) => {
+      const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+      const mailboxIds = activeMailboxes.map((row) => row.id);
+
+      if (mailboxIds.length === 0) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Gmail is not connected. Connect Gmail to manage newsletters.',
+        });
+      }
+
       const row = await ctx.db.query.newsletterFeeds.findFirst({
-        where: and(eq(newsletterFeeds.id, input.feedId), eq(newsletterFeeds.userId, ctx.userId)),
+        where: and(
+          eq(newsletterFeeds.id, input.feedId),
+          eq(newsletterFeeds.userId, ctx.userId),
+          inArray(newsletterFeeds.gmailMailboxId, mailboxIds)
+        ),
       });
 
       if (!row) {
@@ -91,12 +231,51 @@ export const newslettersRouter = router({
         })
         .where(eq(newsletterFeeds.id, input.feedId));
 
-      return { success: true as const };
+      let seededLatestItem = false;
+      let seedReason: string | null = null;
+      const shouldSeedLatest = row.status !== 'ACTIVE' && input.status === 'ACTIVE';
+
+      if (shouldSeedLatest) {
+        try {
+          const seedResult = await seedLatestNewsletterItemForFeed({
+            db: ctx.db,
+            userId: ctx.userId,
+            feedId: row.id,
+            env: ctx.env as TokenRefreshEnv,
+          });
+
+          seededLatestItem = seedResult.created;
+          seedReason = seedResult.reason;
+        } catch (error) {
+          // Status update should still succeed if seeding fails.
+          seedReason = error instanceof Error ? error.message : 'seed_failed';
+        }
+      }
+
+      return {
+        success: true as const,
+        seededLatestItem,
+        seedReason,
+      };
     }),
 
   unsubscribe: protectedProcedure.input(UnsubscribeInputSchema).mutation(async ({ ctx, input }) => {
+    const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+    const mailboxIds = activeMailboxes.map((row) => row.id);
+
+    if (mailboxIds.length === 0) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Gmail is not connected. Connect Gmail to manage newsletters.',
+      });
+    }
+
     const feed = await ctx.db.query.newsletterFeeds.findFirst({
-      where: and(eq(newsletterFeeds.id, input.feedId), eq(newsletterFeeds.userId, ctx.userId)),
+      where: and(
+        eq(newsletterFeeds.id, input.feedId),
+        eq(newsletterFeeds.userId, ctx.userId),
+        inArray(newsletterFeeds.gmailMailboxId, mailboxIds)
+      ),
     });
 
     if (!feed) {
@@ -110,10 +289,7 @@ export const newslettersRouter = router({
     let status: 'REQUESTED' | 'COMPLETED' | 'FAILED' = 'REQUESTED';
     let errorMessage: string | null = null;
 
-    if (
-      feed.unsubscribePostHeader?.toLowerCase().includes('one-click') &&
-      feed.unsubscribeUrl
-    ) {
+    if (feed.unsubscribePostHeader?.toLowerCase().includes('one-click') && feed.unsubscribeUrl) {
       method = 'ONE_CLICK_POST';
       target = feed.unsubscribeUrl;
 
@@ -177,6 +353,14 @@ export const newslettersRouter = router({
   }),
 
   syncNow: protectedProcedure.mutation(async ({ ctx }) => {
+    const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+    if (activeMailboxes.length === 0) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Gmail is not connected. Connect Gmail before syncing newsletters.',
+      });
+    }
+
     try {
       const result = await syncGmailNewslettersForUser(
         ctx.userId,
@@ -184,9 +368,44 @@ export const newslettersRouter = router({
         ctx.env as TokenRefreshEnv
       );
 
+      // Repair/upgrade latest issue links for active feeds (legacy mail.google.com URLs).
+      // This runs only on manual "Sync now" and is best-effort.
+      const mailboxIds = activeMailboxes.map((row) => row.id);
+      const activeFeeds = await ctx.db.query.newsletterFeeds.findMany({
+        where: and(
+          eq(newsletterFeeds.userId, ctx.userId),
+          inArray(newsletterFeeds.gmailMailboxId, mailboxIds),
+          eq(newsletterFeeds.status, 'ACTIVE')
+        ),
+        columns: {
+          id: true,
+        },
+      });
+
+      let repairedFeeds = 0;
+      let repairFailures = 0;
+      for (const feed of activeFeeds) {
+        try {
+          await seedLatestNewsletterItemForFeed({
+            db: ctx.db,
+            userId: ctx.userId,
+            feedId: feed.id,
+            env: ctx.env as TokenRefreshEnv,
+          });
+          repairedFeeds += 1;
+        } catch {
+          repairFailures += 1;
+        }
+      }
+
       return {
         success: true as const,
         result,
+        repair: {
+          attempted: activeFeeds.length,
+          repairedFeeds,
+          repairFailures,
+        },
       };
     } catch (error) {
       throw new TRPCError({
@@ -197,17 +416,31 @@ export const newslettersRouter = router({
   }),
 
   stats: protectedProcedure.query(async ({ ctx }) => {
+    const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+    if (activeMailboxes.length === 0) {
+      return {
+        total: 0,
+        active: 0,
+        hidden: 0,
+        unsubscribed: 0,
+        lastSyncAt: null,
+        lastSyncStatus: 'IDLE',
+        lastSyncError: null,
+      };
+    }
+
+    const mailboxIds = activeMailboxes.map((row) => row.id);
     const feeds = await ctx.db.query.newsletterFeeds.findMany({
-      where: eq(newsletterFeeds.userId, ctx.userId),
+      where: and(
+        eq(newsletterFeeds.userId, ctx.userId),
+        inArray(newsletterFeeds.gmailMailboxId, mailboxIds)
+      ),
       columns: {
         status: true,
       },
     });
 
-    const mailbox = await ctx.db.query.gmailMailboxes.findFirst({
-      where: eq(gmailMailboxes.userId, ctx.userId),
-      orderBy: [desc(gmailMailboxes.updatedAt)],
-    });
+    const mailbox = [...activeMailboxes].sort((a, b) => b.updatedAt - a.updatedAt)[0];
 
     const summary = {
       total: feeds.length,

--- a/apps/worker/src/trpc/routers/newsletters.ts
+++ b/apps/worker/src/trpc/routers/newsletters.ts
@@ -1,0 +1,228 @@
+import { TRPCError } from '@trpc/server';
+import { and, desc, eq, like, lt } from 'drizzle-orm';
+import { z } from 'zod';
+import { ulid } from 'ulid';
+
+import { newsletterFeeds, newsletterUnsubscribeEvents, gmailMailboxes } from '../../db/schema';
+import { syncGmailNewslettersForUser } from '../../newsletters/gmail';
+import type { TokenRefreshEnv } from '../../lib/token-refresh';
+import { protectedProcedure, router } from '../trpc';
+
+const NewsletterFeedStatusSchema = z.enum(['ACTIVE', 'HIDDEN', 'UNSUBSCRIBED']);
+
+const ListNewslettersInputSchema = z.object({
+  status: NewsletterFeedStatusSchema.optional(),
+  search: z.string().trim().min(1).max(100).optional(),
+  limit: z.number().min(1).max(100).default(50),
+  cursor: z.string().optional(),
+});
+
+const UpdateStatusInputSchema = z.object({
+  feedId: z.string().min(1),
+  status: z.enum(['ACTIVE', 'HIDDEN']),
+});
+
+const UnsubscribeInputSchema = z.object({
+  feedId: z.string().min(1),
+});
+
+export const newslettersRouter = router({
+  list: protectedProcedure.input(ListNewslettersInputSchema.optional()).query(async ({ ctx, input }) => {
+    const limit = input?.limit ?? 50;
+    const conditions = [eq(newsletterFeeds.userId, ctx.userId)];
+
+    if (input?.status) {
+      conditions.push(eq(newsletterFeeds.status, input.status));
+    }
+
+    if (input?.search) {
+      const term = `%${input.search.toLowerCase()}%`;
+      conditions.push(
+        like(newsletterFeeds.displayName, term)
+      );
+    }
+
+    if (input?.cursor) {
+      conditions.push(lt(newsletterFeeds.id, input.cursor));
+    }
+
+    const rows = await ctx.db.query.newsletterFeeds.findMany({
+      where: and(...conditions),
+      orderBy: [desc(newsletterFeeds.lastSeenAt), desc(newsletterFeeds.id)],
+      limit: limit + 1,
+    });
+
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+
+    return {
+      items: items.map((row) => ({
+        id: row.id,
+        displayName: row.displayName ?? row.fromAddress ?? 'Newsletter',
+        fromAddress: row.fromAddress,
+        status: row.status,
+        detectionScore: row.detectionScore,
+        lastSeenAt: row.lastSeenAt,
+        firstSeenAt: row.firstSeenAt,
+        unsubscribeUrl: row.unsubscribeUrl,
+        unsubscribeMailto: row.unsubscribeMailto,
+      })),
+      nextCursor: hasMore && items.length > 0 ? items[items.length - 1].id : null,
+      hasMore,
+    };
+  }),
+
+  updateStatus: protectedProcedure
+    .input(UpdateStatusInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const row = await ctx.db.query.newsletterFeeds.findFirst({
+        where: and(eq(newsletterFeeds.id, input.feedId), eq(newsletterFeeds.userId, ctx.userId)),
+      });
+
+      if (!row) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Newsletter feed not found' });
+      }
+
+      await ctx.db
+        .update(newsletterFeeds)
+        .set({
+          status: input.status,
+          updatedAt: Date.now(),
+        })
+        .where(eq(newsletterFeeds.id, input.feedId));
+
+      return { success: true as const };
+    }),
+
+  unsubscribe: protectedProcedure.input(UnsubscribeInputSchema).mutation(async ({ ctx, input }) => {
+    const feed = await ctx.db.query.newsletterFeeds.findFirst({
+      where: and(eq(newsletterFeeds.id, input.feedId), eq(newsletterFeeds.userId, ctx.userId)),
+    });
+
+    if (!feed) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Newsletter feed not found' });
+    }
+
+    const now = Date.now();
+
+    let method: 'URL' | 'MAILTO' | 'ONE_CLICK_POST';
+    let target: string;
+    let status: 'REQUESTED' | 'COMPLETED' | 'FAILED' = 'REQUESTED';
+    let errorMessage: string | null = null;
+
+    if (
+      feed.unsubscribePostHeader?.toLowerCase().includes('one-click') &&
+      feed.unsubscribeUrl
+    ) {
+      method = 'ONE_CLICK_POST';
+      target = feed.unsubscribeUrl;
+
+      try {
+        const response = await fetch(feed.unsubscribeUrl, {
+          method: 'POST',
+        });
+
+        if (!response.ok) {
+          const responseText = await response.text();
+          throw new Error(`HTTP ${response.status}: ${responseText}`);
+        }
+
+        status = 'COMPLETED';
+      } catch (error) {
+        status = 'FAILED';
+        errorMessage = error instanceof Error ? error.message : String(error);
+      }
+    } else if (feed.unsubscribeUrl) {
+      method = 'URL';
+      target = feed.unsubscribeUrl;
+      status = 'REQUESTED';
+    } else if (feed.unsubscribeMailto) {
+      method = 'MAILTO';
+      target = feed.unsubscribeMailto;
+      status = 'REQUESTED';
+    } else {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'This newsletter does not expose an unsubscribe method',
+      });
+    }
+
+    await ctx.db.insert(newsletterUnsubscribeEvents).values({
+      id: ulid(),
+      userId: ctx.userId,
+      newsletterFeedId: feed.id,
+      method,
+      target,
+      status,
+      error: errorMessage,
+      requestedAt: now,
+      completedAt: status === 'COMPLETED' ? now : null,
+    });
+
+    await ctx.db
+      .update(newsletterFeeds)
+      .set({
+        status: 'UNSUBSCRIBED',
+        updatedAt: now,
+      })
+      .where(eq(newsletterFeeds.id, feed.id));
+
+    return {
+      success: true as const,
+      method,
+      target,
+      status,
+      error: errorMessage,
+    };
+  }),
+
+  syncNow: protectedProcedure.mutation(async ({ ctx }) => {
+    try {
+      const result = await syncGmailNewslettersForUser(
+        ctx.userId,
+        ctx.db,
+        ctx.env as TokenRefreshEnv
+      );
+
+      return {
+        success: true as const,
+        result,
+      };
+    } catch (error) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: error instanceof Error ? error.message : 'Failed to sync newsletters',
+      });
+    }
+  }),
+
+  stats: protectedProcedure.query(async ({ ctx }) => {
+    const feeds = await ctx.db.query.newsletterFeeds.findMany({
+      where: eq(newsletterFeeds.userId, ctx.userId),
+      columns: {
+        status: true,
+      },
+    });
+
+    const mailbox = await ctx.db.query.gmailMailboxes.findFirst({
+      where: eq(gmailMailboxes.userId, ctx.userId),
+      orderBy: [desc(gmailMailboxes.updatedAt)],
+    });
+
+    const summary = {
+      total: feeds.length,
+      active: feeds.filter((feed) => feed.status === 'ACTIVE').length,
+      hidden: feeds.filter((feed) => feed.status === 'HIDDEN').length,
+      unsubscribed: feeds.filter((feed) => feed.status === 'UNSUBSCRIBED').length,
+    };
+
+    return {
+      ...summary,
+      lastSyncAt: mailbox?.lastSyncAt ?? null,
+      lastSyncStatus: mailbox?.lastSyncStatus ?? 'IDLE',
+      lastSyncError: mailbox?.lastSyncError ?? null,
+    };
+  }),
+});
+
+export type NewslettersRouter = typeof newslettersRouter;

--- a/apps/worker/src/trpc/routers/subscriptions.ts
+++ b/apps/worker/src/trpc/routers/subscriptions.ts
@@ -54,6 +54,8 @@ import {
 } from '../../sync/service';
 import { getDLQSummary, getDLQEntries, deleteDLQEntry } from '../../sync/dlq-consumer';
 
+const SubscriptionProviderSchema = z.enum([Provider.YOUTUBE, Provider.SPOTIFY]);
+
 // ============================================================================
 // Zod Schemas
 // ============================================================================
@@ -72,7 +74,7 @@ const ListSubscriptionsInputSchema = z.object({
  * Input schema for adding a subscription
  */
 const AddSubscriptionInputSchema = z.object({
-  provider: ProviderSchema,
+  provider: SubscriptionProviderSchema,
   providerChannelId: z.string().min(1),
   name: z.string().optional(),
   imageUrl: z.string().url().optional(),
@@ -103,14 +105,14 @@ const SyncNowInputSchema = z.object({
  * Input schema for discovering available subscriptions from provider
  */
 const DiscoverAvailableInputSchema = z.object({
-  provider: ProviderSchema,
+  provider: SubscriptionProviderSchema,
 });
 
 /**
  * Input schema for searching channels/shows on a provider
  */
 const SearchInputSchema = z.object({
-  provider: ProviderSchema,
+  provider: SubscriptionProviderSchema,
   query: z.string().min(2).max(100),
   limit: z.number().min(1).max(20).default(10),
 });

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -33,9 +33,9 @@ export interface Bindings {
   CLERK_WEBHOOK_SECRET?: string;
   /** AES-256 encryption key for OAuth tokens (hex string) */
   ENCRYPTION_KEY?: string;
-  /** Google OAuth client ID for YouTube */
+  /** Google OAuth client ID for YouTube/Gmail */
   GOOGLE_CLIENT_ID?: string;
-  /** Google OAuth client secret for YouTube */
+  /** Google OAuth client secret for YouTube/Gmail */
   GOOGLE_CLIENT_SECRET?: string;
   /** Spotify OAuth client ID */
   SPOTIFY_CLIENT_ID?: string;

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -36,10 +36,10 @@ database_id = "2ce5331a-233c-48ec-9265-d04ecb539599"
 migrations_dir = "src/db/migrations"
 
 # Cron triggers for scheduled ingestion
-# YouTube polls at :00 (top of hour), Spotify polls at :30 (mid-hour)
+# YouTube polls at :00, Gmail newsletters at :15, Spotify at :30
 # Each provider has its own distributed lock for failure isolation
 [triggers]
-crons = ["0 * * * *", "30 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
 
 # Queue for async pull-to-refresh sync
 # Producer: subscriptions.syncAllAsync tRPC procedure
@@ -106,7 +106,7 @@ ENVIRONMENT = "staging"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.staging.triggers]
-crons = ["0 * * * *", "30 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
 [[env.staging.queues.producers]]
 queue = "zine-sync-queue-staging"
 binding = "SYNC_QUEUE"
@@ -161,7 +161,7 @@ ENVIRONMENT = "production"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
-crons = ["0 * * * *", "30 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *"]
 [[env.production.queues.producers]]
 queue = "zine-sync-queue-prod"
 binding = "SYNC_QUEUE"

--- a/docs/gmail-newsletter-link-ingestion-and-source-view-plan.md
+++ b/docs/gmail-newsletter-link-ingestion-and-source-view-plan.md
@@ -1,0 +1,445 @@
+# Plan: Gmail Newsletter Link-Level Ingestion and Source/Creator Views
+
+## Status
+
+Proposed for implementation.
+
+## Purpose
+
+Define a concrete redesign plan for Gmail newsletters to satisfy two requirements:
+
+1. Inbox items should represent the actual content links inside newsletter emails (not the email shell).
+2. Users should be able to open a creator/source view for newsletters and see all content from that author/publication, similar to existing Spotify/YouTube flows.
+
+This plan builds on the existing Gmail newsletter MVP already implemented in this repo.
+
+---
+
+## Requirements (Locked)
+
+1. Newsletter ingestion is link-first for ACTIVE feeds: extract actual shared links from each issue and ingest those as canonical items.
+2. Newsletter sources are subscribable/opt-in by default (already true) and support feed-level browsing.
+3. Creator/source view supports newsletter creators with latest content + bookmarked content, consistent with current creator UX patterns.
+4. Existing inbox/bookmark/archive lifecycle remains unchanged.
+
+## Non-Goals
+
+1. Full email client behavior.
+2. Storing complete email body content long-term.
+3. Perfect extraction from every newsletter format in v1 (fallback behavior required).
+4. Replacing current YouTube/Spotify polling architecture.
+
+---
+
+## Current State and Gaps
+
+Current Gmail ingestion:
+
+- Detects newsletters from metadata (`From`, `Subject`, `List-*`).
+- Creates one item per Gmail message when feed is ACTIVE.
+- Item fields are mostly email metadata (`title=subject`, `summary=snippet`, URL from first snippet link or Gmail thread fallback).
+
+Gaps versus requirements:
+
+1. One-message-to-one-item model prevents multiple real links per issue.
+2. Email metadata does not guarantee item URL is the primary article.
+3. No robust provenance model for "issue -> extracted links -> canonical items".
+4. Creator latest-content router currently supports only `YOUTUBE` and `SPOTIFY`.
+5. Creator subscribe/check APIs currently reject non-YouTube/Spotify providers.
+
+---
+
+## Proposed Architecture
+
+## High-Level Decision
+
+Keep mailbox/feed detection as-is, but split ingestion into two logical layers:
+
+1. Newsletter issue capture (message-level provenance).
+2. Link-level content ingestion (many canonical items per issue).
+
+The canonical `items` + `user_items` model remains the destination.
+
+## Ingestion Pipeline (Target)
+
+### Stage A: Message Capture (existing sync loop)
+
+For each detected newsletter message:
+
+1. Upsert feed identity.
+2. Persist a `newsletter_messages` row keyed by `(user_id, gmail_message_id)`.
+3. If feed is not `ACTIVE`, stop after provenance write.
+4. If feed is `ACTIVE`, enqueue/process for link extraction.
+
+### Stage B: Body Fetch + Link Extraction
+
+1. Fetch Gmail message with body (`messages.get format=full` or equivalent MIME payload path).
+2. Decode MIME parts and choose best HTML/text representation.
+3. Extract anchor links and plain-text URLs.
+4. Normalize and classify links (content vs unsubscribe/nav/tracking/share).
+5. Persist extracted links in `newsletter_message_links`.
+
+### Stage C: Canonical Item Ingestion from Links
+
+For each content candidate link:
+
+1. Canonicalize URL (strip tracking params, resolve known wrappers).
+2. Reuse existing preview/enrichment pipeline (`fetchLinkPreview`) to determine provider/content metadata.
+3. Upsert canonical `items` row (provider-specific dedupe).
+4. Upsert `user_items` row with `state=INBOX` when first seen.
+5. Persist provenance mapping in `newsletter_message_items`.
+
+### Stage D: Feed and Creator Aggregation
+
+1. Associate each feed to a normalized creator (`creators` row).
+2. Query latest feed content through provenance mappings.
+3. Render creator/source pages from local ingested data.
+
+---
+
+## Data Model Redesign
+
+## New Tables
+
+### `newsletter_messages`
+
+One row per Gmail newsletter message.
+
+Suggested columns:
+
+- `id` TEXT PK (ULID)
+- `user_id` TEXT NOT NULL
+- `gmail_mailbox_id` TEXT NOT NULL
+- `newsletter_feed_id` TEXT NOT NULL
+- `gmail_message_id` TEXT NOT NULL
+- `gmail_thread_id` TEXT
+- `subject` TEXT
+- `from_address` TEXT
+- `from_display_name` TEXT
+- `snippet` TEXT
+- `internal_date` INTEGER
+- `link_extraction_status` TEXT NOT NULL (`PENDING`, `SUCCESS`, `NO_LINKS`, `FAILED`)
+- `link_extraction_error` TEXT
+- `created_at` INTEGER NOT NULL
+- `updated_at` INTEGER NOT NULL
+
+Indexes:
+
+- unique `(user_id, gmail_message_id)`
+- index `(newsletter_feed_id, internal_date)`
+- index `(link_extraction_status, updated_at)`
+
+### `newsletter_message_links`
+
+Raw/normalized links extracted from one newsletter message.
+
+Suggested columns:
+
+- `id` TEXT PK (ULID)
+- `user_id` TEXT NOT NULL
+- `newsletter_message_id` TEXT NOT NULL
+- `url_original` TEXT NOT NULL
+- `url_normalized` TEXT NOT NULL
+- `url_canonical` TEXT
+- `domain` TEXT
+- `position` INTEGER
+- `anchor_text` TEXT
+- `classification` TEXT NOT NULL (`CONTENT`, `NAV`, `UNSUBSCRIBE`, `TRACKING`, `SOCIAL`, `UNKNOWN`)
+- `score` REAL NOT NULL DEFAULT 0
+- `provider_hint` TEXT
+- `created_at` INTEGER NOT NULL
+
+Indexes:
+
+- unique `(newsletter_message_id, url_normalized)`
+- index `(newsletter_message_id, score)`
+- index `(user_id, domain)`
+
+### `newsletter_message_items`
+
+Provenance mapping from issue links to canonical items.
+
+Suggested columns:
+
+- `id` TEXT PK (ULID)
+- `user_id` TEXT NOT NULL
+- `newsletter_feed_id` TEXT NOT NULL
+- `newsletter_message_id` TEXT NOT NULL
+- `newsletter_message_link_id` TEXT
+- `item_id` TEXT NOT NULL
+- `provider` TEXT NOT NULL
+- `provider_id` TEXT NOT NULL
+- `canonical_url` TEXT NOT NULL
+- `rank` INTEGER
+- `created_at` INTEGER NOT NULL
+
+Indexes:
+
+- unique `(user_id, newsletter_message_id, item_id)`
+- index `(newsletter_feed_id, created_at)`
+- index `(item_id)`
+
+## Existing Table Changes
+
+### `newsletter_feeds`
+
+Add:
+
+- `creator_id` TEXT references `creators.id`
+- `last_item_at` INTEGER (optional, for feed list sorting)
+- `item_count` INTEGER default 0 (optional cached metric)
+
+### Keep (but deprecate usage)
+
+- `newsletter_feed_messages` becomes legacy compatibility during migration.
+- New ingestion writes to new tables; old table can be backfilled or removed after cutover.
+
+---
+
+## Creator/Source View Redesign
+
+## Creator Identity for Newsletters
+
+Each newsletter feed maps to one creator:
+
+- `provider = GMAIL`
+- `providerCreatorId = newsletter_feeds.canonical_key`
+- `name = feed.display_name`
+- `handle = feed.from_address`
+- `externalUrl = best publication URL`
+- `imageUrl = favicon/publication image best-effort`
+
+This allows reuse of existing creator screen and items joins.
+
+## API Behavior Changes
+
+### `creators.fetchLatestContent`
+
+Current:
+
+- Supports only YouTube/Spotify via provider APIs.
+
+Target:
+
+- Add `GMAIL` branch that returns latest ingested items from `newsletter_message_items` joined with `items`.
+- No provider API calls for Gmail creator latest-content path.
+
+### `creators.checkSubscription` and `creators.subscribe`
+
+Current:
+
+- Reject non-YouTube/Spotify providers.
+
+Target for `GMAIL` creators:
+
+- `checkSubscription` resolves from linked `newsletter_feed.status` + Gmail connection.
+- `subscribe` sets `newsletter_feed.status = ACTIVE` (idempotent).
+- Optional `unsubscribe/hide` can remain newsletter-router specific.
+
+### Newsletter Router Additions
+
+Add query endpoints:
+
+- `subscriptions.newsletters.feedItems({ feedId, cursor, limit })`
+- `subscriptions.newsletters.messageItems({ messageId })` (debug/provenance)
+- `subscriptions.newsletters.feedStats({ feedId })`
+
+These endpoints power provider-like source pages and diagnostics.
+
+---
+
+## Link Extraction and Ranking Rules
+
+## Candidate Extraction
+
+1. Parse HTML anchors first.
+2. Parse plain text URLs second.
+3. Dedupe by normalized URL.
+
+## Exclusion Rules
+
+Drop URLs matching:
+
+- unsubscribe/manage/preferences/login/account paths
+- tracking redirect-only links
+- social share links without content target
+- image pixel/tracker endpoints
+
+## Prioritization Rules
+
+Score boosts:
+
+- likely content paths (`/p/`, `/article/`, `/posts/`, provider-specific content IDs)
+- links with meaningful anchor text
+- domains matching known content providers
+
+Score penalties:
+
+- nav/footer links
+- repetitive boilerplate links
+
+## Per-Issue Item Cap
+
+Recommended v1 cap: max 5 ingested content links per issue.
+
+Reason:
+
+- Prevent inbox flooding from link-heavy newsletters.
+- Still capture primary shared content.
+
+---
+
+## Privacy, Scopes, and Compliance
+
+1. Gmail scope must permit body read for ACTIVE feed extraction (`gmail.readonly` recommended).
+2. Update connect UX copy to explicitly mention body parsing for link extraction.
+3. Do not persist full email body by default.
+4. Persist only:
+   - message metadata
+   - extracted links and normalized attributes
+   - provenance mappings
+5. Redact or avoid storing sensitive query params in canonical URLs.
+
+---
+
+## Rollout Strategy
+
+## Feature Flags
+
+Add worker flags:
+
+- `NEWSLETTER_LINK_INGESTION_ENABLED`
+- `NEWSLETTER_CREATOR_VIEWS_ENABLED`
+- `NEWSLETTER_LINK_BACKFILL_ENABLED`
+
+## Phase Plan
+
+### Phase 1: Schema and Creator Linking
+
+Deliver:
+
+- New tables + migrations
+- `newsletter_feeds.creator_id`
+- Feed upsert writes/updates creator link
+
+Acceptance criteria:
+
+- Migrations apply cleanly in local and CI.
+- New feed rows always have `creator_id`.
+
+### Phase 2: Link Extraction Pipeline (write-only)
+
+Deliver:
+
+- Body fetch + extraction + classification
+- Persist `newsletter_messages` + `newsletter_message_links`
+- No inbox behavior change yet
+
+Acceptance criteria:
+
+- > = 95% ACTIVE issues produce extraction status (success/no-links/failed).
+- Processing errors are recorded and retryable.
+
+### Phase 3: Link-to-Item Ingestion Cutover
+
+Deliver:
+
+- Create canonical items from extracted links
+- Write `newsletter_message_items`
+- Stop creating metadata-only email-shell inbox items
+
+Acceptance criteria:
+
+- Inbox contains actual linked content URLs for ACTIVE feeds.
+- Duplicate items do not increase for repeated sync runs.
+
+### Phase 4: Creator/Source Views for GMAIL
+
+Deliver:
+
+- Creator router GMAIL support (`latestContent`, `checkSubscription`, `subscribe`)
+- Mobile creator components support GMAIL provider
+- Newsletter feed item list screens and navigation
+
+Acceptance criteria:
+
+- Opening a newsletter creator shows latest linked content.
+- Subscribe action from creator/feed surfaces maps to feed `ACTIVE`.
+
+### Phase 5: Backfill + Cleanup
+
+Deliver:
+
+- Backfill recent ACTIVE messages into new tables
+- Optional remove/retire legacy `newsletter_feed_messages` writes
+
+Acceptance criteria:
+
+- Historical (e.g., last 30 days) ACTIVE issues have link-derived items.
+- Legacy table no longer required by runtime path.
+
+---
+
+## Implementation Work Breakdown (Issue Set)
+
+## Epic: Newsletter Link Ingestion + Source Views
+
+1. DB migration: add `newsletter_messages`, `newsletter_message_links`, `newsletter_message_items`, `newsletter_feeds.creator_id`.
+2. Worker: feed upsert creator-linking via `findOrCreateCreator`.
+3. Worker: Gmail full-message fetch + MIME parsing utility.
+4. Worker: link extraction/classification and persistence.
+5. Worker: canonical link resolution and preview enrichment integration.
+6. Worker: link-based item ingestion + provenance mapping + dedupe.
+7. Worker: creator router support for provider `GMAIL`.
+8. Worker: newsletters router feed/content endpoints for source pages.
+9. Mobile: creator latest-content UI support for `GMAIL`.
+10. Mobile: newsletter feed detail/content list screens and navigation.
+11. Observability: metrics/logging/dashboard + error budget alarms.
+12. Backfill job and cutover/remove legacy ingestion path.
+
+---
+
+## Dependencies and Blockers
+
+1. OAuth scope and consent copy must be finalized before Phase 2 rollout.
+2. MIME parser must be Worker-compatible and tested for large/encoded payloads.
+3. Link canonicalization quality directly impacts dedupe and creator attribution.
+4. Product sign-off needed on per-issue item cap and archived-item resurfacing policy.
+
+---
+
+## Risks and Mitigations
+
+1. Risk: inbox spam from newsletters with many links.
+   Mitigation: cap + scoring + strict link classification.
+2. Risk: wrong links ingested due to boilerplate noise.
+   Mitigation: extraction tests with real fixture corpus; issue-level diagnostics.
+3. Risk: creator fragmentation due to poor canonical keys.
+   Mitigation: creator id keyed by feed canonical key + migration-safe updates.
+4. Risk: runtime latency from body parsing and preview calls.
+   Mitigation: staged async processing + bounded concurrency + retries.
+
+---
+
+## QA and Validation Plan
+
+1. Unit tests:
+   - MIME parsing, link extraction, ranking, URL normalization.
+2. Integration tests:
+   - issue -> links -> items -> inbox state transitions.
+3. Regression tests:
+   - dedupe behavior across repeated sync runs.
+   - creator view behavior for YOUTUBE/SPOTIFY unchanged.
+4. Manual QA:
+   - connect Gmail, subscribe feed, sync, verify inbox items are article links.
+   - open creator/feed view and verify content list + subscribe state.
+
+---
+
+## Final Acceptance Criteria
+
+1. For ACTIVE newsletter feeds, new inbox items use canonical content links extracted from email bodies.
+2. Newsletter creators/publications have a browsable creator/source view showing their content history.
+3. Duplicate ingestion remains idempotent across repeated syncs.
+4. Opt-in defaults and feed management behavior remain intact.
+5. Observability supports debugging at message, link, and item provenance levels.

--- a/docs/gmail-newsletter-subscriptions-epic-issues.md
+++ b/docs/gmail-newsletter-subscriptions-epic-issues.md
@@ -1,0 +1,729 @@
+# Epic: Gmail Newsletter Subscriptions and Inbox Ingestion (MVP)
+
+## Epic Metadata
+
+- **Epic ID**: `GNS-EPIC`
+- **Source Plan**: `docs/gmail-newsletter-subscriptions-plan.md`
+- **Objective**: Deliver Gmail as a first-class source with reliable newsletter detection, inbox ingestion, management controls, and operational hardening.
+- **Primary Outcomes**:
+  - Users can connect Gmail and see newsletter feeds.
+  - Newsletter issues appear in Inbox as article-like items.
+  - Users can manage feed state (`ACTIVE`, `HIDDEN`, `UNSUBSCRIBED`) and trigger unsubscribe actions.
+  - Sync is safe, idempotent, and observable.
+
+## Epic Scope
+
+- OAuth/provider support for Gmail.
+- New newsletter/mailbox data model.
+- Initial + incremental sync pipeline.
+- Detection heuristics and canonical feed identity.
+- Issue-to-item ingestion into existing `items` + `user_items` lifecycle.
+- Newsletter management API + mobile UX.
+- Scheduler, locking, metrics, and rollout controls.
+
+## Epic Non-Goals
+
+- Full email-body storage.
+- Full email-client features.
+- Guaranteed unsubscribe completion for every publisher.
+- Push/watch optimization in MVP.
+
+## Epic Success Criteria
+
+1. Connect completion rate from Gmail connect start to connected state is trackable and healthy.
+2. Detection precision for newsletter feeds is >= 95% on sampled fixtures.
+3. Time-to-first-surfaced newsletter issue after connect <= 2 minutes for small inboxes.
+4. Incremental sync success rate >= 99%.
+5. No duplicate issue ingestion under repeated sync/retry flows.
+
+## Epic Global Dependencies
+
+1. Google API scopes/policy posture for Gmail read access and consent screen approvals.
+2. Gmail API is enabled in each Google Cloud project (dev/staging/prod), with propagation delay accounted for.
+3. Existing provider connection/token infrastructure remains stable.
+4. Feature flag rollout path exists in worker/mobile.
+
+## Epic Critical Blockers (Observed in Dev)
+
+1. `accessNotConfigured` if Gmail API is disabled for a project.
+2. `ACCESS_TOKEN_SCOPE_INSUFFICIENT` if OAuth scopes differ between auth request and callback verification.
+3. D1 FK constraint failures on disconnect when delete order/cascades are not explicit.
+4. Detection false positives for transactional senders (example: ride receipts).
+
+## Epic Done Definition
+
+- All `GNS-*` issues closed.
+- End-to-end manual verification checklist passes.
+- Observability dashboards/alerts in place.
+- No P0/P1 regressions in YouTube/Spotify flows.
+
+---
+
+## Issue Dependency Graph (Execution Order)
+
+1. `GNS-00` -> (`GNS-01`, `GNS-03`)
+2. `GNS-01` + `GNS-03` -> `GNS-02`
+3. `GNS-01` -> `GNS-04`
+4. `GNS-03` + `GNS-04` -> `GNS-05`
+5. `GNS-05` -> `GNS-06`
+6. `GNS-04` -> `GNS-07`
+7. `GNS-04` + `GNS-06` + `GNS-07` -> `GNS-08`
+8. `GNS-05` + `GNS-06` + `GNS-08` -> `GNS-09`
+9. `GNS-03` + `GNS-04` + `GNS-05` -> `GNS-15`
+10. `GNS-02` + `GNS-09` + `GNS-15` -> `GNS-10`
+11. `GNS-09` + `GNS-10` -> `GNS-11`
+12. `GNS-05` + `GNS-06` -> `GNS-12`
+13. `GNS-00` + `GNS-03` + `GNS-05` + `GNS-12` -> `GNS-13`
+14. `GNS-10` + `GNS-11` + `GNS-12` + `GNS-13` -> `GNS-14`
+
+---
+
+## Detailed Issues
+
+## GNS-00: Google Cloud Gmail API + OAuth Scope Preflight
+
+- **Type**: Enablement
+- **Summary**: Validate Google Cloud project/API/scope prerequisites before feature implementation and QA.
+- **Why**: Avoids blocked engineering/test cycles from environment-level misconfiguration.
+- **Primary Files**:
+  - `docs/gmail-newsletter-subscriptions-plan.md`
+  - `apps/mobile/app.config.ts` (or equivalent OAuth config source)
+  - worker environment configuration for OAuth client settings
+
+### Requirements
+
+1. Enable Gmail API in all target Google Cloud projects (dev/staging/prod).
+2. Confirm OAuth consent + test users are configured for development.
+3. Confirm required scopes are explicitly requested and documented (`gmail.readonly` baseline).
+4. Validate redirect URIs and callback origins used by mobile/worker.
+5. Add a short preflight checklist for future environments.
+
+### Acceptance Criteria
+
+1. OAuth callback no longer fails with `accessNotConfigured`.
+2. OAuth callback/token verification no longer fails with insufficient scope for profile lookup.
+3. Preflight checklist exists and is referenced by implementation tickets.
+
+### Dependencies
+
+- None.
+
+### Blockers/Risks
+
+- Google project policy review delays or API enablement propagation lag.
+
+### Verification
+
+- Manual connect smoke test in dev environment.
+- Run preflight checklist against staging configuration before rollout.
+
+## GNS-01: Add `GMAIL` to Shared Provider Domain and Provider-Extensible Surfaces
+
+- **Type**: Foundation
+- **Summary**: Add `GMAIL` to shared enums/schemas and remove hard-coded provider assumptions in shared/mobile/worker interfaces.
+- **Why**: Every subsequent issue depends on provider domain correctness.
+- **Primary Files**:
+  - `packages/shared/src/types/domain.ts`
+  - `packages/shared/src/schemas/index.ts`
+  - provider switch sites in worker/mobile that currently assume YouTube/Spotify only.
+
+### Requirements
+
+1. `GMAIL` is accepted in provider schemas/types used by tRPC inputs and shared contracts.
+2. Existing provider lists are updated to be extensible without breaking compatibility.
+3. No regressions to existing providers.
+
+### Acceptance Criteria
+
+1. Typecheck passes across monorepo.
+2. Existing provider-related tests pass.
+3. New tests assert `GMAIL` is accepted where appropriate.
+
+### Dependencies
+
+- None.
+
+### Blockers/Risks
+
+- Hidden hard-coded provider switches causing runtime branches to reject `GMAIL`.
+
+### Verification
+
+- `bun run typecheck`
+- targeted router validation tests for provider inputs.
+
+---
+
+## GNS-02: Gmail OAuth Support in Mobile Connect Flows
+
+- **Type**: Feature
+- **Summary**: Implement Gmail connection flow from subscriptions UI using existing PKCE/state/callback patterns.
+- **Why**: User entrypoint for feature.
+- **Primary Files**:
+  - `apps/mobile/lib/oauth.ts`
+  - `apps/mobile/app/subscriptions/index.tsx`
+  - `apps/mobile/app/subscriptions/[provider].tsx`
+  - `apps/mobile/app/subscriptions/connect/gmail.tsx`
+
+### Requirements
+
+1. Gmail appears as provider card in subscriptions surfaces.
+2. Connect flow uses PKCE + state registration and callback mutation.
+3. UX communicates read-only data access and control points.
+4. Error states are actionable (scope missing, API disabled, callback failure).
+
+### Acceptance Criteria
+
+1. User can start Gmail connect from Subscriptions.
+2. Successful auth marks Gmail connected in UI.
+3. Failure paths show specific error messaging.
+4. Existing YouTube/Spotify connect UX remains unchanged.
+
+### Dependencies
+
+- `GNS-00`, `GNS-01`, `GNS-03`
+
+### Blockers/Risks
+
+- Misconfigured OAuth env vars/redirect URIs or stale consent scope configuration.
+
+### Verification
+
+- Mobile manual connect/disconnect flows.
+- `apps/mobile` tests for OAuth error handling.
+
+---
+
+## GNS-03: Worker Gmail Auth/Token Refresh Integration
+
+- **Type**: Feature
+- **Summary**: Extend worker auth/token refresh providers to support Gmail lifecycle.
+- **Why**: Sync jobs and callback mailbox setup require stable token handling.
+- **Primary Files**:
+  - `apps/worker/src/lib/auth.ts`
+  - `apps/worker/src/lib/token-refresh.ts`
+  - `apps/worker/src/trpc/routers/connections.ts`
+
+### Requirements
+
+1. Gmail token exchange and refresh are supported.
+2. Token revocation on disconnect is best-effort and non-blocking.
+3. Callback flow fails safely with clear user-facing errors.
+
+### Acceptance Criteria
+
+1. OAuth callback persists Gmail provider connection on success.
+2. Refresh path works for expiring Gmail tokens.
+3. Disconnect revokes token (best effort) and cleans local state.
+
+### Dependencies
+
+- `GNS-00`, `GNS-01`
+
+### Blockers/Risks
+
+- Scope mismatches or disabled Gmail API causing callback/mailbox verification failures.
+
+### Verification
+
+- Worker router tests for callback/disconnect.
+- Manual callback and reconnect path.
+
+---
+
+## GNS-04: Database Migrations for Mailbox and Newsletter Tables
+
+- **Type**: Data Model
+- **Summary**: Add and verify mailbox/newsletter tables and indexes used by Gmail ingestion.
+- **Why**: Core persistence layer.
+- **Primary Files**:
+  - `apps/worker/src/db/schema.ts`
+  - `apps/worker/src/db/migrations/*`
+  - `apps/worker/src/db/migrations/meta/_journal.json`
+
+### Requirements
+
+1. Add/validate tables:
+   - `gmail_mailboxes`
+   - `newsletter_feeds`
+   - `newsletter_feed_messages`
+   - `newsletter_unsubscribe_events`
+2. Include required uniqueness and performance indexes.
+3. Migration is forward-safe in worktree/dev DBs.
+4. Define FK cascading rules or explicit delete ordering to support disconnect cleanup.
+
+### Acceptance Criteria
+
+1. Migration applies without FK errors in local dev DB.
+2. Schema aligns with plan doc columns/indexes.
+3. Rollback/reseed flows remain operable (`dev:reset` + `dev:worktree`).
+4. Disconnect cleanup path can execute without FK constraint failures.
+
+### Dependencies
+
+- `GNS-01`
+
+### Blockers/Risks
+
+- FK delete order mismatches and migration drift.
+
+### Verification
+
+- Run migrations on fresh + existing local DB state.
+- Typecheck and targeted DB integration tests.
+
+---
+
+## GNS-05: Mailbox Lifecycle + Initial Bootstrap Sync
+
+- **Type**: Feature
+- **Summary**: Implement mailbox record lifecycle and first-run bounded sync.
+- **Why**: First content experience after connect.
+- **Primary Files**:
+  - `apps/worker/src/newsletters/gmail.ts`
+  - `apps/worker/src/trpc/routers/connections.ts`
+
+### Requirements
+
+1. Upsert `gmail_mailboxes` on first callback/sync.
+2. Initial sync pulls bounded recent window (e.g., last 30 days).
+3. Sync status fields are updated (`RUNNING`/`SUCCESS`/`ERROR`).
+4. Safe lock behavior prevents duplicate mailbox sync runs.
+
+### Acceptance Criteria
+
+1. Newly connected user gets mailbox row + initial sync attempt.
+2. Sync status and last error fields reflect run outcome.
+3. Duplicate concurrent sync attempts are prevented.
+
+### Dependencies
+
+- `GNS-03`, `GNS-04`
+
+### Blockers/Risks
+
+- Gmail API quotas/rate limits.
+
+### Verification
+
+- Worker sync tests and manual sync run after connect.
+
+---
+
+## GNS-06: Incremental Sync + Stale Cursor Recovery
+
+- **Type**: Feature
+- **Summary**: Implement delta sync via Gmail `historyId` with bounded backfill fallback.
+- **Why**: Required for reliability and scale.
+- **Primary Files**:
+  - `apps/worker/src/newsletters/gmail.ts`
+  - scheduler integration files under `apps/worker/src/sync`/`apps/worker/src/polling`
+
+### Requirements
+
+1. Use saved mailbox `history_id` for incremental fetch.
+2. Detect stale cursor and fallback to bounded initial recovery.
+3. Persist new `history_id` after successful run.
+4. Preserve idempotency across retries.
+
+### Acceptance Criteria
+
+1. Incremental runs ingest only deltas under normal conditions.
+2. 404 stale history fallback recovers without silent data loss.
+3. Re-running same delta does not duplicate items.
+
+### Dependencies
+
+- `GNS-05`
+
+### Blockers/Risks
+
+- Edge cases around history window expiration.
+
+### Verification
+
+- Integration tests for incremental + stale cursor scenarios.
+
+---
+
+## GNS-07: Newsletter Detection Heuristics and Canonical Feed Identity
+
+- **Type**: Feature
+- **Summary**: Build and tune scoring logic + canonical key generation for high precision.
+- **Why**: Quality gate preventing inbox spam/noise.
+- **Primary Files**:
+  - `apps/worker/src/newsletters/gmail.ts`
+  - test fixtures under `apps/worker/src/newsletters/*.test.ts`
+
+### Requirements
+
+1. Weighted signals from `List-*` headers, sender, subject, unsubscribe metadata.
+2. Transactional/promo patterns are penalized/excluded.
+3. Canonical key fallback order:
+   - `List-Id`
+   - unsubscribe target
+   - sender address
+4. Feed visibility gate avoids structural-header-only false positives.
+5. Newly detected feeds default to `UNSUBSCRIBED` (explicit opt-in model).
+
+### Acceptance Criteria
+
+1. Fixture precision target >= 95% for high-confidence newsletters.
+2. Known transactional samples (e.g., receipts/notifications) are excluded.
+3. Canonical keys remain stable for recurring senders.
+4. New feeds are `UNSUBSCRIBED` until user explicitly activates them.
+
+### Dependencies
+
+- `GNS-04`
+
+### Blockers/Risks
+
+- Long-tail newsletter formats and transactional false positives (example: Uber receipts).
+
+### Verification
+
+- Unit tests with positive/negative fixtures.
+- Manual spot checks in seeded inbox data.
+
+---
+
+## GNS-08: Issue-to-Item Mapping and Idempotent Inbox Ingestion
+
+- **Type**: Feature
+- **Summary**: Map eligible newsletter messages to canonical items + user inbox records.
+- **Why**: Core value delivery.
+- **Primary Files**:
+  - `apps/worker/src/newsletters/gmail.ts`
+  - `apps/worker/src/trpc/routers/items.ts` (consumption checks)
+
+### Requirements
+
+1. For eligible messages, create `items` with:
+   - `contentType=ARTICLE`, `provider=GMAIL`
+   - deterministic `providerId`
+   - title/summary/canonicalUrl mapping rules
+2. Insert `user_items` with `state=INBOX`.
+3. Record mapping in `newsletter_feed_messages`.
+4. Idempotency via unique keys and conflict handling.
+5. Respect feed status gating (feeds default to `UNSUBSCRIBED`; only `ACTIVE` ingests).
+
+### Acceptance Criteria
+
+1. Only `ACTIVE` feeds generate inbox items; `HIDDEN`/`UNSUBSCRIBED` do not ingest new items.
+2. Duplicate sync/retry does not create duplicate `items` or `user_items`.
+3. Item opens using article behavior and mapped URL.
+
+### Dependencies
+
+- `GNS-04`, `GNS-06`, `GNS-07`
+
+### Blockers/Risks
+
+- URL quality when snippet lacks reliable primary link.
+
+### Verification
+
+- Integration tests for idempotency and status gating.
+- Manual inbox rendering checks.
+
+---
+
+## GNS-09: Newsletter Management Router (`subscriptions.newsletters.*`)
+
+- **Type**: API
+- **Summary**: Add list/status/unsubscribe/sync/stats endpoints.
+- **Why**: Required for user control and UI composition.
+- **Primary Files**:
+  - `apps/worker/src/trpc/routers/newsletters.ts`
+  - `apps/worker/src/trpc/router.ts` (wiring)
+
+### Requirements
+
+1. Implement procedures:
+   - `list`
+   - `updateStatus`
+   - `unsubscribe`
+   - `syncNow`
+   - `stats`
+2. Procedure auth/ownership checks enforced.
+3. `unsubscribe` records event rows with method and status.
+4. `list` supports search/status/pagination.
+5. `updateStatus` enforces explicit state transitions and never auto-activates newly detected feeds.
+
+### Acceptance Criteria
+
+1. Endpoints return deterministic schema contracts.
+2. Unauthorized or cross-user access is rejected.
+3. Unsubscribe event rows are always written.
+4. Newly detected feeds are returned as `UNSUBSCRIBED` unless explicitly activated.
+
+### Dependencies
+
+- `GNS-05`, `GNS-06`, `GNS-08`
+
+### Blockers/Risks
+
+- Unsubscribe endpoint variability and false success claims.
+
+### Verification
+
+- Router contract tests + integration tests.
+
+---
+
+## GNS-15: Disconnect Lifecycle Integrity (FK-Safe, Idempotent Cleanup)
+
+- **Type**: Reliability/Data Integrity
+- **Summary**: Make Gmail disconnect fully reliable by enforcing deterministic cleanup order/cascades and idempotent behavior.
+- **Why**: Disconnect failures break user trust and can leave sync running against disconnected accounts.
+- **Primary Files**:
+  - `apps/worker/src/trpc/routers/connections.ts`
+  - `apps/worker/src/db/schema.ts`
+  - `apps/worker/src/newsletters/gmail.ts`
+
+### Requirements
+
+1. Disconnect cleanup sequence is FK-safe (or uses correctly defined cascades).
+2. Disconnect is idempotent; repeated calls do not error.
+3. Mailbox sync is halted/unscheduled on disconnect.
+4. Local provider tokens/connection rows are cleaned up in the same operation.
+
+### Acceptance Criteria
+
+1. Disconnect does not produce D1 FK constraint errors.
+2. Repeated disconnect calls return success/benign no-op behavior.
+3. After disconnect, no Gmail mailbox remains eligible for sync.
+
+### Dependencies
+
+- `GNS-03`, `GNS-04`, `GNS-05`
+
+### Blockers/Risks
+
+- Hidden FK dependencies and in-flight scheduler locks during disconnect.
+
+### Verification
+
+- Integration test: connect -> sync -> disconnect -> reconnect.
+- Manual disconnect smoke tests in simulator and worker logs.
+
+---
+
+## GNS-10: Gmail Subscriptions UX (List, Actions, Sync, Connection State)
+
+- **Type**: Mobile Feature
+- **Summary**: Build provider detail UX for Gmail with feed list and actions.
+- **Why**: Usable management surface.
+- **Primary Files**:
+  - `apps/mobile/app/subscriptions/[provider].tsx`
+  - `apps/mobile/hooks/*connections*`
+
+### Requirements
+
+1. Show Gmail connection card/status in subscriptions provider view.
+2. Show newsletter feed list with search and status labels.
+3. Actions:
+   - Subscribe/Hide/Show (status toggle)
+   - Unsubscribe (where applicable)
+   - Sync now
+4. Handle errors with clear alerts and rollback behavior.
+5. Ensure accessible/legible button states and icon fallback behavior.
+6. Feed avatar fallback chain is deterministic:
+   - publication/logo image (if available)
+   - sender-domain favicon (if available)
+   - provider fallback image (Substack icon for substack-hosted feeds, generic mail icon otherwise)
+
+### Acceptance Criteria
+
+1. User can activate/deactivate feeds from list.
+2. Manual sync trigger refreshes list/stats.
+3. Disconnect works without FK/optimistic-cache failures.
+4. UI remains readable in dark theme, including subscription CTA text contrast.
+5. Avatar rendering uses fallback chain without broken images.
+
+### Dependencies
+
+- `GNS-02`, `GNS-09`, `GNS-15`
+
+### Blockers/Risks
+
+- Cache-shape inconsistencies in optimistic updates.
+
+### Verification
+
+- Mobile hook/component tests.
+- Manual on-device/simulator walkthrough.
+
+---
+
+## GNS-11: Unsubscribe Execution Strategy + Event Transparency
+
+- **Type**: Feature
+- **Summary**: Implement method-priority unsubscribe behavior with explicit statusing.
+- **Why**: Critical trust/control requirement.
+- **Primary Files**:
+  - `apps/worker/src/trpc/routers/newsletters.ts`
+  - mobile surfaces showing unsubscribe results.
+
+### Requirements
+
+1. Method priority:
+   - one-click POST
+   - URL
+   - mailto
+2. Event row includes method, target, status, error.
+3. Unknown completion is represented as `REQUESTED`, not `COMPLETED`.
+4. Feed transitions to `UNSUBSCRIBED` in app state.
+
+### Acceptance Criteria
+
+1. Each unsubscribe attempt produces an auditable event row.
+2. Error states are surfaced to user.
+3. No false-positive success messaging.
+
+### Dependencies
+
+- `GNS-09`, `GNS-10`
+
+### Blockers/Risks
+
+- Publisher-specific unsubscribe flows can fail silently.
+
+### Verification
+
+- Unit tests for method selection.
+- Manual tests with mocked failing/successful endpoints.
+
+---
+
+## GNS-12: Scheduler, Locking, and Observability Hardening
+
+- **Type**: Reliability
+- **Summary**: Add operational scheduling, lock safety, and metrics for Gmail sync.
+- **Why**: Needed for production reliability targets.
+- **Primary Files**:
+  - scheduler/polling modules
+  - newsletter sync logger/metrics instrumentation
+
+### Requirements
+
+1. Scheduled incremental sync for active Gmail mailboxes.
+2. Mailbox-level lock to avoid duplicate workers.
+3. Metrics/logs for:
+   - sync duration
+   - processed messages
+   - ingested items
+   - failures by class
+4. Backoff/retry policy for transient Gmail errors.
+
+### Acceptance Criteria
+
+1. Dashboardable counters exist for success/error rates.
+2. Repeated scheduled runs do not race or duplicate.
+3. Alertable error conditions are emitted.
+
+### Dependencies
+
+- `GNS-05`, `GNS-06`
+
+### Blockers/Risks
+
+- Quota throttling and noisy retry loops.
+
+### Verification
+
+- Scheduler integration tests.
+- Log/metric snapshots from local/staging runs.
+
+---
+
+## GNS-13: Security, Privacy, Compliance, and Logging Hygiene
+
+- **Type**: Compliance/Hardening
+- **Summary**: Ensure data minimization, token safety, and policy-aligned behavior.
+- **Why**: Production readiness and provider policy requirements.
+
+### Requirements
+
+1. Tokens remain encrypted at rest (existing AES-GCM path).
+2. Limit stored Gmail data to required metadata/snippet for MVP.
+3. Remove/redact sensitive values from logs.
+4. Validate connection revoke/disconnect behavior and mailbox cleanup.
+5. Document scope usage and policy posture.
+
+### Acceptance Criteria
+
+1. No sensitive token/body data appears in operational logs.
+2. Disconnect reliably halts sync and cleans mailbox-related state.
+3. Compliance checklist sign-off completed for launch.
+
+### Dependencies
+
+- `GNS-00`, `GNS-03`, `GNS-05`, `GNS-12`
+
+### Blockers/Risks
+
+- Late policy requirements from Google review.
+
+### Verification
+
+- Security review checklist and targeted log inspection tests.
+
+---
+
+## GNS-14: End-to-End Validation, Rollout, and Launch Gate
+
+- **Type**: Release
+- **Summary**: Validate complete user/system behavior and execute phased rollout.
+- **Why**: Controlled release with measurable risk.
+
+### Requirements
+
+1. Execute manual checklist from source plan:
+   - connect
+   - initial sync
+   - inbox ingestion
+   - feed hide/unsubscribe
+   - disconnect/reconnect
+2. Launch via feature flags:
+   - internal
+   - beta cohort
+   - wider rollout
+3. Define rollback criteria and on-call playbook.
+4. Confirm success metrics instrumentation is queryable.
+
+### Acceptance Criteria
+
+1. Checklist passes in staging and production canary cohort.
+2. Rollout metrics stay within threshold/error budget.
+3. Rollback path is tested and documented.
+
+### Dependencies
+
+- `GNS-10`, `GNS-11`, `GNS-12`, `GNS-13`, `GNS-15`
+
+### Blockers/Risks
+
+- Unexpected edge-case regressions in existing provider flows.
+
+### Verification
+
+- Release report with pass/fail per acceptance criterion.
+
+---
+
+## Suggested Milestone Mapping
+
+- **Milestone A (Enablement + Foundation)**: `GNS-00` to `GNS-04`
+- **Milestone B (MVP Ingestion Core)**: `GNS-05` to `GNS-09`
+- **Milestone C (Integrity + Management UX)**: `GNS-15`, `GNS-10`, `GNS-11`
+- **Milestone D (Hardening + Launch)**: `GNS-12` to `GNS-14`
+
+---
+
+## Notes for Issue Tracker Import
+
+- Each `GNS-*` issue above is intentionally self-contained and can be copied directly into Beads/Jira/Linear.
+- Keep acceptance criteria as testable checklists in each ticket.
+- Preserve dependency ordering to avoid blocked implementation work.

--- a/docs/gmail-newsletter-subscriptions-plan.md
+++ b/docs/gmail-newsletter-subscriptions-plan.md
@@ -1,0 +1,501 @@
+# Plan: Gmail Newsletter Subscriptions and Inbox Ingestion
+
+## Status
+
+Draft for product + engineering alignment.
+
+## Purpose
+
+Define a concrete implementation plan for a Gmail-connected newsletter feature in Zine, including:
+
+- OAuth account connection
+- Newsletter detection from inbox mail
+- Newsletter issue ingestion into Zine inbox
+- Newsletter management actions (hide/unsubscribe/sync)
+- Security, compliance, and rollout strategy
+
+This plan is intentionally implementation-oriented and mapped to the current monorepo architecture.
+
+---
+
+## Problem Statement
+
+Users can already connect YouTube/Spotify and ingest content automatically. We want a comparable experience for newsletters by connecting Gmail, detecting recurring newsletter senders, and letting users manage those newsletters from Zine.
+
+The feature should feel like "connect once, then newsletters appear and are manageable," with clear controls and privacy boundaries.
+
+---
+
+## Experience Decisions (Locked)
+
+1. Newsletters are a first-class source, alongside existing provider sources (YouTube, Spotify, X, etc.).
+2. Newsletter issues are rendered using the article presentation model, not a custom reader UI.
+3. Newsletter issues flow through the same item lifecycle as other sources:
+   - land in Inbox
+   - can be bookmarked to Library
+   - can be archived
+4. Item detail should use the standard non-X detail path already used by articles.
+5. Gmail connection starts from the Subscriptions page (provider cards), not from a separate settings-first flow.
+6. Gmail connect UX follows the same pattern as existing YouTube/Spotify connect screens (permissions, trust messaging, branded CTA, loading/error handling).
+7. Source management should feel consistent with existing provider connection/subscription surfaces.
+
+---
+
+## Goals
+
+1. Connect Gmail using the same secure OAuth model used by existing provider connections.
+2. Detect newsletters from inbox metadata with high precision.
+3. Create inbox items for newsletter issues so they fit existing triage flows.
+4. Allow users to manage detected newsletters (active, hidden, unsubscribed state).
+5. Keep the system resilient with incremental sync and safe fallback behavior.
+6. Preserve security and data-minimization posture.
+
+## Non-Goals (MVP)
+
+1. Full email-client replacement behavior.
+2. Bulk parsing and storing full email HTML bodies.
+3. Guaranteed one-tap external signup to new newsletters not already in inbox.
+4. Perfect unsubscribe completion for all publishers (best effort with clear status).
+
+---
+
+## Success Metrics
+
+1. Gmail connect completion rate from start -> connected.
+2. Detection precision on sampled feeds (target >= 95 percent high-confidence newsletters).
+3. Time to first newsletter surfaced after connect (target <= 2 minutes for small inboxes).
+4. Daily incremental sync success rate (target >= 99 percent).
+5. Unsubscribe action completion rate with explicit method/result tracking.
+6. Support burden: low volume of duplicate ingestion and missing-item reports.
+
+---
+
+## Architecture Fit (Existing System Reuse)
+
+We reuse major existing components:
+
+1. OAuth state registration + callback flow:
+   - `apps/mobile/lib/oauth.ts`
+   - `apps/worker/src/trpc/routers/connections.ts`
+2. Encrypted token storage in `provider_connections`:
+   - `apps/worker/src/db/schema.ts`
+3. Token refresh + distributed locking:
+   - `apps/worker/src/lib/token-refresh.ts`
+4. Existing ingestion destination model:
+   - `items` + `user_items` for inbox/bookmark/archive states
+5. Existing sync and async job patterns:
+   - `apps/worker/src/sync/*`
+   - `apps/worker/src/polling/*`
+
+Decision: Gmail will be added as a first-class OAuth provider, but newsletter detection/sync stays mailbox-centric instead of reusing YouTube/Spotify subscription polling directly.
+
+Rationale:
+
+1. YouTube/Spotify model is creator/channel polling.
+2. Gmail model is one mailbox stream with message-level delta sync.
+3. Reusing the same tables without mailbox-specific state would create avoidable complexity.
+
+---
+
+## Domain Model Additions
+
+## Enum and Shared Type Updates
+
+1. Add `GMAIL` to provider enums/schemas:
+   - `packages/shared/src/types/domain.ts`
+   - `packages/shared/src/schemas/index.ts`
+2. Extend worker/mobile provider handling wherever provider switches are hard-coded for `YOUTUBE`/`SPOTIFY`.
+
+## Database Changes
+
+Use Unix ms timestamps for all new tables.
+
+### 1) `gmail_mailboxes`
+
+Represents one connected Gmail mailbox per user.
+
+Suggested columns:
+
+- `id` TEXT primary key (ULID)
+- `user_id` TEXT not null
+- `provider_connection_id` TEXT not null references `provider_connections.id`
+- `google_sub` TEXT not null
+- `email` TEXT not null
+- `history_id` TEXT
+- `watch_expiration_at` INTEGER
+- `last_sync_at` INTEGER
+- `last_sync_status` TEXT default `IDLE`
+- `last_sync_error` TEXT
+- `created_at` INTEGER not null
+- `updated_at` INTEGER not null
+
+Suggested indexes:
+
+- unique `(user_id, provider_connection_id)`
+- index on `(last_sync_status, updated_at)`
+
+### 2) `newsletter_feeds`
+
+Canonical newsletter sender/list metadata per user.
+
+Suggested columns:
+
+- `id` TEXT primary key (ULID)
+- `user_id` TEXT not null
+- `gmail_mailbox_id` TEXT not null references `gmail_mailboxes.id`
+- `canonical_key` TEXT not null
+- `list_id` TEXT
+- `from_address` TEXT
+- `display_name` TEXT
+- `unsubscribe_mailto` TEXT
+- `unsubscribe_url` TEXT
+- `unsubscribe_post_header` TEXT
+- `detection_score` REAL not null
+- `status` TEXT not null default `ACTIVE` (`ACTIVE`, `HIDDEN`, `UNSUBSCRIBED`)
+- `first_seen_at` INTEGER not null
+- `last_seen_at` INTEGER not null
+- `created_at` INTEGER not null
+- `updated_at` INTEGER not null
+
+Suggested indexes:
+
+- unique `(user_id, canonical_key)`
+- index `(gmail_mailbox_id, status, last_seen_at)`
+
+### 3) `newsletter_feed_messages`
+
+Mapping between Gmail messages, feeds, and ingested Zine items.
+
+Suggested columns:
+
+- `id` TEXT primary key (ULID)
+- `user_id` TEXT not null
+- `gmail_mailbox_id` TEXT not null references `gmail_mailboxes.id`
+- `newsletter_feed_id` TEXT not null references `newsletter_feeds.id`
+- `gmail_message_id` TEXT not null
+- `gmail_thread_id` TEXT
+- `item_id` TEXT not null references `items.id`
+- `internal_date` INTEGER
+- `created_at` INTEGER not null
+
+Suggested indexes:
+
+- unique `(user_id, gmail_message_id)`
+- index `(newsletter_feed_id, internal_date)`
+
+### 4) `newsletter_unsubscribe_events`
+
+Audit and UX status tracking for unsubscribe attempts.
+
+Suggested columns:
+
+- `id` TEXT primary key (ULID)
+- `user_id` TEXT not null
+- `newsletter_feed_id` TEXT not null references `newsletter_feeds.id`
+- `method` TEXT not null (`URL`, `MAILTO`, `ONE_CLICK_POST`)
+- `target` TEXT not null
+- `status` TEXT not null (`REQUESTED`, `COMPLETED`, `FAILED`)
+- `error` TEXT
+- `requested_at` INTEGER not null
+- `completed_at` INTEGER
+
+Suggested indexes:
+
+- index `(newsletter_feed_id, requested_at)`
+- index `(user_id, requested_at)`
+
+### Migration Notes
+
+1. New migration file should follow existing sequence in `apps/worker/src/db/migrations`.
+2. Update Drizzle schema and corresponding inferred types.
+3. Keep existing legacy ISO timestamp tables unchanged in MVP.
+
+---
+
+## OAuth and Provider Connection Plan
+
+## Mobile
+
+1. Add Gmail OAuth config in `apps/mobile/lib/oauth.ts`.
+2. Reuse PKCE/state flow (`registerState` -> browser auth -> `callback` mutation).
+3. Add Gmail provider card and route flow in subscriptions surfaces:
+   - `apps/mobile/app/subscriptions/index.tsx`
+   - `apps/mobile/app/subscriptions/[provider].tsx`
+   - `apps/mobile/app/subscriptions/connect/gmail.tsx`
+4. Keep Settings as status/management visibility, but connection initiation should originate from Subscriptions UX.
+
+## Worker
+
+1. Extend auth/token exchange support for `GMAIL` in `apps/worker/src/lib/auth.ts`.
+2. Extend token refresh provider config in `apps/worker/src/lib/token-refresh.ts`.
+3. Keep using `provider_connections` for encrypted access/refresh tokens.
+4. On first Gmail callback success, upsert `gmail_mailboxes` row and enqueue initial sync.
+
+## OAuth Scope Strategy (MVP)
+
+Use read-only mailbox scope plus identity scopes, then validate policy posture before production launch.
+
+Pragmatic recommendation for MVP:
+
+1. Start with read-only + metadata retrieval pipeline.
+2. Avoid write scopes in phase 1.
+3. Unsubscribe actions that require user mail send should be explicit and transparent.
+
+---
+
+## Ingestion and Detection Pipeline
+
+## Sync Modes
+
+### Initial Bootstrap Sync
+
+Triggered immediately after successful Gmail connection.
+
+1. Fetch bounded recent window (for example last 30 days).
+2. Pull message IDs in batches.
+3. Fetch message metadata (headers/snippet/internalDate/threadId).
+4. Detect newsletter feed identity and upsert `newsletter_feeds`.
+5. Transform each eligible message into a Zine `item` + `user_item(INBOX)`.
+6. Write mapping row in `newsletter_feed_messages`.
+7. Persist latest `history_id` in `gmail_mailboxes`.
+
+### Incremental Sync
+
+Runs on schedule and on explicit user-triggered sync.
+
+1. Use saved `history_id` for delta fetch.
+2. Process only newly added messages.
+3. If history cursor is invalid or stale, run bounded backfill recovery.
+4. Update mailbox sync status/error fields.
+
+## Detection Heuristics
+
+Use weighted scoring to minimize false positives:
+
+1. Strong positive signals:
+   - `List-Id`
+   - `List-Unsubscribe`
+   - `List-Unsubscribe-Post`
+2. Medium signals:
+   - sender naming conventions (`newsletter`, `digest`, `updates`)
+   - recurring cadence from same sender
+3. Weak/negative signals:
+   - transactional or personal patterns
+   - known receipt/order/password-reset keywords
+
+Store:
+
+1. Detection score
+2. Headers used for classification (normalized)
+3. Canonical feed key generation logic
+
+Canonical key fallback order:
+
+1. Normalized `List-Id`
+2. Normalized unsubscribe target
+3. Normalized sender address
+
+## Item Mapping
+
+Each newsletter issue becomes an item in existing inbox flow:
+
+1. `contentType`: `ARTICLE`
+2. `provider`: `GMAIL`
+3. `providerId`: deterministic user-scoped ID (for example `${googleSub}:${gmailMessageId}`)
+4. `title`: subject header
+5. `summary`: snippet/cleaned preview
+6. `creator`: feed display name or sender
+7. `canonicalUrl`: best outbound primary link if extracted, else Gmail thread fallback URL
+
+Idempotency:
+
+1. Keep `provider + providerId` stable.
+2. Optionally also gate by `newsletter_feed_messages` unique key.
+
+Rendering contract:
+
+1. `contentType = ARTICLE` so cards/detail use article copy and metadata treatment.
+2. No newsletter-specific item detail layout in MVP.
+3. If no thumbnail exists, use existing article fallback rendering.
+4. Primary action remains external open; target is extracted issue URL or mailbox fallback URL.
+
+---
+
+## API Plan (tRPC)
+
+Add router namespace:
+
+- `subscriptions.newsletters.*` (recommended for consistency)
+
+Suggested procedures:
+
+1. `subscriptions.newsletters.list`
+   - filters: `status`, `search`, pagination
+2. `subscriptions.newsletters.updateStatus`
+   - set `ACTIVE` or `HIDDEN`
+3. `subscriptions.newsletters.unsubscribe`
+   - triggers method-specific unsubscribe flow and records event
+4. `subscriptions.newsletters.syncNow`
+   - mailbox-level manual sync trigger
+5. `subscriptions.newsletters.stats`
+   - feed count, last sync, pending errors
+
+Support updates:
+
+1. `subscriptions.connections.list` currently returns fixed keys for YouTube/Spotify; this should become provider-extensible.
+2. Add Gmail-specific connection health to connection UI.
+
+---
+
+## Unsubscribe Strategy
+
+Unsubscribe methods by priority:
+
+1. One-click POST (if header supports it)
+2. Unsubscribe URL (open and confirm completion)
+3. Mailto fallback
+
+Behavior rules:
+
+1. Always record an unsubscribe event row.
+2. Show method used and status in UI.
+3. If completion is uncertain, mark as `REQUESTED` and prompt user to confirm.
+4. Do not silently claim success without verifiable signal.
+
+---
+
+## Security, Privacy, and Compliance
+
+1. Encrypt OAuth tokens at rest (existing AES-256-GCM path).
+2. Minimize stored email data:
+   - store headers/snippet needed for feature
+   - avoid raw body storage in MVP
+3. Redact sensitive data from logs.
+4. Respect revocation:
+   - connection status update
+   - mailbox sync stop
+5. Maintain explicit user controls:
+   - disconnect Gmail
+   - hide feed
+   - unsubscribe trigger history
+6. Complete Google API policy verification/security requirements before production launch.
+
+---
+
+## Operational Plan
+
+1. Scheduler:
+   - run incremental sync on fixed interval for active Gmail mailboxes
+2. Concurrency:
+   - mailbox-level locks in KV to avoid duplicate sync workers
+3. Recovery:
+   - stale/invalid history cursor triggers bounded backfill
+4. Observability:
+   - sync duration, message throughput, detection precision counters
+5. Rate limit handling:
+   - exponential backoff with jitter
+6. Feature flags:
+   - internal users -> beta cohort -> wider rollout
+
+---
+
+## Testing Plan
+
+## Unit Tests
+
+1. Header parser and canonical key builder.
+2. Detection scorer false-positive/false-negative fixtures.
+3. Message-to-item transformer.
+4. Unsubscribe method selector and status transitions.
+
+## Integration Tests
+
+1. OAuth callback creates/updates mailbox state.
+2. Initial sync inserts feeds, messages, items, and user_items idempotently.
+3. Incremental sync handles normal delta and stale cursor fallback.
+4. Disconnect/reconnect behavior reactivates sync state correctly.
+
+## Contract and Router Tests
+
+1. New tRPC procedures validation and authorization.
+2. `connections.list` response compatibility after provider extensibility changes.
+
+## Manual Verification Checklist
+
+1. Connect Gmail on mobile and confirm connected provider status.
+2. Run first sync and verify detected newsletter list appears.
+3. Confirm newsletter issues land in Inbox and can be bookmarked/archived.
+4. Hide a newsletter feed and verify new issues from that feed are suppressed.
+5. Trigger unsubscribe and verify event status is visible.
+6. Disconnect Gmail and verify sync stops with clear status.
+
+---
+
+## Phased Delivery Plan
+
+## Phase 0: Foundation
+
+1. Provider enum/schema updates.
+2. OAuth + token refresh support for Gmail.
+3. DB migrations for mailbox/newsletter tables.
+4. Feature flag plumbing.
+
+Acceptance:
+
+1. Gmail can connect/disconnect with encrypted tokens.
+2. New schema exists with tests passing.
+
+## Phase 1: Detection + Ingestion MVP
+
+1. Initial and incremental mailbox sync jobs.
+2. Newsletter detection heuristics and feed persistence.
+3. Issue ingestion into `items`/`user_items`.
+4. Basic feeds list UI.
+
+Acceptance:
+
+1. User sees detected newsletters and newsletter issues in Inbox.
+2. No duplicate issue ingestion across repeated sync runs.
+
+## Phase 2: Management UX
+
+1. Feed status controls (`ACTIVE`/`HIDDEN`).
+2. Unsubscribe execution and status tracking.
+3. Sync health and last-sync visibility.
+
+Acceptance:
+
+1. User can manage newsletter feeds and see unsubscribe outcomes.
+
+## Phase 3: Hardening and Scale
+
+1. Optional push/watch optimization.
+2. Better outbound-link extraction and ranking.
+3. Detection model tuning and telemetry-driven threshold updates.
+
+Acceptance:
+
+1. Stable sync reliability and lower sync latency at scale.
+
+---
+
+## Risks and Mitigations
+
+1. Risk: False positives classify transactional mail as newsletters.
+   - Mitigation: conservative threshold + user hide feedback loop.
+2. Risk: OAuth/policy review delays launch.
+   - Mitigation: start policy prep early with clear scope and data minimization docs.
+3. Risk: History cursor invalidation causes missed messages.
+   - Mitigation: bounded recovery backfill plus alerting.
+4. Risk: Unsubscribe behavior differs per publisher.
+   - Mitigation: method-aware statuses and transparent user messaging.
+5. Risk: Hard-coded provider assumptions regress existing flows.
+   - Mitigation: provider-extensibility updates plus regression tests on YouTube/Spotify.
+
+---
+
+## Open Product Questions (for follow-up discussion)
+
+1. Should newsletter issues always enter Inbox, or optionally go straight to Library for some users?
+2. Should we expose "auto-hide low-confidence feeds" in MVP or keep detection strictly manual review?
+3. How explicit should unsubscribe UX be when completion cannot be confirmed?

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -23,7 +23,7 @@ export const ContentTypeSchema = z
 /** Schema for content provider platforms */
 export const ProviderSchema = z
   .nativeEnum(Provider)
-  .describe('Content provider platforms supported by Zine (YOUTUBE, SPOTIFY)');
+  .describe('Content provider platforms supported by Zine (YOUTUBE, SPOTIFY, GMAIL, etc.)');
 
 /** Schema for subscription lifecycle status */
 export const SubscriptionStatusSchema = z

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -24,6 +24,7 @@ export enum ContentType {
 export enum Provider {
   YOUTUBE = 'YOUTUBE',
   SPOTIFY = 'SPOTIFY',
+  GMAIL = 'GMAIL',
   RSS = 'RSS',
   SUBSTACK = 'SUBSTACK',
   WEB = 'WEB',


### PR DESCRIPTION
Summary
- refresh the newsletter FAB icon and metadata flow so Gmail newsletter items reuse the existing avatar image sources
- propagate image metadata through subscriptions, items, and shared types to keep inbox and detail views consistent
- update docs and migrations to describe the newsletter ingestion and avatar handling behavior
Testing
- Not run (not requested)