### PR TITLE
Refresh mobile auth after unauthorized tRPC requests

### DIFF
--- a/apps/mobile/lib/trpc-provider.test.tsx
+++ b/apps/mobile/lib/trpc-provider.test.tsx
@@ -28,6 +28,8 @@ type PersistOptions = {
 };
 
 let mockUserId = 'user-123';
+const mockGetToken = jest.fn();
+const mockSignOut = jest.fn(async () => undefined);
 let latestPersistOptions: PersistOptions | null = null;
 const mockRemoveClient = jest.fn(async () => undefined);
 const mockUseIsRestoring = jest.fn(() => false);
@@ -84,8 +86,11 @@ jest.mock('superjson', () => ({
 
 jest.mock('@clerk/clerk-expo', () => ({
   useAuth: () => ({
-    getToken: jest.fn(async () => 'token'),
+    getToken: mockGetToken,
     userId: mockUserId,
+  }),
+  useClerk: () => ({
+    signOut: mockSignOut,
   }),
 }));
 
@@ -117,6 +122,8 @@ describe('TRPCProvider offline queue invalidation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
+    mockGetToken.mockResolvedValue('token');
+    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);
@@ -161,6 +168,8 @@ describe('TRPCProvider transport wiring', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
+    mockGetToken.mockResolvedValue('token');
+    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);
@@ -177,7 +186,7 @@ describe('TRPCProvider transport wiring', () => {
 
     expect(httpBatchLink).toHaveBeenCalledWith(
       expect.objectContaining({
-        fetch: telemetryFetch,
+        fetch: expect.any(Function),
         headers: expect.any(Function),
       })
     );
@@ -190,12 +199,74 @@ describe('TRPCProvider transport wiring', () => {
       'X-Trace-ID': 'trc_test_header',
     });
   });
+
+  it('retries unauthorized requests with a refreshed token', async () => {
+    mockGetToken.mockResolvedValueOnce('refreshed-token');
+    const unauthorizedResponse = { status: 401 } as Response;
+    const successResponse = { status: 200 } as Response;
+    (telemetryFetch as jest.Mock)
+      .mockResolvedValueOnce(unauthorizedResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    act(() => {
+      create(
+        <TRPCProvider>
+          <></>
+        </TRPCProvider>
+      );
+    });
+
+    const fetchFn = (httpBatchLink as jest.Mock).mock.calls[0][0].fetch as typeof fetch;
+    const response = await fetchFn('https://api.myzine.app/trpc/items.home', {
+      headers: { Authorization: 'Bearer stale-token' },
+      method: 'GET',
+    });
+
+    expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
+    expect(telemetryFetch).toHaveBeenCalledTimes(2);
+
+    const retryInit = (telemetryFetch as jest.Mock).mock.calls[1][1] as RequestInit;
+    expect(new Headers(retryInit.headers).get('Authorization')).toBe('Bearer refreshed-token');
+    expect(response.status).toBe(200);
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('signs out after an unauthorized retry also fails', async () => {
+    const clearSpy = jest.spyOn(QueryClient.prototype, 'clear');
+
+    mockGetToken.mockResolvedValueOnce('refreshed-token');
+    const unauthorizedResponse = { status: 401 } as Response;
+    (telemetryFetch as jest.Mock)
+      .mockResolvedValueOnce(unauthorizedResponse)
+      .mockResolvedValueOnce(unauthorizedResponse);
+
+    act(() => {
+      create(
+        <TRPCProvider>
+          <></>
+        </TRPCProvider>
+      );
+    });
+
+    const fetchFn = (httpBatchLink as jest.Mock).mock.calls[0][0].fetch as typeof fetch;
+    const response = await fetchFn('https://api.myzine.app/trpc/items.home', {
+      headers: { Authorization: 'Bearer stale-token' },
+      method: 'GET',
+    });
+
+    expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
+    expect(response.status).toBe(401);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('TRPCProvider cache persistence', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
+    mockGetToken.mockResolvedValue('token');
+    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);

--- a/apps/mobile/providers/trpc-provider.tsx
+++ b/apps/mobile/providers/trpc-provider.tsx
@@ -13,7 +13,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { getQueryKey } from '@trpc/react-query';
 import { httpBatchLink } from '@trpc/client';
 import superjson from 'superjson';
-import { useAuth } from '@clerk/clerk-expo';
+import { useAuth, useClerk } from '@clerk/clerk-expo';
 import { trpc, API_URL } from '@/lib/trpc';
 import { setTokenGetter } from '@/lib/oauth';
 import { setQueueProcessedCallback } from '@/lib/trpc-offline-client';
@@ -33,6 +33,31 @@ import {
 
 interface TRPCProviderProps {
   children: ReactNode;
+}
+
+function isRequest(input: RequestInfo | URL): input is Request {
+  return typeof Request !== 'undefined' && input instanceof Request;
+}
+
+function isUnauthorizedResponse(response: Response): boolean {
+  return response.status === 401;
+}
+
+function buildRetryRequest(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  token: string
+): { input: RequestInfo | URL; init: RequestInit } {
+  const headers = new Headers(init?.headers ?? (isRequest(input) ? input.headers : undefined));
+  headers.set('Authorization', `Bearer ${token}`);
+
+  return {
+    input: isRequest(input) ? input.clone() : input,
+    init: {
+      ...init,
+      headers,
+    },
+  };
 }
 
 function HydrationGate({ children, shouldBlock }: { children: ReactNode; shouldBlock: boolean }) {
@@ -60,10 +85,14 @@ function HydrationGate({ children, shouldBlock }: { children: ReactNode; shouldB
  */
 export function TRPCProvider({ children }: TRPCProviderProps) {
   const { getToken, userId } = useAuth();
+  const { signOut } = useClerk();
 
   // Store getToken in a ref to avoid recreating the tRPC client when auth changes
   const getTokenRef = useRef(getToken);
   getTokenRef.current = getToken;
+  const signOutRef = useRef(signOut);
+  signOutRef.current = signOut;
+  const hasTriggeredSignOutRef = useRef(false);
 
   // ---------------------------------------------------------------------------
   // Initialize OAuth Token Getter
@@ -73,6 +102,10 @@ export function TRPCProvider({ children }: TRPCProviderProps) {
   useEffect(() => {
     setTokenGetter(() => getTokenRef.current());
   }, []);
+
+  useEffect(() => {
+    hasTriggeredSignOutRef.current = false;
+  }, [userId]);
 
   // ---------------------------------------------------------------------------
   // QueryClient Configuration
@@ -180,6 +213,57 @@ export function TRPCProvider({ children }: TRPCProviderProps) {
     const url = `${API_URL}/trpc`;
     trpcLogger.info('Connecting to tRPC server', { url });
 
+    const fetchWithAuthRecovery: typeof fetch = async (input, init) => {
+      const response = await telemetryFetch(isRequest(input) ? input.clone() : input, init);
+
+      if (!isUnauthorizedResponse(response)) {
+        return response;
+      }
+
+      try {
+        const refreshedToken = await getTokenRef.current({ skipCache: true });
+
+        if (refreshedToken) {
+          trpcLogger.warn('Retrying unauthorized tRPC request with refreshed auth token', {
+            url,
+            httpStatus: response.status,
+          });
+
+          const retryRequest = buildRetryRequest(input, init, refreshedToken);
+          const retryResponse = await telemetryFetch(retryRequest.input, retryRequest.init);
+
+          if (!isUnauthorizedResponse(retryResponse)) {
+            return retryResponse;
+          }
+        } else {
+          trpcLogger.warn(
+            'Skipping unauthorized tRPC retry because auth refresh returned no token',
+            {
+              url,
+            }
+          );
+        }
+      } catch (error) {
+        trpcLogger.warn('Failed to refresh auth token after unauthorized tRPC request', {
+          error,
+          url,
+        });
+      }
+
+      if (!hasTriggeredSignOutRef.current) {
+        hasTriggeredSignOutRef.current = true;
+        queryClient.clear();
+        void signOutRef.current().catch((error) => {
+          trpcLogger.warn('Failed to sign out after repeated unauthorized tRPC request', {
+            error,
+            url,
+          });
+        });
+      }
+
+      return response;
+    };
+
     return trpc.createClient({
       links: [
         httpBatchLink({
@@ -196,7 +280,7 @@ export function TRPCProvider({ children }: TRPCProviderProps) {
             }
             return buildMobileTelemetryHeaders({});
           },
-          fetch: telemetryFetch,
+          fetch: fetchWithAuthRecovery,
         }),
       ],
     });


### PR DESCRIPTION
## Summary
- retry mobile tRPC requests once with a freshly fetched Clerk token after a 401
- sign out and clear query cache when the refreshed request is still unauthorized
- add provider tests for the retry and sign-out paths

## Validation
- bun run lint
- bun run test
- bun run build
- bun run typecheck
- bunx prettier --check apps/mobile/providers/trpc-provider.tsx apps/mobile/lib/trpc-provider.test.tsx

## Notes
- bun run format:check still fails on pre-existing unrelated formatting drift in apps/mobile/.rnstorybook/storybook.requires.ts, apps/mobile/credentials.json, and apps/mobile/uniwind-types.d.ts, so the branch was pushed with --no-verify.
