### PR TITLE
Reduce noisy warning logs in worker tests

### DIFF
--- a/apps/worker/src/admin/repair-subscriptions.test.ts
+++ b/apps/worker/src/admin/repair-subscriptions.test.ts
@@ -14,6 +14,7 @@ import {
   verifyRepairs,
   type FindCorruptedResult,
 } from './repair-subscriptions';
+import { expectLoggerErrorCalls } from '../test/mock-logger';
 
 // ============================================================================
 // Mock Date.now for consistent testing
@@ -505,6 +506,7 @@ describe('repairCorruptedSubscriptions', () => {
   describe('error handling', () => {
     it('should handle database errors gracefully', async () => {
       const corrupted = createCorruptedSubscription();
+      const databaseError = new Error('Database error');
 
       const drizzleMock = {
         select: vi.fn(() => ({
@@ -514,7 +516,7 @@ describe('repairCorruptedSubscriptions', () => {
         })),
         update: vi.fn(() => ({
           set: vi.fn(() => ({
-            where: vi.fn(() => Promise.reject(new Error('Database error'))),
+            where: vi.fn(() => Promise.reject(databaseError)),
           })),
         })),
       };
@@ -526,6 +528,9 @@ describe('repairCorruptedSubscriptions', () => {
 
       expect(result.errors.length).toBe(1);
       expect(result.errors[0].error).toContain('Database error');
+      expectLoggerErrorCalls([
+        ['Failed to repair subscription', { subscriptionId: corrupted.id, error: databaseError }],
+      ]);
     });
   });
 

--- a/apps/worker/src/lib/favicon.test.ts
+++ b/apps/worker/src/lib/favicon.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchFavicon } from './favicon';
+import { expectLoggerErrorCalls } from '../test/mock-logger';
 
 // ============================================================================
 // Test HTML Templates
@@ -306,12 +307,16 @@ describe('fetchFavicon', () => {
     });
 
     it('should handle page fetch errors gracefully', async () => {
-      mockFetchError(new Error('Network error'));
+      const networkError = new Error('Network error');
+      mockFetchError(networkError);
 
       const result = await fetchFavicon('https://example.com/page');
 
       // Should return null on error
       expect(result).toBeNull();
+      expectLoggerErrorCalls([
+        ['Favicon fetch failed', { url: 'https://example.com/page', error: networkError }],
+      ]);
     });
 
     it('should handle non-HTML responses', async () => {

--- a/apps/worker/src/lib/opengraph.test.ts
+++ b/apps/worker/src/lib/opengraph.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { scrapeOpenGraph, type OpenGraphData } from './opengraph';
+import { expectLoggerErrorCalls } from '../test/mock-logger';
 
 // ============================================================================
 // Test HTML Templates
@@ -262,12 +263,16 @@ describe('scrapeOpenGraph', () => {
     });
 
     it('should return empty result on network error', async () => {
-      mockFetchError(new Error('Network error'));
+      const networkError = new Error('Network error');
+      mockFetchError(networkError);
 
       const result = await scrapeOpenGraph('https://example.com/page');
 
       expect(result.title).toBeNull();
       expect(result.description).toBeNull();
+      expectLoggerErrorCalls([
+        ['OG scrape failed', { url: 'https://example.com/page', error: networkError }],
+      ]);
     });
 
     it('should handle timeout gracefully', async () => {

--- a/apps/worker/src/polling/scheduler.test.ts
+++ b/apps/worker/src/polling/scheduler.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { expectLoggerErrorCalls } from '../test/mock-logger';
 
 // ============================================================================
 // Mock Dependencies
@@ -916,11 +917,12 @@ describe('Polling Scheduler', () => {
       });
 
       // User 2 will fail with a non-auth error
+      const userBatchError = new Error('Network error for user 2');
       let clientCallCount = 0;
       mockGetYouTubeClientForConnection.mockImplementation(async () => {
         clientCallCount++;
         if (clientCallCount === 2) {
-          throw new Error('Network error for user 2');
+          throw userBatchError;
         }
         return {};
       });
@@ -936,6 +938,20 @@ describe('Polling Scheduler', () => {
       // 2 subscriptions should be processed successfully (user_1 and user_3)
       // user_2's subscription failed but was isolated
       expect(result.processed).toBe(2);
+      expectLoggerErrorCalls([
+        [
+          'User batch processing failed',
+          expect.objectContaining({
+            provider: 'youtube',
+            userId: 'user_2',
+            subscriptionCount: 1,
+            error: expect.objectContaining({
+              message: 'Network error for user 2',
+              type: 'Error',
+            }),
+          }),
+        ],
+      ]);
     });
 
     it('should respect USER_PROCESSING_CONCURRENCY environment variable', async () => {
@@ -1134,8 +1150,9 @@ describe('Polling Scheduler', () => {
       mockGetYouTubeClientForConnection
         .mockResolvedValueOnce({}) // First user succeeds
         .mockResolvedValueOnce({}); // Second user succeeds
+      const subscriptionError = new Error('API Error');
       mockFetchRecentVideos
-        .mockRejectedValueOnce(new Error('API Error')) // First subscription fails
+        .mockRejectedValueOnce(subscriptionError) // First subscription fails
         .mockResolvedValueOnce([]); // Second subscription succeeds
 
       const env = createMockEnv();
@@ -1146,17 +1163,21 @@ describe('Polling Scheduler', () => {
 
       // Both subscriptions should be counted as processed
       expect(result.processed).toBe(2);
+      expectLoggerErrorCalls([
+        ['Error polling subscription', { subscriptionId: 'sub_1', error: subscriptionError }],
+      ]);
     });
 
     it('should update lastPolledAt even on subscription error', async () => {
       const subscription = createMockSubscription({ provider: 'YOUTUBE' });
       const connection = createMockConnection({ provider: 'YOUTUBE' });
+      const subscriptionError = new Error('API Error');
 
       mockTryAcquireLock.mockResolvedValue(true);
       mockDbQuerySubscriptions.findMany.mockResolvedValue([subscription]);
       mockDbQueryConnections.findFirst.mockResolvedValue(connection);
       mockGetYouTubeClientForConnection.mockResolvedValue({});
-      mockFetchRecentVideos.mockRejectedValue(new Error('API Error'));
+      mockFetchRecentVideos.mockRejectedValue(subscriptionError);
 
       const env = createMockEnv();
       const ctx = createMockExecutionContext();
@@ -1166,6 +1187,12 @@ describe('Polling Scheduler', () => {
 
       // lastPolledAt should still be updated to prevent infinite retry
       expect(mockDbUpdate).toHaveBeenCalled();
+      expectLoggerErrorCalls([
+        [
+          'Error polling subscription',
+          { subscriptionId: subscription.id, error: subscriptionError },
+        ],
+      ]);
     });
   });
 

--- a/apps/worker/src/polling/spotify-poller.test.ts
+++ b/apps/worker/src/polling/spotify-poller.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { expectLoggerErrorCalls } from '../test/mock-logger';
 
 // ============================================================================
 // Mock Dependencies
@@ -210,6 +211,63 @@ interface MockSpotifyEpisode {
   isPlayable: boolean;
 }
 
+function expectFailedEpisodeIngestionLogs(
+  failures: Array<{ episodeId: string; errorMessage: string }>
+): void {
+  expectLoggerErrorCalls(
+    failures.map(({ episodeId, errorMessage }) => [
+      'Failed to ingest episode',
+      expect.objectContaining({
+        episodeId,
+        error: expect.objectContaining({
+          message: errorMessage,
+          type: 'Error',
+        }),
+        errorType: 'Error',
+      }),
+    ])
+  );
+}
+
+function expectFailedEpisodeFetchLogs(
+  failures: Array<{ subscriptionId: string; showId: string; errorMessage: string }>
+): void {
+  expectLoggerErrorCalls(
+    failures.map(({ subscriptionId, showId, errorMessage }) => [
+      'Failed to fetch episodes for show',
+      expect.objectContaining({
+        subscriptionId,
+        showId,
+        error: expect.objectContaining({
+          message: errorMessage,
+          type: 'Error',
+        }),
+      }),
+    ])
+  );
+}
+
+function expectCriticalBatchSizeErrorLog(params: {
+  batchSize: number;
+  maxSafe: number;
+  critical: number;
+  userId: string;
+}): void {
+  expectLoggerErrorCalls([
+    [
+      'Critical: Subscription batch size exceeds safe limit',
+      expect.objectContaining({
+        batchSize: params.batchSize,
+        maxSafe: params.maxSafe,
+        critical: params.critical,
+        userId: params.userId,
+        estimatedApiCalls: params.batchSize * 2,
+        estimatedDurationMs: params.batchSize * 100,
+      }),
+    ],
+  ]);
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -274,6 +332,9 @@ describe('Spotify Poller - Watermark Integrity', () => {
       expect(updateCall).toBeDefined();
       expect(updateCall?.values.lastPolledAt).toBeDefined();
       expect(updateCall?.values.lastPublishedAt).toBeUndefined();
+      expectFailedEpisodeIngestionLogs([
+        { episodeId: 'episode1', errorMessage: 'Ingestion failed' },
+      ]);
     });
 
     it('should NOT update lastPublishedAt when all episodes are skipped (already seen)', async () => {
@@ -355,6 +416,9 @@ describe('Spotify Poller - Watermark Integrity', () => {
       // 2024-01-14 at midnight UTC
       const expectedTimestamp = new Date('2024-01-14T00:00:00Z').getTime();
       expect(updateCall?.values.lastPublishedAt).toBe(expectedTimestamp);
+      expectFailedEpisodeIngestionLogs([
+        { episodeId: 'episode1', errorMessage: 'Failed to ingest newest' },
+      ]);
     });
 
     it('should update lastPublishedAt to newest when all episodes ingested successfully', async () => {
@@ -428,6 +492,10 @@ describe('Spotify Poller - Watermark Integrity', () => {
       const updateCall = dbUpdateCalls.find((c) => c.subscriptionId === sub.id);
       const expectedTimestamp = new Date('2024-01-14T00:00:00Z').getTime();
       expect(updateCall?.values.lastPublishedAt).toBe(expectedTimestamp);
+      expectFailedEpisodeIngestionLogs([
+        { episodeId: 'ep1', errorMessage: 'Failed' },
+        { episodeId: 'ep3', errorMessage: 'Failed' },
+      ]);
     });
   });
 
@@ -475,6 +543,7 @@ describe('Spotify Poller - Watermark Integrity', () => {
       expect(updateCall).toBeDefined();
       expect(updateCall?.values.lastPublishedAt).toBeUndefined();
       expect(updateCall?.values.totalItems).toBeUndefined();
+      expectFailedEpisodeIngestionLogs([{ episodeId: 'ep1', errorMessage: 'Ingestion failed' }]);
     });
 
     it('should update lastPublishedAt AND totalItems only when ingestion succeeds', async () => {
@@ -566,6 +635,7 @@ describe('Spotify Poller - Watermark Integrity', () => {
       const update2 = dbUpdateCalls.find((c) => c.subscriptionId === 'sub2');
       expect(update2?.values.lastPublishedAt).toBeDefined();
       expect(update2?.values.totalItems).toBe(21);
+      expectFailedEpisodeIngestionLogs([{ episodeId: 'ep1', errorMessage: 'Failed' }]);
     });
   });
 
@@ -1068,6 +1138,9 @@ describe('Regression: zine-ej0 - lastPublishedAt Corruption Bug', () => {
 
     // Verify lastPolledAt IS updated (so we don't poll too frequently)
     expect(updateCall?.values.lastPolledAt).toBeDefined();
+    expectFailedEpisodeIngestionLogs([
+      { episodeId: 'missed-episode', errorMessage: 'Database constraint violation' },
+    ]);
   });
 
   it('should preserve episode recovery opportunity after transient failure', async () => {
@@ -1097,6 +1170,9 @@ describe('Regression: zine-ej0 - lastPublishedAt Corruption Bug', () => {
     // Watermark should NOT advance
     const firstUpdate = dbUpdateCalls.find((c) => c.subscriptionId === sub.id);
     expect(firstUpdate?.values.lastPublishedAt).toBeUndefined();
+    expectFailedEpisodeIngestionLogs([
+      { episodeId: 'recoverable', errorMessage: 'Transient DB error' },
+    ]);
 
     // Simulate retry: same episode, now succeeds
     dbUpdateCalls.length = 0;
@@ -1259,6 +1335,13 @@ describe('Spotify Poller - Parallel Episode Fetching (zine-p5h)', () => {
       expect(result.errors).toBeDefined();
       expect(result.errors?.length).toBe(1);
       expect(result.errors?.[0].subscriptionId).toBe('sub_fail');
+      expectFailedEpisodeFetchLogs([
+        {
+          subscriptionId: 'sub_fail',
+          showId: 'show_fail',
+          errorMessage: 'API rate limit exceeded',
+        },
+      ]);
     });
 
     it('should respect concurrency limit from environment', async () => {
@@ -1454,6 +1537,13 @@ describe('Spotify Poller - Parallel Episode Fetching (zine-p5h)', () => {
       // Error recorded for failed subscription
       expect(result.errors).toHaveLength(1);
       expect(result.errors?.[0].subscriptionId).toBe('sub_api_error');
+      expectFailedEpisodeFetchLogs([
+        {
+          subscriptionId: 'sub_api_error',
+          showId: 'show_api_error',
+          errorMessage: 'Spotify API error',
+        },
+      ]);
     });
 
     it('should handle all parallel fetches failing gracefully', async () => {
@@ -1493,6 +1583,18 @@ describe('Spotify Poller - Parallel Episode Fetching (zine-p5h)', () => {
       expect(result.processed).toBe(2);
       expect(result.newItems).toBe(0);
       expect(result.errors).toHaveLength(2);
+      expectFailedEpisodeFetchLogs([
+        {
+          subscriptionId: 'sub_fail_1',
+          showId: 'show_fail_1',
+          errorMessage: 'Network error',
+        },
+        {
+          subscriptionId: 'sub_fail_2',
+          showId: 'show_fail_2',
+          errorMessage: 'Network error',
+        },
+      ]);
     });
 
     it('should preserve watermark integrity during parallel processing', async () => {
@@ -1550,6 +1652,9 @@ describe('Spotify Poller - Parallel Episode Fetching (zine-p5h)', () => {
       const update2 = dbUpdateCalls.find((c) => c.subscriptionId === 'sub2');
       expect(update2?.values.lastPublishedAt).toBeUndefined();
       expect(update2?.values.totalItems).toBeUndefined();
+      expectFailedEpisodeIngestionLogs([
+        { episodeId: 'ep-show2', errorMessage: 'Ingestion failed' },
+      ]);
     });
   });
 });
@@ -1905,6 +2010,12 @@ describe('Spotify Poller - Batch Size Guard (zine-3ys)', () => {
 
       // Function should complete without throwing (error is logged, not thrown)
       expect(mockGetMultipleShowsWithCache).toHaveBeenCalled();
+      expectCriticalBatchSizeErrorLog({
+        batchSize: 1001,
+        maxSafe: 500,
+        critical: 1000,
+        userId: subs[0].userId,
+      });
     });
 
     it('should NOT log warning for batches within safe size', async () => {
@@ -2018,6 +2129,12 @@ describe('Spotify Poller - Batch Size Guard (zine-3ys)', () => {
 
       // Should complete - error logged but not thrown
       expect(mockGetMultipleShowsWithCache).toHaveBeenCalled();
+      expectCriticalBatchSizeErrorLog({
+        batchSize: 101,
+        maxSafe: 50,
+        critical: 100,
+        userId: subs[0].userId,
+      });
     });
 
     it('should fall back to default batch thresholds when env values are invalid', async () => {
@@ -2198,6 +2315,12 @@ describe('Spotify Poller - Batch Size Guard (zine-3ys)', () => {
       // (they're all skipped because no delta)
       expect(result.skipped).toBe(110);
       expect(result.processed).toBe(0);
+      expectCriticalBatchSizeErrorLog({
+        batchSize: 110,
+        maxSafe: 50,
+        critical: 100,
+        userId: subs[0].userId,
+      });
     });
 
     it('should correctly estimate API calls and duration in metrics', async () => {

--- a/apps/worker/src/routes/auth.test.ts
+++ b/apps/worker/src/routes/auth.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import type { Env } from '../types';
+import { expectLoggerErrorCalls, mockLogger } from '../test/mock-logger';
 
 // Mock svix for testing
 vi.mock('svix', () => ({
@@ -150,6 +151,7 @@ describe('POST /api/auth/webhook', () => {
 
     const body = (await res.json()) as JsonResponse;
     expect(body.code).toBe('WEBHOOK_NOT_CONFIGURED');
+    expectLoggerErrorCalls([['CLERK_WEBHOOK_SECRET not configured']]);
   });
 
   it('returns 400 if Svix headers are missing', async () => {
@@ -262,8 +264,6 @@ describe('POST /api/auth/webhook', () => {
   });
 
   it('logs but does not process user.updated events', async () => {
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-
     const req = new Request('http://localhost/api/auth/webhook', {
       method: 'POST',
       headers: {
@@ -287,10 +287,9 @@ describe('POST /api/auth/webhook', () => {
 
     const res = await app.fetch(req, mockEnv);
     expect(res.status).toBe(200);
-
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('user.updated'));
-
-    consoleSpy.mockRestore();
+    expect(mockLogger.info).toHaveBeenCalledWith('user.updated - no action needed', {
+      userId: 'user_789',
+    });
   });
 });
 

--- a/apps/worker/src/sync/dlq-consumer.test.ts
+++ b/apps/worker/src/sync/dlq-consumer.test.ts
@@ -89,7 +89,7 @@ function expectHandleSyncDLQErrorLogs(
   batch: MessageBatch<SyncQueueMessage>,
   malformedMessageIds: string[] = []
 ): void {
-  expectLoggerErrorCalls([
+  const expectedCalls: Parameters<typeof expectLoggerErrorCalls>[0] = [
     [
       'DLQ messages received - sync failures requiring investigation',
       expect.objectContaining({
@@ -97,7 +97,7 @@ function expectHandleSyncDLQErrorLogs(
         environment: 'development',
       }),
     ],
-    ...batch.messages.map((message) => [
+    ...batch.messages.map<Parameters<typeof expectLoggerErrorCalls>[0][number]>((message) => [
       malformedMessageIds.includes(message.id)
         ? 'DLQ: Malformed message body'
         : 'DLQ: Subscription sync permanently failed',
@@ -106,7 +106,9 @@ function expectHandleSyncDLQErrorLogs(
         attempts: message.attempts,
       }),
     ]),
-  ]);
+  ];
+
+  expectLoggerErrorCalls(expectedCalls);
 }
 
 // ============================================================================

--- a/apps/worker/src/sync/dlq-consumer.test.ts
+++ b/apps/worker/src/sync/dlq-consumer.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleSyncDLQ, getDLQEntries, getDLQSummary, deleteDLQEntry } from './dlq-consumer';
 import type { SyncQueueMessage } from './types';
 import { getDLQEntryKey, getDLQIndexKey } from './types';
+import { expectLoggerErrorCalls, mockLogger } from '../test/mock-logger';
 
 // ============================================================================
 // Mocks
@@ -23,18 +24,6 @@ import { getDLQEntryKey, getDLQIndexKey } from './types';
 let mockUlidCounter = 0;
 vi.mock('ulid', () => ({
   ulid: () => `01HQXYZ${String(++mockUlidCounter).padStart(17, '0')}`,
-}));
-
-// Mock logger to suppress console output during tests
-vi.mock('../lib/logger', () => ({
-  logger: {
-    child: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    }),
-  },
 }));
 
 // ============================================================================
@@ -96,6 +85,30 @@ function createMockDLQBatch(messages: Message<SyncQueueMessage>[]): MessageBatch
   };
 }
 
+function expectHandleSyncDLQErrorLogs(
+  batch: MessageBatch<SyncQueueMessage>,
+  malformedMessageIds: string[] = []
+): void {
+  expectLoggerErrorCalls([
+    [
+      'DLQ messages received - sync failures requiring investigation',
+      expect.objectContaining({
+        messageCount: batch.messages.length,
+        environment: 'development',
+      }),
+    ],
+    ...batch.messages.map((message) => [
+      malformedMessageIds.includes(message.id)
+        ? 'DLQ: Malformed message body'
+        : 'DLQ: Subscription sync permanently failed',
+      expect.objectContaining({
+        messageId: message.id,
+        attempts: message.attempts,
+      }),
+    ]),
+  ]);
+}
+
 // ============================================================================
 // Mock Environment
 // ============================================================================
@@ -155,6 +168,7 @@ describe('handleSyncDLQ', () => {
       expect.any(String),
       expect.objectContaining({ expirationTtl: 7 * 24 * 60 * 60 })
     );
+    expectHandleSyncDLQErrorLogs(batch);
   });
 
   it('should acknowledge all messages after processing', async () => {
@@ -184,6 +198,7 @@ describe('handleSyncDLQ', () => {
 
     expect(message1.ack).toHaveBeenCalled();
     expect(message2.ack).toHaveBeenCalled();
+    expectHandleSyncDLQErrorLogs(batch);
   });
 
   it('should handle malformed message bodies', async () => {
@@ -205,6 +220,7 @@ describe('handleSyncDLQ', () => {
     // Should still ack and store entry with partial data
     expect(malformedMessage.ack).toHaveBeenCalled();
     expect(kv.put).toHaveBeenCalled();
+    expectHandleSyncDLQErrorLogs(batch, ['msg_malformed']);
   });
 
   it('should include message attempts in DLQ entry', async () => {
@@ -234,6 +250,7 @@ describe('handleSyncDLQ', () => {
 
     const storedEntry = JSON.parse(entryCall![1]);
     expect(storedEntry.attempts).toBe(3);
+    expectHandleSyncDLQErrorLogs(batch);
   });
 
   it('should maintain DLQ index with most recent first', async () => {
@@ -267,6 +284,7 @@ describe('handleSyncDLQ', () => {
     expect(updatedIndex[0]).toMatch(/^01HQXYZ/);
     expect(updatedIndex[1]).toBe('existing_id_1');
     expect(updatedIndex[2]).toBe('existing_id_2');
+    expectHandleSyncDLQErrorLogs(batch);
   });
 
   it('should recover from corrupted DLQ index JSON when storing new entries', async () => {
@@ -296,6 +314,14 @@ describe('handleSyncDLQ', () => {
     const updatedIndex = JSON.parse(indexCall![1]);
     expect(updatedIndex).toHaveLength(1);
     expect(updatedIndex[0]).toMatch(/^01HQXYZ/);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Failed to parse DLQ index JSON; resetting',
+      expect.objectContaining({
+        operation: 'store',
+        error: expect.any(String),
+      })
+    );
+    expectHandleSyncDLQErrorLogs(batch);
   });
 
   it('should store correct DLQ entry structure', async () => {
@@ -333,6 +359,7 @@ describe('handleSyncDLQ', () => {
       environment: 'development',
       deadLetteredAt: expect.any(Number),
     });
+    expectHandleSyncDLQErrorLogs(batch);
   });
 });
 
@@ -410,6 +437,28 @@ describe('getDLQEntries', () => {
     });
 
     await expect(getDLQEntries(kv)).resolves.toEqual([]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Failed to parse DLQ index JSON; resetting',
+      expect.objectContaining({
+        operation: 'list',
+        error: expect.any(String),
+      })
+    );
+  });
+
+  it('should return empty array and warn when index data has invalid shape', async () => {
+    const kv = createMockKV({
+      [getDLQIndexKey()]: JSON.stringify(['entry_1', 42]),
+      [getDLQEntryKey('entry_1')]: JSON.stringify({ id: 'entry_1' }),
+    });
+
+    await expect(getDLQEntries(kv)).resolves.toEqual([]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'DLQ index data has invalid shape; resetting',
+      expect.objectContaining({
+        operation: 'list',
+      })
+    );
   });
 });
 
@@ -589,6 +638,7 @@ describe('DLQ entry TTL', () => {
       expect.any(String),
       { expirationTtl: 604800 }
     );
+    expectHandleSyncDLQErrorLogs(batch);
   });
 });
 
@@ -620,5 +670,6 @@ describe('queue routing', () => {
     expect(message.ack).toHaveBeenCalled();
     // Should store in KV
     expect(kv.put).toHaveBeenCalled();
+    expectHandleSyncDLQErrorLogs(batch);
   });
 });

--- a/apps/worker/src/sync/service.test.ts
+++ b/apps/worker/src/sync/service.test.ts
@@ -26,6 +26,7 @@ import {
   ACTIVE_JOB_TTL_SECONDS,
   type SyncJobStatus,
 } from './types';
+import { mockLogger } from '../test/mock-logger';
 
 vi.mock('../providers/youtube', () => ({
   getYouTubeClientForConnection: vi.fn(async () => ({ client: 'youtube' })),
@@ -483,6 +484,10 @@ describe('updateJobProgress', () => {
 
     // Should not have called put (only get)
     expect(mockKV.put).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith('Job status not found for update', {
+      jobId: TEST_JOB_ID,
+      subscriptionId: 'sub_1',
+    });
   });
 
   it('should increment completed and succeeded on success', async () => {
@@ -1140,6 +1145,13 @@ describe('initiateSyncJob', () => {
       expect(storedStatus.failed).toBe(0);
       expect(storedStatus.itemsFound).toBe(3);
       expect(storedStatus.errors).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Queue not available, falling back to synchronous processing',
+        expect.objectContaining({
+          jobId: result.jobId,
+          userId: TEST_USER_ID,
+        })
+      );
     });
   });
 

--- a/apps/worker/src/test/mock-logger.ts
+++ b/apps/worker/src/test/mock-logger.ts
@@ -1,0 +1,82 @@
+import { expect, vi } from 'vitest';
+
+type ExpectedLoggerCall = [message: unknown, data?: unknown];
+
+let consumedErrorCalls = 0;
+
+function createMockLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+
+  logger.child.mockImplementation(() => logger);
+
+  return logger;
+}
+
+export const mockLogger = createMockLogger();
+
+export function resetMockLogger(): void {
+  consumedErrorCalls = 0;
+  mockLogger.debug.mockClear();
+  mockLogger.info.mockClear();
+  mockLogger.warn.mockClear();
+  mockLogger.error.mockClear();
+  mockLogger.child.mockClear();
+}
+
+export function expectLoggerErrorCalls(expectedCalls: ExpectedLoggerCall[]): void {
+  const actualCalls = mockLogger.error.mock.calls.slice(consumedErrorCalls);
+
+  expect(actualCalls).toHaveLength(expectedCalls.length);
+
+  expectedCalls.forEach(([message, data], index) => {
+    expect(actualCalls[index]?.[0]).toEqual(message);
+    if (data !== undefined) {
+      expect(actualCalls[index]?.[1]).toEqual(data);
+    }
+  });
+
+  consumedErrorCalls += expectedCalls.length;
+}
+
+export function assertNoUnexpectedLoggerErrors(): void {
+  const unexpectedCalls = mockLogger.error.mock.calls.slice(consumedErrorCalls);
+  if (unexpectedCalls.length === 0) {
+    return;
+  }
+
+  const formattedCalls = unexpectedCalls
+    .map((call) =>
+      call
+        .map((value) => {
+          if (typeof value === 'string') {
+            return value;
+          }
+
+          try {
+            return JSON.stringify(value);
+          } catch {
+            return String(value);
+          }
+        })
+        .join(' | ')
+    )
+    .join('\n');
+
+  throw new Error(`Unexpected logger.error calls:\n${formattedCalls}`);
+}
+
+export const mockLoggerModule = {
+  logger: mockLogger,
+  pollLogger: mockLogger,
+  authLogger: mockLogger,
+  webhookLogger: mockLogger,
+  ingestionLogger: mockLogger,
+  healthLogger: mockLogger,
+  quotaLogger: mockLogger,
+};

--- a/apps/worker/src/test/vitest.setup.ts
+++ b/apps/worker/src/test/vitest.setup.ts
@@ -1,0 +1,14 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import { assertNoUnexpectedLoggerErrors, mockLoggerModule, resetMockLogger } from './mock-logger';
+
+// Silence structured logger output during worker tests unless a suite opts into
+// its own local mock. Tests can still assert on the shared spy methods.
+vi.mock('../lib/logger', () => mockLoggerModule);
+
+beforeEach(() => {
+  resetMockLogger();
+});
+
+afterEach(() => {
+  assertNoUnexpectedLoggerErrors();
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -9,6 +9,7 @@ import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
 export default defineWorkersConfig({
   test: {
     globals: true,
+    setupFiles: ['./src/test/vitest.setup.ts'],
     poolOptions: {
       workers: {
         wrangler: {


### PR DESCRIPTION
## Summary
- mock the shared worker logger in Vitest so passing tests stop dumping routine log noise
- fail tests on unexpected logger.error calls and convert intentional error-path tests to assert logger calls explicitly
- extend the worker test coverage updates across sync, auth, scheduler, spotify polling, favicon, opengraph, and repair flows

## Validation
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build
- bun run test
- pre-push hook: bun run format:check && bun run typecheck && bun run --cwd apps/worker test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"

Closes #104