### PR TITLE
Increase Gmail newsletter sync range

### DIFF
--- a/apps/worker/src/newsletters/gmail.ts
+++ b/apps/worker/src/newsletters/gmail.ts
@@ -25,8 +25,8 @@ import { buildNewsletterAvatarUrl } from './avatar';
 const gmailLogger = logger.child('gmail-newsletters');
 
 const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
-const DEFAULT_INITIAL_DAYS = 30;
-const MAX_INITIAL_PAGES = 2;
+const DEFAULT_INITIAL_DAYS = 60;
+const MAX_INITIAL_PAGES = 6;
 const MAX_INCREMENTAL_PAGES = 3;
 const MESSAGE_FETCH_CONCURRENCY = 5;
 const NEWSLETTER_SCORE_THRESHOLD = 0.78;


### PR DESCRIPTION
## Summary
- double the default lookback window for the Gmail newsletter sync to 60 days
- increase the initial pagination limit from 2 to 6 to fetch more newsletters up front

## Testing
- Not run (not requested)