### PR TITLE
Fall back to creator images in item cards

### DIFF
--- a/apps/mobile/components/item-card.stories.tsx
+++ b/apps/mobile/components/item-card.stories.tsx
@@ -88,6 +88,31 @@ export const Cover: Story = {
   },
 };
 
+export const CreatorImageFallback: Story = {
+  render: function Render() {
+    const { width } = useWindowDimensions();
+    const featuredGridItemWidth = getFeaturedGridItemWidth(width - Spacing.md * 2, Spacing.md);
+
+    return (
+      <ScrollView contentContainerStyle={styles.stack} showsVerticalScrollIndicator={false}>
+        <ItemCard item={itemCardFixtures.creatorFallback} shape="row" onPress={() => {}} />
+        <View style={styles.featuredGrid}>
+          <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
+            <ItemCard
+              item={itemCardFixtures.creatorFallback}
+              shape="row"
+              rowStyle="featured"
+              onPress={() => {}}
+            />
+          </View>
+        </View>
+        <ItemCard item={itemCardFixtures.creatorFallback} shape="stack" onPress={() => {}} />
+        <ItemCard item={itemCardFixtures.creatorFallback} shape="cover" onPress={() => {}} />
+      </ScrollView>
+    );
+  },
+};
+
 export const ContentStress: Story = {
   render: function Render() {
     const { width } = useWindowDimensions();

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -17,13 +17,8 @@ import { Typography, Spacing, Radius, IconSizes } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
 import { usePrefetchItemDetail } from '@/hooks/use-prefetch';
 import { formatDuration } from '@/lib/format';
-import {
-  getContentIcon,
-  upgradeSpotifyImageUrl,
-  upgradeYouTubeImageUrl,
-  type ContentType,
-  type Provider,
-} from '@/lib/content-utils';
+import { getItemCardImageCandidates, normalizeItemCardImageUrl } from '@/lib/item-card-image';
+import { getContentIcon, type ContentType, type Provider } from '@/lib/content-utils';
 
 const STACK_IMAGE_HEIGHT = 112;
 const STACK_TITLE_HEIGHT = Typography.bodyMedium.lineHeight;
@@ -94,18 +89,32 @@ export function ItemCard({
   const { colors, motion } = useAppTheme();
   const prefetchItemDetail = usePrefetchItemDetail();
   const mediaTransition = motion.duration.normal;
+  const thumbnailImageUrl = normalizeItemCardImageUrl(item.thumbnailUrl);
+  const creatorImageUrl = normalizeItemCardImageUrl(item.creatorImageUrl);
+  const mediaImageCandidates = getItemCardImageCandidates({
+    thumbnailUrl: thumbnailImageUrl,
+    creatorImageUrl,
+  });
+  const [mediaImageCandidateIndex, setMediaImageCandidateIndex] = useState(0);
   const [subtitleAvatarFailed, setSubtitleAvatarFailed] = useState(false);
 
   const durationText = formatDuration(item.duration) || null;
   const readingTimeText =
     item.readingTimeMinutes && !item.duration ? `${item.readingTimeMinutes} min` : null;
   const inlineLengthText = durationText ?? readingTimeText;
-  const creatorImageUrl =
-    upgradeSpotifyImageUrl(upgradeYouTubeImageUrl(item.creatorImageUrl ?? null)) ?? null;
+  const mediaImageUrl = mediaImageCandidates[mediaImageCandidateIndex] ?? null;
+
+  useEffect(() => {
+    setMediaImageCandidateIndex(0);
+  }, [item.id, thumbnailImageUrl, creatorImageUrl]);
 
   useEffect(() => {
     setSubtitleAvatarFailed(false);
   }, [item.id, creatorImageUrl]);
+
+  const handleMediaImageError = () => {
+    setMediaImageCandidateIndex((currentIndex) => currentIndex + 1);
+  };
 
   const renderSubtitleLeadingVisual = () => {
     if (creatorImageUrl && !subtitleAvatarFailed) {
@@ -140,12 +149,13 @@ export function ItemCard({
           onPress={handlePress}
           style={({ pressed }) => [styles.coverCard, pressed && { opacity: 0.95 }]}
         >
-          {item.thumbnailUrl ? (
+          {mediaImageUrl ? (
             <Image
-              source={{ uri: item.thumbnailUrl }}
+              source={{ uri: mediaImageUrl }}
               style={styles.coverImage}
               contentFit="cover"
               transition={mediaTransition}
+              onError={handleMediaImageError}
             />
           ) : (
             <View style={[styles.coverImage, { backgroundColor: colors.surfaceRaised }]} />
@@ -183,17 +193,16 @@ export function ItemCard({
             pressed && { opacity: 0.7 },
           ]}
         >
-          {item.thumbnailUrl ? (
+          {mediaImageUrl ? (
             <Image
-              source={{ uri: item.thumbnailUrl }}
+              source={{ uri: mediaImageUrl }}
               style={styles.stackImage}
               contentFit="cover"
               transition={mediaTransition}
+              onError={handleMediaImageError}
             />
           ) : (
-            <View style={[styles.stackImage, { backgroundColor: colors.surfaceRaised }]}>
-              {getContentIcon(item.contentType, 32, colors.textTertiary)}
-            </View>
+            <View style={[styles.stackImage, { backgroundColor: colors.surfaceRaised }]} />
           )}
 
           <View style={styles.stackContent}>
@@ -264,16 +273,15 @@ export function ItemCard({
               { backgroundColor: colors.surfaceRaised },
             ]}
           >
-            {item.thumbnailUrl ? (
+            {mediaImageUrl ? (
               <Image
-                source={{ uri: item.thumbnailUrl }}
+                source={{ uri: mediaImageUrl }}
                 style={styles.rowFeaturedThumbnailImage}
                 contentFit="cover"
                 transition={mediaTransition}
+                onError={handleMediaImageError}
               />
-            ) : (
-              getContentIcon(item.contentType, 20, colors.textTertiary)
-            )}
+            ) : null}
           </View>
           <View style={styles.rowFeaturedContent}>
             <Text style={[styles.rowFeaturedTitle, { color: colors.text }]} numberOfLines={2}>
@@ -292,19 +300,18 @@ export function ItemCard({
         style={({ pressed }) => [styles.rowCompactCard, pressed && { opacity: 0.7 }]}
       >
         <View style={styles.rowCompactThumbnailContainer}>
-          {item.thumbnailUrl ? (
+          {mediaImageUrl ? (
             <Image
-              source={{ uri: item.thumbnailUrl }}
+              source={{ uri: mediaImageUrl }}
               style={styles.rowCompactThumbnailImage}
               contentFit="cover"
               transition={mediaTransition}
+              onError={handleMediaImageError}
             />
           ) : (
             <View
               style={[styles.rowCompactThumbnailImage, { backgroundColor: colors.surfaceRaised }]}
-            >
-              {getContentIcon(item.contentType, 20, colors.textTertiary)}
-            </View>
+            />
           )}
         </View>
 

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -89,11 +89,10 @@ export function ItemCard({
   const { colors, motion } = useAppTheme();
   const prefetchItemDetail = usePrefetchItemDetail();
   const mediaTransition = motion.duration.normal;
-  const thumbnailImageUrl = normalizeItemCardImageUrl(item.thumbnailUrl);
   const creatorImageUrl = normalizeItemCardImageUrl(item.creatorImageUrl);
   const mediaImageCandidates = getItemCardImageCandidates({
-    thumbnailUrl: thumbnailImageUrl,
-    creatorImageUrl,
+    thumbnailUrl: item.thumbnailUrl,
+    creatorImageUrl: item.creatorImageUrl,
   });
   const [mediaImageCandidateIndex, setMediaImageCandidateIndex] = useState(0);
   const [subtitleAvatarFailed, setSubtitleAvatarFailed] = useState(false);
@@ -106,14 +105,20 @@ export function ItemCard({
 
   useEffect(() => {
     setMediaImageCandidateIndex(0);
-  }, [item.id, thumbnailImageUrl, creatorImageUrl]);
+  }, [item.id, item.thumbnailUrl, creatorImageUrl]);
 
   useEffect(() => {
     setSubtitleAvatarFailed(false);
   }, [item.id, creatorImageUrl]);
 
   const handleMediaImageError = () => {
-    setMediaImageCandidateIndex((currentIndex) => currentIndex + 1);
+    if (mediaImageUrl === creatorImageUrl) {
+      setSubtitleAvatarFailed(true);
+    }
+
+    setMediaImageCandidateIndex((currentIndex) =>
+      Math.min(currentIndex + 1, mediaImageCandidates.length)
+    );
   };
 
   const renderSubtitleLeadingVisual = () => {

--- a/apps/mobile/components/storybook/fixtures/item-card.ts
+++ b/apps/mobile/components/storybook/fixtures/item-card.ts
@@ -31,6 +31,16 @@ export const itemCardFixtures = {
     provider: 'SUBSTACK',
     readingTimeMinutes: 11,
   },
+  creatorFallback: {
+    id: 'creator-fallback-1',
+    title: 'Missing cover art should fall back to the creator image',
+    creator: 'Fallback Media Weekly',
+    creatorImageUrl: 'https://picsum.photos/seed/zine-creator-fallback/640/640',
+    thumbnailUrl: null,
+    contentType: 'PODCAST',
+    provider: 'SPOTIFY',
+    duration: 1560,
+  },
   stress: {
     id: 'stress-1',
     title:

--- a/apps/mobile/lib/item-card-image.test.ts
+++ b/apps/mobile/lib/item-card-image.test.ts
@@ -1,0 +1,61 @@
+import { getItemCardImageCandidates, normalizeItemCardImageUrl } from './item-card-image';
+
+jest.mock('@/components/icons', () => ({
+  HeadphonesIcon: 'HeadphonesIcon',
+  VideoIcon: 'VideoIcon',
+  ArticleIcon: 'ArticleIcon',
+  PostIcon: 'PostIcon',
+}));
+
+describe('item card image selection', () => {
+  describe('normalizeItemCardImageUrl', () => {
+    it('upgrades YouTube image sizes', () => {
+      expect(normalizeItemCardImageUrl('https://yt3.ggpht.com/ytc/abc123=s88-c-k')).toBe(
+        'https://yt3.ggpht.com/ytc/abc123=s800-c-k'
+      );
+    });
+
+    it('returns null for empty values', () => {
+      expect(normalizeItemCardImageUrl(null)).toBeNull();
+      expect(normalizeItemCardImageUrl(undefined)).toBeNull();
+    });
+  });
+
+  describe('getItemCardImageCandidates', () => {
+    it('prefers the cover image before the creator image', () => {
+      expect(
+        getItemCardImageCandidates({
+          thumbnailUrl: 'https://example.com/cover.jpg',
+          creatorImageUrl: 'https://example.com/creator.jpg',
+        })
+      ).toEqual(['https://example.com/cover.jpg', 'https://example.com/creator.jpg']);
+    });
+
+    it('falls back to the creator image when the cover image is missing', () => {
+      expect(
+        getItemCardImageCandidates({
+          thumbnailUrl: null,
+          creatorImageUrl: 'https://example.com/creator.jpg',
+        })
+      ).toEqual(['https://example.com/creator.jpg']);
+    });
+
+    it('returns no image candidates when neither image exists', () => {
+      expect(
+        getItemCardImageCandidates({
+          thumbnailUrl: null,
+          creatorImageUrl: null,
+        })
+      ).toEqual([]);
+    });
+
+    it('deduplicates identical cover and creator image urls', () => {
+      expect(
+        getItemCardImageCandidates({
+          thumbnailUrl: 'https://example.com/shared.jpg',
+          creatorImageUrl: 'https://example.com/shared.jpg',
+        })
+      ).toEqual(['https://example.com/shared.jpg']);
+    });
+  });
+});

--- a/apps/mobile/lib/item-card-image.test.ts
+++ b/apps/mobile/lib/item-card-image.test.ts
@@ -15,9 +15,16 @@ describe('item card image selection', () => {
       );
     });
 
+    it('trims surrounding whitespace before normalizing', () => {
+      expect(normalizeItemCardImageUrl('  https://example.com/image.jpg  ')).toBe(
+        'https://example.com/image.jpg'
+      );
+    });
+
     it('returns null for empty values', () => {
       expect(normalizeItemCardImageUrl(null)).toBeNull();
       expect(normalizeItemCardImageUrl(undefined)).toBeNull();
+      expect(normalizeItemCardImageUrl('   ')).toBeNull();
     });
   });
 
@@ -56,6 +63,15 @@ describe('item card image selection', () => {
           creatorImageUrl: 'https://example.com/shared.jpg',
         })
       ).toEqual(['https://example.com/shared.jpg']);
+    });
+
+    it('ignores blank image urls after trimming', () => {
+      expect(
+        getItemCardImageCandidates({
+          thumbnailUrl: '   ',
+          creatorImageUrl: ' https://example.com/creator.jpg ',
+        })
+      ).toEqual(['https://example.com/creator.jpg']);
     });
   });
 });

--- a/apps/mobile/lib/item-card-image.ts
+++ b/apps/mobile/lib/item-card-image.ts
@@ -6,17 +6,28 @@ export interface ItemCardImageSources {
 }
 
 export function normalizeItemCardImageUrl(url: string | null | undefined): string | null {
-  return upgradeSpotifyImageUrl(upgradeYouTubeImageUrl(url ?? null)) ?? null;
+  const trimmedUrl = url?.trim();
+
+  if (!trimmedUrl) {
+    return null;
+  }
+
+  return upgradeSpotifyImageUrl(upgradeYouTubeImageUrl(trimmedUrl)) ?? null;
 }
 
 export function getItemCardImageCandidates({
   thumbnailUrl,
   creatorImageUrl,
 }: ItemCardImageSources): string[] {
-  const candidates = [thumbnailUrl ?? null, creatorImageUrl ?? null];
+  const imageCandidates = new Set<string>();
 
-  return candidates.filter(
-    (url, index): url is string =>
-      typeof url === 'string' && url.length > 0 && candidates.indexOf(url) === index
-  );
+  for (const url of [thumbnailUrl, creatorImageUrl]) {
+    const normalizedUrl = normalizeItemCardImageUrl(url);
+
+    if (normalizedUrl) {
+      imageCandidates.add(normalizedUrl);
+    }
+  }
+
+  return [...imageCandidates];
 }

--- a/apps/mobile/lib/item-card-image.ts
+++ b/apps/mobile/lib/item-card-image.ts
@@ -1,0 +1,22 @@
+import { upgradeSpotifyImageUrl, upgradeYouTubeImageUrl } from './content-utils';
+
+export interface ItemCardImageSources {
+  thumbnailUrl?: string | null;
+  creatorImageUrl?: string | null;
+}
+
+export function normalizeItemCardImageUrl(url: string | null | undefined): string | null {
+  return upgradeSpotifyImageUrl(upgradeYouTubeImageUrl(url ?? null)) ?? null;
+}
+
+export function getItemCardImageCandidates({
+  thumbnailUrl,
+  creatorImageUrl,
+}: ItemCardImageSources): string[] {
+  const candidates = [thumbnailUrl ?? null, creatorImageUrl ?? null];
+
+  return candidates.filter(
+    (url, index): url is string =>
+      typeof url === 'string' && url.length > 0 && candidates.indexOf(url) === index
+  );
+}


### PR DESCRIPTION
## Summary
- fall back to the creator image when an item has no cover image, and render no image when neither exists
- harden item-card image candidate selection by trimming blank URLs and avoiding repeated retries of a failed creator image
- add Storybook coverage and focused tests for the new fallback behavior

## Testing
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- pre-push worker CI subset via git push hook