### PR TITLE
Fix delayed inbox swipe optimistic updates

### DIFF
--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -17,6 +17,7 @@ const mockInboxUseInfiniteQuery = jest.fn();
 const mockLibraryUseQuery = jest.fn();
 const mockLibraryUseInfiniteQuery = jest.fn();
 const mockHomeUseQuery = jest.fn();
+const mockBookmarkUseMutation = jest.fn();
 const mockArchiveUseMutation = jest.fn();
 const mockToggleFinishedUseMutation = jest.fn();
 const mockUseUtils = jest.fn();
@@ -34,6 +35,9 @@ jest.mock('../lib/trpc', () => ({
       },
       home: {
         useQuery: mockHomeUseQuery,
+      },
+      bookmark: {
+        useMutation: (...args: unknown[]) => mockBookmarkUseMutation(...args),
       },
       archive: {
         useMutation: (...args: unknown[]) => mockArchiveUseMutation(...args),
@@ -56,6 +60,7 @@ import {
   useLibraryItems,
   useInfiniteLibraryItems,
   useHomeData,
+  useBookmarkItem,
   useArchiveItem,
   useToggleFinished,
 } from './use-items-trpc';
@@ -338,6 +343,13 @@ beforeEach(() => {
     isPending: false,
   }));
 
+  mockBookmarkUseMutation.mockImplementation((config: unknown) => ({
+    ...(config as Record<string, unknown>),
+    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
+    isPending: false,
+  }));
+
   mockToggleFinishedUseMutation.mockImplementation((config: unknown) => ({
     ...(config as Record<string, unknown>),
     mutate: jest.fn(),
@@ -475,6 +487,98 @@ describe('useArchiveItem', () => {
     });
 
     expect(harness.spies.mockGetInvalidate).toHaveBeenCalledWith({ id: item.id });
+  });
+
+  it('applies optimistic archive state immediately without waiting for query cancellation', async () => {
+    const item = createMockItem({ id: 'archive-immediate-item', state: UserItemState.INBOX });
+    const harness = createToggleUtils({
+      inbox: {
+        items: [item],
+        nextCursor: null,
+      },
+      defaultLibrary: {
+        items: [item],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+
+    const neverResolves = new Promise<void>(() => {});
+    (harness.utils.items.library.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.inbox.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.home.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.get.cancel as jest.Mock).mockReturnValue(neverResolves);
+
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getArchiveHandlers();
+
+    const mutatePromise = mutation.onMutate({ id: item.id });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(harness.readInbox()?.items).toHaveLength(0);
+    expect(harness.readLibrary()?.items).toHaveLength(0);
+    expect(harness.readItem(item.id)?.state).toBe(UserItemState.ARCHIVED);
+
+    const pendingSentinel = Symbol('pending');
+    await expect(Promise.race([mutatePromise, Promise.resolve(pendingSentinel)])).resolves.not.toBe(
+      pendingSentinel
+    );
+  });
+});
+
+describe('useBookmarkItem', () => {
+  type BookmarkHandlers = {
+    onMutate: ({ id }: { id: string }) => Promise<unknown>;
+  };
+
+  function getBookmarkHandlers() {
+    const { result } = renderHook(() => useBookmarkItem());
+    return result.current as unknown as BookmarkHandlers;
+  }
+
+  it('applies optimistic bookmark state immediately without waiting for query cancellation', async () => {
+    const item = createMockItem({
+      id: 'bookmark-immediate-item',
+      state: UserItemState.INBOX,
+      bookmarkedAt: null,
+    });
+    const harness = createToggleUtils({
+      inbox: {
+        items: [item],
+        nextCursor: null,
+      },
+      itemsById: {
+        [item.id]: item,
+      },
+    });
+
+    const neverResolves = new Promise<void>(() => {});
+    (harness.utils.items.inbox.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.home.cancel as jest.Mock).mockReturnValue(neverResolves);
+    (harness.utils.items.get.cancel as jest.Mock).mockReturnValue(neverResolves);
+
+    mockUseUtils.mockReturnValue(harness.utils);
+
+    const mutation = getBookmarkHandlers();
+
+    const mutatePromise = mutation.onMutate({ id: item.id });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(harness.readInbox()?.items).toHaveLength(0);
+    expect(harness.readItem(item.id)?.state).toBe(UserItemState.BOOKMARKED);
+    expect(harness.readItem(item.id)?.bookmarkedAt).toEqual(expect.any(String));
+
+    const pendingSentinel = Symbol('pending');
+    await expect(Promise.race([mutatePromise, Promise.resolve(pendingSentinel)])).resolves.not.toBe(
+      pendingSentinel
+    );
   });
 });
 

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -143,14 +143,26 @@ function createOptimisticConfig<TInput extends { id: string }>(
     };
   };
 
+  const invalidateItemQueries = (input: TInput) => {
+    utils.items.inbox.invalidate();
+    utils.items.library.invalidate();
+    utils.items.home.invalidate();
+    if (options.updateSingleItem) {
+      utils.items.get.invalidate({ id: input.id });
+    }
+  };
+
   return {
     onMutate: async (input: TInput): Promise<OptimisticContext> => {
-      // Cancel outgoing queries to prevent race conditions
+      // Apply optimistic state immediately so swipe/tap actions do not wait on query cancellation.
+      // Cancellation still runs in the background to reduce stale overwrite races.
       const cancellations: Promise<void>[] = [utils.items.home.cancel()];
       if (options.updateInbox) cancellations.push(utils.items.inbox.cancel());
       if (options.updateLibrary) cancellations.push(utils.items.library.cancel());
       if (options.updateSingleItem) cancellations.push(utils.items.get.cancel({ id: input.id }));
-      await Promise.all(cancellations);
+      void Promise.all(cancellations).catch(() => {
+        invalidateItemQueries(input);
+      });
 
       // Snapshot previous values for rollback
       const context: OptimisticContext = {};
@@ -207,13 +219,8 @@ function createOptimisticConfig<TInput extends { id: string }>(
     },
     onSettled: (_data: unknown, _err: unknown, vars: TInput) => {
       // Refetch after mutation completes (success or error)
-      utils.items.inbox.invalidate();
-      utils.items.library.invalidate();
-      utils.items.home.invalidate();
+      invalidateItemQueries(vars);
       invalidateRecapQueries(utils);
-      if (options.updateSingleItem) {
-        utils.items.get.invalidate({ id: vars.id });
-      }
     },
   };
 }


### PR DESCRIPTION
## Summary
- apply inbox swipe optimistic cache updates before waiting on query cancellation
- keep cancellation running in the background and invalidate affected queries if it fails
- add regression tests covering immediate optimistic archive and bookmark behavior

## Testing
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`