### PR TITLE
fix(mobile): keep Home inbox cards in sync with Inbox list

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -31,7 +31,7 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { getFeaturedGridItemWidth, getVisibleFeaturedGridItems } from '@/lib/home-layout';
 import {
-  useInboxItems,
+  useInfiniteInboxItems,
   useHomeData,
   useLibraryItems,
   mapContentType,
@@ -56,6 +56,8 @@ function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; col
 // =============================================================================
 // Utility Functions
 // =============================================================================
+
+const INBOX_PAGE_SIZE = 20;
 
 function getGreeting(): string {
   const hour = new Date().getHours();
@@ -160,7 +162,9 @@ export default function HomeScreen() {
   useTabPrefetch('home');
 
   // Data hooks
-  const { data: inboxData, isLoading: isInboxLoading } = useInboxItems();
+  const { data: inboxPages, isLoading: isInboxLoading } = useInfiniteInboxItems({
+    limit: INBOX_PAGE_SIZE,
+  });
   const { data: homeData, isLoading: isHomeLoading } = useHomeData();
   const { data: libraryData } = useLibraryItems();
   const { data: weeklyRecapTeaser, isLoading: isWeeklyRecapLoading } = useWeeklyRecapTeaser({
@@ -198,7 +202,9 @@ export default function HomeScreen() {
   }, [homeData?.recentBookmarks]);
 
   const inboxItems = useMemo((): ItemCardData[] => {
-    return (inboxData?.items ?? []).slice(0, 4).map((item) => ({
+    const allInboxItems = inboxPages?.pages.flatMap((page) => page.items) ?? [];
+
+    return allInboxItems.slice(0, 4).map((item) => ({
       id: item.id,
       title: item.title,
       creator: item.creator,
@@ -209,7 +215,7 @@ export default function HomeScreen() {
       duration: item.duration ?? null,
       readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
-  }, [inboxData?.items]);
+  }, [inboxPages?.pages]);
 
   const podcasts = useMemo((): ItemCardData[] => {
     return (homeData?.byContentType.podcasts ?? []).map((item) => ({

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -144,6 +144,12 @@ jest.mock('@/lib/home-layout', () => ({
 
 jest.mock('@/hooks/use-items-trpc', () => ({
   useInboxItems: () => ({ data: { items: [] }, isLoading: false }),
+  useInfiniteInboxItems: () => ({
+    data: {
+      pages: [{ items: [], nextCursor: null }],
+    },
+    isLoading: false,
+  }),
   useHomeData: () => ({
     data: {
       jumpBackIn: [],


### PR DESCRIPTION
## Problem
Home occasionally showed newer inbox cards than the Inbox tab itself.

## Root cause
Home and Inbox were reading inbox data through different query shapes/keys ( vs ), so they could drift under different cache/update timing.

## Fix
- switched Home inbox preview to , matching Inbox tab query shape and page size
- derive Home preview cards from the same paginated item stream and keep the 4-card preview slice

## Validation
- mobile-design-system: OK
-   console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:369:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:377:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:386:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:399:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:408:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:423:15)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getArchiveHandlers (hooks/use-items-trpc.test.ts:450:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:467:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getArchiveHandlers (hooks/use-items-trpc.test.ts:450:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:516:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getBookmarkHandlers (hooks/use-items-trpc.test.ts:540:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:567:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getToggleHandlers (hooks/use-items-trpc.test.ts:601:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:614:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getToggleHandlers (hooks/use-items-trpc.test.ts:601:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:640:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getToggleHandlers (hooks/use-items-trpc.test.ts:601:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:677:22)

  console.error
    react-test-renderer is deprecated. See https://react.dev/warnings/react-test-renderer

      19 |
      20 |   act(() => {
    > 21 |     renderer = create(createElement(TestComponent));
         |                      ^
      22 |   });
      23 |
      24 |   const getRenderer = () => {

      at Object.<anonymous>.process.env.NODE_ENV.exports.create (../../node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17337:17)
      at test-utils/react-hooks.ts:21:22
      at Object.<anonymous>.process.env.NODE_ENV.exports.act (../../node_modules/react/cjs/react.development.js:814:22)
      at renderHook (test-utils/react-hooks.ts:20:6)
      at getToggleHandlers (hooks/use-items-trpc.test.ts:601:34)
      at Object.<anonymous> (hooks/use-items-trpc.test.ts:743:22)
