### PR TITLE
Add optimistic toggle handling and toast error feedback

### DIFF
--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -1,5 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import * as WebBrowser from 'expo-web-browser';
+import { useToast } from 'heroui-native';
 import { useCallback } from 'react';
 import { Linking, Share } from 'react-native';
 
@@ -12,10 +13,12 @@ import {
   UserItemState,
 } from '@/hooks/use-items-trpc';
 import { logger } from '@/lib/logger';
+import { showError } from '@/lib/toast-utils';
 
 import type { ItemDetailItem } from '../types';
 
 export function useItemDetailActions(item?: ItemDetailItem | null) {
+  const { toast } = useToast();
   const bookmarkMutation = useBookmarkItem();
   const unbookmarkMutation = useUnbookmarkItem();
   const toggleFinishedMutation = useToggleFinished();
@@ -83,8 +86,20 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
     if (!item) return;
     if (item.state !== UserItemState.BOOKMARKED) return;
 
-    toggleFinishedMutation.mutate({ id: item.id });
-  }, [item, toggleFinishedMutation]);
+    toggleFinishedMutation.mutate(
+      { id: item.id },
+      {
+        onError: (error) => {
+          showError(
+            toast,
+            error,
+            'Failed to update completion status',
+            'itemDetail.toggleFinished'
+          );
+        },
+      }
+    );
+  }, [item, toast, toggleFinishedMutation]);
 
   return {
     handleOpenLink,

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -23,6 +23,8 @@ const mockCanOpenURL = jest.fn();
 const mockOpenURL = jest.fn();
 const mockOpenBrowserAsync = jest.fn();
 const mockShare = jest.fn();
+const mockShowError = jest.fn();
+const mockToastManager = { show: jest.fn() };
 
 jest.mock('expo-haptics', () => ({
   impactAsync: jest.fn(() => Promise.resolve()),
@@ -52,6 +54,14 @@ jest.mock('@/lib/logger', () => ({
   logger: {
     error: jest.fn(),
   },
+}));
+
+jest.mock('heroui-native', () => ({
+  useToast: () => ({ toast: mockToastManager }),
+}));
+
+jest.mock('@/lib/toast-utils', () => ({
+  showError: (...args: unknown[]) => mockShowError(...args),
 }));
 
 jest.mock('@/hooks/use-items-trpc', () => ({
@@ -244,6 +254,35 @@ describe('useItemDetailActions', () => {
     } as unknown as ItemDetailItem;
     const { result: bookmarkedResult } = renderHook(() => useItemDetailActions(bookmarkedItem));
     bookmarkedResult.current.handleToggleFinished();
-    expect(mockToggleFinishedMutation.mutate).toHaveBeenCalledWith({ id: baseItem.id });
+    expect(mockToggleFinishedMutation.mutate).toHaveBeenCalledWith(
+      { id: baseItem.id },
+      expect.objectContaining({
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it('shows lightweight error feedback when complete toggle fails', () => {
+    const bookmarkedItem = {
+      ...baseItem,
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(bookmarkedItem));
+
+    result.current.handleToggleFinished();
+
+    const mutateOptions = mockToggleFinishedMutation.mutate.mock.calls[0][1] as {
+      onError: (error: unknown) => void;
+    };
+
+    const error = new Error('Network request failed');
+    mutateOptions.onError(error);
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      mockToastManager,
+      error,
+      'Failed to update completion status',
+      'itemDetail.toggleFinished'
+    );
   });
 });

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -424,4 +424,44 @@ describe('useToggleFinished', () => {
     expect(harness.spies.mockHomeInvalidate).toHaveBeenCalledTimes(1);
     expect(harness.spies.mockGetInvalidate).toHaveBeenCalledWith({ id: item.id });
   });
+
+  it('applies optimistic complete state immediately without waiting for query cancellation', async () => {
+    const item = createMockItem({ id: 'instant-item', isFinished: false });
+    const harness = createToggleUtils({
+      defaultLibrary: {
+        items: [item],
+        nextCursor: null,
+      },
+      finishedLibrary: {
+        items: [],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+
+    const neverResolves = new Promise<void>(() => {});
+    (harness.utils.items.library.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.inbox.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.home.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.get.cancel as jest.Mock).mockReturnValue(neverResolves);
+
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getToggleHandlers();
+
+    const mutatePromise = mutation.onMutate({ id: item.id });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(harness.readLibrary()?.items).toHaveLength(0);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.id).toBe(item.id);
+    expect(harness.readLibrary({ filter: { isFinished: true } })?.items[0]?.isFinished).toBe(true);
+
+    await expect(
+      Promise.race([mutatePromise, Promise.resolve({ didApplyOptimisticUpdate: false })])
+    ).resolves.toEqual({ didApplyOptimisticUpdate: true });
+  });
 });

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -659,19 +659,25 @@ export function useToggleFinished() {
 
   return trpc.items.toggleFinished.useMutation({
     onMutate: async ({ id }): Promise<ToggleFinishedContext> => {
-      // Cancel all potentially affected queries to reduce overwrite races.
-      await Promise.all([
+      incrementPendingCount(id);
+
+      // Apply optimistic state immediately so the UI responds on tap.
+      const didApplyOptimisticUpdate = toggleFinishedInCaches(id);
+
+      // Cancel potentially affected in-flight queries in the background to reduce overwrite races.
+      void Promise.all([
         utils.items.library.cancel(),
         utils.items.inbox.cancel(),
         utils.items.home.cancel(),
         utils.items.get.cancel({ id }),
-      ]);
+      ]).catch(() => {
+        utils.items.library.invalidate();
+        utils.items.inbox.invalidate();
+        utils.items.home.invalidate();
+        utils.items.get.invalidate({ id });
+      });
 
-      incrementPendingCount(id);
-
-      return {
-        didApplyOptimisticUpdate: toggleFinishedInCaches(id),
-      };
+      return { didApplyOptimisticUpdate };
     },
     onError: (_err, { id }, context) => {
       // Revert failed optimistic toggles by inverting once more.


### PR DESCRIPTION
Summary
- ensure toggle completion updates apply optimistically before waiting for query cancellations and handle cancel failures by invalidating
- surface lightweight toast error feedback when the toggle mutation fails and cover it in unit tests
- align uniwind type formatting

Testing
- Not run (not requested)