### PR TITLE
tech-debt: harden mobile provider route normalization

### DIFF
--- a/apps/mobile/lib/route-validation.test.ts
+++ b/apps/mobile/lib/route-validation.test.ts
@@ -101,6 +101,11 @@ describe('route-validation', () => {
       expect(isValidProviderRoute('Gmail')).toBe(true);
     });
 
+    it('returns true for valid providers with surrounding whitespace', () => {
+      expect(isValidProviderRoute(' youtube ')).toBe(true);
+      expect(isValidProviderRoute('\nSpotify\t')).toBe(true);
+    });
+
     it('returns false for invalid providers', () => {
       expect(isValidProviderRoute('invalid')).toBe(false);
       expect(isValidProviderRoute('rss')).toBe(false);
@@ -122,6 +127,11 @@ describe('route-validation', () => {
       expect(normalizeProviderRoute('spotify')).toBe('spotify');
       expect(normalizeProviderRoute('SPOTIFY')).toBe('spotify');
       expect(normalizeProviderRoute('GMAIL')).toBe('gmail');
+    });
+
+    it('trims surrounding whitespace before validating', () => {
+      expect(normalizeProviderRoute('  youtube  ')).toBe('youtube');
+      expect(normalizeProviderRoute('\tSPOTIFY\n')).toBe('spotify');
     });
 
     it('returns undefined for invalid providers', () => {

--- a/apps/mobile/lib/route-validation.ts
+++ b/apps/mobile/lib/route-validation.ts
@@ -108,10 +108,7 @@ export function validateItemId(value: unknown): ValidationResult<string> {
  * }
  */
 export function isValidProviderRoute(value: unknown): value is ProviderRoute {
-  return (
-    typeof value === 'string' &&
-    VALID_PROVIDER_ROUTES.includes(value.toLowerCase() as ProviderRoute)
-  );
+  return normalizeProviderRoute(value) !== undefined;
 }
 
 /**
@@ -126,10 +123,12 @@ export function isValidProviderRoute(value: unknown): value is ProviderRoute {
  */
 export function normalizeProviderRoute(value: unknown): ProviderRoute | undefined {
   if (typeof value !== 'string') return undefined;
-  const lower = value.toLowerCase() as ProviderRoute;
-  if (VALID_PROVIDER_ROUTES.includes(lower)) {
-    return lower;
+
+  const normalized = value.trim().toLowerCase() as ProviderRoute;
+  if (VALID_PROVIDER_ROUTES.includes(normalized)) {
+    return normalized;
   }
+
   return undefined;
 }
 
@@ -210,7 +209,7 @@ export function validateAndConvertDiscoverProvider(
   if (!VALID_DISCOVER_PROVIDER_ROUTES.includes(routeResult.data as DiscoverProviderRoute)) {
     return {
       success: false,
-      message: `Provider \"${routeResult.data}\" is not supported for discovery.`,
+      message: `Provider "${routeResult.data}" is not supported for discovery.`,
     };
   }
 


### PR DESCRIPTION
## Summary
- Refactor `isValidProviderRoute` to reuse `normalizeProviderRoute` instead of duplicating normalization logic.
- Trim surrounding whitespace in `normalizeProviderRoute` before lowercasing and validation.
- Add unit tests covering provider values with surrounding whitespace.
- Fix a lint issue in the same file (remove unnecessary escaping in the provider error message).

## Why
Provider route params can arrive with accidental whitespace (manual deep links, pasted values). Trimming improves resilience and consolidating normalization logic reduces drift risk.

## Validation
- `bun run --cwd apps/mobile test lib/route-validation.test.ts --runInBand` (28 passed)
- `bun run lint --filter=@zine/mobile`
- `bun run typecheck --filter=@zine/mobile`
- Pre-push hook passed full suite: 45 files / 1368 tests
