### PR TITLE
Add infinite scrolling for inbox and library items

### DIFF
--- a/apps/mobile/app/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(tabs)/inbox.tsx
@@ -1,8 +1,15 @@
 import { useNavigation, useRouter, type Href } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import { Surface, useToast } from 'heroui-native';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { View, Text, StyleSheet, Pressable, type ListRenderItemInfo } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  type ListRenderItemInfo,
+} from 'react-native';
 import Animated, { FadeOut, LinearTransition } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -15,7 +22,7 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useConnections, type Connection } from '@/hooks/use-connections';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import {
-  useInboxItems,
+  useInfiniteInboxItems,
   useArchiveItem,
   useBookmarkItem,
   mapContentType,
@@ -33,6 +40,7 @@ import type { ContentType, Provider } from '@/lib/content-utils';
 
 /** How long to wait before clearing reappeared state (ms) */
 const REENTRY_CLEANUP_DELAY = 500;
+const INBOX_PAGE_SIZE = 20;
 
 // =============================================================================
 // Custom Empty State for Inbox
@@ -71,7 +79,8 @@ export default function InboxScreen() {
 
   useTabPrefetch('inbox');
 
-  const { data, isLoading, error } = useInboxItems();
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteInboxItems({ limit: INBOX_PAGE_SIZE });
   const { data: connections } = useConnections();
   const hasReconnectRequiredConnection = (connections ?? []).some((connection: Connection) =>
     isReconnectRequired(connection.status)
@@ -199,20 +208,39 @@ export default function InboxScreen() {
   }, [lastResult, toast]);
 
   // Transform API response to ItemCardData format
-  const inboxItems: ItemCardData[] = (data?.items ?? []).map((item) => ({
-    id: item.id,
-    title: item.title,
-    creator: item.creator,
-    creatorImageUrl: item.creatorImageUrl ?? null,
-    thumbnailUrl: item.thumbnailUrl ?? null,
-    contentType: mapContentType(item.contentType) as ContentType,
-    provider: mapProvider(item.provider) as Provider,
-    duration: item.duration ?? null,
-    readingTimeMinutes: item.readingTimeMinutes ?? null,
-    bookmarkedAt: null,
-    publishedAt: item.publishedAt ?? null,
-    isFinished: item.isFinished,
-  }));
+  const inboxItems: ItemCardData[] = useMemo(
+    () =>
+      (data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        creator: item.creator,
+        creatorImageUrl: item.creatorImageUrl ?? null,
+        thumbnailUrl: item.thumbnailUrl ?? null,
+        contentType: mapContentType(item.contentType) as ContentType,
+        provider: mapProvider(item.provider) as Provider,
+        duration: item.duration ?? null,
+        readingTimeMinutes: item.readingTimeMinutes ?? null,
+        bookmarkedAt: null,
+        publishedAt: item.publishedAt ?? null,
+        isFinished: item.isFinished,
+      })),
+    [data?.pages]
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const inboxCountLabel =
+    inboxItems.length === 0
+      ? 'Decide what to keep'
+      : hasNextPage
+        ? `${inboxItems.length}+ items to triage`
+        : `${inboxItems.length} item${inboxItems.length === 1 ? '' : 's'} to triage`;
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
@@ -250,9 +278,7 @@ export default function InboxScreen() {
               </Animated.View>
             ) : (
               <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-                {inboxItems.length > 0
-                  ? `${inboxItems.length} item${inboxItems.length === 1 ? '' : 's'} to triage`
-                  : 'Decide what to keep'}
+                {inboxCountLabel}
               </Text>
             )}
           </View>
@@ -305,6 +331,15 @@ export default function InboxScreen() {
             refreshing={isSyncing}
             ListEmptyComponent={<InboxEmptyState colors={colors} />}
             itemLayoutAnimation={LinearTransition.springify().damping(15).stiffness(100)}
+            onEndReached={handleEndReached}
+            onEndReachedThreshold={0.6}
+            ListFooterComponent={
+              isFetchingNextPage ? (
+                <View style={styles.loadingFooter}>
+                  <ActivityIndicator size="small" color={colors.primary} />
+                </View>
+              ) : null
+            }
           />
         )}
       </SafeAreaView>
