### PR TITLE
Make mark-as-complete feel instant with optimistic updates

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -54,7 +54,6 @@ export default function ItemDetailScreen() {
     handleToggleFinished,
     bookmarkMutation,
     unbookmarkMutation,
-    toggleFinishedMutation,
   } = useItemDetailActions(item);
 
   const viewState = useItemDetailViewState({
@@ -62,7 +61,6 @@ export default function ItemDetailScreen() {
     colors,
     bookmarkPending: bookmarkMutation.isPending,
     unbookmarkPending: unbookmarkMutation.isPending,
-    toggleFinishedPending: toggleFinishedMutation.isPending,
   });
 
   if (!isValid) {

--- a/apps/mobile/app/item/detail/hooks/useItemDetailViewState.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailViewState.ts
@@ -9,7 +9,6 @@ type ItemDetailViewStateInput = {
   colors: ItemDetailColors;
   bookmarkPending: boolean;
   unbookmarkPending: boolean;
-  toggleFinishedPending: boolean;
 };
 
 export function useItemDetailViewState({
@@ -17,7 +16,6 @@ export function useItemDetailViewState({
   colors,
   bookmarkPending,
   unbookmarkPending,
-  toggleFinishedPending,
 }: ItemDetailViewStateInput) {
   if (!item) {
     return {
@@ -47,7 +45,7 @@ export function useItemDetailViewState({
     ? 'checkmark-circle'
     : 'checkmark-circle-outline';
   const completeActionColor = isBookmarked && isFinished ? colors.success : colors.textSecondary;
-  const isCompleteActionDisabled = !isBookmarked || toggleFinishedPending;
+  const isCompleteActionDisabled = !isBookmarked;
 
   const descriptionLabel = (() => {
     switch (item.contentType) {

--- a/apps/mobile/hooks/use-item-detail-view-state.test.ts
+++ b/apps/mobile/hooks/use-item-detail-view-state.test.ts
@@ -24,7 +24,6 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
-      toggleFinishedPending: false,
     });
 
     expect(viewState.isXPost).toBe(false);
@@ -48,7 +47,6 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
-      toggleFinishedPending: false,
     });
 
     expect(viewState.isXPost).toBe(true);
@@ -66,7 +64,6 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
-      toggleFinishedPending: false,
     });
 
     expect(viewState.bookmarkActionIcon).toBe('bookmark');
@@ -87,7 +84,6 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
-      toggleFinishedPending: false,
     });
 
     expect(viewState.completeActionIcon).toBe('checkmark-circle');

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -1,11 +1,12 @@
 /**
  * Tests for hooks/use-items-trpc.ts
  *
- * Verifies list query hooks use placeholder data for cache-first UX.
+ * Verifies list query hooks use placeholder data for cache-first UX,
+ * plus optimistic toggle/rollback behavior for mark-as-complete.
  */
 
-import { renderHook } from '@testing-library/react-hooks';
-import { ContentType, Provider } from '@zine/shared';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { ContentType, Provider, UserItemState } from '@zine/shared';
 
 // ============================================================================
 // Module-level Mocks
@@ -14,6 +15,8 @@ import { ContentType, Provider } from '@zine/shared';
 const mockInboxUseQuery = jest.fn();
 const mockLibraryUseQuery = jest.fn();
 const mockHomeUseQuery = jest.fn();
+const mockToggleFinishedUseMutation = jest.fn();
+const mockUseUtils = jest.fn();
 
 jest.mock('../lib/trpc', () => ({
   trpc: {
@@ -27,7 +30,11 @@ jest.mock('../lib/trpc', () => ({
       home: {
         useQuery: mockHomeUseQuery,
       },
+      toggleFinished: {
+        useMutation: (...args: unknown[]) => mockToggleFinishedUseMutation(...args),
+      },
     },
+    useUtils: (...args: unknown[]) => mockUseUtils(...args),
   },
 }));
 
@@ -35,7 +42,182 @@ jest.mock('../lib/trpc', () => ({
 // Test Setup
 // ============================================================================
 
-import { useInboxItems, useLibraryItems, useHomeData } from './use-items-trpc';
+import { useInboxItems, useLibraryItems, useHomeData, useToggleFinished } from './use-items-trpc';
+
+function createMockItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'item-1',
+    itemId: 'canonical-1',
+    title: 'Test Item',
+    thumbnailUrl: null,
+    canonicalUrl: 'https://example.com/item-1',
+    contentType: ContentType.ARTICLE,
+    provider: Provider.RSS,
+    creator: 'Test Creator',
+    creatorImageUrl: null,
+    creatorId: null,
+    publisher: null,
+    summary: null,
+    duration: null,
+    publishedAt: null,
+    wordCount: null,
+    readingTimeMinutes: null,
+    state: UserItemState.BOOKMARKED,
+    ingestedAt: '2026-01-01T00:00:00.000Z',
+    bookmarkedAt: '2026-01-01T00:00:00.000Z',
+    lastOpenedAt: null,
+    progress: null,
+    isFinished: false,
+    finishedAt: null,
+    tags: [],
+    ...overrides,
+  };
+}
+
+type MockListData = {
+  items: ReturnType<typeof createMockItem>[];
+  nextCursor: string | null;
+};
+
+function serializeLibraryInput(
+  input?:
+    | {
+        filter?: {
+          isFinished?: boolean;
+          provider?: Provider;
+          contentType?: ContentType;
+        };
+        search?: string;
+      }
+    | undefined
+): string {
+  if (!input) return 'default';
+
+  const filter = input.filter ?? {};
+
+  return JSON.stringify({
+    isFinished: filter.isFinished,
+    provider: filter.provider,
+    contentType: filter.contentType,
+    search: input.search,
+  });
+}
+
+function createToggleUtils(initial?: {
+  defaultLibrary?: MockListData;
+  unfinishedLibrary?: MockListData;
+  finishedLibrary?: MockListData;
+  inbox?: MockListData;
+  itemsById?: Record<string, ReturnType<typeof createMockItem> | undefined>;
+}) {
+  const libraryDataByKey = new Map<string, MockListData | undefined>();
+
+  if (initial?.defaultLibrary) {
+    libraryDataByKey.set('default', initial.defaultLibrary);
+  }
+  if (initial?.unfinishedLibrary) {
+    libraryDataByKey.set(
+      serializeLibraryInput({ filter: { isFinished: false } }),
+      initial.unfinishedLibrary
+    );
+  }
+  if (initial?.finishedLibrary) {
+    libraryDataByKey.set(
+      serializeLibraryInput({ filter: { isFinished: true } }),
+      initial.finishedLibrary
+    );
+  }
+
+  const inboxRef: { current: MockListData | undefined } = {
+    current: initial?.inbox,
+  };
+
+  const itemsById = new Map<string, ReturnType<typeof createMockItem> | undefined>(
+    Object.entries(initial?.itemsById ?? {})
+  );
+
+  const mockLibraryCancel = jest.fn().mockResolvedValue(undefined);
+  const mockInboxCancel = jest.fn().mockResolvedValue(undefined);
+  const mockHomeCancel = jest.fn().mockResolvedValue(undefined);
+  const mockGetCancel = jest.fn().mockResolvedValue(undefined);
+
+  const mockLibraryInvalidate = jest.fn();
+  const mockInboxInvalidate = jest.fn();
+  const mockHomeInvalidate = jest.fn();
+  const mockGetInvalidate = jest.fn();
+
+  const utils = {
+    items: {
+      library: {
+        cancel: mockLibraryCancel,
+        invalidate: mockLibraryInvalidate,
+        getData: jest.fn((input?: Parameters<typeof serializeLibraryInput>[0]) =>
+          libraryDataByKey.get(serializeLibraryInput(input))
+        ),
+        setData: jest.fn((input: Parameters<typeof serializeLibraryInput>[0], updater: unknown) => {
+          const key = serializeLibraryInput(input);
+          const previous = libraryDataByKey.get(key);
+          const next =
+            typeof updater === 'function'
+              ? (updater as (value: MockListData | undefined) => MockListData | undefined)(previous)
+              : (updater as MockListData | undefined);
+          libraryDataByKey.set(key, next);
+          return next;
+        }),
+      },
+      inbox: {
+        cancel: mockInboxCancel,
+        invalidate: mockInboxInvalidate,
+        getData: jest.fn(() => inboxRef.current),
+        setData: jest.fn((_: undefined, updater: unknown) => {
+          const previous = inboxRef.current;
+          const next =
+            typeof updater === 'function'
+              ? (updater as (value: MockListData | undefined) => MockListData | undefined)(previous)
+              : (updater as MockListData | undefined);
+          inboxRef.current = next;
+          return next;
+        }),
+      },
+      home: {
+        cancel: mockHomeCancel,
+        invalidate: mockHomeInvalidate,
+      },
+      get: {
+        cancel: mockGetCancel,
+        invalidate: mockGetInvalidate,
+        getData: jest.fn(({ id }: { id: string }) => itemsById.get(id)),
+        setData: jest.fn(({ id }: { id: string }, updater: unknown) => {
+          const previous = itemsById.get(id);
+          const next =
+            typeof updater === 'function'
+              ? (
+                  updater as (
+                    value: ReturnType<typeof createMockItem> | undefined
+                  ) => ReturnType<typeof createMockItem> | undefined
+                )(previous)
+              : (updater as ReturnType<typeof createMockItem> | undefined);
+          itemsById.set(id, next);
+          return next;
+        }),
+      },
+    },
+  };
+
+  return {
+    utils,
+    readLibrary: (input?: Parameters<typeof serializeLibraryInput>[0]) =>
+      libraryDataByKey.get(serializeLibraryInput(input)),
+    readInbox: () => inboxRef.current,
+    readItem: (id: string) => itemsById.get(id),
+    spies: {
+      mockLibraryInvalidate,
+      mockInboxInvalidate,
+      mockHomeInvalidate,
+      mockGetInvalidate,
+    },
+  };
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -55,6 +237,15 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   });
+
+  mockToggleFinishedUseMutation.mockImplementation((config: unknown) => ({
+    ...(config as Record<string, unknown>),
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }));
+
+  mockUseUtils.mockReturnValue(createToggleUtils().utils);
 });
 
 // ============================================================================
@@ -99,5 +290,138 @@ describe('useItems list queries', () => {
       undefined,
       expect.objectContaining({ placeholderData: expect.any(Function) })
     );
+  });
+});
+
+// ============================================================================
+// useToggleFinished Optimistic Behavior
+// ============================================================================
+
+describe('useToggleFinished', () => {
+  type ToggleHandlers = {
+    onMutate: ({ id }: { id: string }) => Promise<{ didApplyOptimisticUpdate: boolean }>;
+    onError: (
+      error: unknown,
+      vars: { id: string },
+      context?: { didApplyOptimisticUpdate: boolean }
+    ) => void;
+    onSettled: (data: unknown, error: unknown, vars: { id: string }) => void;
+  };
+
+  function getToggleHandlers() {
+    const { result } = renderHook(() => useToggleFinished());
+    return result.current as unknown as ToggleHandlers;
+  }
+
+  it('optimistically toggles from the item detail cache when list caches are empty', async () => {
+    const item = createMockItem({ id: 'detail-only-item', isFinished: false });
+    const harness = createToggleUtils({
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getToggleHandlers();
+
+    await act(async () => {
+      await mutation.onMutate({ id: item.id });
+    });
+
+    expect(harness.readItem(item.id)?.isFinished).toBe(true);
+  });
+
+  it('treats the default library query as unfinished and moves items between unfinished/finished lists', async () => {
+    const item = createMockItem({ id: 'library-item', isFinished: false });
+    const harness = createToggleUtils({
+      defaultLibrary: {
+        items: [item],
+        nextCursor: null,
+      },
+      finishedLibrary: {
+        items: [],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getToggleHandlers();
+
+    let context: { didApplyOptimisticUpdate: boolean } | undefined;
+
+    await act(async () => {
+      context = await mutation.onMutate({ id: item.id });
+    });
+
+    expect(harness.readLibrary()?.items).toHaveLength(0);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.id).toBe(item.id);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.isFinished).toBe(true);
+
+    act(() => {
+      mutation.onError(new Error('Request failed'), { id: item.id }, context);
+    });
+
+    expect(harness.readLibrary()?.items[0]?.id).toBe(item.id);
+    expect(harness.readLibrary()?.items[0]?.isFinished).toBe(false);
+  });
+
+  it('keeps state consistent for rapid toggles and invalidates only after the last settle', async () => {
+    const item = createMockItem({ id: 'rapid-item', isFinished: false });
+    const harness = createToggleUtils({
+      defaultLibrary: {
+        items: [item],
+        nextCursor: null,
+      },
+      finishedLibrary: {
+        items: [],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getToggleHandlers();
+
+    let firstContext: { didApplyOptimisticUpdate: boolean } | undefined;
+    let secondContext: { didApplyOptimisticUpdate: boolean } | undefined;
+
+    await act(async () => {
+      firstContext = await mutation.onMutate({ id: item.id });
+      secondContext = await mutation.onMutate({ id: item.id });
+    });
+
+    expect(harness.readLibrary()?.items[0]?.isFinished).toBe(false);
+
+    act(() => {
+      mutation.onError(new Error('First request failed'), { id: item.id }, firstContext);
+    });
+
+    expect(harness.readLibrary()?.items).toHaveLength(0);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.id).toBe(item.id);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.isFinished).toBe(true);
+
+    act(() => {
+      mutation.onSettled(undefined, new Error('First request failed'), { id: item.id });
+    });
+
+    expect(harness.spies.mockLibraryInvalidate).not.toHaveBeenCalled();
+    expect(harness.spies.mockInboxInvalidate).not.toHaveBeenCalled();
+    expect(harness.spies.mockHomeInvalidate).not.toHaveBeenCalled();
+    expect(harness.spies.mockGetInvalidate).not.toHaveBeenCalled();
+
+    act(() => {
+      mutation.onSettled(undefined, undefined, { id: item.id });
+    });
+
+    expect(secondContext?.didApplyOptimisticUpdate).toBe(true);
+    expect(harness.spies.mockLibraryInvalidate).toHaveBeenCalledTimes(1);
+    expect(harness.spies.mockInboxInvalidate).toHaveBeenCalledTimes(1);
+    expect(harness.spies.mockHomeInvalidate).toHaveBeenCalledTimes(1);
+    expect(harness.spies.mockGetInvalidate).toHaveBeenCalledWith({ id: item.id });
   });
 });


### PR DESCRIPTION
## Summary\n- make mark-as-complete optimistic across item detail + list caches so UI updates instantly\n- harden toggle mutation handling for overlapping requests to avoid flicker/inconsistent state\n- keep complete action enabled while toggle is pending so users can quickly undo\n- add focused tests for optimistic toggle, rollback, and rapid-toggle settle behavior\n\n## Validation\n- bunx eslint apps/mobile/hooks/use-items-trpc.ts apps/mobile/hooks/use-items-trpc.test.ts apps/mobile/app/item/detail/hooks/useItemDetailViewState.ts apps/mobile/hooks/use-item-detail-view-state.test.ts 'apps/mobile/app/item/[id].tsx'\n- bun run --cwd apps/mobile test hooks/use-items-trpc.test.ts hooks/use-item-detail-view-state.test.ts hooks/use-item-detail-actions.test.ts\n- bun run typecheck --filter=@zine/mobile\n\nFixes #102