### PR TITLE
chore(worker): remove unsupported wrangler observability persist field

### DIFF
--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -69,7 +69,6 @@ max_batch_timeout = 30
 enabled = true
 head_sampling_rate = 1
 invocation_logs = true
-persist = true
 
 # Development environment vars
 [vars]
@@ -127,7 +126,6 @@ max_batch_timeout = 30
 enabled = true
 head_sampling_rate = 1
 invocation_logs = true
-persist = true
 
 # Production environment
 [env.production]
@@ -182,7 +180,6 @@ max_batch_timeout = 30
 enabled = true
 head_sampling_rate = 1
 invocation_logs = true
-persist = true
 
 # ============================================================================
 # Required Secrets (set via `wrangler secret put <NAME>`)


### PR DESCRIPTION
## Summary
- remove unsupported `persist` key from `[observability.logs]` in worker wrangler config
- apply the cleanup for dev, staging, and production config blocks
- eliminate noisy warning in local/CI vitest runs (`Unexpected fields found in observability field: "persist"`)

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:worker:ci`
