### PR TITLE
Add Storybook tab behind env flag

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -7,6 +7,8 @@ import { AuthGuard } from '@/components/auth-guard';
 // =============================================================================
 
 export default function TabLayout() {
+  const isStorybookEnabled = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
+
   // Dynamic colors for iOS liquid glass that adapt to light/dark backgrounds
   const dynamicTintColor =
     Platform.OS === 'ios'
@@ -57,6 +59,13 @@ export default function TabLayout() {
             drawable="ic_library"
           />
         </NativeTabs.Trigger>
+
+        {isStorybookEnabled && (
+          <NativeTabs.Trigger name="storybook">
+            <Label>Storybook</Label>
+            <Icon sf={{ default: 'hammer', selected: 'hammer.fill' }} />
+          </NativeTabs.Trigger>
+        )}
 
         {/* explore tab is hidden - not included in triggers */}
       </NativeTabs>

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Platform, DynamicColorIOS } from 'react-native';
-import { NativeTabs, Icon, Label } from 'expo-router/unstable-native-tabs';
+import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { AuthGuard } from '@/components/auth-guard';
 
 // =============================================================================
@@ -39,22 +39,28 @@ export default function TabLayout() {
         }}
       >
         <NativeTabs.Trigger name="index">
-          <Label>Home</Label>
-          <Icon sf={{ default: 'house', selected: 'house.fill' }} drawable="ic_home" />
+          <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
+            sf={{ default: 'house', selected: 'house.fill' }}
+            drawable="ic_home"
+          />
         </NativeTabs.Trigger>
 
         <NativeTabs.Trigger name="inbox">
-          <Label>Inbox</Label>
-          <Icon sf={{ default: 'tray', selected: 'tray.fill' }} drawable="ic_inbox" />
+          <NativeTabs.Trigger.Label>Inbox</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
+            sf={{ default: 'tray', selected: 'tray.fill' }}
+            drawable="ic_inbox"
+          />
         </NativeTabs.Trigger>
 
         <NativeTabs.Trigger name="search" role="search">
-          <Label>Search</Label>
+          <NativeTabs.Trigger.Label>Search</NativeTabs.Trigger.Label>
         </NativeTabs.Trigger>
 
         <NativeTabs.Trigger name="library">
-          <Label>Library</Label>
-          <Icon
+          <NativeTabs.Trigger.Label>Library</NativeTabs.Trigger.Label>
+          <NativeTabs.Trigger.Icon
             sf={{ default: 'books.vertical', selected: 'books.vertical.fill' }}
             drawable="ic_library"
           />
@@ -62,8 +68,8 @@ export default function TabLayout() {
 
         {isStorybookEnabled && (
           <NativeTabs.Trigger name="storybook">
-            <Label>Storybook</Label>
-            <Icon sf={{ default: 'hammer', selected: 'hammer.fill' }} />
+            <NativeTabs.Trigger.Label>Storybook</NativeTabs.Trigger.Label>
+            <NativeTabs.Trigger.Icon sf={{ default: 'hammer', selected: 'hammer.fill' }} />
           </NativeTabs.Trigger>
         )}
 

--- a/apps/mobile/app/(tabs)/storybook.tsx
+++ b/apps/mobile/app/(tabs)/storybook.tsx
@@ -1,6 +1,6 @@
 import { Redirect } from 'expo-router';
 
-import StorybookUI from '../.rnstorybook';
+import StorybookUI from '../../.rnstorybook';
 
 const isStorybookEnabled = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -23,7 +23,6 @@ function PrefetchManager() {
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
-  const isStorybookEnabled = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
 
   return (
     <GestureHandlerRootView style={styles.root}>
@@ -35,9 +34,6 @@ export default function RootLayout() {
               <ToastProvider defaultProps={{ placement: 'bottom' }} maxVisibleToasts={3}>
                 <Stack>
                   <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-                  {isStorybookEnabled && (
-                    <Stack.Screen name="storybook" options={{ headerShown: false }} />
-                  )}
                   <Stack.Screen name="(auth)" options={{ headerShown: false }} />
                   <Stack.Screen name="settings" options={{ headerShown: false }} />
                   <Stack.Screen


### PR DESCRIPTION
## Summary
- add a Storybook tab trigger in the native tabs layout
- show the tab only when `EXPO_PUBLIC_STORYBOOK_ENABLED` is `true`
- move the Storybook screen into the `(tabs)` route group and keep runtime redirect guard when disabled
- remove root-level Storybook stack registration to avoid duplicate routing

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- pre-push checks (`format:check`, `typecheck`, worker CI test subset) passed on push