### PR TITLE
worker: harden pagination cursor decoding

### DIFF
--- a/apps/worker/src/lib/pagination.test.ts
+++ b/apps/worker/src/lib/pagination.test.ts
@@ -46,6 +46,24 @@ describe('pagination utilities', () => {
 
       expect(decodeCursor(invalidPayload)).toBeNull();
     });
+
+    it('returns null for empty cursor fields', () => {
+      const emptyFields = btoa(JSON.stringify({ sortValue: '   ', id: '' }))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      expect(decodeCursor(emptyFields)).toBeNull();
+    });
+
+    it('returns null for invalid date sortValue', () => {
+      const invalidDate = btoa(JSON.stringify({ sortValue: 'not-a-date', id: 'item_1' }))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+
+      expect(decodeCursor(invalidDate)).toBeNull();
+    });
   });
 
   describe('buildPaginatedQuery', () => {

--- a/apps/worker/src/lib/pagination.ts
+++ b/apps/worker/src/lib/pagination.ts
@@ -97,9 +97,17 @@ export function decodeCursor(cursorString: string): PaginationCursor | null {
       typeof parsed.sortValue === 'string' &&
       typeof parsed.id === 'string'
     ) {
+      const sortValue = parsed.sortValue.trim();
+      const id = parsed.id.trim();
+
+      // Reject empty values and non-date sort values to avoid malformed cursors.
+      if (!sortValue || !id || Number.isNaN(Date.parse(sortValue))) {
+        return null;
+      }
+
       return {
-        sortValue: parsed.sortValue,
-        id: parsed.id,
+        sortValue,
+        id,
       };
     }
 


### PR DESCRIPTION
## Summary
- harden  validation in worker pagination utilities
- reject cursors with empty /uid=501(erikjohansson) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),33(_appstore),98(_lpadmin),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh),400(com.apple.access_remote_ae),701(com.apple.sharepoint.group.1)
- reject cursors where  is not a valid date string
- trim values before returning decoded cursor
- add test coverage for empty-field and invalid-date cursor payloads

## Why
Malformed cursor payloads could pass structural checks and propagate unexpected values into pagination query paths. This adds defensive validation while keeping behavior unchanged for valid cursors.

## Validation
- 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-03-19/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...
 ✓ src/lib/pagination.test.ts (11 tests) 31ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  05:35:35
   Duration  607ms (transform 21ms, setup 19ms, collect 8ms, tests 31ms, environment 0ms, prepare 116ms)

[vpw:dbg] Shutting down runtimes...
- 
- 
- 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-03-19/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...
 ✓ src/diagnostics/health.test.ts (2 tests) 487ms
 ✓ src/rss/url.test.ts (4 tests) 602ms
 ✓ src/newsletters/avatar.test.ts (5 tests) 753ms
 ✓ src/lib/telemetry.test.ts (2 tests) 299ms
 ✓ src/trpc/routers/latest-content-content-type.test.ts (3 tests) 374ms
 ✓ src/rss/parser.test.ts (4 tests) 531ms
 ✓ src/lib/weekly-recap.test.ts (7 tests) 1307ms
 ✓ src/lib/pagination.test.ts (11 tests) 1531ms
 ✓ src/rss/discovery.test.ts (3 tests) 179ms
 ✓ src/middleware/auth.test.ts (3 tests) 161ms
 ✓ src/ingestion/processor/prepare.test.ts (3 tests) 211ms
 ✓ src/lib/duration.test.ts (18 tests) 1956ms
 ✓ src/ingestion/processor/write.test.ts (4 tests) 241ms
 ✓ src/trpc/routers/newsletters.test.ts (1 test) 72ms
 ✓ src/rss/service.test.ts (5 tests) 230ms
 ✓ src/lib/fxtwitter.test.ts (23 tests) 2081ms
 ✓ src/trpc/routers/bookmarks.test.ts (19 tests) 1699ms
 ✓ src/trpc/routers/rss.test.ts (7 tests) 275ms
 ✓ src/routes/auth.test.ts (10 tests) 479ms
 ✓ src/newsletters/gmail.test.ts (15 tests) 579ms
 ✓ src/trpc/routers/connections.test.ts (27 tests) 2257ms
 ✓ src/trpc/routers/sources.test.ts (27 tests) 2029ms
 ✓ src/lib/oembed.test.ts (34 tests) 2482ms
 ✓ src/lib/favicon.test.ts (31 tests) 2522ms
 ✓ src/lib/rate-limiter.test.ts (28 tests) 2528ms
 ✓ src/lib/opengraph.test.ts (31 tests) 2451ms
 ✓ src/sync/consumer.test.ts (14 tests) 903ms
 ✓ src/lib/auth.test.ts (25 tests) 1261ms
 ✓ src/lib/locks.test.ts (36 tests) 2625ms
 ✓ src/polling/youtube-poller.test.ts (30 tests) 2165ms
 ✓ src/trpc/routers/subscriptions.test.ts (35 tests) 2596ms
 ✓ src/sync/dlq-consumer.test.ts (23 tests) 1017ms
 ✓ src/lib/link-preview.test.ts (33 tests) 2245ms
 ✓ src/admin/repair-subscriptions.test.ts (22 tests) 1334ms
 ✓ src/polling/adaptive.test.ts (29 tests) 1379ms
 ✓ src/ingestion/transformers.test.ts (38 tests) 2396ms
 ✓ src/ingestion/validation.test.ts (41 tests) 2438ms
 ✓ src/polling/health.test.ts (32 tests) 1422ms
 ✓ src/lib/article-extractor.test.ts (44 tests) 2664ms
 ✓ src/utils/error-utils.test.ts (49 tests) 2922ms
 ✓ src/trpc/routers/creators.test.ts (55 tests) 2921ms
 ✓ src/db/helpers/creators.test.ts (43 tests) 1604ms
 ✓ src/lib/link-parser.test.ts (45 tests) 2663ms
 ✓ src/lib/crypto.test.ts (66 tests) 3215ms
 ✓ src/sync/service.test.ts (49 tests) 1519ms
 ✓ src/trpc/routers/items.test.ts (50 tests) 1365ms
 ✓ src/ingestion/processor.test.ts (46 tests) 1438ms
 ✓ src/providers/spotify.test.ts (77 tests) 3278ms
 ✓ src/providers/youtube.test.ts (84 tests) 3270ms
 ✓ src/polling/spotify-poller.test.ts (45 tests) 3448ms
   ✓ Spotify Poller - Watermark Integrity > pollSingleSpotifySubscription > should NOT update lastPublishedAt when ingestion fails for all episodes 1743ms
 ✓ src/lib/token-refresh.test.ts (65 tests) 13810ms
   ✓ distributed locking behavior > should wait and read updated token when lock held by another 2024ms
   ✓ distributed locking behavior > should throw REFRESH_IN_PROGRESS after wait if still locked and token not updated 4012ms
   ✓ distributed locking behavior > should throw REFRESH_IN_PROGRESS when connection not found after wait 4014ms
   ✓ integration scenarios > should handle multiple rapid refresh requests with locking 2011ms

 Test Files  51 passed (51)
      Tests  1403 passed (1403)
   Start at  05:35:41
   Duration  20.85s (transform 20.59s, setup 8.78s, collect 64.22s, tests 94.21s, environment 10ms, prepare 63.77s)

[vpw:dbg] Shutting down runtimes...
