### PR TITLE
techdebt: harden ISO-8601 duration parsing

### DIFF
--- a/apps/worker/src/lib/duration.test.ts
+++ b/apps/worker/src/lib/duration.test.ts
@@ -60,12 +60,12 @@ describe('parseISO8601Duration', () => {
       expect(parseISO8601Duration('invalid')).toBe(0);
       expect(parseISO8601Duration('1:30')).toBe(0);
       expect(parseISO8601Duration('90')).toBe(0);
+      expect(parseISO8601Duration('PT1M30S-extra')).toBe(0);
+      expect(parseISO8601Duration('P1DT2H')).toBe(0);
     });
 
     it('handles null-like values', () => {
-      // @ts-expect-error - testing runtime behavior
       expect(parseISO8601Duration(null)).toBe(0);
-      // @ts-expect-error - testing runtime behavior
       expect(parseISO8601Duration(undefined)).toBe(0);
     });
   });

--- a/apps/worker/src/lib/duration.ts
+++ b/apps/worker/src/lib/duration.ts
@@ -5,11 +5,13 @@
  * particularly ISO 8601 durations used by YouTube and other APIs.
  */
 
+const ISO8601_TIME_DURATION_PATTERN = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/;
+
 /**
- * Parse ISO 8601 duration format (e.g., "PT1M30S") into seconds.
+ * Parse ISO 8601 time duration format (e.g., "PT1M30S") into seconds.
  * Returns 0 for invalid/empty input (graceful degradation).
  *
- * @param duration - ISO 8601 duration string (e.g., "PT1H30M45S")
+ * @param duration - ISO 8601 duration-like value (e.g., "PT1H30M45S")
  * @returns Duration in seconds, or 0 if invalid
  *
  * @example
@@ -21,12 +23,12 @@
  * parseISO8601Duration("")         // 0 (graceful degradation)
  * ```
  */
-export function parseISO8601Duration(duration: string): number {
-  if (!duration) {
+export function parseISO8601Duration(duration: unknown): number {
+  if (typeof duration !== 'string' || duration.length === 0) {
     return 0;
   }
 
-  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  const match = duration.match(ISO8601_TIME_DURATION_PATTERN);
   if (!match) {
     return 0;
   }


### PR DESCRIPTION
## Summary
- tighten `parseISO8601Duration` to only accept full ISO-8601 time durations (`PT...`) via an anchored regex
- make parser runtime-safe for non-string inputs by accepting `unknown` and returning `0` for invalid values
- expand duration tests to cover trailing-garbage and unsupported day-prefixed inputs
- remove now-unnecessary test `@ts-expect-error` suppressions for null/undefined cases

## Validation
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/worker test:run src/lib/duration.test.ts
- pre-push hook passed (format check, turbo typecheck, worker CI test subset)
