### PR TITLE
fix(mobile): stabilize resume auth refresh + keep Add Link save visible

### DIFF
--- a/apps/mobile/app/add-link.tsx
+++ b/apps/mobile/app/add-link.tsx
@@ -27,12 +27,13 @@ import {
   Platform,
   ScrollView,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { useToast } from 'heroui-native';
 import * as Haptics from 'expo-haptics';
 import Animated from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors, Typography, Spacing, Radius, Shadows } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -191,6 +192,8 @@ export default function AddLinkScreen() {
   const { toast } = useToast();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const headerHeight = useHeaderHeight();
+  const insets = useSafeAreaInsets();
 
   // Input state
   const [url, setUrl] = useState('');
@@ -350,12 +353,13 @@ export default function AddLinkScreen() {
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? headerHeight : 0}
       >
-        <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+        <SafeAreaView style={styles.safeArea} edges={['left', 'right']}>
           <ScrollView
             style={styles.scrollView}
             contentContainerStyle={styles.scrollContent}
+            keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
           >
@@ -444,7 +448,16 @@ export default function AddLinkScreen() {
           </ScrollView>
 
           {/* Save Button */}
-          <View style={[styles.footer, { borderTopColor: colors.border }]}>
+          <View
+            testID="add-link-footer"
+            style={[
+              styles.footer,
+              {
+                borderTopColor: colors.border,
+                paddingBottom: Spacing.xl + insets.bottom,
+              },
+            ]}
+          >
             <Pressable
               onPress={handleSave}
               disabled={!canSave}

--- a/apps/mobile/lib/add-link-screen.test.tsx
+++ b/apps/mobile/lib/add-link-screen.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+const mockBack = jest.fn();
+const mockUsePreview = jest.fn();
+const mockUseSaveBookmark = jest.fn();
+const mockUseHeaderHeight = jest.fn();
+const mockUseSafeAreaInsets = jest.fn();
+
+type Renderer = ReturnType<typeof TestRenderer.create>;
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (accumulator, value) => ({ ...accumulator, ...flattenStyle(value) }),
+      {}
+    );
+  }
+
+  return (style ?? {}) as Record<string, unknown>;
+}
+
+jest.mock('expo-router', () => ({
+  Stack: {
+    Screen: () => null,
+  },
+  useLocalSearchParams: () => ({}),
+  useRouter: () => ({
+    back: mockBack,
+  }),
+}));
+
+jest.mock('@react-navigation/elements', () => ({
+  useHeaderHeight: () => mockUseHeaderHeight(),
+}));
+
+jest.mock('heroui-native', () => ({
+  useToast: () => ({
+    toast: {},
+  }),
+}));
+
+jest.mock('react-native', () => ({
+  __esModule: true,
+  Platform: {
+    OS: 'ios',
+    select: (options: Record<string, unknown>) => options.ios ?? options.default,
+  },
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('view', props, children),
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('text', props, children),
+  TextInput: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('input', props, children),
+  Pressable: ({
+    children,
+    onPress,
+    style,
+    ...props
+  }: {
+    children?: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
+    onPress?: () => void;
+    style?: unknown;
+  }) =>
+    React.createElement(
+      'button',
+      {
+        ...props,
+        onPress,
+        style: typeof style === 'function' ? style({ pressed: false }) : style,
+      },
+      typeof children === 'function' ? children({ pressed: false }) : children
+    ),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+  },
+  ActivityIndicator: (props: Record<string, unknown>) =>
+    React.createElement('activity-indicator', props),
+  Keyboard: {
+    dismiss: jest.fn(),
+  },
+  KeyboardAvoidingView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('keyboard-avoiding-view', props, children),
+  ScrollView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('scroll-view', props, children),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('safe-area-view', props, children),
+  useSafeAreaInsets: () => mockUseSafeAreaInsets(),
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    View: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement('animated-view', props, children),
+    Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement('animated-text', props, children),
+  },
+}));
+
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('svg', props, children),
+  Path: (props: Record<string, unknown>) => React.createElement('path', props),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'dark',
+}));
+
+jest.mock('@/hooks/use-bookmarks', () => ({
+  usePreview: (...args: unknown[]) => mockUsePreview(...args),
+  useSaveBookmark: () => mockUseSaveBookmark(),
+  isValidUrl: (value: string) => value.startsWith('http://') || value.startsWith('https://'),
+}));
+
+jest.mock('@/components/link-preview-card', () => ({
+  LinkPreviewCard: () => React.createElement('link-preview-card'),
+}));
+
+jest.mock('@/lib/toast-utils', () => ({
+  showError: jest.fn(),
+  showSuccess: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+import { Spacing } from '@/constants/theme';
+import AddLinkScreen from '@/app/add-link';
+
+describe('AddLinkScreen keyboard layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHeaderHeight.mockReturnValue(72);
+    mockUseSafeAreaInsets.mockReturnValue({
+      top: 0,
+      right: 0,
+      bottom: 34,
+      left: 0,
+    });
+    mockUsePreview.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockUseSaveBookmark.mockReturnValue({
+      saveFromPreviewAsync: jest.fn(),
+      isPending: false,
+      reset: jest.fn(),
+    });
+  });
+
+  it('uses the active header height for keyboard avoidance', () => {
+    let renderer: Renderer;
+
+    act(() => {
+      renderer = TestRenderer.create(<AddLinkScreen />);
+    });
+
+    const keyboardAvoidingView = renderer!.root.findByType('keyboard-avoiding-view');
+
+    expect(keyboardAvoidingView.props.behavior).toBe('padding');
+    expect(keyboardAvoidingView.props.keyboardVerticalOffset).toBe(72);
+  });
+
+  it('keeps footer spacing aligned with the bottom safe area inset', () => {
+    let renderer: Renderer;
+
+    act(() => {
+      renderer = TestRenderer.create(<AddLinkScreen />);
+    });
+
+    const footer = renderer!.root.findByProps({ testID: 'add-link-footer' });
+    const style = flattenStyle(footer.props.style);
+
+    expect(style.paddingTop).toBe(Spacing.lg);
+    expect(style.paddingBottom).toBe(Spacing.xl + 34);
+  });
+});

