### PR TITLE
worker: harden spotify polling env integer parsing

### DIFF
--- a/apps/worker/src/polling/spotify-poller.test.ts
+++ b/apps/worker/src/polling/spotify-poller.test.ts
@@ -1362,6 +1362,53 @@ describe('Spotify Poller - Parallel Episode Fetching (zine-p5h)', () => {
       expect(maxConcurrent).toBeLessThanOrEqual(5);
     });
 
+    it('should fall back to default concurrency when env var is invalid', async () => {
+      const subs = Array.from({ length: 8 }, (_, i) =>
+        createMockSubscription({
+          id: `sub_${i}`,
+          providerChannelId: `show_${i}`,
+          totalItems: 10,
+        })
+      );
+
+      mockGetMultipleShowsWithCache.mockResolvedValue(
+        createCacheResult(
+          subs.map((s, i) => ({
+            id: s.providerChannelId,
+            name: `Show ${i}`,
+            totalEpisodes: 11,
+          }))
+        )
+      );
+
+      let maxConcurrent = 0;
+      let currentConcurrent = 0;
+
+      mockGetShowEpisodes.mockImplementation(async () => {
+        currentConcurrent++;
+        maxConcurrent = Math.max(maxConcurrent, currentConcurrent);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        currentConcurrent--;
+        return [createMockSpotifyEpisode({ id: 'ep', releaseDate: '2024-01-15' })];
+      });
+
+      mockIngestItem.mockResolvedValue({ created: true, itemId: 'i', userItemId: 'ui' });
+
+      const { pollSpotifySubscriptionsBatched } = await import('./spotify-poller');
+
+      const db = createMockDb();
+      await pollSpotifySubscriptionsBatched(
+        subs as never[],
+        {} as never,
+        subs[0].userId,
+        { SPOTIFY_EPISODE_FETCH_CONCURRENCY: '-2' } as never,
+        db as never
+      );
+
+      expect(maxConcurrent).toBeLessThanOrEqual(5);
+      expect(maxConcurrent).toBeGreaterThan(0);
+    });
+
     it('should return all results including both successes and failures', async () => {
       const sub1 = createMockSubscription({
         id: 'sub_ok',
@@ -1971,6 +2018,44 @@ describe('Spotify Poller - Batch Size Guard (zine-3ys)', () => {
 
       // Should complete - error logged but not thrown
       expect(mockGetMultipleShowsWithCache).toHaveBeenCalled();
+    });
+
+    it('should fall back to default batch thresholds when env values are invalid', async () => {
+      // 501 exceeds default max-safe threshold (500), so this should still process and warn path is exercised
+      const subs = Array.from({ length: 501 }, (_, i) =>
+        createMockSubscription({
+          id: `sub_${i}`,
+          providerChannelId: `show_${i}`,
+          totalItems: 10,
+        })
+      );
+
+      mockGetMultipleShowsWithCache.mockResolvedValue(
+        createCacheResult(
+          subs.map((s, i) => ({
+            id: s.providerChannelId,
+            name: `Show ${i}`,
+            totalEpisodes: 10,
+          }))
+        )
+      );
+
+      const { pollSpotifySubscriptionsBatched } = await import('./spotify-poller');
+
+      const db = createMockDb();
+      const result = await pollSpotifySubscriptionsBatched(
+        subs as never[],
+        {} as never,
+        subs[0].userId,
+        {
+          SPOTIFY_MAX_SAFE_BATCH_SIZE: '-10',
+          SPOTIFY_CRITICAL_BATCH_SIZE: '0',
+        } as never,
+        db as never
+      );
+
+      expect(result.skipped).toBe(501);
+      expect(result.processed).toBe(0);
     });
 
     it('should handle empty batch gracefully (no warnings)', async () => {

--- a/apps/worker/src/polling/spotify-poller.ts
+++ b/apps/worker/src/polling/spotify-poller.ts
@@ -87,6 +87,11 @@ const ESTIMATED_MS_PER_SUBSCRIPTION = 100;
 /** Estimated API calls per subscription (metadata lookup + episode fetch) */
 const ESTIMATED_API_CALLS_PER_SUBSCRIPTION = 2;
 
+function getPositiveIntEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 // ============================================================================
 // Provider Configuration
 // ============================================================================
@@ -136,10 +141,14 @@ export async function pollSpotifySubscriptionsBatched(
   db: DrizzleDB
 ): Promise<BatchPollingResult> {
   // Get configurable batch size thresholds from environment
-  const maxSafeBatchSize =
-    parseInt(env.SPOTIFY_MAX_SAFE_BATCH_SIZE ?? '', 10) || DEFAULT_MAX_SAFE_BATCH_SIZE;
-  const criticalBatchSize =
-    parseInt(env.SPOTIFY_CRITICAL_BATCH_SIZE ?? '', 10) || DEFAULT_CRITICAL_BATCH_SIZE;
+  const maxSafeBatchSize = getPositiveIntEnv(
+    env.SPOTIFY_MAX_SAFE_BATCH_SIZE,
+    DEFAULT_MAX_SAFE_BATCH_SIZE
+  );
+  const criticalBatchSize = getPositiveIntEnv(
+    env.SPOTIFY_CRITICAL_BATCH_SIZE,
+    DEFAULT_CRITICAL_BATCH_SIZE
+  );
 
   // Batch size guard: log warnings/errors for large batches
   if (subs.length > criticalBatchSize) {
@@ -362,8 +371,10 @@ export async function pollSpotifySubscriptionsBatched(
   const pollingErrors: PollingError[] = [];
 
   // Get concurrency limit from environment, falling back to default
-  const concurrency =
-    parseInt(env.SPOTIFY_EPISODE_FETCH_CONCURRENCY ?? '', 10) || DEFAULT_EPISODE_FETCH_CONCURRENCY;
+  const concurrency = getPositiveIntEnv(
+    env.SPOTIFY_EPISODE_FETCH_CONCURRENCY,
+    DEFAULT_EPISODE_FETCH_CONCURRENCY
+  );
   const limit = pLimit(concurrency);
 
   // Parallel episode fetching with concurrency control


### PR DESCRIPTION
## Summary\n- harden Spotify poller env parsing by accepting only positive integers for batch-size and concurrency overrides\n- fall back to safe defaults for missing/invalid/zero/negative values\n- add tests for invalid env values to prevent regressions\n\n## Validation\n- bun run --cwd apps/worker lint\n- bun run --cwd apps/worker typecheck\n- bun run --cwd apps/worker test:run src/polling/spotify-poller.test.ts\n- (pre-push hook) bun run --cwd apps/worker test:run\n