### PR TITLE
Fix creator catalogue taps to open in-app content view

### DIFF
--- a/apps/mobile/components/creator/LatestContentCard.tsx
+++ b/apps/mobile/components/creator/LatestContentCard.tsx
@@ -52,7 +52,8 @@ export interface LatestContentCardProps {
 
 /**
  * LatestContentCard displays a single content item in a horizontal carousel.
- * Tapping the card opens the external URL in the appropriate app.
+ * Tapping the card opens the in-app content detail when an internal ID exists,
+ * and falls back to the external URL when the item is not yet in-app.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
Summary
- ensure Creator back catalogue items route into the app when an internal ID exists while still opening external URLs for yet-to-be-ingested content
- enrich the creator router so we always fetch the user item and bookmark state needed to power the new navigation flow
- confirm LatestContentCard docs reflect the new behavior

Testing
- Not run (not requested)