--- a/apps/mobile/lib/trpc-provider.test.tsx
+++ b/apps/mobile/lib/trpc-provider.test.tsx
@@ -304,6 +304,52 @@ describe('TRPCProvider transport wiring', () => {
     expect(mockSignOut).not.toHaveBeenCalled();
   });
 
+  it('reuses the forced token refresh started on app resume', async () => {
+    const resumeTokenResolver = {
+      current: null as ((token: string | null) => void) | null,
+    };
+    const resumeTokenPromise = new Promise<string | null>((resolve) => {
+      resumeTokenResolver.current = resolve;
+    });
+    mockGetToken.mockImplementationOnce(() => resumeTokenPromise);
+
+    act(() => {
+      create(
+        <TRPCProvider>
+          <></>
+        </TRPCProvider>
+      );
+    });
+
+    act(() => {
+      appStateCallback?.('background');
+    });
+
+    await act(async () => {
+      appStateCallback?.('active');
+    });
+
+    const headersPromise = (httpBatchLink as jest.Mock).mock.calls[0][0].headers();
+
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
+
+    if (!resumeTokenResolver.current) {
+      throw new Error('Resume token resolver was not set');
+    }
+
+    resumeTokenResolver.current('resume-token');
+    const headers = await headersPromise;
+
+    expect(buildMobileTelemetryHeaders).toHaveBeenCalledWith({
+      Authorization: 'Bearer resume-token',
+    });
+    expect(headers).toEqual({
+      Authorization: 'Bearer resume-token',
+      'X-Trace-ID': 'trc_test_header',
+    });
+  });
+
   it('signs out after an unauthorized retry also fails', async () => {
     const clearSpy = jest.spyOn(QueryClient.prototype, 'clear');
 

--- a/apps/mobile/providers/trpc-provider.tsx
+++ b/apps/mobile/providers/trpc-provider.tsx
@@ -38,6 +38,8 @@ interface TRPCProviderProps {
   children: ReactNode;
 }
 
+const AUTH_RESUME_REFRESH_GRACE_MS = 5_000;
+
 function isRequest(input: RequestInfo | URL): input is Request {
   return typeof Request !== 'undefined' && input instanceof Request;
 }
@@ -106,8 +108,51 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
   const signOutRef = useRef(signOut);
   signOutRef.current = signOut;
   const hasTriggeredSignOutRef = useRef(false);
-  const authRefreshPromiseRef = useRef<Promise<boolean> | null>(null);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+  const resumeTokenRefreshRef = useRef<Promise<string | null> | null>(null);
+  const lastResumeAtRef = useRef<number | null>(null);
+
+  const isWithinResumeRefreshGraceWindow = useCallback(() => {
+    if (lastResumeAtRef.current === null) {
+      return false;
+    }
+
+    return Date.now() - lastResumeAtRef.current <= AUTH_RESUME_REFRESH_GRACE_MS;
+  }, []);
+
+  const startResumeTokenRefresh = useCallback(() => {
+    lastResumeAtRef.current = Date.now();
+
+    const refreshPromise: Promise<string | null> = getTokenRef
+      .current({ skipCache: true })
+      .catch((error) => {
+        trpcLogger.warn('Failed to refresh auth token on app resume', { error });
+        return null;
+      })
+      .finally(() => {
+        if (resumeTokenRefreshRef.current === refreshPromise) {
+          resumeTokenRefreshRef.current = null;
+        }
+      });
+
+    resumeTokenRefreshRef.current = refreshPromise;
+    return refreshPromise;
+  }, []);
+
+  const getTokenForAuthRequest = useCallback(
+    async (options?: { skipCache?: boolean }) => {
+      if (resumeTokenRefreshRef.current) {
+        const resumeToken = await resumeTokenRefreshRef.current;
+        if (resumeToken) {
+          return resumeToken;
+        }
+      }
+
+      const shouldSkipCache = options?.skipCache === true || isWithinResumeRefreshGraceWindow();
+      return getTokenRef.current(shouldSkipCache ? { skipCache: true } : options);
+    },
+    [isWithinResumeRefreshGraceWindow]
+  );
 
   // ---------------------------------------------------------------------------
   // Initialize OAuth Token Getter
@@ -115,11 +160,13 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
   // The vanilla tRPC client in oauth.ts needs access to auth tokens for
   // imperative OAuth operations like connectProvider(). This hooks it up.
   useEffect(() => {
-    setTokenGetter(() => getTokenRef.current());
-  }, []);
+    setTokenGetter(() => getTokenForAuthRequest());
+  }, [getTokenForAuthRequest]);
 
   useEffect(() => {
     hasTriggeredSignOutRef.current = false;
+    resumeTokenRefreshRef.current = null;
+    lastResumeAtRef.current = null;
   }, [userId]);
 
   const ensureFreshAuthToken = useCallback(async (): Promise<boolean> => {
@@ -127,52 +174,27 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
       return false;
     }
 
-    if (!authRefreshPromiseRef.current) {
-      const refreshPromise = getTokenRef
-        .current({ skipCache: true })
-        .then((token) => {
-          if (!token) {
-            trpcLogger.warn(
-              'Skipped app resume network work because auth refresh returned no token'
-            );
-            return false;
-          }
-
-          return true;
-        })
-        .catch((error) => {
-          trpcLogger.warn('Skipped app resume network work because auth refresh failed', {
-            error,
-          });
-          return false;
-        })
-        .finally(() => {
-          if (authRefreshPromiseRef.current === refreshPromise) {
-            authRefreshPromiseRef.current = null;
-          }
-        });
-
-      authRefreshPromiseRef.current = refreshPromise;
+    const token = await startResumeTokenRefresh();
+    if (!token) {
+      trpcLogger.warn('Skipped app resume network work because auth refresh returned no token');
+      return false;
     }
 
-    return authRefreshPromiseRef.current;
-  }, [isLoaded, isSignedIn]);
+    return true;
+  }, [isLoaded, isSignedIn, startResumeTokenRefresh]);
 
   useEffect(() => {
-    const handleAppStateChange = (nextState: AppStateStatus) => {
+    const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
       const wasInBackground = /inactive|background/.test(appStateRef.current);
-
       appStateRef.current = nextState;
 
       if (wasInBackground && nextState === 'active') {
-        void ensureFreshAuthToken();
+        void startResumeTokenRefresh();
       }
-    };
-
-    const subscription = AppState.addEventListener('change', handleAppStateChange);
+    });
 
     return () => subscription.remove();
