### PR TITLE
chore: cache eslint artifacts for shared and worker

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "echo 'Worker build handled by Wrangler'",
     "dev": "wrangler dev --ip 0.0.0.0 --port ${WORKER_PORT:-8787}",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "eslint src --ext .ts,.tsx --cache --cache-location .eslintcache",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,12 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "@zine/shared#lint": {
+      "outputs": [".eslintcache"]
+    },
+    "@zine/worker#lint": {
+      "outputs": [".eslintcache"]
+    },
     "typecheck": {
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
## Summary
- enable ESLint cache for @zine/shared and @zine/worker lint scripts
- declare .eslintcache as Turbo outputs for those lint tasks
- improve local lint reruns and Turbo cache reuse without behavior changes

## Validation
- bun run lint ✅
- bun run typecheck ✅
- bun run format:check ✅
- bun run test:worker:ci ⚠️ fails in sandbox (EPERM binding 127.0.0.1)
- bun run test:mobile ⚠️ pre-existing unrelated failures (use-creator.test.ts TS2322, use-rss-feed-discovery.test.ts initialization error)
