### PR TITLE
techdebt: replace inline Bindings import type in creators router

### DIFF
--- a/apps/worker/src/trpc/routers/creators.ts
+++ b/apps/worker/src/trpc/routers/creators.ts
@@ -50,6 +50,7 @@ import { hashString } from '../../rss/url';
 import type { ProviderConnection, TokenRefreshEnv } from '../../lib/token-refresh';
 import { TokenRefreshError } from '../../lib/token-refresh';
 import type { Database } from '../../db';
+import type { Bindings } from '../../types';
 
 // ============================================================================
 // Types
@@ -1204,8 +1205,7 @@ interface CachedLatestContent {
  * Environment type for provider fetch operations
  * Uses Bindings from types.ts - env vars are validated at runtime
  */
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type ProviderFetchEnv = import('../../types').Bindings;
+type ProviderFetchEnv = Bindings;
 
 // ============================================================================
 // Helper Functions


### PR DESCRIPTION
## Summary
- replace inline `import('../../types').Bindings` alias in `creators.ts` with an explicit top-level `import type { Bindings }`
- remove the local eslint suppression that was only needed for the inline import style

## Why
This is a small type-hygiene cleanup that makes imports consistent with the rest of the worker code and removes an unnecessary lint override.

## Validation
- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker test:run src/trpc/routers/creators.test.ts`
