### PR TITLE
Refine featured item card layout

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
+import { getValidFeaturedGridItems } from '@/lib/home-layout';
 import {
   useInboxItems,
   useHomeData,
@@ -151,7 +152,7 @@ export default function HomeScreen() {
 
   // Transform to ItemCardData format for use with ItemCard component
   const jumpBackInItems = useMemo((): ItemCardData[] => {
-    return (homeData?.jumpBackIn ?? []).slice(0, 6).map((item) => ({
+    return (homeData?.jumpBackIn ?? []).map((item) => ({
       id: item.id,
       title: item.title,
       creator: item.publisher ?? item.creator,
@@ -239,13 +240,14 @@ export default function HomeScreen() {
 
   const isLoading = isInboxLoading || isHomeLoading;
 
-  const filteredJumpBackInItems = useMemo(
-    () =>
+  const filteredJumpBackInItems = useMemo(() => {
+    const visibleItems =
       contentTypeFilter === null
         ? jumpBackInItems
-        : jumpBackInItems.filter((item) => item.contentType === contentTypeFilter),
-    [contentTypeFilter, jumpBackInItems]
-  );
+        : jumpBackInItems.filter((item) => item.contentType === contentTypeFilter);
+
+    return getValidFeaturedGridItems(visibleItems);
+  }, [contentTypeFilter, jumpBackInItems]);
 
   const filteredRecentlyBookmarked = useMemo(
     () =>
@@ -347,7 +349,9 @@ export default function HomeScreen() {
                   />
                   <View style={styles.jumpBackInGrid}>
                     {filteredJumpBackInItems.map((item) => (
-                      <ItemCard key={item.id} item={item} shape="row" rowStyle="featured" />
+                      <View key={item.id} style={styles.jumpBackInGridItem}>
+                        <ItemCard item={item} shape="row" rowStyle="featured" />
+                      </View>
                     ))}
                   </View>
                 </Animated.View>
@@ -544,6 +548,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md,
     gap: Spacing.md,
     marginBottom: Spacing.xl,
+  },
+  jumpBackInGridItem: {
+    flexBasis: '48%',
+    flexGrow: 1,
   },
 
   // Inbox Container

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import {
   Pressable,
   FlatList,
   ActivityIndicator,
+  useWindowDimensions,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -27,7 +28,7 @@ import {
 } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
-import { getValidFeaturedGridItems } from '@/lib/home-layout';
+import { getFeaturedGridItemWidth, getVisibleFeaturedGridItems } from '@/lib/home-layout';
 import {
   useInboxItems,
   useHomeData,
@@ -140,8 +141,10 @@ export default function HomeScreen() {
   const scrollViewRef = useRef<ScrollView>(null);
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'dark'];
+  const { width: windowWidth } = useWindowDimensions();
   const greeting = useMemo(() => getGreeting(), []);
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
+  const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
 
   useTabPrefetch('home');
 
@@ -240,14 +243,10 @@ export default function HomeScreen() {
 
   const isLoading = isInboxLoading || isHomeLoading;
 
-  const filteredJumpBackInItems = useMemo(() => {
-    const visibleItems =
-      contentTypeFilter === null
-        ? jumpBackInItems
-        : jumpBackInItems.filter((item) => item.contentType === contentTypeFilter);
-
-    return getValidFeaturedGridItems(visibleItems);
-  }, [contentTypeFilter, jumpBackInItems]);
+  const filteredJumpBackInItems = useMemo(
+    () => getVisibleFeaturedGridItems(jumpBackInItems, contentTypeFilter),
+    [contentTypeFilter, jumpBackInItems]
+  );
 
   const filteredRecentlyBookmarked = useMemo(
     () =>
@@ -349,7 +348,10 @@ export default function HomeScreen() {
                   />
                   <View style={styles.jumpBackInGrid}>
                     {filteredJumpBackInItems.map((item) => (
-                      <View key={item.id} style={styles.jumpBackInGridItem}>
+                      <View
+                        key={item.id}
+                        style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                      >
                         <ItemCard item={item} shape="row" rowStyle="featured" />
                       </View>
                     ))}
@@ -550,8 +552,7 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.xl,
   },
   jumpBackInGridItem: {
-    flexBasis: '48%',
-    flexGrow: 1,
+    minWidth: 0,
   },
 
   // Inbox Container

--- a/apps/mobile/components/item-card.stories.tsx
+++ b/apps/mobile/components/item-card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
-import { ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { Spacing } from '@/constants/theme';
 import { createDarkCanvasDecorator } from '@/components/storybook/decorators';
@@ -33,11 +33,13 @@ export const Compact: Story = {
 };
 
 export const FeaturedRow: Story = {
-  args: {
-    item: itemCardFixtures.article,
-    shape: 'row',
-    rowStyle: 'featured',
-  },
+  render: (args) => (
+    <View style={styles.featuredGrid}>
+      <View style={styles.featuredGridItem}>
+        <ItemCard {...args} item={itemCardFixtures.article} shape="row" rowStyle="featured" />
+      </View>
+    </View>
+  ),
 };
 
 export const Stack: Story = {
@@ -68,5 +70,13 @@ export const ContentStress: Story = {
 const styles = StyleSheet.create({
   stack: {
     gap: Spacing.md,
+  },
+  featuredGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  featuredGridItem: {
+    flexBasis: '48%',
+    flexGrow: 1,
   },
 });

--- a/apps/mobile/components/item-card.stories.tsx
+++ b/apps/mobile/components/item-card.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native';
 
 import { Spacing } from '@/constants/theme';
 import { createDarkCanvasDecorator } from '@/components/storybook/decorators';
 import { itemCardFixtures } from '@/components/storybook/fixtures';
+import { getFeaturedGridItemWidth } from '@/lib/home-layout';
 import { ItemCard } from './item-card';
 
 const meta = {
@@ -33,13 +34,31 @@ export const Compact: Story = {
 };
 
 export const FeaturedRow: Story = {
-  render: (args) => (
-    <View style={styles.featuredGrid}>
-      <View style={styles.featuredGridItem}>
-        <ItemCard {...args} item={itemCardFixtures.article} shape="row" rowStyle="featured" />
+  args: {
+    item: itemCardFixtures.article,
+    shape: 'row',
+    rowStyle: 'featured',
+  },
+  render: function Render(args) {
+    const { width } = useWindowDimensions();
+    const featuredGridItemWidth = getFeaturedGridItemWidth(width - Spacing.md * 2, Spacing.md);
+
+    return (
+      <View style={styles.featuredGrid}>
+        <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
+          <ItemCard {...args} />
+        </View>
+        <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
+          <ItemCard
+            item={itemCardFixtures.video}
+            shape="row"
+            rowStyle="featured"
+            onPress={args.onPress}
+          />
+        </View>
       </View>
-    </View>
-  ),
+    );
+  },
 };
 
 export const Stack: Story = {
@@ -57,14 +76,28 @@ export const Cover: Story = {
 };
 
 export const ContentStress: Story = {
-  render: () => (
-    <ScrollView contentContainerStyle={styles.stack} showsVerticalScrollIndicator={false}>
-      <ItemCard item={itemCardFixtures.stress} shape="row" onPress={() => {}} />
-      <ItemCard item={itemCardFixtures.stress} shape="row" rowStyle="featured" onPress={() => {}} />
-      <ItemCard item={itemCardFixtures.stress} shape="stack" onPress={() => {}} />
-      <ItemCard item={itemCardFixtures.stress} shape="cover" onPress={() => {}} />
-    </ScrollView>
-  ),
+  render: function Render() {
+    const { width } = useWindowDimensions();
+    const featuredGridItemWidth = getFeaturedGridItemWidth(width - Spacing.md * 2, Spacing.md);
+
+    return (
+      <ScrollView contentContainerStyle={styles.stack} showsVerticalScrollIndicator={false}>
+        <ItemCard item={itemCardFixtures.stress} shape="row" onPress={() => {}} />
+        <View style={styles.featuredGrid}>
+          <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
+            <ItemCard
+              item={itemCardFixtures.stress}
+              shape="row"
+              rowStyle="featured"
+              onPress={() => {}}
+            />
+          </View>
+        </View>
+        <ItemCard item={itemCardFixtures.stress} shape="stack" onPress={() => {}} />
+        <ItemCard item={itemCardFixtures.stress} shape="cover" onPress={() => {}} />
+      </ScrollView>
+    );
+  },
 };
 
 const styles = StyleSheet.create({
@@ -74,9 +107,10 @@ const styles = StyleSheet.create({
   featuredGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
+    paddingHorizontal: Spacing.md,
+    gap: Spacing.md,
   },
   featuredGridItem: {
-    flexBasis: '48%',
-    flexGrow: 1,
+    minWidth: 0,
   },
 });

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -207,14 +207,14 @@ export function ItemCard({
           onPress={handlePress}
           style={({ pressed }) => [
             styles.rowFeaturedCard,
-            { backgroundColor: colors.card, borderColor: colors.border },
-            pressed && { opacity: 0.75 },
+            { backgroundColor: colors.surfaceElevated, borderColor: colors.borderDefault },
+            pressed && { opacity: motion.opacity.pressed },
           ]}
         >
           <View
             style={[
               styles.rowFeaturedThumbnailContainer,
-              { backgroundColor: colors.backgroundTertiary },
+              { backgroundColor: colors.surfaceRaised },
             ]}
           >
             {item.thumbnailUrl ? (
@@ -228,7 +228,7 @@ export function ItemCard({
               getContentIcon(item.contentType, 20, colors.textTertiary)
             )}
           </View>
-          <View style={styles.rowFeaturedTitleWrap}>
+          <View style={styles.rowFeaturedContent}>
             <Text style={[styles.rowFeaturedTitle, { color: colors.text }]} numberOfLines={2}>
               {item.title}
             </Text>
@@ -334,38 +334,36 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
+    alignItems: 'stretch',
     borderRadius: Radius.lg,
     borderWidth: 1,
     overflow: 'hidden',
   },
   rowFeaturedWrapper: {
-    flexBasis: '48%',
-    flexGrow: 1,
-    height: 72,
+    width: '100%',
+    height: 56,
   },
   rowFeaturedThumbnailContainer: {
-    width: 64,
+    width: 56,
     height: '100%',
     alignItems: 'center',
     justifyContent: 'center',
+    flexShrink: 0,
   },
   rowFeaturedThumbnailImage: {
     width: '100%',
     height: '100%',
   },
-  rowFeaturedTitleWrap: {
+  rowFeaturedContent: {
     flex: 1,
-    paddingVertical: 2,
-    paddingRight: Spacing.xs,
+    minWidth: 0,
     justifyContent: 'center',
+    paddingLeft: Spacing.sm,
+    paddingRight: Spacing.md,
   },
   rowFeaturedTitle: {
-    ...Typography.bodySmall,
+    ...Typography.labelSmallPlain,
     fontWeight: '600',
-    // design-system-exception: preserve existing Jump Back In line-height while the 12/14 token gap is unresolved.
-    lineHeight: 14,
   },
 
   stackCard: {

--- a/apps/mobile/lib/home-layout.test.ts
+++ b/apps/mobile/lib/home-layout.test.ts
@@ -1,6 +1,14 @@
-import { getValidFeaturedGridItems } from './home-layout';
+import {
+  getFeaturedGridItemWidth,
+  getValidFeaturedGridItems,
+  getVisibleFeaturedGridItems,
+} from './home-layout';
 
 describe('getValidFeaturedGridItems', () => {
+  it('returns an empty array when there are no items', () => {
+    expect(getValidFeaturedGridItems([])).toEqual([]);
+  });
+
   it('returns an empty array when there is only one item', () => {
     expect(getValidFeaturedGridItems([1])).toEqual([]);
   });
@@ -18,5 +26,46 @@ describe('getValidFeaturedGridItems', () => {
 
   it('caps results at six items', () => {
     expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6, 7, 8])).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe('getVisibleFeaturedGridItems', () => {
+  const items = [
+    { id: 'article-1', contentType: 'article' },
+    { id: 'article-2', contentType: 'article' },
+    { id: 'article-3', contentType: 'article' },
+    { id: 'article-4', contentType: 'article' },
+    { id: 'article-5', contentType: 'article' },
+    { id: 'article-6', contentType: 'article' },
+    { id: 'video-1', contentType: 'video' },
+    { id: 'video-2', contentType: 'video' },
+  ] as const;
+
+  it('filters before truncating so later matches can still fill the grid', () => {
+    expect(getVisibleFeaturedGridItems(items, 'video')).toEqual([
+      { id: 'video-1', contentType: 'video' },
+      { id: 'video-2', contentType: 'video' },
+    ]);
+  });
+
+  it('preserves the even-count cap after filtering', () => {
+    expect(getVisibleFeaturedGridItems(items, 'article')).toEqual([
+      { id: 'article-1', contentType: 'article' },
+      { id: 'article-2', contentType: 'article' },
+      { id: 'article-3', contentType: 'article' },
+      { id: 'article-4', contentType: 'article' },
+      { id: 'article-5', contentType: 'article' },
+      { id: 'article-6', contentType: 'article' },
+    ]);
+  });
+});
+
+describe('getFeaturedGridItemWidth', () => {
+  it('splits the available width into two columns after subtracting the gap', () => {
+    expect(getFeaturedGridItemWidth(358, 16)).toBe(171);
+  });
+
+  it('clamps negative widths to zero', () => {
+    expect(getFeaturedGridItemWidth(8, 16)).toBe(0);
   });
 });

--- a/apps/mobile/lib/home-layout.test.ts
+++ b/apps/mobile/lib/home-layout.test.ts
@@ -1,0 +1,22 @@
+import { getValidFeaturedGridItems } from './home-layout';
+
+describe('getValidFeaturedGridItems', () => {
+  it('returns an empty array when there is only one item', () => {
+    expect(getValidFeaturedGridItems([1])).toEqual([]);
+  });
+
+  it('keeps even counts up to six', () => {
+    expect(getValidFeaturedGridItems([1, 2])).toEqual([1, 2]);
+    expect(getValidFeaturedGridItems([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
+    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('rounds odd counts down to the nearest even count', () => {
+    expect(getValidFeaturedGridItems([1, 2, 3])).toEqual([1, 2]);
+    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('caps results at six items', () => {
+    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6, 7, 8])).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});

--- a/apps/mobile/lib/home-layout.ts
+++ b/apps/mobile/lib/home-layout.ts
@@ -1,0 +1,8 @@
+const MAX_FEATURED_GRID_ITEMS = 6;
+
+export function getValidFeaturedGridItems<T>(items: T[]): T[] {
+  const cappedItems = items.slice(0, MAX_FEATURED_GRID_ITEMS);
+  const evenCount = cappedItems.length - (cappedItems.length % 2);
+
+  return cappedItems.slice(0, evenCount);
+}

--- a/apps/mobile/lib/home-layout.ts
+++ b/apps/mobile/lib/home-layout.ts
@@ -1,8 +1,29 @@
 const MAX_FEATURED_GRID_ITEMS = 6;
+const FEATURED_GRID_COLUMNS = 2;
 
-export function getValidFeaturedGridItems<T>(items: T[]): T[] {
+interface FeaturedGridItem {
+  contentType: string;
+}
+
+export function getValidFeaturedGridItems<T>(items: readonly T[]): T[] {
   const cappedItems = items.slice(0, MAX_FEATURED_GRID_ITEMS);
   const evenCount = cappedItems.length - (cappedItems.length % 2);
 
   return cappedItems.slice(0, evenCount);
+}
+
+export function getFeaturedGridItemWidth(containerWidth: number, gap: number): number {
+  return Math.max(0, (containerWidth - gap * (FEATURED_GRID_COLUMNS - 1)) / FEATURED_GRID_COLUMNS);
+}
+
+export function getVisibleFeaturedGridItems<T extends FeaturedGridItem>(
+  items: readonly T[],
+  contentTypeFilter: string | null
+): T[] {
+  const visibleItems =
+    contentTypeFilter === null
+      ? items
+      : items.filter((item) => item.contentType === contentTypeFilter);
+
+  return getValidFeaturedGridItems(visibleItems);
 }


### PR DESCRIPTION
## Summary
- compact the featured Jump Back In cards into a fixed-height row with edge-aligned left media
- enforce valid featured grid counts and exact two-column sizing through shared home-layout helpers
- align Storybook coverage with the real compact-width layout and add regression tests for filtering and width math

## Testing
- bun run format:check
- bun run design-system:check
- bun run lint
- bun run typecheck
- bun run build
- bun run --cwd apps/mobile test --runInBand home-layout.test.ts
- bun run test:worker:ci