### PR TITLE
Fix iOS preview deployment and auth defaults

### DIFF
--- a/apps/mobile/lib/oauth.ts
+++ b/apps/mobile/lib/oauth.ts
@@ -67,7 +67,6 @@ function createVanillaClient(seed?: { traceId?: string }) {
     links: [
       httpBatchLink({
         url: `${API_URL}/trpc`,
-        methodOverride: 'POST',
         transformer: superjson,
         headers: async () => {
           if (_getToken) {

--- a/apps/mobile/lib/trpc-offline-client.ts
+++ b/apps/mobile/lib/trpc-offline-client.ts
@@ -107,7 +107,6 @@ export function createOfflineTRPCClient(seed?: { traceId?: string; clientRequest
     links: [
       httpBatchLink({
         url,
-        methodOverride: 'POST',
         transformer: superjson, // Must match server configuration
         headers: async () => {
           const authHeaders = await getAuthHeaders();

--- a/apps/mobile/lib/trpc-provider.test.tsx
+++ b/apps/mobile/lib/trpc-provider.test.tsx
@@ -166,7 +166,7 @@ describe('TRPCProvider transport wiring', () => {
     mockGetItem.mockResolvedValue(null);
   });
 
-  it('configures httpBatchLink with POST, telemetry headers, and telemetry fetch', async () => {
+  it('configures httpBatchLink with telemetry headers and telemetry fetch', async () => {
     act(() => {
       create(
         <TRPCProvider>
@@ -177,7 +177,6 @@ describe('TRPCProvider transport wiring', () => {
 
     expect(httpBatchLink).toHaveBeenCalledWith(
       expect.objectContaining({
-        methodOverride: 'POST',
         fetch: telemetryFetch,
         headers: expect.any(Function),
       })

--- a/apps/mobile/providers/trpc-provider.tsx
+++ b/apps/mobile/providers/trpc-provider.tsx
@@ -184,7 +184,6 @@ export function TRPCProvider({ children }: TRPCProviderProps) {
       links: [
         httpBatchLink({
           url,
-          methodOverride: 'POST',
           transformer: superjson, // Required for Date serialization - must match server
           headers: async () => {
             try {

--- a/apps/worker/src/middleware/auth.test.ts
+++ b/apps/worker/src/middleware/auth.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for authentication middleware
+ *
+ * @vitest-environment miniflare
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '../types';
+
+const { mockVerifyClerkToken, mockInsert } = vi.hoisted(() => {
+  const mockOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+  const mockValues = vi.fn().mockReturnValue({
+    onConflictDoNothing: mockOnConflictDoNothing,
+  });
+  const mockInsert = vi.fn().mockReturnValue({
+    values: mockValues,
+  });
+
+  return {
+    mockVerifyClerkToken: vi.fn(),
+    mockOnConflictDoNothing,
+    mockValues,
+    mockInsert,
+  };
+});
+
+vi.mock('../lib/auth', () => ({
+  verifyClerkToken: mockVerifyClerkToken,
+}));
+
+vi.mock('../db', () => ({
+  createDb: vi.fn(() => ({
+    insert: mockInsert,
+  })),
+}));
+
+import { authMiddleware } from './auth';
+
+interface AuthResponse {
+  userId?: string | null;
+  code?: string;
+  error?: string;
+}
+
+function createTestApp() {
+  const app = new Hono<Env>();
+
+  app.use('*', async (c, next) => {
+    c.set('requestId', 'test-request-id');
+    await next();
+  });
+
+  app.use('/protected', authMiddleware());
+  app.get('/protected', (c) => c.json({ userId: c.get('userId') ?? null }));
+
+  return app;
+}
+
+function createMockEnv(overrides: Partial<Env['Bindings']> = {}): Env['Bindings'] {
+  return {
+    DB: {} as D1Database,
+    WEBHOOK_IDEMPOTENCY: {} as KVNamespace,
+    OAUTH_STATE_KV: {} as KVNamespace,
+    ARTICLE_CONTENT: {} as R2Bucket,
+    SPOTIFY_CACHE: {} as KVNamespace,
+    CREATOR_CONTENT_CACHE: {} as KVNamespace,
+    ENVIRONMENT: 'test',
+    ...overrides,
+  } as Env['Bindings'];
+}
+
+describe('authMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyClerkToken.mockReset();
+  });
+
+  it('bypasses auth only for development without a configured Clerk JWKS URL', async () => {
+    const app = createTestApp();
+    const req = new Request('http://localhost/protected');
+
+    const res = await app.fetch(req, createMockEnv({ ENVIRONMENT: 'development' }));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as AuthResponse).toEqual({ userId: 'dev-user-001' });
+    expect(mockVerifyClerkToken).not.toHaveBeenCalled();
+  });
+
+  it('requires an auth header outside development even when CLERK_JWKS_URL is unset', async () => {
+    const app = createTestApp();
+    const req = new Request('http://localhost/protected');
+
+    const res = await app.fetch(req, createMockEnv({ ENVIRONMENT: 'production' }));
+
+    expect(res.status).toBe(401);
+    expect((await res.json()) as AuthResponse).toMatchObject({
+      code: 'MISSING_AUTH_HEADER',
+      error: 'Authorization header is required',
+    });
+    expect(mockVerifyClerkToken).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the myzine Clerk JWKS URL when none is configured', async () => {
+    mockVerifyClerkToken.mockResolvedValue({
+      success: true,
+      userId: 'user_live_123',
+      payload: { sub: 'user_live_123' },
+    });
+
+    const app = createTestApp();
+    const req = new Request('http://localhost/protected', {
+      headers: {
+        Authorization: 'Bearer test-token',
+      },
+    });
+
+    const res = await app.fetch(req, createMockEnv({ ENVIRONMENT: 'production' }));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as AuthResponse).toEqual({ userId: 'user_live_123' });
+    expect(mockVerifyClerkToken).toHaveBeenCalledWith(
+      'test-token',
+      'https://clerk.myzine.app/.well-known/jwks.json'
+    );
+  });
+});

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -12,7 +12,7 @@ import { users } from '../db/schema';
 /**
  * Default JWKS URL for Clerk (can be overridden via environment)
  */
-const DEFAULT_CLERK_JWKS_URL = 'https://clerk.zine.app/.well-known/jwks.json';
+const DEFAULT_CLERK_JWKS_URL = 'https://clerk.myzine.app/.well-known/jwks.json';
 
 /**
  * Development user ID used when auth is bypassed
@@ -43,6 +43,14 @@ function createAuthError(message: string, code: string, requestId: string): Auth
     code,
     requestId,
   };
+}
+
+function shouldUseDevelopmentAuthBypass(env: Env['Bindings']): boolean {
+  return env.ENVIRONMENT === 'development' && !env.CLERK_JWKS_URL;
+}
+
+function getClerkJwksUrl(env: Env['Bindings']): string {
+  return env.CLERK_JWKS_URL || DEFAULT_CLERK_JWKS_URL;
 }
 
 /**
@@ -76,7 +84,7 @@ export function authMiddleware(): MiddlewareHandler<Env> {
     const requestId = c.get('requestId') || 'unknown';
 
     // Development bypass: use mock user ID when no auth is configured
-    if (c.env.ENVIRONMENT === 'development' || !c.env.CLERK_JWKS_URL) {
+    if (shouldUseDevelopmentAuthBypass(c.env)) {
       // Ensure dev user exists in database (only once per process)
       if (!devUserEnsured) {
         try {
@@ -131,7 +139,7 @@ export function authMiddleware(): MiddlewareHandler<Env> {
     }
 
     // Get JWKS URL from environment or use default
-    const jwksUrl = c.env.CLERK_JWKS_URL || DEFAULT_CLERK_JWKS_URL;
+    const jwksUrl = getClerkJwksUrl(c.env);
 
     // Verify the token
     const result = await verifyClerkToken(token, jwksUrl);
@@ -191,7 +199,7 @@ export function optionalAuthMiddleware(): MiddlewareHandler<Env> {
       return;
     }
 
-    const jwksUrl = c.env.CLERK_JWKS_URL || DEFAULT_CLERK_JWKS_URL;
+    const jwksUrl = getClerkJwksUrl(c.env);
     const result = await verifyClerkToken(token, jwksUrl);
 
     // Set userId if valid, null otherwise


### PR DESCRIPTION
## Summary
- tidy Storybook requires file and align imports to the generated format
- stop forcing POST on mobile TRPC links so telemetry fetch hookup can use defaults and update related tests
- make `deploy:ios:preview` script support local vs remote builds, tighten shell safety, and add a remote mode flag
- default worker auth to the `myzine` Clerk domain, add helpers for dev bypass logic, and cover middleware behavior with new tests

## Testing
- Not run (not requested)