@@ -362,6 +397,10 @@ const styles = StyleSheet.create({
   // List
   listContent: {
     paddingBottom: Spacing['3xl'],
+  },
+  loadingFooter: {
+    paddingVertical: Spacing.lg,
+    alignItems: 'center',
   },
   emptyListContent: {
     flexGrow: 1,

--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -3,7 +3,17 @@ import { useState, useMemo, useCallback, useEffect, useRef, type ComponentType }
 import * as Haptics from 'expo-haptics';
 import { Surface } from 'heroui-native';
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { View, Text, ScrollView, StyleSheet, Pressable, TextInput } from 'react-native';
+import {
+  ActivityIndicator,
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  Pressable,
+  TextInput,
+  FlatList,
+  type ListRenderItemInfo,
+} from 'react-native';
 import Animated from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
@@ -28,7 +38,7 @@ import {
 } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
-import { useLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
+import { useInfiniteLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
 import type { ContentType as ApiContentType, UIContentType, Provider } from '@/lib/content-utils';
 
 // =============================================================================
@@ -58,6 +68,8 @@ function PlusIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: str
 // =============================================================================
 // Filter Options
 // =============================================================================
+
+const LIBRARY_PAGE_SIZE = 20;
 
 const filterOptions: {
   id: string;
@@ -114,7 +126,7 @@ const filterOptions: {
 export default function LibraryScreen() {
   const router = useRouter();
   const navigation = useNavigation();
-  const listScrollRef = useRef<ScrollView>(null);
+  const listScrollRef = useRef<FlatList<ItemCardData>>(null);
   const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -178,32 +190,59 @@ export default function LibraryScreen() {
   );
 
   // Fetch library items from tRPC with memoized filter
-  const { data, isLoading, error } = useLibraryItems({
-    filter,
-    search: debouncedSearchQuery || undefined,
-  });
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteLibraryItems({
+      filter,
+      search: debouncedSearchQuery || undefined,
+      limit: LIBRARY_PAGE_SIZE,
+    });
 
   // Transform API response to ItemCardData format
-  const libraryItems: ItemCardData[] = (data?.items ?? []).map((item) => ({
-    id: item.id,
-    title: item.title,
-    creator: item.creator,
-    creatorImageUrl: item.creatorImageUrl ?? null,
-    thumbnailUrl: item.thumbnailUrl ?? null,
-    contentType: mapContentType(item.contentType) as UIContentType,
-    provider: mapProvider(item.provider) as Provider,
-    duration: item.duration ?? null,
-    readingTimeMinutes: item.readingTimeMinutes ?? null,
-    bookmarkedAt: item.bookmarkedAt ?? null,
-    publishedAt: item.publishedAt ?? null,
-    isFinished: item.isFinished,
-  }));
+  const libraryItems: ItemCardData[] = useMemo(
+    () =>
+      (data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        creator: item.creator,
+        creatorImageUrl: item.creatorImageUrl ?? null,
+        thumbnailUrl: item.thumbnailUrl ?? null,
+        contentType: mapContentType(item.contentType) as UIContentType,
+        provider: mapProvider(item.provider) as Provider,
+        duration: item.duration ?? null,
+        readingTimeMinutes: item.readingTimeMinutes ?? null,
+        bookmarkedAt: item.bookmarkedAt ?? null,
+        publishedAt: item.publishedAt ?? null,
+        isFinished: item.isFinished,
+      })),
+    [data?.pages]
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
+      <ItemCard item={item} shape="row" index={index} />
+    ),
+    []
+  );
+
+  const libraryCountLabel = isLoading
+    ? 'Loading...'
+    : hasNextPage
+      ? `${libraryItems.length}+ saved items`
+      : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`;
 
   useEffect(() => {
     return navigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
 
-      listScrollRef.current?.scrollTo({ y: 0, animated: true });
+      listScrollRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
   }, [navigation]);
 
@@ -224,9 +263,7 @@ export default function LibraryScreen() {
             </Pressable>
           </View>
           <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-            {isLoading
-              ? 'Loading...'
-              : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`}
+            {libraryCountLabel}
           </Text>
         </View>
 
@@ -297,17 +334,24 @@ export default function LibraryScreen() {
             }
           />
         ) : (
-          <ScrollView
+          <FlatList
             ref={listScrollRef}
+            data={libraryItems}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
             style={styles.listContainer}
             contentContainerStyle={styles.listContent}
             showsVerticalScrollIndicator={false}
-          >
-            {libraryItems.map((item, index) => (
-              <ItemCard key={item.id} item={item} shape="row" index={index} />
-            ))}
-            <View style={styles.bottomSpacer} />
-          </ScrollView>
+            onEndReached={handleEndReached}
+            onEndReachedThreshold={0.6}
+            ListFooterComponent={
+              <View style={styles.listFooter}>
+                {isFetchingNextPage ? (
+                  <ActivityIndicator size="small" color={colors.primary} />
+                ) : null}
+              </View>
+            }
+          />
         )}
       </SafeAreaView>
     </Surface>
@@ -384,9 +428,9 @@ const styles = StyleSheet.create({
   listContent: {
     paddingBottom: Spacing['3xl'],
   },
-
-  // Bottom spacer
-  bottomSpacer: {
-    height: 40,
+  listFooter: {
+    minHeight: Spacing['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -13,7 +13,9 @@ import { ContentType, Provider, UserItemState } from '@zine/shared';
 // ============================================================================
 
 const mockInboxUseQuery = jest.fn();
+const mockInboxUseInfiniteQuery = jest.fn();
 const mockLibraryUseQuery = jest.fn();
+const mockLibraryUseInfiniteQuery = jest.fn();
 const mockHomeUseQuery = jest.fn();
 const mockToggleFinishedUseMutation = jest.fn();
 const mockUseUtils = jest.fn();
@@ -23,9 +25,11 @@ jest.mock('../lib/trpc', () => ({
     items: {
       inbox: {
         useQuery: mockInboxUseQuery,
+        useInfiniteQuery: mockInboxUseInfiniteQuery,
       },
       library: {
         useQuery: mockLibraryUseQuery,
+        useInfiniteQuery: mockLibraryUseInfiniteQuery,
       },
       home: {
         useQuery: mockHomeUseQuery,
@@ -42,7 +46,14 @@ jest.mock('../lib/trpc', () => ({
 // Test Setup
 // ============================================================================
 
-import { useInboxItems, useLibraryItems, useHomeData, useToggleFinished } from './use-items-trpc';
+import {
+  useInboxItems,
+  useInfiniteInboxItems,
+  useLibraryItems,
+  useInfiniteLibraryItems,
+  useHomeData,
+  useToggleFinished,
+} from './use-items-trpc';
 
 function createMockItem(overrides: Record<string, unknown> = {}) {
   return {
@@ -227,10 +238,26 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   });
+  mockInboxUseInfiniteQuery.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+  });
   mockLibraryUseQuery.mockReturnValue({
     data: null,
     isLoading: false,
     error: null,
+  });
+  mockLibraryUseInfiniteQuery.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
   });
   mockHomeUseQuery.mockReturnValue({
     data: null,
@@ -290,6 +317,40 @@ describe('useItems list queries', () => {
       undefined,
       expect.objectContaining({ placeholderData: expect.any(Function) })
     );
+  });
+
+  it('configures infinite inbox queries with cursor pagination', () => {
+    renderHook(() => useInfiniteInboxItems({ limit: 30 }));
+
+    expect(mockInboxUseInfiniteQuery).toHaveBeenCalledWith(
+      { limit: 30 },
+      expect.objectContaining({
+        getNextPageParam: expect.any(Function),
+        placeholderData: expect.any(Function),
+      })
+    );
+
+    const options = mockInboxUseInfiniteQuery.mock.calls[0][1];
+    expect(options.getNextPageParam({ nextCursor: 'cursor-123', items: [] })).toBe('cursor-123');
+  });
+
+  it('configures infinite library queries with trimmed search input', () => {
+    renderHook(() =>
+      useInfiniteLibraryItems({
+        search: '  all in  ',
+      })
+    );
+
+    expect(mockLibraryUseInfiniteQuery).toHaveBeenCalledWith(
+      { search: 'all in' },
+      expect.objectContaining({
+        getNextPageParam: expect.any(Function),
+        placeholderData: expect.any(Function),
+      })
+    );
+
+    const options = mockLibraryUseInfiniteQuery.mock.calls[0][1];
+    expect(options.getNextPageParam({ nextCursor: 'cursor-abc', items: [] })).toBe('cursor-abc');
   });
 });
 

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -33,6 +33,7 @@ type TrpcUtils = ReturnType<typeof trpc.useUtils>;
 
 /** Inbox/Library query data type */
 type ListQueryData = ReturnType<TrpcUtils['items']['inbox']['getData']>;
+type InfiniteListQueryData = ReturnType<TrpcUtils['items']['inbox']['getInfiniteData']>;
 
 /** Single item query data type */
 type ItemQueryData = ReturnType<TrpcUtils['items']['get']['getData']>;
@@ -44,7 +45,27 @@ type ListItem = NonNullable<ListQueryData>['items'][number];
 type OptimisticContext = {
   previousInbox?: ListQueryData;
   previousLibrary?: ListQueryData;
+  previousInfiniteInbox?: InfiniteListQueryData;
+  previousInfiniteLibrary?: InfiniteListQueryData;
   previousItem?: ItemQueryData;
+};
+
+type InboxItemsOptions = {
+  filter?: {
+    provider?: Provider;
+    contentType?: ContentType;
+  };
+  limit?: number;
+};
+
+type LibraryItemsOptions = {
+  filter?: {
+    provider?: Provider;
+    contentType?: ContentType;
+    isFinished?: boolean;
+  };
+  search?: string;
+  limit?: number;
 };
 
 // ============================================================================
@@ -91,6 +112,32 @@ function createOptimisticConfig<TInput extends { id: string }>(
     ) => NonNullable<ItemQueryData>;
   }
 ) {
+  const updateListData = (
+    old: ListQueryData,
+    updateItems: (items: ListItem[]) => ListItem[]
+  ): ListQueryData => {
+    if (!old) return old;
+    return {
+      ...old,
+      items: updateItems(old.items),
+    };
+  };
+
+  const updateInfiniteListData = (
+    old: InfiniteListQueryData | undefined,
+    updateItems: (items: ListItem[]) => ListItem[]
+  ) => {
+    if (!old) return old;
+
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        items: updateItems(page.items),
+      })),
+    };
+  };
+
   return {
     onMutate: async (input: TInput): Promise<OptimisticContext> => {
       // Cancel outgoing queries to prevent race conditions
@@ -105,23 +152,23 @@ function createOptimisticConfig<TInput extends { id: string }>(
 
       if (options.updateInbox) {
         context.previousInbox = utils.items.inbox.getData();
+        context.previousInfiniteInbox = utils.items.inbox.getInfiniteData();
         utils.items.inbox.setData(undefined, (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            items: options.updateInbox!(old.items, input),
-          };
+          return updateListData(old, (items) => options.updateInbox!(items, input));
+        });
+        utils.items.inbox.setInfiniteData(undefined, (old) => {
+          return updateInfiniteListData(old, (items) => options.updateInbox!(items, input));
         });
       }
 
       if (options.updateLibrary) {
         context.previousLibrary = utils.items.library.getData();
+        context.previousInfiniteLibrary = utils.items.library.getInfiniteData();
         utils.items.library.setData(undefined, (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            items: options.updateLibrary!(old.items, input),
-          };
+          return updateListData(old, (items) => options.updateLibrary!(items, input));
+        });
+        utils.items.library.setInfiniteData(undefined, (old) => {
+          return updateInfiniteListData(old, (items) => options.updateLibrary!(items, input));
         });
       }
 
@@ -140,8 +187,14 @@ function createOptimisticConfig<TInput extends { id: string }>(
       if (context?.previousInbox) {
         utils.items.inbox.setData(undefined, context.previousInbox);
       }
+      if (context?.previousInfiniteInbox) {
+        utils.items.inbox.setInfiniteData(undefined, context.previousInfiniteInbox);
+      }
       if (context?.previousLibrary) {
         utils.items.library.setData(undefined, context.previousLibrary);
+      }
+      if (context?.previousInfiniteLibrary) {
+        utils.items.library.setInfiniteData(undefined, context.previousInfiniteLibrary);
       }
       if (context?.previousItem) {
         utils.items.get.setData({ id: vars.id }, context.previousItem);
@@ -217,6 +270,49 @@ export function formatDuration(seconds?: number | null): string | undefined {
   return `${minutes}:${String(secs).padStart(2, '0')}`;
 }
 
+function buildInboxItemsInput(options?: InboxItemsOptions) {
+  const filter = options?.filter
+    ? {
+        ...(options.filter.provider !== undefined ? { provider: options.filter.provider } : {}),
+        ...(options.filter.contentType !== undefined
+          ? { contentType: options.filter.contentType }
+          : {}),
+      }
+    : undefined;
+
+  const input = options
+    ? {
+        ...(options.limit !== undefined ? { limit: options.limit } : {}),
+        ...(filter && Object.keys(filter).length > 0 ? { filter } : {}),
+      }
+    : undefined;
+
+  return input;
+}
+
+function buildLibraryItemsInput(options?: LibraryItemsOptions) {
+  const filter = options?.filter
+    ? {
+        ...(options.filter.provider !== undefined ? { provider: options.filter.provider } : {}),
+        ...(options.filter.contentType !== undefined
+          ? { contentType: options.filter.contentType }
+          : {}),
+        ...(options.filter.isFinished ? { isFinished: true } : {}),
+      }
+    : undefined;
+
+  const search = options?.search?.trim();
+  const input = options
+    ? {
+        ...(options.limit !== undefined ? { limit: options.limit } : {}),
+        ...(filter && Object.keys(filter).length > 0 ? { filter } : {}),
+        ...(search ? { search } : {}),
+      }
+    : undefined;
+
+  return input;
+}
+
 // ============================================================================
 // Query Hooks
 // ============================================================================
@@ -242,14 +338,15 @@ export function formatDuration(seconds?: number | null): string | undefined {
  *   ));
  * }
  */
-export function useInboxItems(options?: {
-  filter?: {
-    provider?: Provider;
-    contentType?: ContentType;
-  };
-  limit?: number;
-}) {
-  return trpc.items.inbox.useQuery(options, {
+export function useInboxItems(options?: InboxItemsOptions) {
+  return trpc.items.inbox.useQuery(buildInboxItemsInput(options), {
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useInfiniteInboxItems(options?: InboxItemsOptions) {
+  return trpc.items.inbox.useInfiniteQuery(buildInboxItemsInput(options) ?? {}, {
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
   });
 }
@@ -291,35 +388,15 @@ export function useInboxItems(options?: {
  *   // ...
  * }
  */
-export function useLibraryItems(options?: {
-  filter?: {
-    provider?: Provider;
-    contentType?: ContentType;
-    isFinished?: boolean;
-  };
-  search?: string;
-  limit?: number;
-}) {
-  const filter = options?.filter
-    ? {
-        ...(options.filter.provider !== undefined ? { provider: options.filter.provider } : {}),
-        ...(options.filter.contentType !== undefined
-          ? { contentType: options.filter.contentType }
-          : {}),
-        ...(options.filter.isFinished ? { isFinished: true } : {}),
-      }
-    : undefined;
+export function useLibraryItems(options?: LibraryItemsOptions) {
+  return trpc.items.library.useQuery(buildLibraryItemsInput(options), {
+    placeholderData: keepPreviousData,
+  });
+}
 
-  const search = options?.search?.trim();
-  const input = options
-    ? {
-        ...(options.limit !== undefined ? { limit: options.limit } : {}),
-        ...(filter && Object.keys(filter).length > 0 ? { filter } : {}),
-        ...(search ? { search } : {}),
-      }
-    : undefined;
-
-  return trpc.items.library.useQuery(input, {
+export function useInfiniteLibraryItems(options?: LibraryItemsOptions) {
+  return trpc.items.library.useInfiniteQuery(buildLibraryItemsInput(options) ?? {}, {
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
   });
 }

--- a/apps/mobile/hooks/use-prefetch.test.ts
+++ b/apps/mobile/hooks/use-prefetch.test.ts
@@ -11,7 +11,9 @@ import type { AppStateStatus } from 'react-native';
 
 const mockPrefetchHome = jest.fn(() => Promise.resolve());
 const mockPrefetchInbox = jest.fn(() => Promise.resolve());
+const mockPrefetchInboxInfinite = jest.fn(() => Promise.resolve());
 const mockPrefetchLibrary = jest.fn(() => Promise.resolve());
+const mockPrefetchLibraryInfinite = jest.fn(() => Promise.resolve());
 const mockPrefetchSubscriptions = jest.fn(() => Promise.resolve());
 const mockPrefetchConnections = jest.fn(() => Promise.resolve());
 const mockPrefetchItem = jest.fn(() => Promise.resolve());
@@ -19,8 +21,8 @@ const mockPrefetchItem = jest.fn(() => Promise.resolve());
 const mockUtils = {
   items: {
     home: { prefetch: mockPrefetchHome },
-    inbox: { prefetch: mockPrefetchInbox },
-    library: { prefetch: mockPrefetchLibrary },
+    inbox: { prefetch: mockPrefetchInbox, prefetchInfinite: mockPrefetchInboxInfinite },
+    library: { prefetch: mockPrefetchLibrary, prefetchInfinite: mockPrefetchLibraryInfinite },
     get: { prefetch: mockPrefetchItem },
   },
   subscriptions: {
@@ -91,7 +93,9 @@ describe('prefetch strategy hooks', () => {
 
     expect(mockPrefetchHome).toHaveBeenCalledTimes(1);
     expect(mockPrefetchInbox).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchInboxInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchLibrary).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchLibraryInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchSubscriptions).toHaveBeenCalledTimes(1);
     expect(mockPrefetchConnections).toHaveBeenCalledTimes(1);
   });
@@ -116,7 +120,9 @@ describe('prefetch strategy hooks', () => {
 
     expect(mockPrefetchHome).toHaveBeenCalledTimes(1);
     expect(mockPrefetchInbox).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchInboxInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchLibrary).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchLibraryInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchSubscriptions).toHaveBeenCalledTimes(1);
     expect(mockPrefetchConnections).toHaveBeenCalledTimes(1);
   });
@@ -125,7 +131,9 @@ describe('prefetch strategy hooks', () => {
     renderHook(() => useTabPrefetch('home'));
 
     expect(mockPrefetchInbox).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchInboxInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchLibrary).toHaveBeenCalledTimes(1);
+    expect(mockPrefetchLibraryInfinite).toHaveBeenCalledTimes(1);
     expect(mockPrefetchHome).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/hooks/use-prefetch.ts
+++ b/apps/mobile/hooks/use-prefetch.ts
@@ -31,8 +31,13 @@ function prefetchListQueries(
 ) {
   const listPrefetchers: Record<ListQueryKey, () => Promise<unknown>> = {
     home: () => utils.items.home.prefetch(),
-    inbox: () => utils.items.inbox.prefetch(),
-    library: () => utils.items.library.prefetch(),
+    inbox: () =>
+      Promise.all([utils.items.inbox.prefetch(), utils.items.inbox.prefetchInfinite(undefined)]),
+    library: () =>
+      Promise.all([
+        utils.items.library.prefetch(),
+        utils.items.library.prefetchInfinite(undefined),
+      ]),
   };
 
   targets.forEach((target) => {


### PR DESCRIPTION
## Summary
- switch Inbox and Library to cursor-based infinite queries with a 20-item page size
- progressively load more items on scroll with inline loading indicators instead of stopping at the first page
- keep optimistic item updates and tab prefetching aligned with infinite-query caches
- add hook coverage for infinite query configuration and prefetch behavior

## Testing
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run format:check`