### PR TITLE
Show archive action for unbookmarked detail items

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -51,9 +51,11 @@ export default function ItemDetailScreen() {
     handleOpenLink,
     handleShare,
     handleToggleBookmark,
-    handleToggleFinished,
+    handleSecondaryAction,
     bookmarkMutation,
+    archiveMutation,
     unbookmarkMutation,
+    toggleFinishedMutation,
   } = useItemDetailActions(item);
 
   const viewState = useItemDetailViewState({
@@ -61,6 +63,8 @@ export default function ItemDetailScreen() {
     colors,
     bookmarkPending: bookmarkMutation.isPending,
     unbookmarkPending: unbookmarkMutation.isPending,
+    archivePending: archiveMutation.isPending,
+    toggleFinishedPending: toggleFinishedMutation.isPending,
   });
 
   if (!isValid) {
@@ -93,7 +97,7 @@ export default function ItemDetailScreen() {
         onOpenLink={handleOpenLink}
         onShare={handleShare}
         onBookmarkToggle={handleToggleBookmark}
-        onComplete={handleToggleFinished}
+        onSecondaryAction={handleSecondaryAction}
         onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
         onCreatorPress={
           item.creatorId ? () => router.push(`/creator/${item.creatorId}`) : undefined
@@ -101,9 +105,9 @@ export default function ItemDetailScreen() {
         bookmarkActionIcon={viewState.bookmarkActionIcon}
         bookmarkActionColor={viewState.bookmarkActionColor}
         isBookmarkActionDisabled={viewState.isBookmarkActionDisabled}
-        completeActionIcon={viewState.completeActionIcon}
-        completeActionColor={viewState.completeActionColor}
-        isCompleteActionDisabled={viewState.isCompleteActionDisabled}
+        secondaryActionIcon={viewState.secondaryActionIcon}
+        secondaryActionColor={viewState.secondaryActionColor}
+        isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
         creatorData={creatorData}
       />
     );
@@ -140,11 +144,11 @@ export default function ItemDetailScreen() {
           bookmarkActionIcon={viewState.bookmarkActionIcon}
           bookmarkActionColor={viewState.bookmarkActionColor}
           isBookmarkActionDisabled={viewState.isBookmarkActionDisabled}
-          completeActionIcon={viewState.completeActionIcon}
-          completeActionColor={viewState.completeActionColor}
-          isCompleteActionDisabled={viewState.isCompleteActionDisabled}
+          secondaryActionIcon={viewState.secondaryActionIcon}
+          secondaryActionColor={viewState.secondaryActionColor}
+          isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
           onBookmarkToggle={handleToggleBookmark}
-          onComplete={handleToggleFinished}
+          onSecondaryAction={handleSecondaryAction}
           onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
           onShare={handleShare}
           onOpenLink={handleOpenLink}
@@ -169,11 +173,11 @@ export default function ItemDetailScreen() {
         bookmarkActionIcon={viewState.bookmarkActionIcon}
         bookmarkActionColor={viewState.bookmarkActionColor}
         isBookmarkActionDisabled={viewState.isBookmarkActionDisabled}
-        completeActionIcon={viewState.completeActionIcon}
-        completeActionColor={viewState.completeActionColor}
-        isCompleteActionDisabled={viewState.isCompleteActionDisabled}
+        secondaryActionIcon={viewState.secondaryActionIcon}
+        secondaryActionColor={viewState.secondaryActionColor}
+        isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
         onBookmarkToggle={handleToggleBookmark}
-        onComplete={handleToggleFinished}
+        onSecondaryAction={handleSecondaryAction}
         onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
         onShare={handleShare}
         onOpenLink={handleOpenLink}

--- a/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
@@ -15,11 +15,11 @@ type ItemDetailActionsProps = {
   bookmarkActionIcon: keyof typeof Ionicons.glyphMap;
   bookmarkActionColor: string;
   isBookmarkActionDisabled: boolean;
-  completeActionIcon: keyof typeof Ionicons.glyphMap;
-  completeActionColor: string;
-  isCompleteActionDisabled: boolean;
+  secondaryActionIcon: keyof typeof Ionicons.glyphMap;
+  secondaryActionColor: string;
+  isSecondaryActionDisabled: boolean;
   onBookmarkToggle: () => void;
-  onComplete: () => void;
+  onSecondaryAction: () => void;
   onManageTags: () => void;
   onShare: () => void;
   onOpenLink: () => void;
@@ -32,11 +32,11 @@ export function ItemDetailActions({
   bookmarkActionIcon,
   bookmarkActionColor,
   isBookmarkActionDisabled,
-  completeActionIcon,
-  completeActionColor,
-  isCompleteActionDisabled,
+  secondaryActionIcon,
+  secondaryActionColor,
+  isSecondaryActionDisabled,
   onBookmarkToggle,
-  onComplete,
+  onSecondaryAction,
   onManageTags,
   onShare,
   onOpenLink,
@@ -56,10 +56,10 @@ export function ItemDetailActions({
           disabled={isBookmarkActionDisabled}
         />
         <IconActionButton
-          icon={completeActionIcon}
-          color={completeActionColor}
-          onPress={onComplete}
-          disabled={isCompleteActionDisabled}
+          icon={secondaryActionIcon}
+          color={secondaryActionColor}
+          onPress={onSecondaryAction}
+          disabled={isSecondaryActionDisabled}
         />
         <IconActionButton
           icon="add-circle-outline"

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -20,11 +20,11 @@ type ItemDetailContentProps = {
   bookmarkActionIcon: keyof typeof Ionicons.glyphMap;
   bookmarkActionColor: string;
   isBookmarkActionDisabled: boolean;
-  completeActionIcon: keyof typeof Ionicons.glyphMap;
-  completeActionColor: string;
-  isCompleteActionDisabled: boolean;
+  secondaryActionIcon: keyof typeof Ionicons.glyphMap;
+  secondaryActionColor: string;
+  isSecondaryActionDisabled: boolean;
   onBookmarkToggle: () => void;
-  onComplete: () => void;
+  onSecondaryAction: () => void;
   onManageTags: () => void;
   onShare: () => void;
   onOpenLink: () => void;
@@ -42,11 +42,11 @@ export function ItemDetailContent({
   bookmarkActionIcon,
   bookmarkActionColor,
   isBookmarkActionDisabled,
-  completeActionIcon,
-  completeActionColor,
-  isCompleteActionDisabled,
+  secondaryActionIcon,
+  secondaryActionColor,
+  isSecondaryActionDisabled,
   onBookmarkToggle,
-  onComplete,
+  onSecondaryAction,
   onManageTags,
   onShare,
   onOpenLink,
@@ -74,11 +74,11 @@ export function ItemDetailContent({
         bookmarkActionIcon={bookmarkActionIcon}
         bookmarkActionColor={bookmarkActionColor}
         isBookmarkActionDisabled={isBookmarkActionDisabled}
-        completeActionIcon={completeActionIcon}
-        completeActionColor={completeActionColor}
-        isCompleteActionDisabled={isCompleteActionDisabled}
+        secondaryActionIcon={secondaryActionIcon}
+        secondaryActionColor={secondaryActionColor}
+        isSecondaryActionDisabled={isSecondaryActionDisabled}
         onBookmarkToggle={onBookmarkToggle}
-        onComplete={onComplete}
+        onSecondaryAction={onSecondaryAction}
         onManageTags={onManageTags}
         onShare={onShare}
         onOpenLink={onOpenLink}

--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { Linking, Share } from 'react-native';
 
 import {
+  useArchiveItem,
   useBookmarkItem,
   useMarkItemOpened,
   useToggleFinished,
@@ -20,6 +21,7 @@ import type { ItemDetailItem } from '../types';
 export function useItemDetailActions(item?: ItemDetailItem | null) {
   const { toast } = useToast();
   const bookmarkMutation = useBookmarkItem();
+  const archiveMutation = useArchiveItem();
   const unbookmarkMutation = useUnbookmarkItem();
   const toggleFinishedMutation = useToggleFinished();
   const markOpenedMutation = useMarkItemOpened();
@@ -82,9 +84,20 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
     }
   }, [bookmarkMutation, item, unbookmarkMutation]);
 
-  const handleToggleFinished = useCallback(() => {
+  const handleSecondaryAction = useCallback(() => {
     if (!item) return;
-    if (item.state !== UserItemState.BOOKMARKED) return;
+
+    if (item.state !== UserItemState.BOOKMARKED) {
+      archiveMutation.mutate(
+        { id: item.id },
+        {
+          onError: (error) => {
+            showError(toast, error, 'Failed to archive item', 'itemDetail.archive');
+          },
+        }
+      );
+      return;
+    }
 
     toggleFinishedMutation.mutate(
       { id: item.id },
@@ -99,14 +112,15 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
         },
       }
     );
-  }, [item, toast, toggleFinishedMutation]);
+  }, [archiveMutation, item, toast, toggleFinishedMutation]);
 
   return {
     handleOpenLink,
     handleShare,
     handleToggleBookmark,
-    handleToggleFinished,
+    handleSecondaryAction,
     bookmarkMutation,
+    archiveMutation,
     unbookmarkMutation,
     toggleFinishedMutation,
   };

--- a/apps/mobile/app/item/detail/hooks/useItemDetailViewState.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailViewState.ts
@@ -9,6 +9,8 @@ type ItemDetailViewStateInput = {
   colors: ItemDetailColors;
   bookmarkPending: boolean;
   unbookmarkPending: boolean;
+  archivePending: boolean;
+  toggleFinishedPending: boolean;
 };
 
 export function useItemDetailViewState({
@@ -16,6 +18,8 @@ export function useItemDetailViewState({
   colors,
   bookmarkPending,
   unbookmarkPending,
+  archivePending,
+  toggleFinishedPending,
 }: ItemDetailViewStateInput) {
   if (!item) {
     return {
@@ -25,10 +29,10 @@ export function useItemDetailViewState({
       descriptionLabel: 'Description',
       bookmarkActionIcon: 'bookmark-outline' as keyof typeof Ionicons.glyphMap,
       bookmarkActionColor: colors.textSecondary,
-      completeActionIcon: 'checkmark-circle-outline' as keyof typeof Ionicons.glyphMap,
-      completeActionColor: colors.textSecondary,
+      secondaryActionIcon: 'archive-outline' as keyof typeof Ionicons.glyphMap,
+      secondaryActionColor: colors.textSecondary,
       isBookmarkActionDisabled: true,
-      isCompleteActionDisabled: true,
+      isSecondaryActionDisabled: true,
     };
   }
 
@@ -41,11 +45,15 @@ export function useItemDetailViewState({
     : 'bookmark-outline';
   const bookmarkActionColor = isBookmarked ? colors.primary : colors.textSecondary;
 
-  const completeActionIcon: keyof typeof Ionicons.glyphMap = isFinished
-    ? 'checkmark-circle'
-    : 'checkmark-circle-outline';
-  const completeActionColor = isBookmarked && isFinished ? colors.success : colors.textSecondary;
-  const isCompleteActionDisabled = !isBookmarked;
+  const secondaryActionIcon: keyof typeof Ionicons.glyphMap = isBookmarked
+    ? isFinished
+      ? 'checkmark-circle'
+      : 'checkmark-circle-outline'
+    : item.state === UserItemState.ARCHIVED
+      ? 'archive'
+      : 'archive-outline';
+  const secondaryActionColor = isBookmarked && isFinished ? colors.success : colors.textSecondary;
+  const isSecondaryActionDisabled = isBookmarked ? toggleFinishedPending : archivePending;
 
   const descriptionLabel = (() => {
     switch (item.contentType) {
@@ -69,9 +77,9 @@ export function useItemDetailViewState({
     descriptionLabel,
     bookmarkActionIcon,
     bookmarkActionColor,
-    completeActionIcon,
-    completeActionColor,
+    secondaryActionIcon,
+    secondaryActionColor,
     isBookmarkActionDisabled,
-    isCompleteActionDisabled,
+    isSecondaryActionDisabled,
   };
 }

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -152,15 +152,15 @@ export function XPostBookmarkView({
   onOpenLink,
   onShare,
   onBookmarkToggle,
-  onComplete,
+  onSecondaryAction,
   onManageTags,
   onCreatorPress,
   bookmarkActionIcon,
   bookmarkActionColor,
   isBookmarkActionDisabled,
-  completeActionIcon,
-  completeActionColor,
-  isCompleteActionDisabled,
+  secondaryActionIcon,
+  secondaryActionColor,
+  isSecondaryActionDisabled,
   creatorData,
 }: {
   item: {
@@ -182,15 +182,15 @@ export function XPostBookmarkView({
   onOpenLink: () => void;
   onShare: () => void;
   onBookmarkToggle: () => void;
-  onComplete: () => void;
+  onSecondaryAction: () => void;
   onManageTags: () => void;
   onCreatorPress?: () => void;
   bookmarkActionIcon: keyof typeof Ionicons.glyphMap;
   bookmarkActionColor: string;
   isBookmarkActionDisabled: boolean;
-  completeActionIcon: keyof typeof Ionicons.glyphMap;
-  completeActionColor: string;
-  isCompleteActionDisabled: boolean;
+  secondaryActionIcon: keyof typeof Ionicons.glyphMap;
+  secondaryActionColor: string;
+  isSecondaryActionDisabled: boolean;
   creatorData?: { handle?: string | null } | null;
 }) {
   const canManageTags = item.state === UserItemState.BOOKMARKED;
@@ -286,10 +286,10 @@ export function XPostBookmarkView({
             disabled={isBookmarkActionDisabled}
           />
           <IconActionButton
-            icon={completeActionIcon}
-            color={completeActionColor}
-            onPress={onComplete}
-            disabled={isCompleteActionDisabled}
+            icon={secondaryActionIcon}
+            color={secondaryActionColor}
+            onPress={onSecondaryAction}
+            disabled={isSecondaryActionDisabled}
           />
           <IconActionButton
             icon="add-circle-outline"

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -15,6 +15,7 @@ import type { ItemDetailItem } from '@/app/item/detail/types';
 // ============================================================================
 
 const mockBookmarkMutation = { mutate: jest.fn(), isPending: false };
+const mockArchiveMutation = { mutate: jest.fn(), isPending: false };
 const mockUnbookmarkMutation = { mutate: jest.fn(), isPending: false };
 const mockToggleFinishedMutation = { mutate: jest.fn(), isPending: false };
 const mockMarkOpenedMutation = { mutate: jest.fn(), isPending: false };
@@ -74,8 +75,10 @@ jest.mock('@/hooks/use-items-trpc', () => ({
   UserItemState: {
     BOOKMARKED: 'BOOKMARKED',
     INBOX: 'INBOX',
+    ARCHIVED: 'ARCHIVED',
   },
   useBookmarkItem: () => mockBookmarkMutation,
+  useArchiveItem: () => mockArchiveMutation,
   useUnbookmarkItem: () => mockUnbookmarkMutation,
   useToggleFinished: () => mockToggleFinishedMutation,
   useMarkItemOpened: () => mockMarkOpenedMutation,
@@ -109,12 +112,13 @@ describe('useItemDetailActions', () => {
       await result.current.handleOpenLink();
       await result.current.handleShare();
       result.current.handleToggleBookmark();
-      result.current.handleToggleFinished();
+      result.current.handleSecondaryAction();
     });
 
     expect(mockCanOpenURL).not.toHaveBeenCalled();
     expect(mockShare).not.toHaveBeenCalled();
     expect(mockBookmarkMutation.mutate).not.toHaveBeenCalled();
+    expect(mockArchiveMutation.mutate).not.toHaveBeenCalled();
     expect(mockUnbookmarkMutation.mutate).not.toHaveBeenCalled();
     expect(mockToggleFinishedMutation.mutate).not.toHaveBeenCalled();
   });
@@ -243,23 +247,32 @@ describe('useItemDetailActions', () => {
     expect(mockUnbookmarkMutation.mutate).toHaveBeenCalledWith({ id: baseItem.id });
   });
 
-  it('only toggles finished for bookmarked items', () => {
+  it('archives non-bookmarked items from the secondary action', () => {
     const { result: inboxResult } = renderHook(() => useItemDetailActions(baseItem));
-    inboxResult.current.handleToggleFinished();
+    inboxResult.current.handleSecondaryAction();
+    expect(mockArchiveMutation.mutate).toHaveBeenCalledWith(
+      { id: baseItem.id },
+      expect.objectContaining({
+        onError: expect.any(Function),
+      })
+    );
     expect(mockToggleFinishedMutation.mutate).not.toHaveBeenCalled();
+  });
 
+  it('keeps the complete toggle for bookmarked items', () => {
     const bookmarkedItem = {
       ...baseItem,
       state: UserItemState.BOOKMARKED,
     } as unknown as ItemDetailItem;
     const { result: bookmarkedResult } = renderHook(() => useItemDetailActions(bookmarkedItem));
-    bookmarkedResult.current.handleToggleFinished();
+    bookmarkedResult.current.handleSecondaryAction();
     expect(mockToggleFinishedMutation.mutate).toHaveBeenCalledWith(
       { id: baseItem.id },
       expect.objectContaining({
         onError: expect.any(Function),
       })
     );
+    expect(mockArchiveMutation.mutate).not.toHaveBeenCalled();
   });
 
   it('shows lightweight error feedback when complete toggle fails', () => {
@@ -269,7 +282,7 @@ describe('useItemDetailActions', () => {
     } as unknown as ItemDetailItem;
     const { result } = renderHook(() => useItemDetailActions(bookmarkedItem));
 
-    result.current.handleToggleFinished();
+    result.current.handleSecondaryAction();
 
     const mutateOptions = mockToggleFinishedMutation.mutate.mock.calls[0][1] as {
       onError: (error: unknown) => void;
@@ -283,6 +296,26 @@ describe('useItemDetailActions', () => {
       error,
       'Failed to update completion status',
       'itemDetail.toggleFinished'
+    );
+  });
+
+  it('shows lightweight error feedback when archiving fails', () => {
+    const { result } = renderHook(() => useItemDetailActions(baseItem));
+
+    result.current.handleSecondaryAction();
+
+    const mutateOptions = mockArchiveMutation.mutate.mock.calls[0][1] as {
+      onError: (error: unknown) => void;
+    };
+
+    const error = new Error('Archive request failed');
+    mutateOptions.onError(error);
+
+    expect(mockShowError).toHaveBeenCalledWith(
+      mockToastManager,
+      error,
+      'Failed to archive item',
+      'itemDetail.archive'
     );
   });
 });

--- a/apps/mobile/hooks/use-item-detail-view-state.test.ts
+++ b/apps/mobile/hooks/use-item-detail-view-state.test.ts
@@ -24,14 +24,17 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
+      archivePending: false,
+      toggleFinishedPending: false,
     });
 
     expect(viewState.isXPost).toBe(false);
     expect(viewState.hasThumbnail).toBe(false);
     expect(viewState.headerAspectRatio).toBe(1);
     expect(viewState.isBookmarkActionDisabled).toBe(true);
-    expect(viewState.isCompleteActionDisabled).toBe(true);
+    expect(viewState.isSecondaryActionDisabled).toBe(true);
     expect(viewState.bookmarkActionIcon).toBe('bookmark-outline');
+    expect(viewState.secondaryActionIcon).toBe('archive-outline');
   });
 
   it('marks X posts and uses post description label', () => {
@@ -47,6 +50,8 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
+      archivePending: false,
+      toggleFinishedPending: false,
     });
 
     expect(viewState.isXPost).toBe(true);
@@ -64,14 +69,17 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
+      archivePending: false,
+      toggleFinishedPending: false,
     });
 
     expect(viewState.bookmarkActionIcon).toBe('bookmark');
     expect(viewState.bookmarkActionColor).toBe(Colors.dark.primary);
     expect(viewState.isBookmarkActionDisabled).toBe(false);
-    expect(viewState.isCompleteActionDisabled).toBe(false);
+    expect(viewState.isSecondaryActionDisabled).toBe(false);
     expect(viewState.descriptionLabel).toBe('About this video');
     expect(viewState.headerAspectRatio).toBeCloseTo(16 / 9);
+    expect(viewState.secondaryActionIcon).toBe('checkmark-circle-outline');
   });
 
   it('uses success colors for finished bookmarks', () => {
@@ -84,9 +92,26 @@ describe('useItemDetailViewState', () => {
       colors: Colors.dark,
       bookmarkPending: false,
       unbookmarkPending: false,
+      archivePending: false,
+      toggleFinishedPending: false,
     });
 
-    expect(viewState.completeActionIcon).toBe('checkmark-circle');
-    expect(viewState.completeActionColor).toBe(Colors.dark.success);
+    expect(viewState.secondaryActionIcon).toBe('checkmark-circle');
+    expect(viewState.secondaryActionColor).toBe(Colors.dark.success);
+  });
+
+  it('shows an archive action for non-bookmarked items', () => {
+    const viewState = useItemDetailViewState({
+      item: baseItem,
+      colors: Colors.dark,
+      bookmarkPending: false,
+      unbookmarkPending: false,
+      archivePending: false,
+      toggleFinishedPending: false,
+    });
+
+    expect(viewState.secondaryActionIcon).toBe('archive-outline');
+    expect(viewState.secondaryActionColor).toBe(Colors.dark.textSecondary);
+    expect(viewState.isSecondaryActionDisabled).toBe(false);
   });
 });

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -17,6 +17,7 @@ const mockInboxUseInfiniteQuery = jest.fn();
 const mockLibraryUseQuery = jest.fn();
 const mockLibraryUseInfiniteQuery = jest.fn();
 const mockHomeUseQuery = jest.fn();
+const mockArchiveUseMutation = jest.fn();
 const mockToggleFinishedUseMutation = jest.fn();
 const mockUseUtils = jest.fn();
 
@@ -33,6 +34,9 @@ jest.mock('../lib/trpc', () => ({
       },
       home: {
         useQuery: mockHomeUseQuery,
+      },
+      archive: {
+        useMutation: (...args: unknown[]) => mockArchiveUseMutation(...args),
       },
       toggleFinished: {
         useMutation: (...args: unknown[]) => mockToggleFinishedUseMutation(...args),
@@ -52,6 +56,7 @@ import {
   useLibraryItems,
   useInfiniteLibraryItems,
   useHomeData,
+  useArchiveItem,
   useToggleFinished,
 } from './use-items-trpc';
 
@@ -88,6 +93,11 @@ function createMockItem(overrides: Record<string, unknown> = {}) {
 type MockListData = {
   items: ReturnType<typeof createMockItem>[];
   nextCursor: string | null;
+};
+
+type MockInfiniteListData = {
+  pages: MockListData[];
+  pageParams: unknown[];
 };
 
 function serializeLibraryInput(
@@ -142,6 +152,22 @@ function createToggleUtils(initial?: {
   const inboxRef: { current: MockListData | undefined } = {
     current: initial?.inbox,
   };
+  const inboxInfiniteRef: { current: MockInfiniteListData | undefined } = {
+    current: initial?.inbox
+      ? {
+          pages: [initial.inbox],
+          pageParams: [],
+        }
+      : undefined,
+  };
+  const libraryInfiniteRef: { current: MockInfiniteListData | undefined } = {
+    current: initial?.defaultLibrary
+      ? {
+          pages: [initial.defaultLibrary],
+          pageParams: [],
+        }
+      : undefined,
+  };
 
   const itemsById = new Map<string, ReturnType<typeof createMockItem> | undefined>(
     Object.entries(initial?.itemsById ?? {})
@@ -165,6 +191,7 @@ function createToggleUtils(initial?: {
         getData: jest.fn((input?: Parameters<typeof serializeLibraryInput>[0]) =>
           libraryDataByKey.get(serializeLibraryInput(input))
         ),
+        getInfiniteData: jest.fn(() => libraryInfiniteRef.current),
         setData: jest.fn((input: Parameters<typeof serializeLibraryInput>[0], updater: unknown) => {
           const key = serializeLibraryInput(input);
           const previous = libraryDataByKey.get(key);
@@ -175,11 +202,25 @@ function createToggleUtils(initial?: {
           libraryDataByKey.set(key, next);
           return next;
         }),
+        setInfiniteData: jest.fn((_: undefined, updater: unknown) => {
+          const previous = libraryInfiniteRef.current;
+          const next =
+            typeof updater === 'function'
+              ? (
+                  updater as (
+                    value: MockInfiniteListData | undefined
+                  ) => MockInfiniteListData | undefined
+                )(previous)
+              : (updater as MockInfiniteListData | undefined);
+          libraryInfiniteRef.current = next;
+          return next;
+        }),
       },
       inbox: {
         cancel: mockInboxCancel,
         invalidate: mockInboxInvalidate,
         getData: jest.fn(() => inboxRef.current),
+        getInfiniteData: jest.fn(() => inboxInfiniteRef.current),
         setData: jest.fn((_: undefined, updater: unknown) => {
           const previous = inboxRef.current;
           const next =
@@ -187,6 +228,19 @@ function createToggleUtils(initial?: {
               ? (updater as (value: MockListData | undefined) => MockListData | undefined)(previous)
               : (updater as MockListData | undefined);
           inboxRef.current = next;
+          return next;
+        }),
+        setInfiniteData: jest.fn((_: undefined, updater: unknown) => {
+          const previous = inboxInfiniteRef.current;
+          const next =
+            typeof updater === 'function'
+              ? (
+                  updater as (
+                    value: MockInfiniteListData | undefined
+                  ) => MockInfiniteListData | undefined
+                )(previous)
+              : (updater as MockInfiniteListData | undefined);
+          inboxInfiniteRef.current = next;
           return next;
         }),
       },
@@ -264,6 +318,13 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   });
+
+  mockArchiveUseMutation.mockImplementation((config: unknown) => ({
+    ...(config as Record<string, unknown>),
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }));
 
   mockToggleFinishedUseMutation.mockImplementation((config: unknown) => ({
     ...(config as Record<string, unknown>),
@@ -351,6 +412,57 @@ describe('useItems list queries', () => {
 
     const options = mockLibraryUseInfiniteQuery.mock.calls[0][1];
     expect(options.getNextPageParam({ nextCursor: 'cursor-abc', items: [] })).toBe('cursor-abc');
+  });
+});
+
+describe('useArchiveItem', () => {
+  type ArchiveHandlers = {
+    onMutate: ({ id }: { id: string }) => Promise<unknown>;
+    onError: (error: unknown, vars: { id: string }, context?: unknown) => void;
+    onSettled: (data: unknown, error: unknown, vars: { id: string }) => void;
+  };
+
+  function getArchiveHandlers() {
+    const { result } = renderHook(() => useArchiveItem());
+    return result.current as unknown as ArchiveHandlers;
+  }
+
+  it('optimistically updates the single item cache when archiving from detail', async () => {
+    const item = createMockItem({ id: 'archive-item', state: UserItemState.INBOX });
+    const harness = createToggleUtils({
+      inbox: {
+        items: [item],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getArchiveHandlers();
+
+    let context: unknown;
+
+    await act(async () => {
+      context = await mutation.onMutate({ id: item.id });
+    });
+
+    expect(harness.readInbox()?.items).toHaveLength(0);
+    expect(harness.readItem(item.id)?.state).toBe(UserItemState.ARCHIVED);
+
+    act(() => {
+      mutation.onError(new Error('Archive failed'), { id: item.id }, context);
+    });
+
+    expect(harness.readInbox()?.items[0]?.id).toBe(item.id);
+    expect(harness.readItem(item.id)?.state).toBe(UserItemState.INBOX);
+
+    act(() => {
+      mutation.onSettled(undefined, undefined, { id: item.id });
+    });
+
+    expect(harness.spies.mockGetInvalidate).toHaveBeenCalledWith({ id: item.id });
   });
 });
 

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -523,6 +523,10 @@ export function useArchiveItem() {
     createOptimisticConfig(utils, {
       updateInbox: (items, { id }) => items.filter((item) => item.id !== id),
       updateLibrary: (items, { id }) => items.filter((item) => item.id !== id),
+      updateSingleItem: (item) => ({
+        ...item,
+        state: UserItemState.ARCHIVED,
+      }),
     })
   );
 }


### PR DESCRIPTION
## Summary
- show the archive action on the item detail page when the item is not bookmarked
- keep the existing completion check behavior for bookmarked items
- update the archive mutation's optimistic single-item cache so the detail screen reflects the archived state immediately

## Verification
- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- verified in the iOS simulator that bookmarked items still use the completion action and non-bookmarked items show the archive action