### PR TITLE
fix(worker): dedupe newsletter unsubscribe identities

### DIFF
--- a/apps/worker/src/newsletters/gmail.test.ts
+++ b/apps/worker/src/newsletters/gmail.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computeNewsletterScore,
   isLikelyNewsletterFeedIdentity,
+  normalizeUnsubscribeIdentityUrl,
   selectBestNewsletterIssueUrl,
   shouldUpgradeNewsletterIssueUrl,
 } from './gmail';
@@ -123,6 +124,30 @@ describe('gmail newsletter detection', () => {
     expect(uberIdentity).toBe(false);
     expect(substackIdentity).toBe(true);
     expect(stratecheryIdentity).toBe(true);
+  });
+
+  it('normalizes volatile unsubscribe tokens out of newsletter identity URLs', () => {
+    const firstUrl =
+      'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?access_token=token-a&channel=email';
+    const secondUrl =
+      'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?channel=email&access_token=token-b';
+
+    expect(normalizeUnsubscribeIdentityUrl(firstUrl)).toBe(
+      'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?channel=email'
+    );
+    expect(normalizeUnsubscribeIdentityUrl(secondUrl)).toBe(
+      'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?channel=email'
+    );
+  });
+
+  it('retains stable unsubscribe identity parameters while removing tracking params', () => {
+    const normalizedUrl = normalizeUnsubscribeIdentityUrl(
+      'https://newsletter.example.com/unsubscribe?list=weekly&user=user-123&utm_source=gmail&token=secret'
+    );
+
+    expect(normalizedUrl).toBe(
+      'https://newsletter.example.com/unsubscribe?list=weekly&user=user-123'
+    );
   });
 
   it('prefers real content links over unsubscribe/manage links', () => {

--- a/apps/worker/src/newsletters/gmail.ts
+++ b/apps/worker/src/newsletters/gmail.ts
@@ -213,6 +213,56 @@ function normalizeKeySegment(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+const VOLATILE_UNSUBSCRIBE_PARAM_NAMES = new Set([
+  'access_token',
+  'auth',
+  'expires',
+  'expiration',
+  'exp',
+  'hash',
+  'jwt',
+  'signature',
+  'sig',
+  'timestamp',
+  'token',
+  'ts',
+]);
+
+export function normalizeUnsubscribeIdentityUrl(rawUrl: string): string {
+  const normalizedCandidate = normalizeCandidateUrl(rawUrl) ?? rawUrl.trim();
+
+  try {
+    const parsed = new URL(normalizedCandidate);
+    parsed.hash = '';
+
+    const retainedEntries = Array.from(parsed.searchParams.entries())
+      .filter(([key]) => {
+        const normalizedKey = key.trim().toLowerCase();
+        return !(
+          normalizedKey.startsWith('utm_') ||
+          normalizedKey.startsWith('mc_') ||
+          VOLATILE_UNSUBSCRIBE_PARAM_NAMES.has(normalizedKey)
+        );
+      })
+      .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+        if (leftKey === rightKey) {
+          return leftValue.localeCompare(rightValue);
+        }
+
+        return leftKey.localeCompare(rightKey);
+      });
+
+    parsed.search = '';
+    for (const [key, value] of retainedEntries) {
+      parsed.searchParams.append(key, value);
+    }
+
+    return parsed.toString();
+  } catch {
+    return normalizeKeySegment(normalizedCandidate);
+  }
+}
+
 function parseAddress(value: string): { email: string; displayName: string } {
   const trimmed = value.trim();
   const bracketMatch = trimmed.match(/^(.*)<([^>]+)>$/);
@@ -1057,7 +1107,7 @@ function buildCanonicalKey(params: {
   }
 
   if (params.unsubscribeUrl) {
-    return `unsub-url:${normalizeKeySegment(params.unsubscribeUrl)}`;
+    return `unsub-url:${normalizeKeySegment(normalizeUnsubscribeIdentityUrl(params.unsubscribeUrl))}`;
   }
 
   if (params.unsubscribeMailto) {

--- a/apps/worker/src/trpc/routers/newsletters.test.ts
+++ b/apps/worker/src/trpc/routers/newsletters.test.ts
@@ -69,9 +69,10 @@ describe('newslettersRouter', () => {
     vi.clearAllMocks();
   });
 
-  it('returns branded newsletters with strong list headers', async () => {
+  it('returns branded newsletters with strong list headers and dedupes unstable unsubscribe keys', async () => {
     const ctx = createMockCtx();
     const caller = newslettersRouter.createCaller(ctx as never);
+    const now = Date.now();
 
     ctx.mocks.mockProviderConnectionsFindFirst.mockResolvedValue({
       id: 'conn_1',
@@ -88,7 +89,7 @@ describe('newslettersRouter', () => {
     ]);
     ctx.mocks.mockNewsletterFeedsFindMany.mockResolvedValue([
       {
-        id: 'feed_stratechery',
+        id: 'feed_stratechery_newer',
         gmailMailboxId: 'mailbox_1',
         userId: 'user_test_123',
         displayName: 'Stratechery',
@@ -96,11 +97,26 @@ describe('newslettersRouter', () => {
         listId: null,
         unsubscribeMailto: null,
         unsubscribeUrl:
-          'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?channel=email',
+          'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?channel=email&access_token=new-token',
         status: 'HIDDEN',
         detectionScore: 0.83,
-        lastSeenAt: Date.now(),
-        firstSeenAt: Date.now(),
+        lastSeenAt: now,
+        firstSeenAt: now,
+      },
+      {
+        id: 'feed_stratechery_older',
+        gmailMailboxId: 'mailbox_1',
+        userId: 'user_test_123',
+        displayName: 'Stratechery',
+        fromAddress: 'email@stratechery.com',
+        listId: null,
+        unsubscribeMailto: null,
+        unsubscribeUrl:
+          'https://stratechery.passport.online/api/1.0.0/users/test/channelOptOut?access_token=old-token&channel=email',
+        status: 'HIDDEN',
+        detectionScore: 0.83,
+        lastSeenAt: now - 1000,
+        firstSeenAt: now - 1000,
       },
       {
         id: 'feed_github',
@@ -123,7 +139,7 @@ describe('newslettersRouter', () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toMatchObject({
-      id: 'feed_stratechery',
+      id: 'feed_stratechery_newer',
       displayName: 'Stratechery',
       fromAddress: 'email@stratechery.com',
     });

--- a/apps/worker/src/trpc/routers/newsletters.ts
+++ b/apps/worker/src/trpc/routers/newsletters.ts
@@ -14,6 +14,7 @@ import {
 import {
   syncGmailNewslettersForUser,
   isLikelyNewsletterFeedIdentity,
+  normalizeUnsubscribeIdentityUrl,
   seedLatestNewsletterItemForFeed,
 } from '../../newsletters/gmail';
 import type { TokenRefreshEnv } from '../../lib/token-refresh';
@@ -80,6 +81,27 @@ async function getActiveGmailMailboxes(
   });
 }
 
+function buildFeedIdentityKey(feed: {
+  listId: string | null;
+  unsubscribeUrl: string | null;
+  unsubscribeMailto: string | null;
+  fromAddress: string | null;
+}): string {
+  if (feed.listId) {
+    return `list:${feed.listId.trim().toLowerCase()}`;
+  }
+
+  if (feed.unsubscribeUrl) {
+    return `unsub-url:${normalizeUnsubscribeIdentityUrl(feed.unsubscribeUrl).trim().toLowerCase()}`;
+  }
+
+  if (feed.unsubscribeMailto) {
+    return `unsub-mailto:${feed.unsubscribeMailto.trim().toLowerCase()}`;
+  }
+
+  return `from:${(feed.fromAddress ?? '').trim().toLowerCase()}`;
+}
+
 export const newslettersRouter = router({
   list: protectedProcedure
     .input(ListNewslettersInputSchema.optional())
@@ -121,15 +143,31 @@ export const newslettersRouter = router({
       });
 
       const hasMore = rows.length > limit;
-      const visibleRows = (hasMore ? rows.slice(0, limit) : rows).filter((row) =>
-        isLikelyNewsletterFeedIdentity({
-          listId: row.listId,
-          unsubscribeMailto: row.unsubscribeMailto,
-          unsubscribeUrl: row.unsubscribeUrl,
-          fromAddress: row.fromAddress,
-          displayName: row.displayName,
-        })
-      );
+      const candidateRows = hasMore ? rows.slice(0, limit) : rows;
+      const visibleRows: typeof candidateRows = [];
+      const seenIdentityKeys = new Set<string>();
+
+      for (const row of candidateRows) {
+        if (
+          !isLikelyNewsletterFeedIdentity({
+            listId: row.listId,
+            unsubscribeMailto: row.unsubscribeMailto,
+            unsubscribeUrl: row.unsubscribeUrl,
+            fromAddress: row.fromAddress,
+            displayName: row.displayName,
+          })
+        ) {
+          continue;
+        }
+
+        const identityKey = buildFeedIdentityKey(row);
+        if (seenIdentityKeys.has(identityKey)) {
+          continue;
+        }
+
+        seenIdentityKeys.add(identityKey);
+        visibleRows.push(row);
+      }
 
       const latestThumbnailByFeedId = new Map<string, string | null>();
       const visibleFeedIds = visibleRows.map((row) => row.id);


### PR DESCRIPTION
## Summary
- normalize newsletter unsubscribe URLs before building canonical feed identities so volatile tokens do not create duplicate Stratechery feeds
- dedupe newsletter list responses by normalized identity so older duplicate rows collapse to the newest visible feed
- add worker tests covering unstable unsubscribe URLs and router-level deduping behavior

## Testing
- In the main worktree, ran `bun run test:run src/newsletters/gmail.test.ts src/trpc/routers/newsletters.test.ts`
- In the main worktree, ran `bun run lint`
- In the main worktree, ran `bun run typecheck`