### PR TITLE
Enable collapsing Safari toolbar for embedded links

### DIFF
--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -32,6 +32,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
 
       if (isArticle && !isSubstack) {
         await WebBrowser.openBrowserAsync(item.canonicalUrl, {
+          enableBarCollapsing: true,
           presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
         });
       } else {
@@ -40,6 +41,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
           await Linking.openURL(item.canonicalUrl);
         } else if (isSubstack) {
           await WebBrowser.openBrowserAsync(item.canonicalUrl, {
+            enableBarCollapsing: true,
             presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
           });
         }

--- a/apps/mobile/components/external-link.tsx
+++ b/apps/mobile/components/external-link.tsx
@@ -17,6 +17,7 @@ export function ExternalLink({ href, ...rest }: Props) {
           event.preventDefault();
           // Open the link in an in-app browser.
           await openBrowserAsync(href, {
+            enableBarCollapsing: true,
             presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
           });
         }


### PR DESCRIPTION
Summary
- enable collapsing browser bars whenever we open links through the article detail actions or the reusable external link component
- keep the in-app readers full-screen so navigation chrome slides away while scrolling

Testing
- Not run (not requested)