### PR TITLE
Swap inbox swipe actions so right saves and left archives

### DIFF
--- a/apps/mobile/components/swipeable-inbox-item.stories.tsx
+++ b/apps/mobile/components/swipeable-inbox-item.stories.tsx
@@ -43,15 +43,15 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => <SwipeableHarness prompt="Swipe right to archive and left to save." />,
+  render: () => <SwipeableHarness prompt="Swipe right to save and left to archive." />,
 };
 
 export const ArchivePath: Story = {
-  render: () => <SwipeableHarness prompt="Archive path: swipe right until release threshold." />,
+  render: () => <SwipeableHarness prompt="Archive path: swipe left until release threshold." />,
 };
 
 export const BookmarkPath: Story = {
-  render: () => <SwipeableHarness prompt="Bookmark path: swipe left until release threshold." />,
+  render: () => <SwipeableHarness prompt="Save path: swipe right until release threshold." />,
 };
 
 export const AccessibilityActions: Story = {

--- a/apps/mobile/components/swipeable-inbox-item.tsx
+++ b/apps/mobile/components/swipeable-inbox-item.tsx
@@ -5,12 +5,12 @@
  * Uses ReanimatedSwipeable from react-native-gesture-handler for 60 FPS performance.
  *
  * Features:
+ * - Swipe right to save (primary color panel)
  * - Swipe left to archive (gray action panel)
- * - Swipe right to bookmark (primary color panel)
  * - Full swipe auto-completes action
  * - Partial swipe + release animates back smoothly
  * - Smooth exit animation when action completes
- * - Haptic feedback on action completion (Light for archive, Medium for bookmark)
+ * - Haptic feedback on action completion (Medium for save, Light for archive)
  * - Long-press context menu as accessibility fallback
  * - VoiceOver accessibility actions
  *
@@ -144,8 +144,8 @@ interface ActionPanelProps {
 }
 
 /**
- * Left action panel (Archive) - revealed when swiping right
- * Gray/neutral styling per design spec (soft delete, not destructive)
+ * Left action panel (Save) - revealed when swiping right
+ * Primary color styling per design spec
  */
 function LeftActionPanel({ progress }: ActionPanelProps) {
   const colorScheme = useColorScheme();
@@ -162,24 +162,18 @@ function LeftActionPanel({ progress }: ActionPanelProps) {
   });
 
   return (
-    <View
-      style={[
-        styles.actionPanel,
-        styles.leftActionPanel,
-        { backgroundColor: colors.backgroundTertiary },
-      ]}
-    >
+    <View style={[styles.actionPanel, styles.leftActionPanel, { backgroundColor: colors.primary }]}>
       <Animated.View style={[styles.actionContent, animatedStyle]}>
-        <ArchiveIcon size={24} color={colors.textSecondary} />
-        <Text style={[styles.actionLabel, { color: colors.textSecondary }]}>Archive</Text>
+        <BookmarkIcon size={24} color={colors.buttonPrimaryText} />
+        <Text style={[styles.actionLabel, { color: colors.buttonPrimaryText }]}>Save</Text>
       </Animated.View>
     </View>
   );
 }
 
 /**
- * Right action panel (Bookmark) - revealed when swiping left
- * Primary color styling per design spec
+ * Right action panel (Archive) - revealed when swiping left
+ * Gray/neutral styling per design spec (soft delete, not destructive)
  */
 function RightActionPanel({ progress }: ActionPanelProps) {
   const colorScheme = useColorScheme();
@@ -197,11 +191,15 @@ function RightActionPanel({ progress }: ActionPanelProps) {
 
   return (
     <View
-      style={[styles.actionPanel, styles.rightActionPanel, { backgroundColor: colors.primary }]}
+      style={[
+        styles.actionPanel,
+        styles.rightActionPanel,
+        { backgroundColor: colors.backgroundTertiary },
+      ]}
     >
       <Animated.View style={[styles.actionContent, animatedStyle]}>
-        <BookmarkIcon size={24} color={colors.buttonPrimaryText} />
-        <Text style={[styles.actionLabel, { color: colors.buttonPrimaryText }]}>Save</Text>
+        <ArchiveIcon size={24} color={colors.textSecondary} />
+        <Text style={[styles.actionLabel, { color: colors.textSecondary }]}>Archive</Text>
       </Animated.View>
     </View>
   );
@@ -246,9 +244,9 @@ export function SwipeableInboxItem({
   const executeAction = useCallback(
     (direction: 'left' | 'right') => {
       if (direction === 'left') {
-        onBookmark(item.id);
-      } else {
         onArchive(item.id);
+      } else {
+        onBookmark(item.id);
       }
     },
     [item.id, onArchive, onBookmark]
@@ -275,14 +273,14 @@ export function SwipeableInboxItem({
   }, [item.id, onArchive]);
 
   /**
-   * Render left actions (Archive) - appears when swiping right
+   * Render left actions (Save) - appears when swiping right
    */
   const renderLeftActions = (progress: SharedValue<number>, _dragX: SharedValue<number>) => {
     return <LeftActionPanel progress={progress} />;
   };
 
   /**
-   * Render right actions (Bookmark) - appears when swiping left
+   * Render right actions (Archive) - appears when swiping left
    */
   const renderRightActions = (progress: SharedValue<number>, _dragX: SharedValue<number>) => {
     return <RightActionPanel progress={progress} />;
@@ -303,20 +301,19 @@ export function SwipeableInboxItem({
   const handleSwipeableOpen = useCallback(
     (direction: 'left' | 'right') => {
       // Trigger haptic feedback on action completion
-      // Archive (swipe right) = Light haptic (subtle, neutral action)
-      // Bookmark (swipe left) = Medium haptic (more prominent, positive action)
+      // Save (swipe right) = Medium haptic (prominent, positive action)
+      // Archive (swipe left) = Light haptic (subtle, neutral action)
       if (direction === 'right') {
+        // Save action - more satisfying feedback
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      } else {
         // Archive action - subtle feedback
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      } else {
-        // Bookmark action - more satisfying feedback
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       }
 
-      // Set exit direction to trigger exit animation
-      // Archive (swipe right) exits to left, Bookmark (swipe left) exits to right
-      const exitDir = direction === 'right' ? 'left' : 'right';
-      setExitDirection(exitDir);
+      // Set exit direction to trigger exit animation.
+      // Each action exits in the same direction as its swipe.
+      setExitDirection(direction);
 
       // Execute the action callback
       executeAction(direction);
@@ -407,7 +404,7 @@ export function SwipeableInboxItem({
       accessible={true}
       accessibilityRole="button"
       accessibilityLabel={`${item.title}${item.creator ? ` by ${item.creator}` : ''}`}
-      accessibilityHint="Swipe right to archive, swipe left to save. Double tap and hold for more options."
+      accessibilityHint="Swipe right to save, swipe left to archive. Double tap and hold for more options."
       accessibilityActions={accessibilityActions}
       onAccessibilityAction={handleAccessibilityAction}
     >
@@ -453,10 +450,10 @@ const styles = StyleSheet.create({
     minHeight: 44,
   },
   leftActionPanel: {
-    // Archive panel - left side (revealed on right swipe)
+    // Save panel - left side (revealed on right swipe)
   },
   rightActionPanel: {
-    // Bookmark panel - right side (revealed on left swipe)
+    // Archive panel - right side (revealed on left swipe)
   },
   actionContent: {
     justifyContent: 'center',

--- a/apps/mobile/lib/inbox-swipeable-acceptance.test.ts
+++ b/apps/mobile/lib/inbox-swipeable-acceptance.test.ts
@@ -83,7 +83,7 @@ const ANIMATION_CONSTANTS = {
 
 /** Helper to get exit direction based on swipe direction */
 function getExitDirection(swipeDir: 'left' | 'right'): 'left' | 'right' {
-  return swipeDir === 'right' ? 'left' : 'right';
+  return swipeDir;
 }
 
 /** Theme colors for action panels */
@@ -155,13 +155,10 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
 
   describe('2. Swipe left reveals archive action with gray/neutral styling', () => {
     it('swipe left reveals right action panel (archive)', () => {
-      // NOTE: The implementation has swipe left → bookmark, swipe right → archive
-      // This test documents the actual behavior vs. original spec
-      // The implementation follows iOS mail conventions: swipe right = archive/delete
-      const swipeDirection = 'right'; // Archive is actually on right swipe
+      const swipeDirection = 'left';
       const revealedAction = 'archive';
 
-      expect(swipeDirection).toBe('right');
+      expect(swipeDirection).toBe('left');
       expect(revealedAction).toBe('archive');
     });
 
@@ -192,11 +189,10 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
 
   describe('3. Swipe right reveals bookmark action with primary color', () => {
     it('swipe right reveals left action panel (bookmark)', () => {
-      // NOTE: The implementation has swipe left → bookmark (right panel)
-      const swipeDirection = 'left'; // Bookmark is on left swipe
+      const swipeDirection = 'right';
       const revealedAction = 'bookmark';
 
-      expect(swipeDirection).toBe('left');
+      expect(swipeDirection).toBe('right');
       expect(revealedAction).toBe('bookmark');
     });
 
@@ -313,14 +309,14 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
     });
 
     it('archive action exits to the left (SlideOutLeft)', () => {
-      const swipeDirection: 'left' | 'right' = 'right'; // Archive
+      const swipeDirection: 'left' | 'right' = 'left'; // Archive
       const exitDirection = getExitDirection(swipeDirection);
 
       expect(exitDirection).toBe('left');
     });
 
     it('bookmark action exits to the right (SlideOutRight)', () => {
-      const swipeDirection: 'left' | 'right' = 'left'; // Bookmark
+      const swipeDirection: 'left' | 'right' = 'right'; // Bookmark
       const exitDirection = getExitDirection(swipeDirection);
 
       expect(exitDirection).toBe('right');
@@ -481,7 +477,7 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
     });
 
     it('archive rollback enters from left (direction it exited)', () => {
-      const swipeDirection: 'left' | 'right' = 'right'; // Archive swipe
+      const swipeDirection: 'left' | 'right' = 'left'; // Archive swipe
       const exitDirection = getExitDirection(swipeDirection);
       const enterDirection = exitDirection; // Re-enter from same direction
 
@@ -489,7 +485,7 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
     });
 
     it('bookmark rollback enters from right (direction it exited)', () => {
-      const swipeDirection: 'left' | 'right' = 'left'; // Bookmark swipe
+      const swipeDirection: 'left' | 'right' = 'right'; // Bookmark swipe
       const exitDirection = getExitDirection(swipeDirection);
       const enterDirection = exitDirection; // Re-enter from same direction
 
@@ -574,7 +570,7 @@ describe('Inbox Swipeable Redesign - GitHub #41 Acceptance Criteria', () => {
 
     it('accessibility hint describes available gestures', () => {
       const hint =
-        'Swipe right to archive, swipe left to save. Double tap and hold for more options.';
+        'Swipe right to save, swipe left to archive. Double tap and hold for more options.';
 
       expect(hint).toContain('Swipe');
       expect(hint).toContain('archive');

--- a/apps/mobile/lib/swipeable-inbox-crossplatform.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-crossplatform.test.ts
@@ -136,22 +136,13 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
         const platform: SupportedPlatform = 'ios';
         const swipeDirection = 'left';
 
-        // onSwipeableOpen('right') is called when user swipes left
-        // This reveals the left action panel (archive)
-        // Note: Direction in callback is opposite to swipe direction
-        // Per implementation: swipe LEFT reveals RIGHT panel (bookmark)
-        // Swipe RIGHT reveals LEFT panel (archive)
-        // So swipe left → bookmark, swipe right → archive
         const actionFromSwipe =
           swipeDirection === 'left'
-            ? 'bookmark' // Swipe left = bookmark (right panel)
-            : 'archive'; // Swipe right = archive (left panel)
+            ? 'archive' // Swipe left = archive (right panel)
+            : 'bookmark'; // Swipe right = save (left panel)
 
         expect(platform).toBe('ios');
-        expect(actionFromSwipe).toBe('bookmark');
-        // Note: Test matrix says "Swipe left → archive" but implementation has
-        // swipe left → bookmark, swipe right → archive
-        // Updating understanding based on code review
+        expect(actionFromSwipe).toBe('archive');
       });
 
       it('swipe left triggers archive on Android', () => {
@@ -159,11 +150,10 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
         const platform: SupportedPlatform = 'android';
         const swipeDirection = 'left';
 
-        // Same behavior as iOS - react-native-gesture-handler provides consistency
-        const actionFromSwipe = swipeDirection === 'left' ? 'bookmark' : 'archive';
+        const actionFromSwipe = swipeDirection === 'left' ? 'archive' : 'bookmark';
 
         expect(platform).toBe('android');
-        expect(actionFromSwipe).toBe('bookmark');
+        expect(actionFromSwipe).toBe('archive');
       });
     });
 
@@ -173,11 +163,10 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
         const platform: SupportedPlatform = 'ios';
         const swipeDirection = 'right';
 
-        // Per implementation: swipe right reveals left panel (archive)
-        const actionFromSwipe = swipeDirection === 'right' ? 'archive' : 'bookmark';
+        const actionFromSwipe = swipeDirection === 'right' ? 'bookmark' : 'archive';
 
         expect(platform).toBe('ios');
-        expect(actionFromSwipe).toBe('archive');
+        expect(actionFromSwipe).toBe('bookmark');
       });
 
       it('swipe right triggers bookmark on Android', () => {
@@ -185,64 +174,47 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
         const platform: SupportedPlatform = 'android';
         const swipeDirection = 'right';
 
-        // Same behavior as iOS
-        const actionFromSwipe = swipeDirection === 'right' ? 'archive' : 'bookmark';
+        const actionFromSwipe = swipeDirection === 'right' ? 'bookmark' : 'archive';
 
         expect(platform).toBe('android');
-        expect(actionFromSwipe).toBe('archive');
+        expect(actionFromSwipe).toBe('bookmark');
       });
     });
 
     describe('Direction Mapping Clarification', () => {
       it('documents actual swipe-to-action mapping', () => {
         // Clarifying the actual implementation from swipeable-inbox-item.tsx:
-        // - renderLeftActions shows Archive (gray panel)
-        // - renderRightActions shows Bookmark (primary panel)
-        // - Swipe RIGHT reveals LEFT actions (Archive)
-        // - Swipe LEFT reveals RIGHT actions (Bookmark)
+        // - renderLeftActions shows Save (primary panel)
+        // - renderRightActions shows Archive (neutral panel)
+        // - Swipe RIGHT reveals LEFT actions (Save)
+        // - Swipe LEFT reveals RIGHT actions (Archive)
         const swipeMapping = {
           swipeRight: {
             reveals: 'leftPanel',
-            action: 'archive',
-            haptic: 'Light',
-            exitDirection: 'left',
-          },
-          swipeLeft: {
-            reveals: 'rightPanel',
             action: 'bookmark',
             haptic: 'Medium',
             exitDirection: 'right',
           },
+          swipeLeft: {
+            reveals: 'rightPanel',
+            action: 'archive',
+            haptic: 'Light',
+            exitDirection: 'left',
+          },
         };
 
-        expect(swipeMapping.swipeRight.action).toBe('archive');
-        expect(swipeMapping.swipeLeft.action).toBe('bookmark');
+        expect(swipeMapping.swipeRight.action).toBe('bookmark');
+        expect(swipeMapping.swipeLeft.action).toBe('archive');
       });
 
       it('test matrix naming matches epic issue description', () => {
-        // From epic zine-g05:
-        // - Swipe left → Archive (soft delete, gray styling)
-        // - Swipe right → Bookmark (save to library, primary color)
-        // The implementation reverses this convention:
-        // - Swipe left → reveals RIGHT panel → Bookmark (Save)
-        // - Swipe right → reveals LEFT panel → Archive
-
-        // This test documents the discrepancy between epic spec and implementation
-        // The epic says "Swipe left → Archive" but implementation has "Swipe left → Bookmark"
-        // This should be verified during manual testing
-        const epicSpec = {
+        const implementation = {
           swipeLeft: 'archive',
           swipeRight: 'bookmark',
         };
 
-        const implementation = {
-          swipeLeft: 'bookmark', // reveals RIGHT panel with bookmark
-          swipeRight: 'archive', // reveals LEFT panel with archive
-        };
-
-        // Document the difference - during manual testing, verify which is correct
-        expect(epicSpec.swipeLeft).not.toBe(implementation.swipeLeft);
-        // NOTE: This may require implementation fix or epic update
+        expect(implementation.swipeLeft).toBe('archive');
+        expect(implementation.swipeRight).toBe('bookmark');
       });
     });
   });
@@ -350,11 +322,11 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
     });
 
     it('exit direction matches swipe direction semantically', () => {
-      // Archive (swipe right) → exits left (item slides out to the left)
-      // Bookmark (swipe left) → exits right (item slides out to the right)
+      // Archive (swipe left) → exits left.
+      // Save (swipe right) → exits right.
       const exitMapping = {
-        archive: 'left', // Swipe right, exit left
-        bookmark: 'right', // Swipe left, exit right
+        archive: 'left',
+        bookmark: 'right',
       };
 
       expect(exitMapping.archive).toBe('left');
@@ -716,7 +688,7 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
 
       it('accessibilityHint describes available actions', () => {
         const hint =
-          'Swipe right to archive, swipe left to save. Double tap and hold for more options.';
+          'Swipe right to save, swipe left to archive. Double tap and hold for more options.';
 
         expect(hint).toContain('Swipe');
         expect(hint).toContain('archive');
@@ -823,8 +795,8 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
           '1. Open iOS Simulator (iPhone 14 Pro recommended)',
           '2. Build and run the app: npx expo run:ios',
           '3. Navigate to Inbox tab',
-          '4. Test swipe left → verify bookmark action',
-          '5. Test swipe right → verify archive action',
+          '4. Test swipe left → verify archive action',
+          '5. Test swipe right → verify save action',
           '6. Test partial swipe (<100px) → verify snap-back',
           '7. Test full swipe (>100px) → verify action triggers',
           '8. Test exit animation → verify smooth slide out',
@@ -855,8 +827,8 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
           '1. Open Android Emulator (Pixel 7 API 34 recommended)',
           '2. Build and run the app: npx expo run:android',
           '3. Navigate to Inbox tab',
-          '4. Test swipe left → verify bookmark action',
-          '5. Test swipe right → verify archive action',
+          '4. Test swipe left → verify archive action',
+          '5. Test swipe right → verify save action',
           '6. Test partial swipe (<100px) → verify snap-back',
           '7. Test full swipe (>100px) → verify action triggers',
           '8. Test exit animation → verify smooth slide out',

--- a/apps/mobile/lib/swipeable-inbox-item.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-item.test.ts
@@ -169,24 +169,24 @@ describe('SwipeableInboxItem', () => {
   });
 
   describe('swipe directions', () => {
-    it('swipe left reveals bookmark action (right panel)', () => {
-      // Per design spec: Swipe left -> right action panel -> bookmark
-      // This maps to onSwipeableOpen('left') -> onBookmark
+    it('swipe left reveals archive action (right panel)', () => {
+      // Per current spec: Swipe left -> right action panel -> archive
+      // This maps to onSwipeableOpen('left') -> onArchive
       const swipeDirection = 'left';
-      const expectedAction = 'bookmark';
-
-      expect(swipeDirection).toBe('left');
-      expect(expectedAction).toBe('bookmark');
-    });
-
-    it('swipe right reveals archive action (left panel)', () => {
-      // Per design spec: Swipe right -> left action panel -> archive
-      // This maps to onSwipeableOpen('right') -> onArchive
-      const swipeDirection = 'right';
       const expectedAction = 'archive';
 
-      expect(swipeDirection).toBe('right');
+      expect(swipeDirection).toBe('left');
       expect(expectedAction).toBe('archive');
+    });
+
+    it('swipe right reveals save action (left panel)', () => {
+      // Per current spec: Swipe right -> left action panel -> save
+      // This maps to onSwipeableOpen('right') -> onBookmark
+      const swipeDirection = 'right';
+      const expectedAction = 'bookmark';
+
+      expect(swipeDirection).toBe('right');
+      expect(expectedAction).toBe('bookmark');
     });
   });
 
@@ -330,48 +330,48 @@ describe('SwipeableInboxItem', () => {
     // Test that simulates the handleSwipeableOpen logic from the component
     // The actual ReanimatedSwipeable callback behavior is tested via manual testing
 
-    it('onSwipeableOpen with direction "left" triggers bookmark callback', () => {
-      // Per issue zine-e28: Swiping left triggers bookmark
-      // onSwipeableOpen('left') = right panel revealed = bookmark action
+    it('onSwipeableOpen with direction "left" triggers archive callback', () => {
+      // Per current behavior: Swiping left triggers archive
+      // onSwipeableOpen('left') = right panel revealed = archive action
       const bookmarkIds: string[] = [];
       const archiveIds: string[] = [];
       const item = createMockItem({ id: 'swipe-test-1' });
 
       const handleSwipeableOpen = (direction: 'left' | 'right') => {
         if (direction === 'left') {
-          // Swiped left = right action panel revealed = bookmark
-          bookmarkIds.push(item.id);
-        } else if (direction === 'right') {
-          // Swiped right = left action panel revealed = archive
+          // Swiped left = right action panel revealed = archive
           archiveIds.push(item.id);
+        } else if (direction === 'right') {
+          // Swiped right = left action panel revealed = save
+          bookmarkIds.push(item.id);
         }
       };
 
       handleSwipeableOpen('left');
 
-      expect(bookmarkIds).toContain('swipe-test-1');
-      expect(archiveIds).not.toContain('swipe-test-1');
+      expect(archiveIds).toContain('swipe-test-1');
+      expect(bookmarkIds).not.toContain('swipe-test-1');
     });
 
-    it('onSwipeableOpen with direction "right" triggers archive callback', () => {
-      // Per issue zine-e28: Swiping right triggers archive
-      // onSwipeableOpen('right') = left panel revealed = archive action
+    it('onSwipeableOpen with direction "right" triggers bookmark callback', () => {
+      // Per current behavior: Swiping right triggers save
+      // onSwipeableOpen('right') = left panel revealed = save action
       const bookmarkIds: string[] = [];
       const archiveIds: string[] = [];
       const item = createMockItem({ id: 'swipe-test-2' });
 
       const handleSwipeableOpen = (direction: 'left' | 'right') => {
         if (direction === 'left') {
-          bookmarkIds.push(item.id);
-        } else if (direction === 'right') {
           archiveIds.push(item.id);
+        } else if (direction === 'right') {
+          bookmarkIds.push(item.id);
         }
       };
 
       handleSwipeableOpen('right');
 
-      expect(archiveIds).toContain('swipe-test-2');
-      expect(bookmarkIds).not.toContain('swipe-test-2');
+      expect(bookmarkIds).toContain('swipe-test-2');
+      expect(archiveIds).not.toContain('swipe-test-2');
     });
 
     it('swipe threshold equals action panel width for consistent feel', () => {
@@ -544,7 +544,7 @@ describe('SwipeableInboxItem', () => {
       expect(mutationCalls[0].id).toBe('prop-test');
     });
 
-    it('archive flow: swipe right -> onSwipeableOpen("right") -> onArchive -> mutation', () => {
+    it('archive flow: swipe left -> onSwipeableOpen("left") -> onArchive -> mutation', () => {
       // Per issue zine-4v6: Full integration flow
       const flow: string[] = [];
       const mutationCalls: { id: string }[] = [];
@@ -563,15 +563,15 @@ describe('SwipeableInboxItem', () => {
 
       const handleSwipeableOpen = (direction: 'left' | 'right', itemId: string) => {
         flow.push(`onSwipeableOpen: ${direction}`);
-        if (direction === 'right') {
+        if (direction === 'left') {
           handleArchive(itemId);
         }
       };
 
       // Simulate the full swipe flow
-      handleSwipeableOpen('right', 'flow-test-item');
+      handleSwipeableOpen('left', 'flow-test-item');
 
-      expect(flow).toEqual(['onSwipeableOpen: right', 'handleArchive called', 'mutation called']);
+      expect(flow).toEqual(['onSwipeableOpen: left', 'handleArchive called', 'mutation called']);
       expect(mutationCalls[0].id).toBe('flow-test-item');
     });
 
@@ -614,27 +614,19 @@ describe('SwipeableInboxItem', () => {
     });
 
     it('archive action exits to the left (SlideOutLeft)', () => {
-      // Per issue zine-av9: Archive exits left (continues in swipe direction)
-      // Swipe right reveals archive -> item exits left
+      // Per issue zine-av9: Archive exits left.
+      const getExitDirection = (swipeDir: 'left' | 'right') => swipeDir;
 
-      // Helper that mirrors component logic
-      const getExitDirection = (swipeDir: 'left' | 'right') =>
-        swipeDir === 'right' ? 'left' : 'right';
-
-      const exitDir = getExitDirection('right');
+      const exitDir = getExitDirection('left');
 
       expect(exitDir).toBe('left');
     });
 
     it('bookmark action exits to the right (SlideOutRight)', () => {
-      // Per issue zine-av9: Bookmark exits right (continues in swipe direction)
-      // Swipe left reveals bookmark -> item exits right
+      // Per issue zine-av9: Save exits right.
+      const getExitDirection = (swipeDir: 'left' | 'right') => swipeDir;
 
-      // Helper that mirrors component logic
-      const getExitDirection = (swipeDir: 'left' | 'right') =>
-        swipeDir === 'right' ? 'left' : 'right';
-
-      const exitDir = getExitDirection('left');
+      const exitDir = getExitDirection('right');
 
       expect(exitDir).toBe('right');
     });
@@ -654,15 +646,14 @@ describe('SwipeableInboxItem', () => {
 
       // Simulating handleSwipeableOpen from component
       const handleSwipeableOpen = (direction: 'left' | 'right') => {
-        const exitDir = direction === 'right' ? 'left' : 'right';
+        const exitDir = direction;
         setExitDirection(exitDir);
         executeAction(direction);
       };
 
       handleSwipeableOpen('right');
 
-      // Exit animation trigger comes before action execution
-      expect(events).toEqual(['exit:left', 'action:right']);
+      expect(events).toEqual(['exit:right', 'action:right']);
     });
 
     it('exit direction state starts as null (no animation pending)', () => {
@@ -693,12 +684,12 @@ describe('SwipeableInboxItem', () => {
     it('exit animation direction maps correctly for both actions', () => {
       // Per issue zine-av9: Comprehensive mapping test
       const testCases = [
-        { swipe: 'right', action: 'archive', exitDir: 'left' },
-        { swipe: 'left', action: 'bookmark', exitDir: 'right' },
+        { swipe: 'left', action: 'archive', exitDir: 'left' },
+        { swipe: 'right', action: 'bookmark', exitDir: 'right' },
       ] as const;
 
       testCases.forEach(({ swipe, exitDir }) => {
-        const computedExitDir = swipe === 'right' ? 'left' : 'right';
+        const computedExitDir = swipe;
         expect(computedExitDir).toBe(exitDir);
       });
     });
@@ -769,7 +760,7 @@ describe('SwipeableInboxItem', () => {
       const processedItems: { id: string; action: string }[] = [];
 
       const processSwipe = (itemId: string, direction: 'left' | 'right') => {
-        const action = direction === 'right' ? 'archive' : 'bookmark';
+        const action = direction === 'right' ? 'bookmark' : 'archive';
         processedItems.push({ id: itemId, action });
       };
 
@@ -779,9 +770,9 @@ describe('SwipeableInboxItem', () => {
       processSwipe('item-3', 'right');
 
       expect(processedItems).toEqual([
-        { id: 'item-1', action: 'archive' },
-        { id: 'item-2', action: 'bookmark' },
-        { id: 'item-3', action: 'archive' },
+        { id: 'item-1', action: 'bookmark' },
+        { id: 'item-2', action: 'archive' },
+        { id: 'item-3', action: 'bookmark' },
       ]);
     });
   });
@@ -900,20 +891,20 @@ describe('SwipeableInboxItem', () => {
       const testCases = [
         {
           action: 'archive',
-          swipeDir: 'right',
+          swipeDir: 'left',
           exitDir: 'left',
           enterDir: 'left',
         },
         {
           action: 'bookmark',
-          swipeDir: 'left',
+          swipeDir: 'right',
           exitDir: 'right',
           enterDir: 'right',
         },
       ] as const;
 
       testCases.forEach(({ action, swipeDir, exitDir, enterDir }) => {
-        const computedExitDir = swipeDir === 'right' ? 'left' : 'right';
+        const computedExitDir = swipeDir;
         expect(computedExitDir).toBe(exitDir);
         expect(enterDir).toBe(exitDir); // Enter from same direction as exit
         expect(action).toBeDefined(); // Just to use the variable
@@ -1234,11 +1225,11 @@ describe('SwipeableInboxItem', () => {
       let exitDirection: ExitDirection = null;
 
       const handleBookmarkAction = () => {
-        exitDirection = 'right'; // Same as swipe left -> bookmark
+        exitDirection = 'right'; // Same as swipe right -> save
       };
 
       const handleArchiveAction = () => {
-        exitDirection = 'left'; // Same as swipe right -> archive
+        exitDirection = 'left'; // Same as swipe left -> archive
       };
 
       handleBookmarkAction();
@@ -1341,7 +1332,7 @@ describe('SwipeableInboxItem', () => {
     it('component has appropriate accessibility hint', () => {
       // Per issue zine-9mi: VoiceOver users know how to interact
       const accessibilityHint =
-        'Swipe right to archive, swipe left to save. Double tap and hold for more options.';
+        'Swipe right to save, swipe left to archive. Double tap and hold for more options.';
 
       expect(accessibilityHint).toContain('Swipe');
       expect(accessibilityHint).toContain('archive');

--- a/apps/mobile/lib/swipeable-inbox-performance.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-performance.test.ts
@@ -301,11 +301,11 @@ describe('SwipeableInboxItem Performance Configuration', () => {
       // Per issue zine-iln: Rapid swipes work correctly
       // Each swipe is independent, no shared state corruption
       const swipeSequence = [
-        { id: 'item-1', direction: 'right', action: 'archive' },
-        { id: 'item-2', direction: 'left', action: 'bookmark' },
-        { id: 'item-3', direction: 'right', action: 'archive' },
-        { id: 'item-4', direction: 'left', action: 'bookmark' },
-        { id: 'item-5', direction: 'right', action: 'archive' },
+        { id: 'item-1', direction: 'right', action: 'bookmark' },
+        { id: 'item-2', direction: 'left', action: 'archive' },
+        { id: 'item-3', direction: 'right', action: 'bookmark' },
+        { id: 'item-4', direction: 'left', action: 'archive' },
+        { id: 'item-5', direction: 'right', action: 'bookmark' },
       ];
 
       // All swipes should be independent


### PR DESCRIPTION
- Update the swipeable inbox item UI, accessibility hints, and haptics to make swiping right trigger save/bookmark and swiping left trigger archive, including adjusting action panels and animation directions
- Align the related storybook prompt text and acceptance/cross-platform tests with the new gesture mapping

**Testing**
- Not run (not requested)