### PR TITLE
fix: keep iOS preview builds on reachable backend

### DIFF
--- a/apps/mobile/lib/trpc.test.ts
+++ b/apps/mobile/lib/trpc.test.ts
@@ -1,0 +1,23 @@
+import { resolveApiUrl } from './trpc';
+
+describe('resolveApiUrl', () => {
+  it('returns undefined when EXPO_PUBLIC_API_URL is not set', () => {
+    expect(resolveApiUrl(undefined, 'ios', true)).toBeUndefined();
+  });
+
+  it('maps localhost to 10.0.2.2 for android development', () => {
+    expect(resolveApiUrl('http://localhost:8787', 'android', true)).toBe('http://10.0.2.2:8787');
+  });
+
+  it('keeps configured https URL for ios development', () => {
+    expect(resolveApiUrl('https://api.myzine.app', 'ios', true)).toBe('https://api.myzine.app');
+  });
+
+  it('forces production API for non-dev localhost on ios', () => {
+    expect(resolveApiUrl('http://localhost:8787', 'ios', false)).toBe('https://api.myzine.app');
+  });
+
+  it('forces production API for non-dev 127.0.0.1 on android', () => {
+    expect(resolveApiUrl('http://127.0.0.1:8787', 'android', false)).toBe('https://api.myzine.app');
+  });
+});

--- a/apps/mobile/lib/trpc.ts
+++ b/apps/mobile/lib/trpc.ts
@@ -40,15 +40,37 @@ export const trpc = createTRPCReact<AppRouter>();
  *
  * @returns The API URL for the current platform
  */
+export function resolveApiUrl(
+  configuredUrl: string | undefined,
+  platform: string,
+  isDev: boolean
+): string | undefined {
+  if (!configuredUrl) return undefined;
+
+  const trimmed = configuredUrl.trim();
+  const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/i.test(trimmed);
+
+  // Preview/release builds installed on physical devices cannot reach localhost.
+  // If a local .env.preview accidentally sets localhost, force the production API.
+  if (!isDev && isLocalhost) {
+    return 'https://api.myzine.app';
+  }
+
+  if (platform === 'android') {
+    return trimmed.replace('localhost', '10.0.2.2');
+  }
+
+  return trimmed;
+}
+
 function getApiUrl(): string {
-  const configuredUrl = process.env.EXPO_PUBLIC_API_URL;
+  const configuredUrl = resolveApiUrl(
+    process.env.EXPO_PUBLIC_API_URL,
+    Platform.OS,
+    typeof __DEV__ === 'boolean' ? __DEV__ : false
+  );
 
   if (configuredUrl) {
-    // For Android emulator, substitute localhost with the special host alias
-    // This allows worktree-generated .env.local (which uses localhost) to work
-    if (Platform.OS === 'android') {
-      return configuredUrl.replace('localhost', '10.0.2.2');
-    }
     return configuredUrl;
   }
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint && bun run design-system:check",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "build:ios:preview": "env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- eas build --platform ios --profile preview --local --output ./build/preview.ipa --non-interactive",
+    "build:ios:preview": "env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- env EXPO_PUBLIC_API_URL=https://api.myzine.app eas build --platform ios --profile preview --local --output ./build/preview.ipa --non-interactive",
     "deploy:ios:preview": "./scripts/build-and-install-ios.sh"
   },
   "dependencies": {

--- a/apps/mobile/scripts/build-and-install-ios.sh
+++ b/apps/mobile/scripts/build-and-install-ios.sh
@@ -19,7 +19,7 @@ BUILD_SUCCESS=0
 for attempt in $(seq 1 "$MAX_BUILD_ATTEMPTS"); do
     echo -e "${YELLOW}Build attempt ${attempt}/${MAX_BUILD_ATTEMPTS}${NC}"
 
-    BUILD_JSON=$(env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- eas build --platform ios --profile preview --non-interactive --wait --json 2>/dev/null || true)
+    BUILD_JSON=$(env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- env EXPO_PUBLIC_API_URL=https://api.myzine.app eas build --platform ios --profile preview --non-interactive --wait --json 2>/dev/null || true)
 
     BUILD_URL=$(echo "$BUILD_JSON" | jq -r 'if type == "array" then .[0].artifacts.buildUrl // .[0].artifacts.applicationArchiveUrl // .[0].artifacts.url else .artifacts.buildUrl // .artifacts.applicationArchiveUrl // .artifacts.url end // empty')
 


### PR DESCRIPTION
## Summary\n- harden mobile API URL resolution to prevent non-dev builds from using localhost/127.0.0.1\n- force preview iOS build scripts to use https://api.myzine.app even when local .env.preview is present\n- add unit tests for API URL resolution behavior\n\n## Why\nPreview IPA installs on physical iPhones cannot reach localhost. If a local .env.preview sets EXPO_PUBLIC_API_URL to localhost, the app boots with no data.\n\n## Validation\n- bun run --cwd apps/mobile test -- lib/trpc.test.ts\n- bun run --cwd apps/mobile lint\n- bunx turbo run typecheck --filter=@zine/mobile\n- pre-push hooks passed (prettier, design-system check, turbo typecheck, worker vitest suite)