### PR TITLE
techdebt: remove unsafe cast in LatestContentCard navigation

### DIFF
--- a/apps/mobile/components/creator/LatestContentCard.tsx
+++ b/apps/mobile/components/creator/LatestContentCard.tsx
@@ -119,7 +119,7 @@ export function LatestContentCard({ item, creatorId, provider }: LatestContentCa
       destination: 'internal',
     });
 
-    router.push(`/item/${userItemId}` as any);
+    router.push({ pathname: '/item/[id]', params: { id: String(userItemId) } });
   };
 
   // Build metadata line (date · duration)


### PR DESCRIPTION
## Summary
- replace unsafe `as any` cast in latest creator content navigation
- switch to typed Expo Router object form: `{ pathname: '/item/[id]', params: { id: String(userItemId) } }`
- keep runtime behavior unchanged while improving type safety

## Validation
- `/Users/erikjohansson/dev/zine/node_modules/.bin/prettier --check apps/mobile/components/creator/LatestContentCard.tsx`
- `git diff --check`

## Notes
- Attempted broader lint/typecheck from worktree, but local worktree environment lacks required toolchain/dependencies (e.g. `expo` not found and missing workspace module resolution). Scoped file-level validation above passes.
