### PR TITLE
Limit Storybook env to dev workflows

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,7 +3,7 @@
   "main": "index.js",
   "version": "1.0.0",
   "scripts": {
-    "dev": "EXPO_HOSTNAME=100.92.242.50 expo start -c --port ${METRO_PORT:-8081}",
+    "dev": "EXPO_PUBLIC_STORYBOOK_ENABLED=true EXPO_HOSTNAME=100.92.242.50 expo start -c --port ${METRO_PORT:-8081}",
     "storybook:start": "EXPO_PUBLIC_STORYBOOK_ENABLED=true EXPO_HOSTNAME=100.92.242.50 expo start -c --port ${METRO_PORT:-8081}",
     "storybook:generate": "sb-rn-get-stories",
     "start": "expo start -c",
@@ -13,7 +13,7 @@
     "lint": "expo lint",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "build:ios:preview": "dotenv -e .env.preview -- eas build --platform ios --profile preview --local --output ./build/preview.ipa --non-interactive",
+    "build:ios:preview": "env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- eas build --platform ios --profile preview --local --output ./build/preview.ipa --non-interactive",
     "deploy:ios:preview": "./scripts/build-and-install-ios.sh"
   },
   "dependencies": {

--- a/apps/mobile/scripts/build-and-install-ios.sh
+++ b/apps/mobile/scripts/build-and-install-ios.sh
@@ -19,7 +19,7 @@ BUILD_SUCCESS=0
 for attempt in $(seq 1 "$MAX_BUILD_ATTEMPTS"); do
     echo -e "${YELLOW}Build attempt ${attempt}/${MAX_BUILD_ATTEMPTS}${NC}"
 
-    BUILD_JSON=$(dotenv -e .env.preview -- eas build --platform ios --profile preview --non-interactive --wait --json 2>/dev/null || true)
+    BUILD_JSON=$(env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- eas build --platform ios --profile preview --non-interactive --wait --json 2>/dev/null || true)
 
     BUILD_URL=$(echo "$BUILD_JSON" | jq -r 'if type == "array" then .[0].artifacts.buildUrl // .[0].artifacts.applicationArchiveUrl // .[0].artifacts.url else .artifacts.buildUrl // .artifacts.applicationArchiveUrl // .artifacts.url end // empty')
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -160,9 +160,10 @@ if [ "$CURRENT_PORT" != "$WORKER_PORT" ]; then
 EXPO_PUBLIC_API_URL=http://localhost:$WORKER_PORT
 EOF
 
-    # Append other env vars from main's .env.local (excluding API_URL)
+    # Append other env vars from main's .env.local (excluding API_URL and dev-only flags)
     if [ -f "$MAIN_WORKTREE/apps/mobile/.env.local" ]; then
         grep -v "^EXPO_PUBLIC_API_URL=" "$MAIN_WORKTREE/apps/mobile/.env.local" | \
+            grep -v "^EXPO_PUBLIC_STORYBOOK_ENABLED=" | \
             grep -v "^#" | grep -v "^$" >> apps/mobile/.env.local 2>/dev/null || true
         echo "   ✓ Copied secrets from main's .env.local"
     else


### PR DESCRIPTION
## Summary
- Scope `EXPO_PUBLIC_STORYBOOK_ENABLED=true` to the mobile `dev` script so Storybook links are only enabled in local dev workflows.
- Prevent preview iOS builds from inheriting Storybook flags by unsetting `EXPO_PUBLIC_STORYBOOK_ENABLED` and setting `EXPO_NO_DOTENV=1` in both preview build commands.
- Exclude `EXPO_PUBLIC_STORYBOOK_ENABLED` when generating/copying `apps/mobile/.env.local` in `scripts/dev.sh` so worktree env seeding cannot leak it.

## Testing
- Not run (script and config changes only).