### PR TITLE
Unify creator source subscriptions and RSS feed discovery

### DIFF
--- a/apps/mobile/app/creator/[id].tsx
+++ b/apps/mobile/app/creator/[id].tsx
@@ -32,6 +32,39 @@ import { useCreator, useCreatorBookmarks } from '@/hooks/use-creator';
 import { analytics, type CreatorViewSource } from '@/lib/analytics';
 import { upgradeYouTubeImageUrl, upgradeSpotifyImageUrl } from '@/lib/content-utils';
 
+function isHttpUrl(value: string | null | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getSourceUrlForDiscovery(
+  externalUrl: string | null,
+  providerCreatorId: string,
+  bookmarkCanonicalUrl: string | undefined
+): string | null {
+  if (isHttpUrl(externalUrl)) {
+    return externalUrl;
+  }
+
+  if (isHttpUrl(providerCreatorId)) {
+    return providerCreatorId;
+  }
+
+  if (isHttpUrl(bookmarkCanonicalUrl)) {
+    return bookmarkCanonicalUrl;
+  }
+
+  return null;
+}
+
 // ============================================================================
 // Floating Header Button
 // ============================================================================
@@ -153,6 +186,11 @@ export default function CreatorScreen() {
 
   // Success state with creator data
   const hasImage = !!creator.imageUrl;
+  const sourceUrlForDiscovery = getSourceUrlForDiscovery(
+    creator.externalUrl,
+    creator.providerCreatorId,
+    bookmarks[0]?.canonicalUrl
+  );
 
   // Render with parallax if creator has an image
   if (hasImage) {
@@ -176,7 +214,7 @@ export default function CreatorScreen() {
             headerHeightFraction={0.35}
           >
             <Animated.View>
-              <CreatorHeader creator={creator} />
+              <CreatorHeader creator={creator} sourceUrlForDiscovery={sourceUrlForDiscovery} />
               <CreatorBookmarks creatorId={id ?? ''} />
               {creator.provider === 'GMAIL' ? (
                 <CreatorPublications creatorId={id ?? ''} />
@@ -216,7 +254,7 @@ export default function CreatorScreen() {
           headerHeightFraction={0.45}
         >
           <Animated.View>
-            <CreatorHeader creator={creator} />
+            <CreatorHeader creator={creator} sourceUrlForDiscovery={sourceUrlForDiscovery} />
             <CreatorBookmarks creatorId={id ?? ''} />
             {creator.provider === 'GMAIL' ? (
               <CreatorPublications creatorId={id ?? ''} />

--- a/apps/mobile/components/creator/CreatorLatestContent.test.ts
+++ b/apps/mobile/components/creator/CreatorLatestContent.test.ts
@@ -124,6 +124,8 @@ describe('CreatorLatestContent', () => {
     mockUseColorScheme.mockReturnValue('light');
   });
 
+  const supportedProviders = ['YOUTUBE', 'SPOTIFY', 'RSS', 'WEB', 'SUBSTACK'];
+
   describe('provider filtering', () => {
     it('shows for YOUTUBE provider', () => {
       mockUseCreatorLatestContent.mockReturnValue({
@@ -137,7 +139,7 @@ describe('CreatorLatestContent', () => {
       // Component should render for YOUTUBE
       // Verified by checking the hook is called
       const provider = 'YOUTUBE';
-      expect(['YOUTUBE', 'SPOTIFY'].includes(provider)).toBe(true);
+      expect(supportedProviders.includes(provider)).toBe(true);
     });
 
     it('shows for SPOTIFY provider', () => {
@@ -150,22 +152,32 @@ describe('CreatorLatestContent', () => {
       });
 
       const provider = 'SPOTIFY';
-      expect(['YOUTUBE', 'SPOTIFY'].includes(provider)).toBe(true);
+      expect(supportedProviders.includes(provider)).toBe(true);
     });
 
-    it('returns null for SUBSTACK provider', () => {
+    it('shows for SUBSTACK provider', () => {
       const provider = 'SUBSTACK';
-      expect(['YOUTUBE', 'SPOTIFY'].includes(provider)).toBe(false);
+      expect(supportedProviders.includes(provider)).toBe(true);
+    });
+
+    it('shows for RSS provider', () => {
+      const provider = 'RSS';
+      expect(supportedProviders.includes(provider)).toBe(true);
+    });
+
+    it('shows for WEB provider', () => {
+      const provider = 'WEB';
+      expect(supportedProviders.includes(provider)).toBe(true);
     });
 
     it('returns null for TWITTER provider', () => {
       const provider = 'TWITTER';
-      expect(['YOUTUBE', 'SPOTIFY'].includes(provider)).toBe(false);
+      expect(supportedProviders.includes(provider)).toBe(false);
     });
 
     it('returns null for POCKET provider', () => {
       const provider = 'POCKET';
-      expect(['YOUTUBE', 'SPOTIFY'].includes(provider)).toBe(false);
+      expect(supportedProviders.includes(provider)).toBe(false);
     });
   });
 

--- a/apps/mobile/hooks/use-rss-feed-discovery.test.ts
+++ b/apps/mobile/hooks/use-rss-feed-discovery.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRssFeedDiscovery } from './use-rss-feed-discovery';
+
+const mockDiscoverUseQuery = jest.fn();
+const mockAddUseMutation = jest.fn();
+const mockRssListInvalidate = jest.fn();
+const mockRssStatsInvalidate = jest.fn();
+const mockItemsInboxInvalidate = jest.fn();
+const mockItemsHomeInvalidate = jest.fn();
+
+jest.mock('../lib/trpc', () => ({
+  trpc: {
+    subscriptions: {
+      rss: {
+        discover: {
+          useQuery: mockDiscoverUseQuery,
+        },
+        add: {
+          useMutation: mockAddUseMutation,
+        },
+      },
+    },
+    useUtils: jest.fn(() => ({
+      subscriptions: {
+        rss: {
+          list: {
+            invalidate: mockRssListInvalidate,
+          },
+          stats: {
+            invalidate: mockRssStatsInvalidate,
+          },
+        },
+      },
+      items: {
+        inbox: {
+          invalidate: mockItemsInboxInvalidate,
+        },
+        home: {
+          invalidate: mockItemsHomeInvalidate,
+        },
+      },
+    })),
+  },
+}));
+
+describe('useRssFeedDiscovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockDiscoverUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    mockAddUseMutation.mockReturnValue({
+      mutate: jest.fn(),
+      mutateAsync: jest.fn(),
+      isPending: false,
+      error: null,
+    });
+  });
+
+  it('disables discovery for invalid URLs', () => {
+    renderHook(() => useRssFeedDiscovery('not-a-url', true));
+
+    expect(mockDiscoverUseQuery).toHaveBeenCalledWith(
+      { url: 'not-a-url' },
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it('returns discovered candidates', () => {
+    mockDiscoverUseQuery.mockReturnValue({
+      data: {
+        sourceUrl: 'https://example.com/post',
+        sourceOrigin: 'https://example.com',
+        checkedAt: 123,
+        cached: false,
+        candidates: [
+          {
+            feedUrl: 'https://example.com/feed.xml',
+            title: 'Example Feed',
+            description: null,
+            siteUrl: 'https://example.com',
+            discoveredFrom: 'page_link',
+            score: 100,
+            subscription: null,
+          },
+        ],
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const { result } = renderHook(() => useRssFeedDiscovery('https://example.com/post', true));
+
+    expect(result.current.candidates).toHaveLength(1);
+    expect(result.current.candidates[0]?.feedUrl).toBe('https://example.com/feed.xml');
+    expect(result.current.sourceOrigin).toBe('https://example.com');
+  });
+
+  it('invalidates rss and item queries when subscribe succeeds', () => {
+    let mutationOptions: { onSuccess?: () => void } | undefined;
+    mockAddUseMutation.mockImplementation((options: { onSuccess?: () => void }) => {
+      mutationOptions = options;
+      return {
+        mutate: jest.fn(),
+        mutateAsync: jest.fn(),
+        isPending: false,
+        error: null,
+      };
+    });
+
+    renderHook(() => useRssFeedDiscovery('https://example.com/post', true));
+    mutationOptions?.onSuccess?.();
+
+    expect(mockRssListInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockRssStatsInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockItemsInboxInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockItemsHomeInvalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/hooks/use-rss-feed-discovery.ts
+++ b/apps/mobile/hooks/use-rss-feed-discovery.ts
@@ -1,0 +1,55 @@
+import { trpc } from '@/lib/trpc';
+import type { RssDiscoverOutput } from '@/lib/trpc-types';
+
+export type DiscoveredRssCandidate = RssDiscoverOutput['candidates'][number];
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function useRssFeedDiscovery(url: string, enabled: boolean) {
+  const utils = trpc.useUtils();
+  const normalizedUrl = url.trim();
+  const shouldDiscover = enabled && isHttpUrl(normalizedUrl);
+
+  const discoverQuery = trpc.subscriptions.rss.discover.useQuery(
+    { url: normalizedUrl },
+    {
+      enabled: shouldDiscover,
+      staleTime: 5 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const addMutation = trpc.subscriptions.rss.add.useMutation({
+    onSuccess: () => {
+      utils.subscriptions.rss.list.invalidate();
+      utils.subscriptions.rss.stats.invalidate();
+      utils.items.inbox.invalidate();
+      utils.items.home.invalidate();
+    },
+  });
+
+  const candidates = discoverQuery.data?.candidates ?? [];
+
+  return {
+    sourceUrl: discoverQuery.data?.sourceUrl ?? normalizedUrl,
+    sourceOrigin: discoverQuery.data?.sourceOrigin ?? null,
+    candidates,
+    checkedAt: discoverQuery.data?.checkedAt ?? null,
+    cached: discoverQuery.data?.cached ?? false,
+    isDiscovering: discoverQuery.isLoading || discoverQuery.isFetching,
+    discoveryError: discoverQuery.error,
+    subscribeToFeed: addMutation.mutate,
+    subscribeToFeedAsync: addMutation.mutateAsync,
+    isSubscribing: addMutation.isPending,
+    subscribeError: addMutation.error,
+    refetchDiscovery: discoverQuery.refetch,
+  };
+}

--- a/apps/mobile/lib/trpc-types.ts
+++ b/apps/mobile/lib/trpc-types.ts
@@ -25,3 +25,5 @@ export type NewslettersStatsOutput = RouterOutputs['subscriptions']['newsletters
 export type RssListInput = RouterInputs['subscriptions']['rss']['list'];
 export type RssListOutput = RouterOutputs['subscriptions']['rss']['list'];
 export type RssStatsOutput = RouterOutputs['subscriptions']['rss']['stats'];
+export type RssDiscoverInput = RouterInputs['subscriptions']['rss']['discover'];
+export type RssDiscoverOutput = RouterOutputs['subscriptions']['rss']['discover'];

--- a/apps/worker/src/db/migrations/0007_add_rss_discovery_cache.sql
+++ b/apps/worker/src/db/migrations/0007_add_rss_discovery_cache.sql
@@ -1,0 +1,22 @@
+-- Created: 2026-02-20
+-- Add cache table for RSS feed autodiscovery results.
+
+CREATE TABLE `rss_discovery_cache` (
+  `id` text PRIMARY KEY NOT NULL,
+  `source_origin` text NOT NULL,
+  `source_origin_hash` text NOT NULL,
+  `source_url` text NOT NULL,
+  `candidates_json` text NOT NULL,
+  `status` text DEFAULT 'SUCCESS' NOT NULL,
+  `last_error` text,
+  `checked_at` integer NOT NULL,
+  `expires_at` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `rss_discovery_cache_source_origin_idx` ON `rss_discovery_cache` (`source_origin`);
+--> statement-breakpoint
+CREATE INDEX `rss_discovery_cache_expires_idx` ON `rss_discovery_cache` (`expires_at`);
+--> statement-breakpoint
+CREATE INDEX `rss_discovery_cache_source_origin_hash_idx` ON `rss_discovery_cache` (`source_origin_hash`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1771392000000,
       "tag": "0006_add_rss_feeds",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1771545600000,
+      "tag": "0007_add_rss_discovery_cache",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -426,6 +426,33 @@ export const rssFeedItems = sqliteTable(
 );
 
 // ============================================================================
+// RSS Discovery Cache
+// ============================================================================
+// Caches feed autodiscovery results by site origin to avoid repeated rescans.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const rssDiscoveryCache = sqliteTable(
+  'rss_discovery_cache',
+  {
+    id: text('id').primaryKey(), // Hash-derived key
+    sourceOrigin: text('source_origin').notNull(), // e.g. https://example.com
+    sourceOriginHash: text('source_origin_hash').notNull(),
+    sourceUrl: text('source_url').notNull(), // Last normalized URL that triggered discovery
+    candidatesJson: text('candidates_json').notNull(), // JSON string of discovered candidates
+    status: text('status').notNull().default('SUCCESS'), // SUCCESS | EMPTY | ERROR
+    lastError: text('last_error'),
+    checkedAt: integer('checked_at').notNull(), // Unix ms
+    expiresAt: integer('expires_at').notNull(), // Unix ms
+    createdAt: integer('created_at').notNull(), // Unix ms
+    updatedAt: integer('updated_at').notNull(), // Unix ms
+  },
+  (table) => [
+    uniqueIndex('rss_discovery_cache_source_origin_idx').on(table.sourceOrigin),
+    index('rss_discovery_cache_expires_idx').on(table.expiresAt),
+    index('rss_discovery_cache_source_origin_hash_idx').on(table.sourceOriginHash),
+  ]
+);
+
+// ============================================================================
 // Subscriptions (User subscriptions to specific channels/shows)
 // ============================================================================
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.

--- a/apps/worker/src/rss/discovery.test.ts
+++ b/apps/worker/src/rss/discovery.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { discoverFeedsForUrl, extractFeedLinksFromHtml } from './discovery';
+
+const VALID_FEED_XML = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <link>https://example.com</link>
+    <description>Example</description>
+    <item>
+      <title>Post</title>
+      <link>https://example.com/post</link>
+      <guid>post-1</guid>
+    </item>
+  </channel>
+</rss>`;
+
+function createMockDb(overrides?: { cachedRow?: Record<string, unknown> | null }) {
+  const findFirst = vi.fn().mockResolvedValue(overrides?.cachedRow ?? null);
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+
+  return {
+    db: {
+      query: {
+        rssDiscoveryCache: {
+          findFirst,
+        },
+      },
+      insert,
+    } as unknown as Parameters<typeof discoverFeedsForUrl>[0],
+    mocks: {
+      findFirst,
+      insert,
+      values,
+      onConflictDoUpdate,
+    },
+  };
+}
+
+describe('rss discovery', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('extracts feed links from HTML link alternate tags', () => {
+    const html = `
+      <html>
+        <head>
+          <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
+          <link rel="alternate" type="application/atom+xml" href="https://example.com/atom.xml" />
+          <link rel="stylesheet" href="/styles.css" />
+        </head>
+      </html>
+    `;
+
+    const links = extractFeedLinksFromHtml(html, 'https://example.com/article');
+
+    expect(links).toContain('https://example.com/feed.xml');
+    expect(links).toContain('https://example.com/atom.xml');
+    expect(links).toHaveLength(2);
+  });
+
+  it('returns cached discovery result when cache is fresh', async () => {
+    const { db } = createMockDb({
+      cachedRow: {
+        id: 'hash',
+        sourceOrigin: 'https://example.com',
+        sourceOriginHash: 'hash',
+        sourceUrl: 'https://example.com/article',
+        candidatesJson: JSON.stringify([
+          {
+            feedUrl: 'https://example.com/feed.xml',
+            title: 'Example Feed',
+            description: null,
+            siteUrl: 'https://example.com/',
+            discoveredFrom: 'page_link',
+            score: 100,
+          },
+        ]),
+        status: 'SUCCESS',
+        lastError: null,
+        checkedAt: 123,
+        expiresAt: Date.now() + 60_000,
+        createdAt: 123,
+        updatedAt: 123,
+      },
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await discoverFeedsForUrl(db, 'https://example.com/article');
+
+    expect(result.cached).toBe(true);
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.feedUrl).toBe('https://example.com/feed.xml');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('discovers feeds from page links and writes cache', async () => {
+    const { db, mocks } = createMockDb();
+
+    const fetchSpy = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url === 'https://example.com/article') {
+        return new Response(
+          `<html><head><link rel="alternate" type="application/rss+xml" href="/feed.xml" /></head></html>`,
+          { status: 200, headers: { 'content-type': 'text/html' } }
+        );
+      }
+      if (url === 'https://example.com/feed.xml') {
+        return new Response(VALID_FEED_XML, {
+          status: 200,
+          headers: { 'content-type': 'application/rss+xml' },
+        });
+      }
+      if (url === 'https://example.com/') {
+        return new Response('<html><head></head></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+      // Common-path candidates return 404 to keep this test focused on page autodiscovery.
+      return new Response('Not Found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await discoverFeedsForUrl(db, 'https://example.com/article');
+
+    expect(result.cached).toBe(false);
+    expect(result.candidates.length).toBeGreaterThan(0);
+    expect(result.candidates[0]?.feedUrl).toBe('https://example.com/feed.xml');
+    expect(result.candidates[0]?.discoveredFrom).toBe('page_link');
+    expect(mocks.insert).toHaveBeenCalled();
+    expect(mocks.values).toHaveBeenCalled();
+    expect(mocks.onConflictDoUpdate).toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/rss/discovery.ts
+++ b/apps/worker/src/rss/discovery.ts
@@ -1,0 +1,415 @@
+import { eq } from 'drizzle-orm';
+
+import type { Database } from '../db';
+import { rssDiscoveryCache } from '../db/schema';
+import { logger } from '../lib/logger';
+import { parseRssFeedXml } from './parser';
+import { hashString, normalizeFeedUrl } from './url';
+
+const discoveryLogger = logger.child('rss-discovery');
+
+const FEED_ACCEPT_HEADER =
+  'application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8';
+const HTML_ACCEPT_HEADER =
+  'text/html,application/xhtml+xml,application/xml;q=0.9,text/xml;q=0.8,*/*;q=0.7';
+
+const FEED_MIME_TYPES = new Set([
+  'application/rss+xml',
+  'application/atom+xml',
+  'application/feed+json',
+  'application/xml',
+  'text/xml',
+]);
+
+const COMMON_FEED_PATHS = [
+  '/feed',
+  '/rss',
+  '/rss.xml',
+  '/atom.xml',
+  '/feed.xml',
+  '/index.xml',
+] as const;
+
+const LINK_TAG_REGEX = /<link\b[^>]*>/gi;
+const ATTRIBUTE_REGEX =
+  /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_HTML_BYTES = 1_500_000;
+const MAX_FEED_BYTES = 1_500_000;
+const MAX_VALIDATED_CANDIDATES = 5;
+const MAX_CANDIDATES_TO_VALIDATE = 12;
+const SUCCESS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const EMPTY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const ERROR_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+type DiscoverySource = 'page_link' | 'site_link' | 'common_path';
+type CacheStatus = 'SUCCESS' | 'EMPTY' | 'ERROR';
+
+interface DiscoveryCandidateSeed {
+  feedUrl: string;
+  score: number;
+  discoveredFrom: DiscoverySource;
+}
+
+export interface DiscoveredFeedCandidate {
+  feedUrl: string;
+  title: string | null;
+  description: string | null;
+  siteUrl: string | null;
+  discoveredFrom: DiscoverySource;
+  score: number;
+}
+
+export interface DiscoverFeedsResult {
+  sourceUrl: string;
+  sourceOrigin: string;
+  checkedAt: number;
+  cached: boolean;
+  candidates: DiscoveredFeedCandidate[];
+}
+
+interface DiscoverFeedsOptions {
+  refresh?: boolean;
+}
+
+function parseLinkTagAttributes(tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  let match: RegExpExecArray | null;
+
+  ATTRIBUTE_REGEX.lastIndex = 0;
+  while ((match = ATTRIBUTE_REGEX.exec(tag)) !== null) {
+    const key = match[1]?.toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    if (key) {
+      attributes[key] = value.trim();
+    }
+  }
+
+  return attributes;
+}
+
+function looksLikeFeedHref(href: string): boolean {
+  const value = href.toLowerCase();
+  return (
+    value.includes('/feed') ||
+    value.includes('/rss') ||
+    value.includes('/atom') ||
+    value.endsWith('.xml')
+  );
+}
+
+export function extractFeedLinksFromHtml(html: string, baseUrl: string): string[] {
+  const links = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  LINK_TAG_REGEX.lastIndex = 0;
+  while ((match = LINK_TAG_REGEX.exec(html)) !== null) {
+    const tag = match[0];
+    const attrs = parseLinkTagAttributes(tag);
+    const href = attrs.href;
+    if (!href) continue;
+
+    const rel = attrs.rel?.toLowerCase().split(/\s+/).filter(Boolean);
+    if (!rel?.includes('alternate')) continue;
+
+    const mimeType = attrs.type?.toLowerCase().split(';')[0].trim() ?? null;
+    if (mimeType && !FEED_MIME_TYPES.has(mimeType) && !looksLikeFeedHref(href)) {
+      continue;
+    }
+    if (!mimeType && !looksLikeFeedHref(href)) {
+      continue;
+    }
+
+    try {
+      const resolved = new URL(href, baseUrl);
+      if (resolved.protocol === 'http:' || resolved.protocol === 'https:') {
+        links.add(resolved.toString());
+      }
+    } catch {
+      // Ignore malformed link hrefs.
+    }
+  }
+
+  return [...links];
+}
+
+function parseCachedCandidates(value: string): DiscoveredFeedCandidate[] {
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') return null;
+        const candidate = entry as Partial<DiscoveredFeedCandidate>;
+        if (
+          typeof candidate.feedUrl !== 'string' ||
+          typeof candidate.score !== 'number' ||
+          (candidate.discoveredFrom !== 'page_link' &&
+            candidate.discoveredFrom !== 'site_link' &&
+            candidate.discoveredFrom !== 'common_path')
+        ) {
+          return null;
+        }
+
+        return {
+          feedUrl: candidate.feedUrl,
+          score: candidate.score,
+          discoveredFrom: candidate.discoveredFrom,
+          title: typeof candidate.title === 'string' ? candidate.title : null,
+          description: typeof candidate.description === 'string' ? candidate.description : null,
+          siteUrl: typeof candidate.siteUrl === 'string' ? candidate.siteUrl : null,
+        } satisfies DiscoveredFeedCandidate;
+      })
+      .filter((candidate): candidate is DiscoveredFeedCandidate => candidate !== null);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchText(url: string, accept: string, maxBytes: number): Promise<string> {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: accept,
+      'User-Agent': 'ZineRSSDiscoveryBot/1.0 (+https://myzine.app)',
+    },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status})`);
+  }
+
+  const payload = await response.arrayBuffer();
+  if (payload.byteLength > maxBytes) {
+    throw new Error(`Payload too large (${payload.byteLength} bytes)`);
+  }
+
+  return new TextDecoder().decode(payload);
+}
+
+function addCandidate(
+  candidates: Map<string, DiscoveryCandidateSeed>,
+  rawUrl: string,
+  discoveredFrom: DiscoverySource,
+  score: number
+) {
+  let normalizedFeedUrl: string;
+  try {
+    normalizedFeedUrl = normalizeFeedUrl(rawUrl);
+  } catch {
+    return;
+  }
+
+  const existing = candidates.get(normalizedFeedUrl);
+  if (!existing || score > existing.score) {
+    candidates.set(normalizedFeedUrl, {
+      feedUrl: normalizedFeedUrl,
+      discoveredFrom,
+      score,
+    });
+  }
+}
+
+async function validateFeedCandidate(
+  seed: DiscoveryCandidateSeed
+): Promise<DiscoveredFeedCandidate | null> {
+  try {
+    const xml = await fetchText(seed.feedUrl, FEED_ACCEPT_HEADER, MAX_FEED_BYTES);
+    const parsed = parseRssFeedXml(xml, seed.feedUrl);
+
+    return {
+      feedUrl: seed.feedUrl,
+      title: parsed.title ?? null,
+      description: parsed.description ?? null,
+      siteUrl: parsed.siteUrl ?? null,
+      discoveredFrom: seed.discoveredFrom,
+      score: seed.score,
+    };
+  } catch (error) {
+    discoveryLogger.debug('Rejected invalid feed candidate', {
+      feedUrl: seed.feedUrl,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+async function upsertDiscoveryCache(params: {
+  db: Database;
+  sourceOrigin: string;
+  sourceUrl: string;
+  candidates: DiscoveredFeedCandidate[];
+  checkedAt: number;
+  status: CacheStatus;
+  lastError: string | null;
+  ttlMs: number;
+}) {
+  const { db, sourceOrigin, sourceUrl, candidates, checkedAt, status, lastError, ttlMs } = params;
+  const sourceOriginHash = hashString(sourceOrigin);
+  const expiresAt = checkedAt + ttlMs;
+
+  await db
+    .insert(rssDiscoveryCache)
+    .values({
+      id: sourceOriginHash,
+      sourceOrigin,
+      sourceOriginHash,
+      sourceUrl,
+      candidatesJson: JSON.stringify(candidates),
+      status,
+      lastError,
+      checkedAt,
+      expiresAt,
+      createdAt: checkedAt,
+      updatedAt: checkedAt,
+    })
+    .onConflictDoUpdate({
+      target: rssDiscoveryCache.sourceOrigin,
+      set: {
+        sourceOriginHash,
+        sourceUrl,
+        candidatesJson: JSON.stringify(candidates),
+        status,
+        lastError,
+        checkedAt,
+        expiresAt,
+        updatedAt: checkedAt,
+      },
+    });
+}
+
+export async function discoverFeedsForUrl(
+  db: Database,
+  rawUrl: string,
+  options: DiscoverFeedsOptions = {}
+): Promise<DiscoverFeedsResult> {
+  const sourceUrl = normalizeFeedUrl(rawUrl);
+  const sourceOrigin = new URL(sourceUrl).origin;
+  const now = Date.now();
+
+  const cached = await db.query.rssDiscoveryCache.findFirst({
+    where: eq(rssDiscoveryCache.sourceOrigin, sourceOrigin),
+  });
+
+  if (cached && !options.refresh && cached.expiresAt > now) {
+    return {
+      sourceUrl,
+      sourceOrigin,
+      checkedAt: cached.checkedAt,
+      cached: true,
+      candidates: parseCachedCandidates(cached.candidatesJson),
+    };
+  }
+
+  const candidateSeeds = new Map<string, DiscoveryCandidateSeed>();
+  let lastError: string | null = null;
+
+  try {
+    try {
+      const sourceHtml = await fetchText(sourceUrl, HTML_ACCEPT_HEADER, MAX_HTML_BYTES);
+      const pageLinks = extractFeedLinksFromHtml(sourceHtml, sourceUrl);
+      for (const link of pageLinks) {
+        addCandidate(candidateSeeds, link, 'page_link', 100);
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+      discoveryLogger.debug('Failed to inspect article page for feed links', {
+        sourceUrl,
+        error: lastError,
+      });
+    }
+
+    const homepageUrl = `${sourceOrigin}/`;
+    if (homepageUrl !== sourceUrl) {
+      try {
+        const homepageHtml = await fetchText(homepageUrl, HTML_ACCEPT_HEADER, MAX_HTML_BYTES);
+        const homepageLinks = extractFeedLinksFromHtml(homepageHtml, homepageUrl);
+        for (const link of homepageLinks) {
+          addCandidate(candidateSeeds, link, 'site_link', 80);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!lastError) {
+          lastError = message;
+        }
+        discoveryLogger.debug('Failed to inspect homepage for feed links', {
+          sourceOrigin,
+          error: message,
+        });
+      }
+    }
+
+    for (let index = 0; index < COMMON_FEED_PATHS.length; index += 1) {
+      const path = COMMON_FEED_PATHS[index];
+      const url = new URL(path, sourceOrigin).toString();
+      addCandidate(candidateSeeds, url, 'common_path', 50 - index);
+    }
+
+    const rankedCandidates = [...candidateSeeds.values()]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_CANDIDATES_TO_VALIDATE);
+
+    const candidates: DiscoveredFeedCandidate[] = [];
+    for (const seed of rankedCandidates) {
+      const validated = await validateFeedCandidate(seed);
+      if (!validated) continue;
+      candidates.push(validated);
+      if (candidates.length >= MAX_VALIDATED_CANDIDATES) {
+        break;
+      }
+    }
+
+    const checkedAt = Date.now();
+    const status: CacheStatus = candidates.length > 0 ? 'SUCCESS' : 'EMPTY';
+    const ttlMs = candidates.length > 0 ? SUCCESS_CACHE_TTL_MS : EMPTY_CACHE_TTL_MS;
+
+    await upsertDiscoveryCache({
+      db,
+      sourceOrigin,
+      sourceUrl,
+      candidates,
+      checkedAt,
+      status,
+      lastError,
+      ttlMs,
+    });
+
+    return {
+      sourceUrl,
+      sourceOrigin,
+      checkedAt,
+      cached: false,
+      candidates,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const checkedAt = Date.now();
+    await upsertDiscoveryCache({
+      db,
+      sourceOrigin,
+      sourceUrl,
+      candidates: [],
+      checkedAt,
+      status: 'ERROR',
+      lastError: message,
+      ttlMs: ERROR_CACHE_TTL_MS,
+    });
+
+    discoveryLogger.error('RSS discovery failed', {
+      sourceUrl,
+      error: message,
+    });
+
+    return {
+      sourceUrl,
+      sourceOrigin,
+      checkedAt,
+      cached: false,
+      candidates: [],
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- move RSS autodiscovery subscription UX into the creator/author surface as a source-level subscription flow
- extend creator latest content to support RSS/WEB/SUBSTACK with up to 20 recent posts from discovered feeds
- add progressive thumbnail enrichment for feed posts using a lazy follow-up resolver and cache
- add RSS discovery caching migration and supporting router/hook/tests

## Validation
- pre-commit lint-staged passed
- pre-push checks passed (format check, typecheck, worker test suite subset)
- targeted mobile and worker tests for creator latest content/discovery passed during development