### PR TITLE
Fix latest-content item materialization for WEB/RSS/SUBSTACK creators

### DIFF
--- a/apps/worker/src/trpc/routers/creators.ts
+++ b/apps/worker/src/trpc/routers/creators.ts
@@ -26,9 +26,10 @@ import {
   newsletterFeeds,
   newsletterFeedMessages,
 } from '../../db/schema';
-import { ContentType, UserItemState, YOUTUBE_SHORTS_MAX_DURATION_SECONDS } from '@zine/shared';
+import { UserItemState, YOUTUBE_SHORTS_MAX_DURATION_SECONDS } from '@zine/shared';
 import { decodeCursor, encodeCursor } from '../../lib/pagination';
 import { toItemView, type ItemView } from './items';
+import { getLatestContentItemContentType } from './latest-content-content-type';
 import {
   getYouTubeClientForConnection,
   getUploadsPlaylistId,
@@ -853,7 +854,8 @@ export const creatorsRouter = router({
         });
       }
 
-      if (!['YOUTUBE', 'SPOTIFY'].includes(creator.provider)) {
+      const contentType = getLatestContentItemContentType(creator.provider);
+      if (!contentType) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: 'Provider not supported for latest content',
@@ -861,7 +863,6 @@ export const creatorsRouter = router({
       }
 
       const now = new Date().toISOString();
-      const contentType = creator.provider === 'YOUTUBE' ? ContentType.VIDEO : ContentType.PODCAST;
       const publishedAtIso = input.publishedAt ? new Date(input.publishedAt).toISOString() : null;
 
       const existingItem = await ctx.db

--- a/apps/worker/src/trpc/routers/latest-content-content-type.test.ts
+++ b/apps/worker/src/trpc/routers/latest-content-content-type.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { ContentType } from '@zine/shared';
+
+import { getLatestContentItemContentType } from './latest-content-content-type';
+
+describe('getLatestContentItemContentType', () => {
+  it('maps YouTube and Spotify providers to media content types', () => {
+    expect(getLatestContentItemContentType('YOUTUBE')).toBe(ContentType.VIDEO);
+    expect(getLatestContentItemContentType('SPOTIFY')).toBe(ContentType.PODCAST);
+  });
+
+  it('maps source-based providers to article content type', () => {
+    expect(getLatestContentItemContentType('RSS')).toBe(ContentType.ARTICLE);
+    expect(getLatestContentItemContentType('WEB')).toBe(ContentType.ARTICLE);
+    expect(getLatestContentItemContentType('SUBSTACK')).toBe(ContentType.ARTICLE);
+  });
+
+  it('returns null for unsupported providers', () => {
+    expect(getLatestContentItemContentType('GMAIL')).toBeNull();
+  });
+});

--- a/apps/worker/src/trpc/routers/latest-content-content-type.ts
+++ b/apps/worker/src/trpc/routers/latest-content-content-type.ts
@@ -1,0 +1,22 @@
+import { ContentType } from '@zine/shared';
+
+/**
+ * Maps creator latest-content providers to canonical content types when
+ * materializing user items from creator-page taps.
+ */
+export function getLatestContentItemContentType(provider: string): ContentType | null {
+  switch (provider) {
+    case 'YOUTUBE':
+      return ContentType.VIDEO;
+    case 'SPOTIFY':
+      return ContentType.PODCAST;
+    case 'RSS':
+    case 'WEB':
+    case 'SUBSTACK':
+      return ContentType.ARTICLE;
+    case 'X':
+      return ContentType.POST;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract latest-content provider-to-content-type mapping into a dedicated helper.
- Use that helper in creators.ensureLatestContentItem so WEB/RSS/SUBSTACK creators are materialized instead of rejected.
- Add focused unit tests covering provider mapping behavior.

## Testing
- CI=1 bun run --cwd apps/worker test:run src/trpc/routers/latest-content-content-type.test.ts
- Pre-push checks during git push passed:
  - bun run format:check
  - turbo run typecheck
  - cd apps/worker && vitest run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'
- Manual iOS simulator + Expo Go verification passed:
  - Opened a WEB creator page in Expo app.
  - Tapped a latest-content row.
  - Confirmed POST /trpc/creators.ensureLatestContentItem returned 200.
  - Confirmed navigation to internal item detail and DB row with content_type=ARTICLE and user_items.state=INBOX.


Closes #96
