### PR TITLE
Refine subheader styling and item card metadata

### DIFF
--- a/apps/mobile/app/(auth)/sign-in.tsx
+++ b/apps/mobile/app/(auth)/sign-in.tsx
@@ -250,7 +250,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     subtitle: {
       ...Typography.bodyLarge,
-      color: colors.textSecondary,
+      color: colors.textSubheader,
     },
     errorContainer: {
       backgroundColor: `${colors.error}15`,
@@ -335,7 +335,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     footerText: {
       ...Typography.bodyMedium,
-      color: colors.textSecondary,
+      color: colors.textSubheader,
     },
     linkText: {
       ...Typography.titleSmall,

--- a/apps/mobile/app/(auth)/sign-up.tsx
+++ b/apps/mobile/app/(auth)/sign-up.tsx
@@ -341,7 +341,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     subtitle: {
       ...Typography.bodyLarge,
-      color: colors.textSecondary,
+      color: colors.textSubheader,
     },
     errorContainer: {
       backgroundColor: `${colors.error}15`,
@@ -443,7 +443,7 @@ function createStyles(colors: typeof Colors.light) {
     },
     footerText: {
       ...Typography.bodyMedium,
-      color: colors.textSecondary,
+      color: colors.textSubheader,
     },
     linkText: {
       ...Typography.titleSmall,

--- a/apps/mobile/app/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(tabs)/inbox.tsx
@@ -45,7 +45,7 @@ function InboxEmptyState({ colors }: { colors: (typeof Colors)['light'] }) {
         <InboxArrowIcon size={48} color={colors.primary} />
       </View>
       <Text style={[styles.emptyTitle, { color: colors.text }]}>Your inbox is clear</Text>
-      <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
+      <Text style={[styles.emptyDescription, { color: colors.textSubheader }]}>
         New content from your sources will appear here. Bookmark what you want to keep, archive the
         rest.
       </Text>
@@ -208,6 +208,7 @@ export default function InboxScreen() {
     contentType: mapContentType(item.contentType) as ContentType,
     provider: mapProvider(item.provider) as Provider,
     duration: item.duration ?? null,
+    readingTimeMinutes: item.readingTimeMinutes ?? null,
     bookmarkedAt: null,
     publishedAt: item.publishedAt ?? null,
     isFinished: item.isFinished,
@@ -248,7 +249,7 @@ export default function InboxScreen() {
                 </Text>
               </Animated.View>
             ) : (
-              <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
+              <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
                 {inboxItems.length > 0
                   ? `${inboxItems.length} item${inboxItems.length === 1 ? '' : 's'} to triage`
                   : 'Decide what to keep'}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -164,6 +164,7 @@ export default function HomeScreen() {
       contentType: mapContentType(item.contentType) as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.jumpBackIn]);
 
@@ -177,6 +178,7 @@ export default function HomeScreen() {
       contentType: mapContentType(item.contentType) as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.recentBookmarks]);
 
@@ -190,6 +192,7 @@ export default function HomeScreen() {
       contentType: mapContentType(item.contentType) as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [inboxData?.items]);
 
@@ -203,6 +206,7 @@ export default function HomeScreen() {
       contentType: 'podcast' as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.byContentType.podcasts]);
 
@@ -216,6 +220,7 @@ export default function HomeScreen() {
       contentType: 'video' as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.byContentType.videos]);
 
@@ -229,6 +234,7 @@ export default function HomeScreen() {
       contentType: 'article' as ContentType,
       provider: mapProvider(item.provider) as Provider,
       duration: item.duration ?? null,
+      readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.byContentType.articles]);
 
@@ -296,7 +302,7 @@ export default function HomeScreen() {
           <Animated.View style={styles.header}>
             <View style={styles.headerTopRow}>
               <View style={styles.headerTitleWrap}>
-                <Text style={[styles.greeting, { color: colors.textSecondary }]}>{greeting}</Text>
+                <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
                 <Text style={[styles.headerTitle, { color: colors.text }]}>Home</Text>
               </View>
               <Pressable

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -193,6 +193,7 @@ export default function LibraryScreen() {
     contentType: mapContentType(item.contentType) as UIContentType,
     provider: mapProvider(item.provider) as Provider,
     duration: item.duration ?? null,
+    readingTimeMinutes: item.readingTimeMinutes ?? null,
     bookmarkedAt: item.bookmarkedAt ?? null,
     publishedAt: item.publishedAt ?? null,
     isFinished: item.isFinished,
@@ -222,7 +223,7 @@ export default function LibraryScreen() {
               <PlusIcon size={22} color={colors.text} />
             </Pressable>
           </View>
-          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
             {isLoading
               ? 'Loading...'
               : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`}

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -43,6 +43,7 @@ export default function SearchTabScreen() {
         contentType: mapContentType(item.contentType) as ContentType,
         provider: mapProvider(item.provider) as Provider,
         duration: item.duration ?? null,
+        readingTimeMinutes: item.readingTimeMinutes ?? null,
         bookmarkedAt: item.bookmarkedAt ?? null,
         publishedAt: item.publishedAt ?? null,
         isFinished: item.isFinished,

--- a/apps/mobile/app/add-link.tsx
+++ b/apps/mobile/app/add-link.tsx
@@ -128,7 +128,7 @@ function EmptyState({ colors }: { colors: typeof Colors.light }) {
   return (
     <Animated.View style={styles.stateContainer}>
       <LinkIcon size={48} color={colors.textTertiary} />
-      <Text style={[styles.stateTitle, { color: colors.textSecondary }]}>
+      <Text style={[styles.stateTitle, { color: colors.textSubheader }]}>
         Paste a link to get started
       </Text>
       <Text style={[styles.stateMessage, { color: colors.textTertiary }]}>
@@ -146,7 +146,7 @@ function LoadingState({ colors }: { colors: typeof Colors.light }) {
   return (
     <Animated.View style={styles.stateContainer}>
       <ActivityIndicator size="large" color={colors.primary} />
-      <Text style={[styles.stateTitle, { color: colors.textSecondary }]}>Fetching preview...</Text>
+      <Text style={[styles.stateTitle, { color: colors.textSubheader }]}>Fetching preview...</Text>
     </Animated.View>
   );
 }
@@ -168,7 +168,7 @@ function ErrorState({
     <Animated.View style={styles.stateContainer}>
       <AlertCircleIcon size={48} color={colors.error} />
       <Text style={[styles.stateTitle, { color: colors.text }]}>{"Couldn't load preview"}</Text>
-      <Text style={[styles.stateMessage, { color: colors.textSecondary }]}>{message}</Text>
+      <Text style={[styles.stateMessage, { color: colors.textSubheader }]}>{message}</Text>
       {onRetry && (
         <Pressable
           onPress={onRetry}

--- a/apps/mobile/app/creator/[id].tsx
+++ b/apps/mobile/app/creator/[id].tsx
@@ -142,7 +142,7 @@ export default function CreatorScreen() {
         <View style={styles.errorContainer}>
           <Text style={[styles.errorEmoji]}>:(</Text>
           <Text style={[styles.errorTitle, { color: colors.text }]}>Something went wrong</Text>
-          <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>
+          <Text style={[styles.errorMessage, { color: colors.textSubheader }]}>
             {error.message}
           </Text>
           <Pressable
@@ -172,7 +172,7 @@ export default function CreatorScreen() {
         <View style={styles.errorContainer}>
           <Text style={[styles.errorEmoji]}>?</Text>
           <Text style={[styles.errorTitle, { color: colors.text }]}>Creator not found</Text>
-          <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>
+          <Text style={[styles.errorMessage, { color: colors.textSubheader }]}>
             This creator may have been removed or does not exist.
           </Text>
         </View>

--- a/apps/mobile/app/item-tags/[id].tsx
+++ b/apps/mobile/app/item-tags/[id].tsx
@@ -206,14 +206,14 @@ export default function ItemTagsScreen() {
       <SafeAreaView style={styles.safeArea} edges={['bottom']}>
         <View style={styles.header}>
           <Text style={[styles.title, { color: colors.text }]}>Tags</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]} numberOfLines={2}>
+          <Text style={[styles.subtitle, { color: colors.textSubheader }]} numberOfLines={2}>
             {item.title}
           </Text>
         </View>
 
         {!isBookmarked && (
           <View style={[styles.warningBox, { backgroundColor: colors.backgroundSecondary }]}>
-            <Text style={[styles.warningText, { color: colors.textSecondary }]}>
+            <Text style={[styles.warningText, { color: colors.textSubheader }]}>
               Only bookmarked items can have tags.
             </Text>
           </View>
@@ -238,7 +238,7 @@ export default function ItemTagsScreen() {
         </View>
 
         <View style={styles.selectedSection}>
-          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>Selected</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>Selected</Text>
           <View style={styles.tagWrap}>
             {selectedTags.length === 0 ? (
               <Text style={[styles.emptySelected, { color: colors.textTertiary }]}>
@@ -266,7 +266,7 @@ export default function ItemTagsScreen() {
         </View>
 
         <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
-          <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>All tags</Text>
+          <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>All tags</Text>
 
           {canCreateTag && isBookmarked && (
             <Pressable

--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -15,7 +15,7 @@ export function ItemDetailDescription({ summary, label, colors }: ItemDetailDesc
     <>
       <Text style={[styles.descriptionLabel, { color: colors.text }]}>{label}</Text>
       <LinkedText
-        style={[styles.description, { color: colors.textSecondary }]}
+        style={[styles.description, { color: colors.textSubheader }]}
         linkColor={colors.primary}
       >
         {summary}

--- a/apps/mobile/app/onboarding/connect.tsx
+++ b/apps/mobile/app/onboarding/connect.tsx
@@ -98,7 +98,7 @@ function ProviderCard({
         </View>
         <View style={styles.providerInfo}>
           <Text style={[styles.providerName, { color: colors.text }]}>{name}</Text>
-          <Text style={[styles.providerDescription, { color: colors.textSecondary }]}>
+          <Text style={[styles.providerDescription, { color: colors.textSubheader }]}>
             {description}
           </Text>
         </View>
@@ -130,7 +130,7 @@ interface ComingSoonCardProps {
 function ComingSoonCard({ colors }: ComingSoonCardProps) {
   return (
     <View style={[styles.comingSoonCard, { backgroundColor: colors.backgroundSecondary }]}>
-      <Text style={[styles.comingSoonTitle, { color: colors.textSecondary }]}>
+      <Text style={[styles.comingSoonTitle, { color: colors.textSubheader }]}>
         More coming soon...
       </Text>
       <Text style={[styles.comingSoonDescription, { color: colors.textTertiary }]}>
@@ -185,7 +185,7 @@ export default function OnboardingConnectScreen() {
         {/* Header */}
         <View style={styles.header}>
           <Text style={[styles.title, { color: colors.text }]}>Connect your favorite sources</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.subtitle, { color: colors.textSubheader }]}>
             Import your subscriptions from YouTube and Spotify to get started
           </Text>
         </View>

--- a/apps/mobile/app/onboarding/select-channels.tsx
+++ b/apps/mobile/app/onboarding/select-channels.tsx
@@ -189,7 +189,7 @@ export default function SelectChannelsScreen() {
           <Text style={[styles.headerTitle, { color: colors.text }]}>
             Your {providerDisplayName} subscriptions
           </Text>
-          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
             Select channels to follow in Zine
           </Text>
         </View>

--- a/apps/mobile/app/settings/connections.tsx
+++ b/apps/mobile/app/settings/connections.tsx
@@ -113,7 +113,7 @@ function ProviderCard({
         </View>
         <View style={styles.providerInfo}>
           <Text style={[styles.providerName, { color: colors.text }]}>{config.name}</Text>
-          <Text style={[styles.providerDescription, { color: colors.textSecondary }]}>
+          <Text style={[styles.providerDescription, { color: colors.textSubheader }]}>
             {config.description}
           </Text>
         </View>
@@ -129,7 +129,7 @@ function ProviderCard({
                 <Text style={[styles.statusText, { color: colors.success }]}>Connected</Text>
               </View>
               {connection?.providerUserId && (
-                <Text style={[styles.userId, { color: colors.textSecondary }]}>
+                <Text style={[styles.userId, { color: colors.textSubheader }]}>
                   {connection.providerUserId}
                 </Text>
               )}
@@ -179,7 +179,7 @@ function LoadingState({ colors }: { colors: typeof Colors.light }) {
   return (
     <View style={styles.loadingContainer}>
       <ActivityIndicator size="large" color={colors.primary} />
-      <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+      <Text style={[styles.loadingText, { color: colors.textSubheader }]}>
         Loading connections...
       </Text>
     </View>
@@ -300,7 +300,7 @@ export default function ConnectionsScreen() {
     >
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Header Description */}
-        <Text style={[styles.headerDescription, { color: colors.textSecondary }]}>
+        <Text style={[styles.headerDescription, { color: colors.textSubheader }]}>
           Connect your accounts to import subscriptions and get updates in your inbox.
         </Text>
 

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -64,7 +64,7 @@ function SettingsRow({
         <View style={icon ? undefined : styles.rowTextContainer}>
           <Text style={[styles.rowTitle, { color: titleColor ?? colors.text }]}>{title}</Text>
           {subtitle && (
-            <Text style={[styles.rowSubtitle, { color: colors.textSecondary }]}>{subtitle}</Text>
+            <Text style={[styles.rowSubtitle, { color: colors.textSubheader }]}>{subtitle}</Text>
           )}
         </View>
       </View>
@@ -171,7 +171,7 @@ function SettingsScreenContent({
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={[]}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         {/* Connected Accounts Section */}
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+        <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>
           CONNECTED ACCOUNTS
         </Text>
 
@@ -232,7 +232,7 @@ function SettingsScreenContent({
         </View>
 
         {/* Subscriptions Section */}
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>SUBSCRIPTIONS</Text>
+        <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>SUBSCRIPTIONS</Text>
 
         <View style={[styles.section, { backgroundColor: colors.card }]}>
           <SettingsRow
@@ -246,7 +246,7 @@ function SettingsScreenContent({
         {/* Account Section */}
         {authEnabled && (
           <>
-            <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>ACCOUNT</Text>
+            <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>ACCOUNT</Text>
 
             <View style={[styles.section, { backgroundColor: colors.card }]}>
               <SettingsRow title="Sign Out" titleColor={colors.error} onPress={handleSignOut} />
@@ -255,7 +255,7 @@ function SettingsScreenContent({
         )}
 
         {/* About Section */}
-        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>ABOUT</Text>
+        <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>ABOUT</Text>
 
         <View style={[styles.section, { backgroundColor: colors.card }]}>
           <SettingsRow title="Version" rightText={`${appVersion} (${buildNumber})`} />
@@ -267,7 +267,7 @@ function SettingsScreenContent({
 
         {isDeveloperDiagnosticsEnabled && (
           <>
-            <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>DEVELOPER</Text>
+            <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>DEVELOPER</Text>
 
             <View style={[styles.section, { backgroundColor: colors.card }]}>
               <SettingsRow

--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -229,7 +229,7 @@ function ConnectionStatusCard({
                   <Text style={[styles.statusLabel, { color: colors.success }]}>Connected</Text>
                 </View>
                 {connection?.providerUserId && (
-                  <Text style={[styles.connectionDetail, { color: colors.textSecondary }]}>
+                  <Text style={[styles.connectionDetail, { color: colors.textSubheader }]}>
                     {connection.providerUserId}
                   </Text>
                 )}
@@ -422,7 +422,7 @@ function NewsletterItem({
           </Text>
           {feed.fromAddress && (
             <Text
-              style={[styles.connectionDetail, { color: colors.textSecondary }]}
+              style={[styles.connectionDetail, { color: colors.textSubheader }]}
               numberOfLines={1}
             >
               {feed.fromAddress}
@@ -481,7 +481,7 @@ function EmptyChannelsState({ provider, isConnected, colors }: EmptyChannelsStat
       <Text style={[styles.emptyTitle, { color: colors.text }]}>
         {isConnected ? `No ${config.contentName} found` : `Connect ${config.name}`}
       </Text>
-      <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
+      <Text style={[styles.emptyDescription, { color: colors.textSubheader }]}>
         {isConnected
           ? `We couldn't find any ${config.contentName} in your ${config.name} account.`
           : `Connect your ${config.name} account to see your ${config.contentName} and add them to Zine.`}
@@ -903,7 +903,7 @@ export default function ProviderDetailScreen() {
               ) : (
                 <View style={styles.loadingChannels}>
                   <ActivityIndicator size="large" color={colors.primary} />
-                  <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+                  <Text style={[styles.loadingText, { color: colors.textSubheader }]}>
                     Loading {config.contentName}...
                   </Text>
                 </View>
@@ -968,7 +968,7 @@ export default function ProviderDetailScreen() {
               ) : (
                 <View style={styles.loadingChannels}>
                   <ActivityIndicator size="large" color={colors.primary} />
-                  <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+                  <Text style={[styles.loadingText, { color: colors.textSubheader }]}>
                     Loading {config.contentName}...
                   </Text>
                 </View>

--- a/apps/mobile/app/subscriptions/connect/gmail.tsx
+++ b/apps/mobile/app/subscriptions/connect/gmail.tsx
@@ -28,7 +28,7 @@ function PermissionItem({
       <Text style={styles.permissionIcon}>{icon}</Text>
       <View style={styles.permissionText}>
         <Text style={[styles.permissionTitle, { color: colors.text }]}>{title}</Text>
-        <Text style={[styles.permissionDescription, { color: colors.textSecondary }]}>
+        <Text style={[styles.permissionDescription, { color: colors.textSubheader }]}>
           {description}
         </Text>
       </View>
@@ -77,7 +77,7 @@ function GmailConnectContent() {
             <Text style={styles.providerIcon}>📬</Text>
           </View>
           <Text style={[styles.title, { color: colors.text }]}>Connect Gmail</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.subtitle, { color: colors.textSubheader }]}>
             Import newsletters from your inbox into Zine
           </Text>
         </View>
@@ -88,7 +88,7 @@ function GmailConnectContent() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
-          <Text style={[styles.permissionsHeader, { color: colors.textSecondary }]}>
+          <Text style={[styles.permissionsHeader, { color: colors.textSubheader }]}>
             WHAT WE&apos;LL ACCESS
           </Text>
           <View style={styles.permissionsList}>
@@ -113,7 +113,7 @@ function GmailConnectContent() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
-          <Text style={[styles.permissionsHeader, { color: colors.textSecondary }]}>
+          <Text style={[styles.permissionsHeader, { color: colors.textSubheader }]}>
             WHAT WE WON&apos;T DO
           </Text>
           <View style={styles.permissionsList}>
@@ -158,7 +158,7 @@ function GmailConnectContent() {
         </Pressable>
 
         {isConnecting && (
-          <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+          <Text style={[styles.loadingText, { color: colors.textSubheader }]}>
             Opening Gmail authorization...
           </Text>
         )}

--- a/apps/mobile/app/subscriptions/connect/spotify.tsx
+++ b/apps/mobile/app/subscriptions/connect/spotify.tsx
@@ -46,7 +46,7 @@ function PermissionItem({
       <Text style={styles.permissionIcon}>{icon}</Text>
       <View style={styles.permissionText}>
         <Text style={[styles.permissionTitle, { color: colors.text }]}>{title}</Text>
-        <Text style={[styles.permissionDescription, { color: colors.textSecondary }]}>
+        <Text style={[styles.permissionDescription, { color: colors.textSubheader }]}>
           {description}
         </Text>
       </View>
@@ -98,7 +98,7 @@ function SpotifyConnectContent() {
             <Text style={styles.providerIcon}>🎧</Text>
           </View>
           <Text style={[styles.title, { color: colors.text }]}>Connect Spotify</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.subtitle, { color: colors.textSubheader }]}>
             Import your saved podcasts and shows to Zine
           </Text>
         </View>
@@ -110,7 +110,7 @@ function SpotifyConnectContent() {
             { backgroundColor: colors.card, borderColor: colors.border },
           ]}
         >
-          <Text style={[styles.permissionsHeader, { color: colors.textSecondary }]}>
+          <Text style={[styles.permissionsHeader, { color: colors.textSubheader }]}>
             WHAT WE&apos;LL ACCESS
           </Text>
           <View style={styles.permissionsList}>
@@ -166,7 +166,7 @@ function SpotifyConnectContent() {
 
         {/* Loading State Message */}
         {isConnecting && (
-          <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+          <Text style={[styles.loadingText, { color: colors.textSubheader }]}>
             Opening Spotify authorization...
           </Text>
         )}

--- a/apps/mobile/app/subscriptions/connect/youtube.tsx
+++ b/apps/mobile/app/subscriptions/connect/youtube.tsx
@@ -143,7 +143,7 @@ function YouTubeConnectContent() {
             <YouTubeIcon size={48} />
           </View>
           <Text style={[styles.title, { color: colors.text }]}>Connect YouTube</Text>
-          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.subtitle, { color: colors.textSubheader }]}>
             Import your YouTube subscriptions to see new videos from your favorite creators
           </Text>
         </View>
@@ -151,7 +151,7 @@ function YouTubeConnectContent() {
         {/* What we CAN access */}
         <View style={[styles.permissionSection, { backgroundColor: colors.card }]}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>What Zine can access</Text>
-          <Text style={[styles.sectionSubtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.sectionSubtitle, { color: colors.textSubheader }]}>
             Read-only access to:
           </Text>
 
@@ -204,8 +204,8 @@ function YouTubeConnectContent() {
 
         {/* Security note */}
         <View style={styles.securityNote}>
-          <ShieldIcon color={colors.textSecondary} />
-          <Text style={[styles.securityText, { color: colors.textSecondary }]}>
+          <ShieldIcon color={colors.textSubheader} />
+          <Text style={[styles.securityText, { color: colors.textSubheader }]}>
             You can disconnect at any time from Settings. Your data is encrypted and never shared.
           </Text>
         </View>

--- a/apps/mobile/app/subscriptions/discover/[provider].tsx
+++ b/apps/mobile/app/subscriptions/discover/[provider].tsx
@@ -171,7 +171,7 @@ export default function ProviderDiscoverScreen() {
           <Text style={[styles.headerTitle, { color: colors.text }]}>
             Your {providerDisplayName} Subscriptions
           </Text>
-          <Text style={[styles.headerSubtitle, { color: colors.textSecondary }]}>
+          <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
             Select channels to follow in Zine
             {selectedCount > 0 && ` (${selectedCount} selected)`}
           </Text>
@@ -194,7 +194,7 @@ export default function ProviderDiscoverScreen() {
             subscribeQueued ? (
               <View style={styles.footerLoader}>
                 <ActivityIndicator size="small" color={colors.primary} />
-                <Text style={[styles.footerText, { color: colors.textSecondary }]}>
+                <Text style={[styles.footerText, { color: colors.textSubheader }]}>
                   Changes will sync when online...
                 </Text>
               </View>

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -118,7 +118,7 @@ function ProviderCard({
       ? {
           dotColor: colors.primary,
           text: 'Feed source',
-          textColor: colors.textSecondary,
+          textColor: colors.textSubheader,
           showCount: true,
         }
       : getStatusDisplay(connectionStatus, colors);

--- a/apps/mobile/app/subscriptions/rss.tsx
+++ b/apps/mobile/app/subscriptions/rss.tsx
@@ -46,7 +46,7 @@ function FeedRow(props: {
         <Text style={[styles.feedStatus, { color: colors.textTertiary }]}>{feed.status}</Text>
       </View>
 
-      <Text style={[styles.feedUrl, { color: colors.textSecondary }]} numberOfLines={1}>
+      <Text style={[styles.feedUrl, { color: colors.textSubheader }]} numberOfLines={1}>
         {feed.feedUrl}
       </Text>
 
@@ -265,13 +265,13 @@ export default function RssSubscriptionsScreen() {
               </Pressable>
 
               <View style={styles.statsRow}>
-                <Text style={[styles.statsText, { color: colors.textSecondary }]}>
+                <Text style={[styles.statsText, { color: colors.textSubheader }]}>
                   {stats?.active ?? 0} active
                 </Text>
-                <Text style={[styles.statsText, { color: colors.textSecondary }]}>
+                <Text style={[styles.statsText, { color: colors.textSubheader }]}>
                   {stats?.paused ?? 0} paused
                 </Text>
-                <Text style={[styles.statsText, { color: colors.textSecondary }]}>
+                <Text style={[styles.statsText, { color: colors.textSubheader }]}>
                   {stats?.error ?? 0} error
                 </Text>
               </View>
@@ -296,7 +296,7 @@ export default function RssSubscriptionsScreen() {
             ) : (
               <View style={styles.emptyState}>
                 <Text style={[styles.emptyTitle, { color: colors.text }]}>No RSS feeds yet</Text>
-                <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
+                <Text style={[styles.emptyDescription, { color: colors.textSubheader }]}>
                   Add a feed URL to start receiving new articles in your inbox.
                 </Text>
               </View>

--- a/apps/mobile/components/creator/CreatorBookmarks.tsx
+++ b/apps/mobile/components/creator/CreatorBookmarks.tsx
@@ -140,7 +140,7 @@ export function CreatorBookmarks({ creatorId, stateOverride }: CreatorBookmarksP
         <Text style={styles.title} tone="primary">
           Your Bookmarks
         </Text>
-        <Text style={styles.count} tone="secondary">
+        <Text style={styles.count} tone="subheader">
           {items.length} item{items.length === 1 ? '' : 's'}
         </Text>
       </View>

--- a/apps/mobile/components/creator/CreatorHeader.tsx
+++ b/apps/mobile/components/creator/CreatorHeader.tsx
@@ -282,14 +282,14 @@ export function CreatorHeader({
 
       {/* Handle (e.g., @waveform) */}
       {handle ? (
-        <Text style={styles.handle} tone="secondary">
+        <Text style={styles.handle} tone="subheader">
           {handle}
         </Text>
       ) : null}
 
       {/* Description */}
       {creator.description && (
-        <Text style={styles.description} tone="secondary" numberOfLines={4}>
+        <Text style={styles.description} tone="subheader" numberOfLines={4}>
           {creator.description}
         </Text>
       )}
@@ -314,7 +314,7 @@ export function CreatorHeader({
                 <Text style={styles.subscriptionTitle} tone="primary" numberOfLines={1}>
                   {creator.name}
                 </Text>
-                <Text style={styles.subscriptionSubtitle} tone="secondary">
+                <Text style={styles.subscriptionSubtitle} tone="subheader">
                   {reason === 'NOT_CONNECTED'
                     ? `Connect ${providerName} to subscribe`
                     : reason === 'SOURCE_NOT_FOUND'
@@ -374,21 +374,21 @@ export function CreatorHeader({
               {isDiscovering && candidates.length === 0 ? (
                 <View style={styles.subscriptionLoadingRow}>
                   <ActivityIndicator size="small" color={colors.textSecondary} />
-                  <Text style={styles.subscriptionHint} tone="secondary">
+                  <Text style={styles.subscriptionHint} tone="subheader">
                     {`Checking ${sourceHost ?? 'this source'} for RSS feeds...`}
                   </Text>
                 </View>
               ) : null}
 
               {!isDiscovering && !isHttpUrl(discoveryUrl) ? (
-                <Text style={styles.subscriptionHint} tone="secondary">
+                <Text style={styles.subscriptionHint} tone="subheader">
                   Save content from this creator to discover an RSS feed.
                 </Text>
               ) : null}
 
               {!isDiscovering && discoveryError && candidates.length === 0 ? (
                 <>
-                  <Text style={styles.subscriptionHint} tone="secondary">
+                  <Text style={styles.subscriptionHint} tone="subheader">
                     {`Couldn't check ${sourceHost ?? 'this source'} for RSS feeds.`}
                   </Text>
                   <Button
@@ -407,7 +407,7 @@ export function CreatorHeader({
               !discoveryError &&
               isHttpUrl(discoveryUrl) &&
               candidates.length === 0 ? (
-                <Text style={styles.subscriptionHint} tone="secondary">
+                <Text style={styles.subscriptionHint} tone="subheader">
                   {`No RSS feed detected for ${sourceHost ?? 'this source'} yet.`}
                 </Text>
               ) : null}
@@ -431,7 +431,7 @@ export function CreatorHeader({
                       <Text style={styles.subscriptionTitle} tone="primary" numberOfLines={1}>
                         {candidateLabel}
                       </Text>
-                      <Text style={styles.subscriptionSubtitle} tone="secondary" numberOfLines={1}>
+                      <Text style={styles.subscriptionSubtitle} tone="subheader" numberOfLines={1}>
                         {candidate.feedUrl}
                       </Text>
                       {statusLabel ? (

--- a/apps/mobile/components/creator/CreatorLatestContent.tsx
+++ b/apps/mobile/components/creator/CreatorLatestContent.tsx
@@ -106,7 +106,7 @@ function ConnectPrompt({ provider, message, connectUrl, colors }: ConnectPromptP
 
   return (
     <View style={[styles.promptContainer, { backgroundColor: colors.surfaceSubtle }]}>
-      <Text style={styles.promptText} tone="secondary">
+      <Text style={styles.promptText} tone="subheader">
         {message}
       </Text>
       {connectUrl && (
@@ -138,7 +138,7 @@ function ReconnectPrompt({ provider, connectUrl, colors }: ReconnectPromptProps)
 
   return (
     <View style={[styles.promptContainer, { backgroundColor: colors.surfaceSubtle }]}>
-      <Text style={styles.promptText} tone="secondary">
+      <Text style={styles.promptText} tone="subheader">
         Your {providerDisplayName} connection needs to be refreshed
       </Text>
       {connectUrl && (
@@ -427,7 +427,7 @@ export function CreatorLatestContent({
         <Text style={styles.title} tone="primary">
           {sectionTitle}
         </Text>
-        <Text style={styles.emptyText} tone="secondary">
+        <Text style={styles.emptyText} tone="subheader">
           No recent content found
         </Text>
       </View>

--- a/apps/mobile/components/creator/CreatorPublications.tsx
+++ b/apps/mobile/components/creator/CreatorPublications.tsx
@@ -113,7 +113,7 @@ export function CreatorPublications({ creatorId, stateOverride }: CreatorPublica
             Past Publications
           </Text>
         </View>
-        <Text style={styles.emptyText} tone="secondary">
+        <Text style={styles.emptyText} tone="subheader">
           No publications found yet
         </Text>
       </View>
@@ -126,7 +126,7 @@ export function CreatorPublications({ creatorId, stateOverride }: CreatorPublica
         <Text style={styles.title} tone="primary">
           Past Publications
         </Text>
-        <Text style={styles.count} tone="secondary">
+        <Text style={styles.count} tone="subheader">
           {items.length} item{items.length === 1 ? '' : 's'}
         </Text>
       </View>

--- a/apps/mobile/components/creator/LatestContentCard.tsx
+++ b/apps/mobile/components/creator/LatestContentCard.tsx
@@ -164,7 +164,7 @@ export function LatestContentCard({ item, creatorId, provider }: LatestContentCa
         {showMetaRow && (
           <View style={styles.metaRow}>
             {metaLine ? (
-              <Text style={styles.meta} tone="secondary">
+              <Text style={styles.meta} tone="subheader">
                 {metaLine}
               </Text>
             ) : null}

--- a/apps/mobile/components/error-boundary.tsx
+++ b/apps/mobile/components/error-boundary.tsx
@@ -46,7 +46,7 @@ function DefaultErrorFallback({
       <Text variant="titleMedium" style={styles.title} colorScheme={colorScheme}>
         Something went wrong
       </Text>
-      <Text variant="bodyMedium" tone="secondary" style={styles.message} colorScheme={colorScheme}>
+      <Text variant="bodyMedium" tone="subheader" style={styles.message} colorScheme={colorScheme}>
         {errorMessage}
       </Text>
       <Button label="Try Again" onPress={onRetry} colorScheme={colorScheme} />

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -96,7 +96,8 @@ export function FilterChip({
     ? (selectedColor ?? colors.borderDefault)
     : colors.borderSubtle;
   const selectedForegroundColor = hasTintedSelection ? selectedColor : colors.textPrimary;
-  const iconColor = isSelected ? selectedForegroundColor : colors.textTertiary;
+  const unselectedForegroundColor = colors.textSubheader;
+  const iconColor = isSelected ? selectedForegroundColor : unselectedForegroundColor;
   const displayedCount = count && count > 0 ? (count > 99 ? '99+' : String(count)) : null;
 
   const sizeStyles = size === 'small' ? styles.chipSmall : styles.chipMedium;
@@ -122,16 +123,22 @@ export function FilterChip({
       ) : null}
       <Text
         variant={size === 'small' ? 'labelSmallPlain' : 'labelMedium'}
-        tone={isSelected ? 'primary' : 'secondary'}
-        style={[textStyles, isSelected ? { color: selectedForegroundColor } : null]}
+        tone={isSelected ? 'primary' : 'subheader'}
+        style={[
+          textStyles,
+          { color: isSelected ? selectedForegroundColor : unselectedForegroundColor },
+        ]}
       >
         {label}
       </Text>
       {displayedCount ? (
         <Text
           variant="bodySmall"
-          tone={isSelected ? 'primary' : 'tertiary'}
-          style={[styles.count, isSelected ? { color: selectedForegroundColor } : null]}
+          tone={isSelected ? 'primary' : 'subheader'}
+          style={[
+            styles.count,
+            { color: isSelected ? selectedForegroundColor : unselectedForegroundColor },
+          ]}
         >
           {displayedCount}
         </Text>

--- a/apps/mobile/components/home/channel-card.tsx
+++ b/apps/mobile/components/home/channel-card.tsx
@@ -95,7 +95,7 @@ export function ChannelCard({ channel, provider, isSelected, onToggle, colors }:
           {channel.name}
         </Text>
         <Text
-          style={[styles.channelDescription, { color: colors.textSecondary }]}
+          style={[styles.channelDescription, { color: colors.textSubheader }]}
           numberOfLines={1}
         >
           {provider === 'YOUTUBE' ? 'YouTube Channel' : 'Spotify Podcast'}

--- a/apps/mobile/components/home/content-card.tsx
+++ b/apps/mobile/components/home/content-card.tsx
@@ -91,7 +91,7 @@ export function ContentCard({ item, colors, variant = 'default', onPress }: Cont
         <Text style={[styles.contentTitle, { color: colors.text }]} numberOfLines={2}>
           {item.title}
         </Text>
-        <Text style={[styles.contentSource, { color: colors.textSecondary }]} numberOfLines={1}>
+        <Text style={[styles.contentSource, { color: colors.textSubheader }]} numberOfLines={1}>
           {item.source}
         </Text>
       </View>

--- a/apps/mobile/components/home/quick-stats.tsx
+++ b/apps/mobile/components/home/quick-stats.tsx
@@ -49,7 +49,7 @@ export function QuickStats({ colors, stats, isLoading = false }: QuickStatsProps
           <View style={[styles.statIcon, { backgroundColor: colors.background }]}>{stat.icon}</View>
           <View style={styles.statText}>
             <Text style={[styles.statValue, { color: colors.text }]}>{stat.value}</Text>
-            <Text style={[styles.statLabel, { color: colors.textSecondary }]}>{stat.label}</Text>
+            <Text style={[styles.statLabel, { color: colors.textSubheader }]}>{stat.label}</Text>
           </View>
         </View>
       ))}

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -13,13 +13,12 @@ import { useRouter, type Href } from 'expo-router';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
 
-import { Typography, Spacing, Radius, ContentColors, IconSizes } from '@/constants/theme';
+import { Typography, Spacing, Radius, IconSizes } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
 import { usePrefetchItemDetail } from '@/hooks/use-prefetch';
 import { formatDuration } from '@/lib/format';
 import {
   getContentIcon,
-  mapContentType,
   upgradeSpotifyImageUrl,
   upgradeYouTubeImageUrl,
   type ContentType,
@@ -95,21 +94,14 @@ export function ItemCard({
   const { colors, motion } = useAppTheme();
   const prefetchItemDetail = usePrefetchItemDetail();
   const mediaTransition = motion.duration.normal;
-  const [showInlineTitleLength, setShowInlineTitleLength] = useState(false);
   const [subtitleAvatarFailed, setSubtitleAvatarFailed] = useState(false);
 
-  const contentType = mapContentType(item.contentType);
-  const contentColor = ContentColors[contentType];
-  const durationText = formatDuration(item.duration);
+  const durationText = formatDuration(item.duration) || null;
   const readingTimeText =
     item.readingTimeMinutes && !item.duration ? `${item.readingTimeMinutes} min` : null;
   const inlineLengthText = durationText ?? readingTimeText;
   const creatorImageUrl =
     upgradeSpotifyImageUrl(upgradeYouTubeImageUrl(item.creatorImageUrl ?? null)) ?? null;
-
-  useEffect(() => {
-    setShowInlineTitleLength(false);
-  }, [item.id, inlineLengthText, rowStyle, shape]);
 
   useEffect(() => {
     setSubtitleAvatarFailed(false);
@@ -128,7 +120,7 @@ export function ItemCard({
       );
     }
 
-    return getContentIcon(item.contentType, IconSizes.xs, colors.textSecondary);
+    return getContentIcon(item.contentType, IconSizes.xs, colors.textSubheader);
   };
 
   const handlePress = () => {
@@ -205,38 +197,42 @@ export function ItemCard({
           )}
 
           <View style={styles.stackContent}>
-            {inlineLengthText ? (
-              <View style={styles.inlineTitleMeasurement} pointerEvents="none" accessible={false}>
-                <Text
-                  style={[styles.stackTitle, { color: colors.text }]}
-                  onTextLayout={(event) => {
-                    const fitsOnOneLine = event.nativeEvent.lines.length <= 1;
-                    setShowInlineTitleLength((current) =>
-                      current === fitsOnOneLine ? current : fitsOnOneLine
-                    );
-                  }}
-                >
-                  {item.title}
-                  <Text style={[styles.inlineTitleLength, { color: colors.textSecondary }]}>
-                    {` · ${inlineLengthText}`}
-                  </Text>
-                </Text>
-              </View>
-            ) : null}
             <Text style={[styles.stackTitle, { color: colors.text }]} numberOfLines={1}>
               {item.title}
-              {showInlineTitleLength && inlineLengthText ? (
-                <Text style={[styles.inlineTitleLength, { color: colors.textSecondary }]}>
-                  {` · ${inlineLengthText}`}
-                </Text>
-              ) : null}
             </Text>
             <View style={styles.stackMeta}>
               <View style={styles.stackMetaIcon}>{renderSubtitleLeadingVisual()}</View>
-              <View style={[styles.stackTypeDot, { backgroundColor: contentColor }]} />
-              <Text style={[styles.stackSource, { color: colors.textSecondary }]} numberOfLines={1}>
-                {item.creator}
-              </Text>
+              <View style={styles.stackMetaTextGroup}>
+                <View style={styles.stackMetaCreatorContainer}>
+                  <Text
+                    style={[
+                      styles.stackSource,
+                      styles.stackMetaCreator,
+                      { color: colors.textSubheader },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {item.creator}
+                  </Text>
+                </View>
+                {inlineLengthText ? (
+                  <>
+                    <View
+                      style={[styles.stackTypeDot, { backgroundColor: colors.textSubheader }]}
+                    />
+                    <Text
+                      style={[
+                        styles.stackSource,
+                        styles.stackMetaLength,
+                        { color: colors.textSubheader },
+                      ]}
+                      numberOfLines={1}
+                    >
+                      {inlineLengthText}
+                    </Text>
+                  </>
+                ) : null}
+              </View>
             </View>
           </View>
         </Pressable>
@@ -308,41 +304,38 @@ export function ItemCard({
         </View>
 
         <View style={styles.rowCompactContent}>
-          {inlineLengthText ? (
-            <View style={styles.inlineTitleMeasurement} pointerEvents="none" accessible={false}>
-              <Text
-                style={[styles.rowCompactTitle, { color: colors.text }]}
-                onTextLayout={(event) => {
-                  const fitsOnOneLine = event.nativeEvent.lines.length <= 1;
-                  setShowInlineTitleLength((current) =>
-                    current === fitsOnOneLine ? current : fitsOnOneLine
-                  );
-                }}
-              >
-                {item.title}
-                <Text style={[styles.inlineTitleLength, { color: colors.textSecondary }]}>
-                  {` · ${inlineLengthText}`}
-                </Text>
-              </Text>
-            </View>
-          ) : null}
           <Text style={[styles.rowCompactTitle, { color: colors.text }]} numberOfLines={1}>
             {item.title}
-            {showInlineTitleLength && inlineLengthText ? (
-              <Text style={[styles.inlineTitleLength, { color: colors.textSecondary }]}>
-                {` · ${inlineLengthText}`}
-              </Text>
-            ) : null}
           </Text>
           <View style={styles.rowCompactMeta}>
             <View style={styles.rowCompactMetaIcon}>{renderSubtitleLeadingVisual()}</View>
-            <View style={[styles.rowCompactMetaDot, { backgroundColor: contentColor }]} />
             <Text
-              style={[styles.rowCompactMetaText, { color: colors.textSecondary }]}
+              style={[
+                styles.rowCompactMetaText,
+                styles.rowCompactMetaCreator,
+                { color: colors.textSubheader },
+              ]}
               numberOfLines={1}
             >
               {item.creator}
             </Text>
+            {inlineLengthText ? (
+              <>
+                <View
+                  style={[styles.rowCompactMetaDot, { backgroundColor: colors.textSubheader }]}
+                />
+                <Text
+                  style={[
+                    styles.rowCompactMetaText,
+                    styles.rowCompactMetaLength,
+                    { color: colors.textSubheader },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {inlineLengthText}
+                </Text>
+              </>
+            ) : null}
           </View>
         </View>
       </Pressable>
@@ -387,6 +380,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.xs,
+    minWidth: 0,
   },
   rowCompactMetaIcon: {
     width: IconSizes.xs,
@@ -395,9 +389,9 @@ const styles = StyleSheet.create({
     flexShrink: 0,
   },
   rowCompactMetaDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
+    width: 4,
+    height: 4,
+    borderRadius: 2,
     flexShrink: 0,
   },
   subtitleAvatar: {
@@ -407,7 +401,13 @@ const styles = StyleSheet.create({
   },
   rowCompactMetaText: {
     ...Typography.bodySmall,
-    flex: 1,
+  },
+  rowCompactMetaCreator: {
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  rowCompactMetaLength: {
+    flexShrink: 0,
   },
 
   rowFeaturedCard: {
@@ -468,18 +468,11 @@ const styles = StyleSheet.create({
     minHeight: STACK_TITLE_HEIGHT,
     marginBottom: Spacing.xs,
   },
-  inlineTitleLength: {
-    ...Typography.bodySmall,
-  },
-  inlineTitleMeasurement: {
-    height: 0,
-    opacity: 0,
-    overflow: 'hidden',
-  },
   stackMeta: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.xs,
+    minWidth: 0,
   },
   stackMetaIcon: {
     width: IconSizes.xs,
@@ -487,15 +480,32 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flexShrink: 0,
   },
+  stackMetaTextGroup: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
   stackTypeDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
+    width: 4,
+    height: 4,
+    borderRadius: 2,
     flexShrink: 0,
   },
   stackSource: {
     ...Typography.bodySmall,
-    flex: 1,
+  },
+  stackMetaCreatorContainer: {
+    flexShrink: 1,
+    maxWidth: '70%',
+    minWidth: 0,
+  },
+  stackMetaCreator: {
+    minWidth: 0,
+  },
+  stackMetaLength: {
+    flexShrink: 0,
   },
 
   coverCard: {

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -203,7 +203,12 @@ export function ItemCard({
             <View style={styles.stackMeta}>
               <View style={styles.stackMetaIcon}>{renderSubtitleLeadingVisual()}</View>
               <View style={styles.stackMetaTextGroup}>
-                <View style={styles.stackMetaCreatorContainer}>
+                <View
+                  style={[
+                    styles.stackMetaCreatorContainer,
+                    inlineLengthText ? styles.stackMetaCreatorContainerWithLength : null,
+                  ]}
+                >
                   <Text
                     style={[
                       styles.stackSource,
@@ -498,8 +503,10 @@ const styles = StyleSheet.create({
   },
   stackMetaCreatorContainer: {
     flexShrink: 1,
-    maxWidth: '70%',
     minWidth: 0,
+  },
+  stackMetaCreatorContainerWithLength: {
+    maxWidth: '70%',
   },
   stackMetaCreator: {
     minWidth: 0,

--- a/apps/mobile/components/list-states.tsx
+++ b/apps/mobile/components/list-states.tsx
@@ -33,7 +33,7 @@ export function LoadingState({ message }: LoadingStateProps) {
     <View style={styles.container}>
       <ActivityIndicator size="large" color={colors.primary} />
       {message ? (
-        <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+        <Text variant="bodyMedium" tone="subheader" style={styles.message}>
           {message}
         </Text>
       ) : null}
@@ -86,7 +86,7 @@ export function ErrorState({
         {title}
       </Text>
       {message ? (
-        <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+        <Text variant="bodyMedium" tone="subheader" style={styles.message}>
           {message}
         </Text>
       ) : null}
@@ -144,7 +144,7 @@ export function EmptyState({
         {title}
       </Text>
       {message ? (
-        <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+        <Text variant="bodyMedium" tone="subheader" style={styles.message}>
           {message}
         </Text>
       ) : null}
@@ -199,7 +199,7 @@ export function NotFoundState({
         {title}
       </Text>
       {message ? (
-        <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+        <Text variant="bodyMedium" tone="subheader" style={styles.message}>
           {message}
         </Text>
       ) : null}
@@ -246,7 +246,7 @@ export function InvalidParamState({
       <Text variant="titleMedium" style={styles.title}>
         {title}
       </Text>
-      <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+      <Text variant="bodyMedium" tone="subheader" style={styles.message}>
         {message}
       </Text>
       <Button label={backLabel} onPress={handleBack} />

--- a/apps/mobile/components/oauth-error-boundary.tsx
+++ b/apps/mobile/components/oauth-error-boundary.tsx
@@ -58,7 +58,7 @@ function OAuthErrorFallback({ provider, error, onRetry }: OAuthErrorFallbackProp
       <Text variant="titleMedium" style={styles.title}>
         {display.title}
       </Text>
-      <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+      <Text variant="bodyMedium" tone="subheader" style={styles.message}>
         {display.description}
       </Text>
       {error.recoverable && onRetry ? <Button label={buttonText} onPress={onRetry} /> : null}

--- a/apps/mobile/components/primitives/text.stories.tsx
+++ b/apps/mobile/components/primitives/text.stories.tsx
@@ -44,6 +44,7 @@ const variants = [
 
 const tones = [
   'primary',
+  'subheader',
   'secondary',
   'tertiary',
   'accent',

--- a/apps/mobile/components/primitives/text.tsx
+++ b/apps/mobile/components/primitives/text.tsx
@@ -14,6 +14,7 @@ export type TextVariant = keyof typeof Typography;
 
 export type TextTone =
   | 'primary'
+  | 'subheader'
   | 'secondary'
   | 'tertiary'
   | 'inverse'
@@ -45,6 +46,8 @@ export interface TextProps extends RNTextProps {
 
 function getToneColor(colors: ThemeColors, tone: TextTone): string {
   switch (tone) {
+    case 'subheader':
+      return colors.textSubheader;
     case 'secondary':
       return colors.textSecondary;
     case 'tertiary':

--- a/apps/mobile/components/query-error-boundary.tsx
+++ b/apps/mobile/components/query-error-boundary.tsx
@@ -80,7 +80,7 @@ export function QueryErrorBoundary({
         <Text variant="titleMedium" style={styles.title}>
           {isNetwork ? 'Connection Problem' : 'Something went wrong'}
         </Text>
-        <Text variant="bodyMedium" tone="secondary" style={styles.message}>
+        <Text variant="bodyMedium" tone="subheader" style={styles.message}>
           {errorMessage}
         </Text>
         <Button label={isNetwork ? 'Retry' : 'Try Again'} onPress={handleReset} />

--- a/apps/mobile/components/storybook/foundations-tokens.stories.tsx
+++ b/apps/mobile/components/storybook/foundations-tokens.stories.tsx
@@ -39,9 +39,14 @@ const colorSections: ColorSection[] = [
         note: 'Default reading copy and high-emphasis labels.',
       },
       {
+        name: 'textSubheader',
+        value: Colors.dark.textSubheader,
+        note: 'Readable subheaders, metadata rows, and supporting descriptions.',
+      },
+      {
         name: 'textSecondary',
         value: Colors.dark.textSecondary,
-        note: 'Metadata, supporting labels, and secondary actions.',
+        note: 'Secondary actions, disabled labels, and neutral control text.',
       },
       {
         name: 'textTertiary',

--- a/apps/mobile/components/subscriptions/channel-item.tsx
+++ b/apps/mobile/components/subscriptions/channel-item.tsx
@@ -146,7 +146,7 @@ function ChannelItemComponent({
           <Text style={styles.name} colors={colors} numberOfLines={1}>
             {channel.name}
           </Text>
-          <Text style={styles.description} colors={colors} tone="secondary" numberOfLines={1}>
+          <Text style={styles.description} colors={colors} tone="subheader" numberOfLines={1}>
             {channel.description || getProviderDescription(provider)}
           </Text>
         </View>
@@ -178,7 +178,7 @@ function ChannelItemComponent({
           {channel.name}
         </Text>
         {channel.description && (
-          <Text style={styles.description} colors={colors} tone="secondary" numberOfLines={2}>
+          <Text style={styles.description} colors={colors} tone="subheader" numberOfLines={2}>
             {channel.description}
           </Text>
         )}

--- a/apps/mobile/components/subscriptions/channel-selection-list.tsx
+++ b/apps/mobile/components/subscriptions/channel-selection-list.tsx
@@ -239,7 +239,7 @@ export function ChannelSelectionList({
       {/* Select All / Deselect All (multi-select mode only) */}
       {mode === 'multi' && channels.length > 0 && (
         <View style={styles.selectionActions}>
-          <Text style={styles.selectionCount} tone="secondary">
+          <Text style={styles.selectionCount} tone="subheader">
             {selectedCount} of {totalCount} selected
           </Text>
           <Pressable onPress={allSelected ? deselectAll : selectAll}>

--- a/apps/mobile/constants/theme.ts
+++ b/apps/mobile/constants/theme.ts
@@ -72,6 +72,7 @@ export const Colors = {
   light: {
     // Core - Light theme (kept for compatibility, but app uses dark only)
     text: '#0F172A',
+    textSubheader: 'rgba(15, 23, 42, 0.72)',
     textSecondary: '#64748B',
     textTertiary: '#94A3B8',
     textPrimary: '#0F172A',
@@ -139,6 +140,7 @@ export const Colors = {
   dark: {
     // Core - Pure black background
     text: '#FFFFFF',
+    textSubheader: 'rgba(255, 255, 255, 0.82)',
     textSecondary: '#A0A0A0',
     textTertiary: '#6A6A6A',
     textPrimary: '#FFFFFF',

--- a/apps/mobile/lib/connection-status.test.ts
+++ b/apps/mobile/lib/connection-status.test.ts
@@ -26,7 +26,7 @@ describe('getStatusDisplay', () => {
 
       expect(result.dotColor).toBe(colors.success);
       expect(result.text).toBe('Connected');
-      expect(result.textColor).toBe(colors.textSecondary);
+      expect(result.textColor).toBe(colors.textSubheader);
       expect(result.showCount).toBe(true);
     });
 
@@ -156,7 +156,7 @@ describe('getStatusDisplay', () => {
       const result = getStatusDisplay('ACTIVE', lightColors);
 
       expect(result.dotColor).toBe(lightColors.success);
-      expect(result.textColor).toBe(lightColors.textSecondary);
+      expect(result.textColor).toBe(lightColors.textSubheader);
     });
 
     it('uses theme colors consistently across all statuses', () => {
@@ -168,7 +168,7 @@ describe('getStatusDisplay', () => {
 
         // All colors should be hex strings
         expect(result.dotColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
-        expect(result.textColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        expect(result.textColor).toMatch(/^(#[0-9A-Fa-f]{6}|rgba?\(.+\))$/);
       }
     });
   });

--- a/apps/mobile/lib/connection-status.ts
+++ b/apps/mobile/lib/connection-status.ts
@@ -59,7 +59,7 @@ export function getStatusDisplay(
       return {
         dotColor: colors.success,
         text: 'Connected',
-        textColor: colors.textSecondary,
+        textColor: colors.textSubheader,
         showCount: true,
       };
     case 'EXPIRED':

--- a/apps/mobile/lib/item-card-compact-metadata.test.ts
+++ b/apps/mobile/lib/item-card-compact-metadata.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for ItemCard compact row text treatment.
+ * Tests for ItemCard compact row metadata treatment.
  *
  * The ItemCard component uses react-native components that require native modules.
  * Full component rendering tests are done via manual testing in the iOS simulator.
  *
- * This test file validates the metadata and inline-length logic mirrored from the
+ * This test file validates the metadata and length-label logic mirrored from the
  * compact row implementation without importing the actual component.
  */
 
@@ -56,7 +56,13 @@ function getInlineLengthText(item: ItemCardData): string | null {
 }
 
 function buildCompactSubtitleText(item: ItemCardData): string {
-  return item.creator;
+  const inlineLengthText = getInlineLengthText(item);
+
+  if (!inlineLengthText) {
+    return item.creator;
+  }
+
+  return `${item.creator} · ${inlineLengthText}`;
 }
 
 function getSubtitleLeadingVisualMode(
@@ -67,7 +73,7 @@ function getSubtitleLeadingVisualMode(
 }
 
 describe('ItemCard compact row text treatment', () => {
-  describe('inline title length', () => {
+  describe('compact metadata length', () => {
     it('uses duration when available for video items', () => {
       const item = createMockItem({
         contentType: 'VIDEO' as ContentType,
@@ -117,8 +123,12 @@ describe('ItemCard compact row text treatment', () => {
   });
 
   describe('subtitle text', () => {
-    it('uses creator name only', () => {
-      const item = createMockItem({ creator: 'John Doe' });
+    it('uses creator name only when no duration or reading time exists', () => {
+      const item = createMockItem({
+        creator: 'John Doe',
+        duration: null,
+        readingTimeMinutes: null,
+      });
 
       expect(buildCompactSubtitleText(item)).toBe('John Doe');
     });
@@ -127,6 +137,8 @@ describe('ItemCard compact row text treatment', () => {
       const item = createMockItem({
         creator: 'John Doe',
         contentType: 'VIDEO' as ContentType,
+        duration: null,
+        readingTimeMinutes: null,
       });
 
       const subtitle = buildCompactSubtitleText(item);
@@ -134,15 +146,25 @@ describe('ItemCard compact row text treatment', () => {
       expect(subtitle).not.toContain('Video');
     });
 
-    it('does not append duration to subtitle text', () => {
+    it('appends duration to subtitle text', () => {
       const item = createMockItem({
         creator: 'John Doe',
         duration: 300,
       });
 
       const subtitle = buildCompactSubtitleText(item);
-      expect(subtitle).toBe('John Doe');
-      expect(subtitle).not.toContain('5:00');
+      expect(subtitle).toBe('John Doe · 5:00');
+    });
+
+    it('appends reading time to subtitle text when duration is missing', () => {
+      const item = createMockItem({
+        creator: 'John Doe',
+        duration: null,
+        readingTimeMinutes: 5,
+      });
+
+      const subtitle = buildCompactSubtitleText(item);
+      expect(subtitle).toBe('John Doe · 5 min');
     });
   });
 
@@ -196,7 +218,7 @@ describe('ItemCard compact row text treatment', () => {
     });
 
     it('subtitle separator dot dimensions meet minimum visibility', () => {
-      const SEPARATOR_DOT_SIZE = 6;
+      const SEPARATOR_DOT_SIZE = 4;
       const MIN_VISIBLE_SIZE = 4;
 
       expect(SEPARATOR_DOT_SIZE).toBeGreaterThanOrEqual(MIN_VISIBLE_SIZE);

--- a/apps/mobile/lib/item-card-compact-metadata.test.ts
+++ b/apps/mobile/lib/item-card-compact-metadata.test.ts
@@ -5,12 +5,13 @@
  * Full component rendering tests are done via manual testing in the iOS simulator.
  *
  * This test file validates the metadata and length-label logic mirrored from the
- * compact row implementation without importing the actual component.
+ * compact and stack row implementations without importing the actual component.
  */
 
 import { IconSizes } from '../constants/theme';
 import type { ItemCardData } from '../components/item-card';
 import type { ContentType, Provider } from '../lib/content-utils';
+import { formatDuration } from '../lib/format';
 
 function createMockItem(overrides: Partial<ItemCardData> = {}): ItemCardData {
   return {
@@ -28,21 +29,8 @@ function createMockItem(overrides: Partial<ItemCardData> = {}): ItemCardData {
   };
 }
 
-function formatDuration(seconds: number | null | undefined): string | null {
-  if (!seconds) return null;
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
-
-  if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
-  }
-
-  return `${minutes}:${secs.toString().padStart(2, '0')}`;
-}
-
 function getInlineLengthText(item: ItemCardData): string | null {
-  const durationText = formatDuration(item.duration);
+  const durationText = formatDuration(item.duration) || null;
 
   if (durationText) {
     return durationText;
@@ -65,6 +53,10 @@ function buildCompactSubtitleText(item: ItemCardData): string {
   return `${item.creator} · ${inlineLengthText}`;
 }
 
+function getStackCreatorMaxWidth(item: ItemCardData): string | null {
+  return getInlineLengthText(item) ? '70%' : null;
+}
+
 function getSubtitleLeadingVisualMode(
   item: ItemCardData,
   avatarLoadFailed = false
@@ -80,7 +72,7 @@ describe('ItemCard compact row text treatment', () => {
         duration: 300,
       });
 
-      expect(getInlineLengthText(item)).toBe('5:00');
+      expect(getInlineLengthText(item)).toBe('5m');
     });
 
     it('uses duration when available for podcast items', () => {
@@ -89,7 +81,7 @@ describe('ItemCard compact row text treatment', () => {
         duration: 3600,
       });
 
-      expect(getInlineLengthText(item)).toBe('1:00:00');
+      expect(getInlineLengthText(item)).toBe('1h 0m');
     });
 
     it('uses reading time when no duration exists', () => {
@@ -109,7 +101,18 @@ describe('ItemCard compact row text treatment', () => {
         readingTimeMinutes: 10,
       });
 
-      expect(getInlineLengthText(item)).toBe('5:00');
+      expect(getInlineLengthText(item)).toBe('5m');
+    });
+
+    it('falls back to reading time when the shared formatter returns an empty duration string', () => {
+      const item = createMockItem({
+        contentType: 'ARTICLE' as ContentType,
+        duration: null,
+        readingTimeMinutes: 7,
+      });
+
+      expect(formatDuration(item.duration)).toBe('');
+      expect(getInlineLengthText(item)).toBe('7 min');
     });
 
     it('returns null when no applicable length exists', () => {
@@ -153,7 +156,7 @@ describe('ItemCard compact row text treatment', () => {
       });
 
       const subtitle = buildCompactSubtitleText(item);
-      expect(subtitle).toBe('John Doe · 5:00');
+      expect(subtitle).toBe('John Doe · 5m');
     });
 
     it('appends reading time to subtitle text when duration is missing', () => {
@@ -195,6 +198,25 @@ describe('ItemCard compact row text treatment', () => {
   });
 
   describe('layout constraints', () => {
+    it('stack cards do not reserve creator width when no length label exists', () => {
+      const item = createMockItem({
+        creator: 'Long Creator Name',
+        duration: null,
+        readingTimeMinutes: null,
+      });
+
+      expect(getStackCreatorMaxWidth(item)).toBeNull();
+    });
+
+    it('stack cards reserve creator width when a length label exists', () => {
+      const item = createMockItem({
+        creator: 'Long Creator Name',
+        duration: 300,
+      });
+
+      expect(getStackCreatorMaxWidth(item)).toBe('70%');
+    });
+
     it('title truncation is set to single line', () => {
       const TITLE_LINES = 1;
 

--- a/docs/mobile/design-system/foundations.md
+++ b/docs/mobile/design-system/foundations.md
@@ -23,6 +23,7 @@ Use `Colors[scheme]` and semantic tokens before literal color values.
 Core dark tokens:
 
 - `text`
+- `textSubheader`
 - `textSecondary`
 - `textTertiary`
 - `background`
@@ -39,7 +40,7 @@ Core dark tokens:
 
 Semantic aliases for new shared component work:
 
-- Text: `textPrimary`, `textSecondary`, `textTertiary`, `textInverse`
+- Text: `textPrimary`, `textSubheader`, `textSecondary`, `textTertiary`, `textInverse`
 - Surface: `surfaceCanvas`, `surfaceSubtle`, `surfaceElevated`, `surfaceRaised`
 - Accent: `accent`, `accentMuted`, `accentForeground`
 - Border: `borderDefault`, `borderSubtle`


### PR DESCRIPTION
## Summary
- introduce a brighter `textSubheader` token and apply it across subheader/supporting-copy surfaces
- update `ItemCard` metadata treatment so creator, duration, and reading time render consistently in compact and stack layouts
- brighten unselected filter chips and align Home screen subtitle usage with the new token

## Verification
- bun run format:check
- bun run lint
- bun run design-system:check
- bun run typecheck
- bun run test
- bun run build
- manual iOS simulator verification in Expo Go