-  }, [ensureFreshAuthToken]);
+  }, [startResumeTokenRefresh]);
 
   // ---------------------------------------------------------------------------
   // QueryClient Configuration
@@ -290,7 +312,7 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
       }
 
       try {
-        const refreshedToken = await getTokenRef.current({ skipCache: true });
+        const refreshedToken = await getTokenForAuthRequest({ skipCache: true });
 
         if (refreshedToken) {
           trpcLogger.warn('Retrying unauthorized tRPC request with refreshed auth token', {
@@ -340,7 +362,7 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
           transformer: superjson, // Required for Date serialization - must match server
           headers: async () => {
             try {
-              const token = await getTokenRef.current();
+              const token = await getTokenForAuthRequest();
               if (token) {
                 return buildMobileTelemetryHeaders({ Authorization: `Bearer ${token}` });
               }


### PR DESCRIPTION
## Summary
- reuse the in-flight forced token refresh after app resume so immediate tRPC calls use the fresh token
- apply a short post-resume grace window for auth fetches to avoid stale-token races
- keep Add Link Save button visible above iOS keyboard by using header height + bottom insets
- add regression tests for both auth-refresh reuse and Add Link footer spacing/keyboard offset

## Validation
- bun run --cwd apps/mobile test -- lib/trpc-provider.test.tsx lib/add-link-screen.test.tsx
