### PR TITLE
Add library search feature with native tab UI

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -46,6 +46,10 @@ export default function TabLayout() {
           <Icon sf={{ default: 'tray', selected: 'tray.fill' }} drawable="ic_inbox" />
         </NativeTabs.Trigger>
 
+        <NativeTabs.Trigger name="search" role="search">
+          <Label>Search</Label>
+        </NativeTabs.Trigger>
+
         <NativeTabs.Trigger name="library">
           <Label>Library</Label>
           <Icon

--- a/apps/mobile/app/(tabs)/search/_layout.tsx
+++ b/apps/mobile/app/(tabs)/search/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from 'expo-router';
+
+export default function SearchLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        headerLargeTitle: true,
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Stack } from 'expo-router';
+import { Surface } from 'heroui-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { type ItemCardData, ItemCard } from '@/components/item-card';
+import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
+import { Colors, Spacing } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { mapContentType, mapProvider, useLibraryItems } from '@/hooks/use-items-trpc';
+import type { ContentType, Provider } from '@/lib/content-utils';
+
+export default function SearchTabScreen() {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery.trim());
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [searchQuery]);
+
+  const { data, isLoading, error } = useLibraryItems({
+    search: debouncedSearchQuery || undefined,
+  });
+
+  const libraryItems: ItemCardData[] = useMemo(
+    () =>
+      (data?.items ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        creator: item.creator,
+        thumbnailUrl: item.thumbnailUrl ?? null,
+        contentType: mapContentType(item.contentType) as ContentType,
+        provider: mapProvider(item.provider) as Provider,
+        duration: item.duration ?? null,
+        bookmarkedAt: item.bookmarkedAt ?? null,
+        publishedAt: item.publishedAt ?? null,
+        isFinished: item.isFinished,
+      })),
+    [data?.items]
+  );
+
+  return (
+    <Surface style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen
+        options={{
+          title: 'Search',
+          headerSearchBarOptions: {
+            placeholder: 'Search your library',
+            hideWhenScrolling: false,
+            onChangeText: (event) => {
+              setSearchQuery(event.nativeEvent.text);
+            },
+          },
+        }}
+      />
+
+      <SafeAreaView style={styles.safeArea} edges={['left', 'right']}>
+        {isLoading ? (
+          <LoadingState />
+        ) : error ? (
+          <ErrorState message={error.message} />
+        ) : libraryItems.length === 0 ? (
+          <EmptyState
+            title={debouncedSearchQuery ? 'No matches found' : 'Search your library'}
+            message={
+              debouncedSearchQuery
+                ? 'Try a different title or creator name.'
+                : 'Type in the search bar to find saved items by title or creator.'
+            }
+          />
+        ) : (
+          <ScrollView
+            style={styles.listContainer}
+            contentContainerStyle={styles.listContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {libraryItems.map((item, index) => (
+              <ItemCard key={item.id} item={item} variant="compact" index={index} />
+            ))}
+            <View style={styles.bottomSpacer} />
+          </ScrollView>
+        )}
+      </SafeAreaView>
+    </Surface>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  listContainer: {
+    flex: 1,
+  },
+  listContent: {
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing['3xl'],
+  },
+  bottomSpacer: {
+    height: Spacing.lg,
+  },
+});

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -79,6 +79,19 @@ describe('useItems list queries', () => {
     );
   });
 
+  it('trims library search query before requesting data', () => {
+    renderHook(() =>
+      useLibraryItems({
+        search: '  all in  ',
+      })
+    );
+
+    expect(mockLibraryUseQuery).toHaveBeenCalledWith(
+      { search: 'all in' },
+      expect.objectContaining({ placeholderData: expect.any(Function) })
+    );
+  });
+
   it('uses placeholderData for home data', () => {
     renderHook(() => useHomeData());
 

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -258,6 +258,7 @@ export function useInboxItems(options?: {
  *
  * Returns items that have been saved for later consumption.
  * Supports filtering by provider, content type, and completion status.
+ * Supports optional search by item title or creator.
  *
  * @param options - Optional filter and pagination options
  * @param options.filter.provider - Filter by content provider (YOUTUBE, SPOTIFY, etc.)
@@ -265,6 +266,7 @@ export function useInboxItems(options?: {
  * @param options.filter.isFinished - Filter by completion status
  *   - undefined/false: show only unfinished items (default)
  *   - true: show only finished items
+ * @param options.search - Optional search query (title/creator)
  * @param options.limit - Maximum number of items to return
  * @returns tRPC query result with items array and pagination cursor
  *
@@ -294,6 +296,7 @@ export function useLibraryItems(options?: {
     contentType?: ContentType;
     isFinished?: boolean;
   };
+  search?: string;
   limit?: number;
 }) {
   const filter = options?.filter
@@ -306,10 +309,12 @@ export function useLibraryItems(options?: {
       }
     : undefined;
 
+  const search = options?.search?.trim();
   const input = options
     ? {
-        ...options,
+        ...(options.limit !== undefined ? { limit: options.limit } : {}),
         ...(filter && Object.keys(filter).length > 0 ? { filter } : {}),
+        ...(search ? { search } : {}),
       }
     : undefined;
 


### PR DESCRIPTION
- Summary
  - introduce a dedicated native search tab that wires the existing library search UI to a debounced query
  - extend the TRPC library endpoint to accept trimmed search terms with punctuation- and consonant-aware matching plus supporting tests
  - add search-aware feedback messaging in the library tab and tidy related hooks/types
- Testing
  - Not run (not requested)