### PR TITLE
refactor(mobile): remove conditional require from swipeable context menu

### DIFF
--- a/apps/mobile/components/swipeable-inbox-item.tsx
+++ b/apps/mobile/components/swipeable-inbox-item.tsx
@@ -55,6 +55,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
+import ContextMenuView from 'react-native-context-menu-view';
 
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { ArchiveIcon, BookmarkIcon } from '@/components/icons';
@@ -76,12 +77,10 @@ type ContextMenuProps = {
 // Fallback component that just renders children (for Expo Go)
 const ContextMenuFallback = ({ children }: ContextMenuProps) => <>{children}</>;
 
-// Only load native module if it's actually available
-const ContextMenuNative = isContextMenuAvailable
-  ? // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('react-native-context-menu-view').default
-  : null;
-const ContextMenu: React.ComponentType<ContextMenuProps> = ContextMenuNative ?? ContextMenuFallback;
+// ContextMenuView import is safe in Expo Go; we still gate rendering on native availability
+const ContextMenu: React.ComponentType<ContextMenuProps> = isContextMenuAvailable
+  ? (ContextMenuView as React.ComponentType<ContextMenuProps>)
+  : ContextMenuFallback;
 
 // ============================================================================
 // Types


### PR DESCRIPTION
## Summary
- Replace conditional `require('react-native-context-menu-view')` with static import in `SwipeableInboxItem`
- Keep native-availability gating via `UIManager.getViewManagerConfig('ContextMenu')`
- Preserve Expo Go fallback behavior while removing lint suppression and require-based tech debt

## Validation
- `bunx eslint apps/mobile/components/swipeable-inbox-item.tsx`
- `bun run --cwd apps/mobile test -- swipeable-inbox-performance.test.ts`
- pre-push hook suite during `git push` passed (45 files / 1368 tests)
