### PR TITLE
Refactor mobile subscriptions and hooks

### DIFF
--- a/apps/mobile/app/subscriptions/connect/gmail.tsx
+++ b/apps/mobile/app/subscriptions/connect/gmail.tsx
@@ -51,9 +51,9 @@ function GmailConnectContent() {
 
     try {
       await connectProvider('GMAIL');
-      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
-      await (utils as any).subscriptions?.newsletters?.stats?.invalidate?.();
-      await (utils as any).subscriptions?.newsletters?.list?.invalidate?.();
+      await utils.subscriptions.connections.list.invalidate();
+      await utils.subscriptions.newsletters.stats.invalidate();
+      await utils.subscriptions.newsletters.list.invalidate();
       router.replace('/subscriptions/gmail' as const);
     } catch (err) {
       const rawMessage = err instanceof Error ? err.message : 'Connection failed';

--- a/apps/mobile/app/subscriptions/connect/spotify.tsx
+++ b/apps/mobile/app/subscriptions/connect/spotify.tsx
@@ -73,7 +73,7 @@ function SpotifyConnectContent() {
     try {
       await connectProvider('SPOTIFY');
       // Invalidate connections cache so UI shows updated state immediately
-      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
+      await utils.subscriptions.connections.list.invalidate();
       // On success, navigate to subscriptions discover screen
       router.replace('/subscriptions/discover/spotify' as const);
     } catch (err) {

--- a/apps/mobile/app/subscriptions/connect/youtube.tsx
+++ b/apps/mobile/app/subscriptions/connect/youtube.tsx
@@ -112,7 +112,7 @@ function YouTubeConnectContent() {
     try {
       await connectProvider('YOUTUBE');
       // Invalidate connections cache so UI shows updated state immediately
-      await (utils as any).subscriptions?.connections?.list?.invalidate?.();
+      await utils.subscriptions.connections.list.invalidate();
       // On success, navigate to subscriptions discover screen
       router.replace('/subscriptions/discover/youtube' as const);
     } catch (err) {

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -170,10 +170,10 @@ export default function SubscriptionsScreen() {
 
   const { data: connections, isLoading: connectionsLoading } = useConnections();
   const { subscriptions, isLoading: subscriptionsLoading } = useSubscriptions();
-  const newsletterStatsQuery = (trpc as any).subscriptions.newsletters.stats.useQuery(undefined, {
+  const newsletterStatsQuery = trpc.subscriptions.newsletters.stats.useQuery(undefined, {
     staleTime: 60 * 1000,
   });
-  const rssStatsQuery = (trpc as any).subscriptions.rss.stats.useQuery(undefined, {
+  const rssStatsQuery = trpc.subscriptions.rss.stats.useQuery(undefined, {
     staleTime: 60 * 1000,
   });
 
@@ -193,9 +193,9 @@ export default function SubscriptionsScreen() {
   const gmailConnection = connections?.find(
     (connection: Connection) => connection.provider === 'GMAIL'
   );
-  const youtubeStatus = (youtubeConnection?.status as ConnectionStatus) ?? null;
-  const spotifyStatus = (spotifyConnection?.status as ConnectionStatus) ?? null;
-  const gmailStatus = (gmailConnection?.status as ConnectionStatus) ?? null;
+  const youtubeStatus = youtubeConnection?.status ?? null;
+  const spotifyStatus = spotifyConnection?.status ?? null;
+  const gmailStatus = gmailConnection?.status ?? null;
   const rssStatus: ConnectionStatus = 'ACTIVE';
 
   // Count subscriptions per provider

--- a/apps/mobile/components/creator/LatestContentCard.tsx
+++ b/apps/mobile/components/creator/LatestContentCard.tsx
@@ -90,8 +90,11 @@ export function LatestContentCard({ item, creatorId, provider }: LatestContentCa
       externalUrl: hasInternalItem ? undefined : item.url,
     });
 
-    if (hasInternalItem) {
-      router.push(`/item/${item.itemId}` as any);
+    if (hasInternalItem && item.itemId) {
+      router.push({
+        pathname: '/item/[id]',
+        params: { id: item.itemId },
+      });
       return;
     }
 

--- a/apps/mobile/hooks/use-connections.test.ts
+++ b/apps/mobile/hooks/use-connections.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';
+import { Provider } from '@zine/shared';
 
 // ============================================================================
 // Module-level Mocks
@@ -199,15 +200,15 @@ describe('useDisconnectConnection', () => {
     const { result } = renderHook(() => useDisconnectConnection());
 
     await act(async () => {
-      await result.current.mutate({ provider: 'YOUTUBE' });
+      await result.current.mutate({ provider: Provider.YOUTUBE });
     });
 
     const [queryKey, updater] = mockConnectionsSetData.mock.calls[0];
     expect(queryKey).toBeUndefined();
 
-    const updated = updater([createConnection('YOUTUBE'), createConnection('SPOTIFY')]);
-    expect(updated).toHaveLength(1);
-    expect(updated[0].provider).toBe('SPOTIFY');
+    const updated = updater(createConnectionsMap());
+    expect(updated.YOUTUBE).toBeNull();
+    expect(updated.SPOTIFY).not.toBeNull();
 
     const defaultCall = mockSubscriptionsSetData.mock.calls.find(
       ([input]) => input && Object.keys(input).length === 0
@@ -232,7 +233,7 @@ describe('useDisconnectConnection', () => {
     const { result } = renderHook(() => useDisconnectConnection());
 
     await act(async () => {
-      await result.current.mutate({ provider: 'GMAIL' });
+      await result.current.mutate({ provider: Provider.GMAIL });
     });
 
     const [queryKey, updater] = mockConnectionsSetData.mock.calls[0];
@@ -254,7 +255,7 @@ describe('useDisconnectConnection', () => {
     const { result } = renderHook(() => useDisconnectConnection());
 
     await act(async () => {
-      await expect(result.current.mutate({ provider: 'YOUTUBE' })).rejects.toThrow(
+      await expect(result.current.mutate({ provider: Provider.YOUTUBE })).rejects.toThrow(
         'Failed to disconnect'
       );
     });
@@ -278,7 +279,7 @@ describe('useDisconnectConnection', () => {
     const { result } = renderHook(() => useDisconnectConnection());
 
     await act(async () => {
-      await result.current.mutate({ provider: 'YOUTUBE' });
+      await result.current.mutate({ provider: Provider.YOUTUBE });
     });
 
     expect(mockConnectionsInvalidate).toHaveBeenCalled();
@@ -289,7 +290,7 @@ describe('useDisconnectConnection', () => {
     const { result } = renderHook(() => useDisconnectConnection());
 
     await act(async () => {
-      await result.current.mutate({ provider: 'GMAIL' });
+      await result.current.mutate({ provider: Provider.GMAIL });
     });
 
     expect(mockNewslettersListCancel).toHaveBeenCalledWith({ limit: 100, search: undefined });

--- a/apps/mobile/hooks/use-prefetch.ts
+++ b/apps/mobile/hooks/use-prefetch.ts
@@ -49,8 +49,8 @@ export function useBaselinePrefetchOnFocus() {
     if (isRestoring) return;
 
     prefetchListQueries(utils, ['home', 'inbox', 'library']);
-    prefetchSafely(() => (utils as any).subscriptions.list.prefetch({}));
-    prefetchSafely(() => (utils as any).subscriptions.connections.list.prefetch(undefined));
+    prefetchSafely(() => utils.subscriptions.list.prefetch({}));
+    prefetchSafely(() => utils.subscriptions.connections.list.prefetch());
   }, [isRestoring, utils]);
 
   useEffect(() => {

--- a/apps/mobile/hooks/use-rss-feeds.ts
+++ b/apps/mobile/hooks/use-rss-feeds.ts
@@ -1,92 +1,68 @@
 import { trpc } from '@/lib/trpc';
+import type { RssListOutput, RssStatsOutput } from '@/lib/trpc-types';
 
-export type RssFeedStatus = 'ACTIVE' | 'PAUSED' | 'UNSUBSCRIBED' | 'ERROR';
-
-export interface RssFeed {
-  id: string;
-  feedUrl: string;
-  title: string;
-  description: string | null;
-  siteUrl: string | null;
-  imageUrl: string | null;
-  status: RssFeedStatus;
-  errorCount: number;
-  lastError: string | null;
-  lastPolledAt: number | null;
-  lastSuccessAt: number | null;
-  createdAt: number;
-  updatedAt: number;
-}
+export type RssFeed = RssListOutput['items'][number];
+export type RssFeedStatus = RssFeed['status'];
 
 export function useRssFeeds() {
-  const utils = trpc.useUtils() as any;
+  const utils = trpc.useUtils();
 
-  const listQuery = (trpc as any).subscriptions.rss.list.useQuery(
+  const listQuery = trpc.subscriptions.rss.list.useQuery(
     { limit: 100 },
     {
       staleTime: 60 * 1000,
     }
   );
 
-  const statsQuery = (trpc as any).subscriptions.rss.stats.useQuery(undefined, {
+  const statsQuery = trpc.subscriptions.rss.stats.useQuery(undefined, {
     staleTime: 60 * 1000,
   });
 
-  const addMutation = (trpc as any).subscriptions.rss.add.useMutation({
+  const addMutation = trpc.subscriptions.rss.add.useMutation({
     onSuccess: () => {
-      utils.subscriptions?.rss?.list?.invalidate?.();
-      utils.subscriptions?.rss?.stats?.invalidate?.();
-      utils.items?.inbox?.invalidate?.();
-      utils.items?.home?.invalidate?.();
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
+      utils.items.inbox.invalidate();
+      utils.items.home.invalidate();
     },
   });
 
-  const pauseMutation = (trpc as any).subscriptions.rss.pause.useMutation({
+  const pauseMutation = trpc.subscriptions.rss.pause.useMutation({
     onSuccess: () => {
-      utils.subscriptions?.rss?.list?.invalidate?.();
-      utils.subscriptions?.rss?.stats?.invalidate?.();
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
     },
   });
 
-  const resumeMutation = (trpc as any).subscriptions.rss.resume.useMutation({
+  const resumeMutation = trpc.subscriptions.rss.resume.useMutation({
     onSuccess: () => {
-      utils.subscriptions?.rss?.list?.invalidate?.();
-      utils.subscriptions?.rss?.stats?.invalidate?.();
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
     },
   });
 
-  const removeMutation = (trpc as any).subscriptions.rss.remove.useMutation({
+  const removeMutation = trpc.subscriptions.rss.remove.useMutation({
     onSuccess: () => {
-      utils.subscriptions?.rss?.list?.invalidate?.();
-      utils.subscriptions?.rss?.stats?.invalidate?.();
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
     },
   });
 
-  const syncNowMutation = (trpc as any).subscriptions.rss.syncNow.useMutation({
+  const syncNowMutation = trpc.subscriptions.rss.syncNow.useMutation({
     onSuccess: () => {
-      utils.subscriptions?.rss?.list?.invalidate?.();
-      utils.subscriptions?.rss?.stats?.invalidate?.();
-      utils.items?.inbox?.invalidate?.();
-      utils.items?.home?.invalidate?.();
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
+      utils.items.inbox.invalidate();
+      utils.items.home.invalidate();
     },
   });
 
-  const allFeeds = ((listQuery.data as { items?: RssFeed[] } | undefined)?.items ??
-    []) as RssFeed[];
+  const allFeeds = listQuery.data?.items ?? [];
   const visibleFeeds = allFeeds.filter((feed) => feed.status !== 'UNSUBSCRIBED');
 
   return {
     feeds: visibleFeeds,
-    stats: statsQuery.data as
-      | {
-          total: number;
-          active: number;
-          paused: number;
-          unsubscribed: number;
-          error: number;
-          lastSuccessAt: number | null;
-        }
-      | undefined,
+    stats: statsQuery.data as RssStatsOutput | undefined,
     isLoading: listQuery.isLoading || statsQuery.isLoading,
     isSyncing: syncNowMutation.isPending,
     addingFeed: addMutation.isPending,

--- a/apps/mobile/hooks/use-subscriptions.test.ts
+++ b/apps/mobile/hooks/use-subscriptions.test.ts
@@ -319,7 +319,7 @@ describe('useSubscriptions', () => {
       expect(newSub.imageUrl).toBe('https://example.com/thumb.jpg');
       expect(newSub.status).toBe('ACTIVE');
       expect(typeof newSub.createdAt).toBe('number');
-      expect(newSub.lastItemAt).toBeNull();
+      expect(newSub.lastPublishedAt).toBeNull();
     });
 
     it('handles subscribe when cache is empty (undefined)', () => {

--- a/apps/mobile/hooks/use-sync-now.ts
+++ b/apps/mobile/hooks/use-sync-now.ts
@@ -19,6 +19,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { trpc } from '../lib/trpc';
+import type { SyncSubscriptionOutput } from '../lib/trpc-types';
 
 // ============================================================================
 // Types
@@ -108,10 +109,8 @@ export function useSyncNow(subscriptionId: string): UseSyncNowReturn {
   // Track the interval ID for cleanup
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Using type assertion until router is updated with proper typing
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mutation = (trpc as any).subscriptions.syncNow.useMutation({
-    onSuccess: (data: { success: boolean; itemsFound: number }) => {
+  const mutation = trpc.subscriptions.syncNow.useMutation({
+    onSuccess: (data: SyncSubscriptionOutput) => {
       const itemsFound = data.itemsFound ?? 0;
 
       setLastResult({
@@ -126,7 +125,7 @@ export function useSyncNow(subscriptionId: string): UseSyncNowReturn {
       // Start cooldown after successful sync
       setCooldownSeconds(DEFAULT_COOLDOWN_SECONDS);
     },
-    onError: (error: { data?: { code?: string }; message?: string }) => {
+    onError: (error) => {
       if (error.data?.code === 'TOO_MANY_REQUESTS') {
         // Parse cooldown from error message or use default
         // Server message format: "Please wait X minutes between manual syncs"

--- a/apps/mobile/lib/select-channels-screen.test.ts
+++ b/apps/mobile/lib/select-channels-screen.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for onboarding select-channels navigation behavior.
+ *
+ * Ensures invalid provider redirects happen from an effect (not during render),
+ * preventing React's "Cannot update a component while rendering..." warning.
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import SelectChannelsScreen from '@/app/onboarding/select-channels';
+
+const mockUseLocalSearchParams = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockUseLocalSearchParams(),
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+  Stack: {
+    Screen: () => null,
+  },
+}));
+
+jest.mock('heroui-native', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children: React.ReactNode }) => children ?? null,
+}));
+
+jest.mock('@/hooks/use-subscriptions', () => ({
+  useSubscriptions: () => ({
+    subscribe: jest.fn(),
+  }),
+}));
+
+const mockDiscoverAvailableUseQuery = jest.fn();
+
+jest.mock('@/lib/trpc', () => ({
+  trpc: {
+    subscriptions: {
+      discover: {
+        available: {
+          useQuery: (...args: unknown[]) => mockDiscoverAvailableUseQuery(...args),
+        },
+      },
+    },
+  },
+}));
+
+jest.mock('@/components/subscriptions', () => ({
+  ChannelSelectionList: () => null,
+  ChannelSelectionActionBar: () => null,
+}));
+
+describe('SelectChannelsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDiscoverAvailableUseQuery.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  it('redirects invalid provider without render-time navigation warning', () => {
+    mockUseLocalSearchParams.mockReturnValue({ provider: 'invalid-provider' });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    act(() => {
+      TestRenderer.create(React.createElement(SelectChannelsScreen));
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith('/onboarding/connect');
+
+    const renderWarnings = consoleErrorSpy.mock.calls.filter(([firstArg]) => {
+      return (
+        typeof firstArg === 'string' &&
+        firstArg.includes('Cannot update a component') &&
+        firstArg.includes('while rendering a different component')
+      );
+    });
+
+    expect(renderWarnings).toHaveLength(0);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/mobile/lib/trpc-types.ts
+++ b/apps/mobile/lib/trpc-types.ts
@@ -1,0 +1,27 @@
+import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '../../worker/src/trpc/router';
+
+export type RouterInputs = inferRouterInputs<AppRouter>;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+export type SubscriptionsListInput = RouterInputs['subscriptions']['list'];
+export type SubscriptionsListOutput = RouterOutputs['subscriptions']['list'];
+export type SubscriptionListItemOutput = SubscriptionsListOutput['items'][number];
+export type AddSubscriptionInput = RouterInputs['subscriptions']['add'];
+export type RemoveSubscriptionInput = RouterInputs['subscriptions']['remove'];
+export type SyncSubscriptionInput = RouterInputs['subscriptions']['syncNow'];
+export type SyncSubscriptionOutput = RouterOutputs['subscriptions']['syncNow'];
+
+export type ConnectionsListOutput = RouterOutputs['subscriptions']['connections']['list'];
+export type DisconnectConnectionInput = RouterInputs['subscriptions']['connections']['disconnect'];
+
+export type DiscoverAvailableInput = RouterInputs['subscriptions']['discover']['available'];
+export type DiscoverAvailableOutput = RouterOutputs['subscriptions']['discover']['available'];
+
+export type NewslettersListInput = RouterInputs['subscriptions']['newsletters']['list'];
+export type NewslettersListOutput = RouterOutputs['subscriptions']['newsletters']['list'];
+export type NewslettersStatsOutput = RouterOutputs['subscriptions']['newsletters']['stats'];
+
+export type RssListInput = RouterInputs['subscriptions']['rss']['list'];
+export type RssListOutput = RouterOutputs['subscriptions']['rss']['list'];
+export type RssStatsOutput = RouterOutputs['subscriptions']['rss']['stats'];


### PR DESCRIPTION
- Summary
  - refactor onboarding channel selection to avoid render-time navigation side effects
  - redirect invalid provider values from useEffect instead of during render
  - add a regression test to guard against the React warning ("Cannot update a component while rendering a different component")

- Testing
  - bun run typecheck
  - bun run lint
  - bun run test
  - bun run --cwd apps/mobile test lib/select-channels-screen.test.ts

- Manual verification
  - launched iOS simulator against this worktree (bun run dev:worktree)
  - deep-linked to /onboarding/select-channels?provider=invalid-provider
  - verified redirect to onboarding connect screen with no render-time navigation warning
