### PR TITLE
Use native Substack app when opening Substack articles

### DIFF
--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -28,8 +28,9 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
 
     try {
       const isArticle = item.contentType === ContentType.ARTICLE;
+      const isSubstack = item.provider === 'SUBSTACK' || item.provider === 'substack';
 
-      if (isArticle) {
+      if (isArticle && !isSubstack) {
         await WebBrowser.openBrowserAsync(item.canonicalUrl, {
           presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
         });
@@ -37,6 +38,10 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
         const supported = await Linking.canOpenURL(item.canonicalUrl);
         if (supported) {
           await Linking.openURL(item.canonicalUrl);
+        } else if (isSubstack) {
+          await WebBrowser.openBrowserAsync(item.canonicalUrl, {
+            presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+          });
         }
       }
 

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -139,6 +139,46 @@ describe('useItemDetailActions', () => {
     expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
   });
 
+  it('opens substack articles with Linking instead of in-app browser', async () => {
+    const item = {
+      ...baseItem,
+      provider: 'SUBSTACK',
+      contentType: 'ARTICLE',
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(item));
+
+    await act(async () => {
+      await result.current.handleOpenLink();
+    });
+
+    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to browser when substack can not be opened', async () => {
+    mockCanOpenURL.mockResolvedValueOnce(false);
+
+    const item = {
+      ...baseItem,
+      provider: 'SUBSTACK',
+      contentType: 'ARTICLE',
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(item));
+
+    await act(async () => {
+      await result.current.handleOpenLink();
+    });
+
+    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenURL).not.toHaveBeenCalled();
+    expect(mockOpenBrowserAsync).toHaveBeenCalledWith(item.canonicalUrl, {
+      presentationStyle: 'FULL_SCREEN',
+    });
+  });
+
   it('does not mark opened when item is not bookmarked', async () => {
     const { result } = renderHook(() => useItemDetailActions(baseItem));
 


### PR DESCRIPTION
Summary
- keep using the in-app browser for regular articles but open substack links through the native app when possible
- fall back to the in-app browser when linking to Substack content fails and verify the hook behavior

Testing
- Not run (not requested)