### PR TITLE
chore: harden observability CLI arg parsing

### DIFF
--- a/scripts/lib/observability.test.ts
+++ b/scripts/lib/observability.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   buildIncidentReport,
   filterDiagnosticRecords,
+  parseCommandArgs,
   redactDiagnosticValue,
   scanWorkerRuntimeConsoleUsage,
   summarizeDiagnosticRecords,
@@ -155,6 +156,27 @@ describe('buildIncidentReport', () => {
     expect(report.verdict).toBe('queue_dlq_backlog');
     expect(report.nextQueries).toContain('bun run diag:queue:dlq');
     expect(report.candidateFixes[0]?.action).toContain('Inspect DLQ message metadata');
+  });
+});
+
+describe('parseCommandArgs', () => {
+  it('parses equals assignments, repeated flags, and positional args', () => {
+    const parsed = parseCommandArgs([
+      '--since=2h',
+      '--provider',
+      'youtube',
+      '--provider=spotify',
+      '--verbose',
+      '--',
+      'incident-123',
+    ]);
+
+    expect(parsed).toEqual({
+      _: ['incident-123'],
+      since: '2h',
+      provider: ['youtube', 'spotify'],
+      verbose: true,
+    });
   });
 });
 

--- a/scripts/lib/observability.ts
+++ b/scripts/lib/observability.ts
@@ -621,22 +621,53 @@ export function parseCommandArgs(argv: string[]): Record<string, string | boolea
     _: [],
   };
 
+  const appendValue = (key: string, value: string | boolean): void => {
+    const existing = parsed[key];
+
+    if (existing === undefined) {
+      parsed[key] = value;
+      return;
+    }
+
+    if (Array.isArray(existing)) {
+      parsed[key] = [...existing, String(value)];
+      return;
+    }
+
+    parsed[key] = [String(existing), String(value)];
+  };
+
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
+    if (token === '--') {
+      (parsed._ as string[]).push(...argv.slice(index + 1));
+      break;
+    }
+
     if (!token.startsWith('--')) {
       (parsed._ as string[]).push(token);
       continue;
     }
 
-    const key = token.slice(2);
-    const next = argv[index + 1];
+    const assignment = token.slice(2);
+    const equalsIndex = assignment.indexOf('=');
 
-    if (!next || next.startsWith('--')) {
-      parsed[key] = true;
+    if (equalsIndex > -1) {
+      const key = assignment.slice(0, equalsIndex);
+      const value = assignment.slice(equalsIndex + 1);
+      appendValue(key, value);
       continue;
     }
 
-    parsed[key] = next;
+    const key = assignment;
+    const next = argv[index + 1];
+
+    if (!next || next.startsWith('--')) {
+      appendValue(key, true);
+      continue;
+    }
+
+    appendValue(key, next);
     index += 1;
   }
 


### PR DESCRIPTION
## Summary
- improve  to support  style flags
- support repeated flags by collecting values into arrays
- handle  sentinel so positional args can follow boolean flags safely
- add focused unit coverage for the new parser behavior

## Validation
- [0m[1mbun test [0m[2mv1.3.4 (5eb2145b)[0m
- 
- pre-push hook: 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-03-17/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts... (auto-ran on push)
