### PR TITLE
Improve inbox swipe responsiveness

### DIFF
--- a/apps/mobile/app/(tabs)/inbox.tsx
+++ b/apps/mobile/app/(tabs)/inbox.tsx
@@ -30,6 +30,12 @@ import {
 } from '@/hooks/use-items-trpc';
 import { useSyncAll } from '@/hooks/use-sync-all';
 import { isReconnectRequired } from '@/lib/connection-status';
+import {
+  addPendingDismissedId,
+  filterPendingDismissedItems,
+  pruneResolvedPendingDismissedIds,
+  removePendingDismissedId,
+} from '@/lib/inbox-optimistic-dismissal';
 import { useNetworkStatus } from '@/hooks/use-network-status';
 import { showSuccess, showWarning, showError } from '@/lib/toast-utils';
 import type { ContentType, Provider } from '@/lib/content-utils';
@@ -89,6 +95,7 @@ export default function InboxScreen() {
   // Track items that should animate in after a failed mutation (rollback)
   // Maps item ID to the direction they should enter from
   const [reappearingItems, setReappearingItems] = useState<Map<string, EnterDirection>>(new Map());
+  const [pendingDismissedItemIds, setPendingDismissedItemIds] = useState<Set<string>>(new Set());
   const listRef = useRef<Animated.FlatList<ItemCardData>>(null);
 
   // Action mutations for swipeable items with rollback handling
@@ -113,10 +120,12 @@ export default function InboxScreen() {
 
   const handleArchive = useCallback(
     (id: string) => {
+      setPendingDismissedItemIds((prev) => addPendingDismissedId(prev, id));
       archiveMutation.mutate(
         { id },
         {
           onError: () => {
+            setPendingDismissedItemIds((prev) => removePendingDismissedId(prev, id));
             // Archive exits left, so reappear from left
             markAsReappearing(id, 'left');
             showError(toast, new Error('Archive failed'), 'Failed to archive item', 'archive');
@@ -129,10 +138,12 @@ export default function InboxScreen() {
 
   const handleBookmark = useCallback(
     (id: string) => {
+      setPendingDismissedItemIds((prev) => addPendingDismissedId(prev, id));
       bookmarkMutation.mutate(
         { id },
         {
           onError: () => {
+            setPendingDismissedItemIds((prev) => removePendingDismissedId(prev, id));
             // Bookmark exits right, so reappear from right
             markAsReappearing(id, 'right');
             showError(toast, new Error('Bookmark failed'), 'Failed to save item', 'bookmark');
@@ -227,6 +238,15 @@ export default function InboxScreen() {
     [data?.pages]
   );
 
+  const visibleInboxItems = useMemo(
+    () => filterPendingDismissedItems(inboxItems, pendingDismissedItemIds),
+    [inboxItems, pendingDismissedItemIds]
+  );
+
+  useEffect(() => {
+    setPendingDismissedItemIds((prev) => pruneResolvedPendingDismissedIds(prev, inboxItems));
+  }, [inboxItems]);
+
   const handleEndReached = useCallback(() => {
     if (!hasNextPage || isFetchingNextPage) {
       return;
@@ -236,11 +256,11 @@ export default function InboxScreen() {
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const inboxCountLabel =
-    inboxItems.length === 0
+    visibleInboxItems.length === 0
       ? 'Decide what to keep'
       : hasNextPage
-        ? `${inboxItems.length}+ items to triage`
-        : `${inboxItems.length} item${inboxItems.length === 1 ? '' : 's'} to triage`;
+        ? `${visibleInboxItems.length}+ items to triage`
+        : `${visibleInboxItems.length} item${visibleInboxItems.length === 1 ? '' : 's'} to triage`;
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
@@ -319,12 +339,12 @@ export default function InboxScreen() {
         ) : (
           <Animated.FlatList
             ref={listRef}
-            data={inboxItems}
+            data={visibleInboxItems}
             renderItem={renderItem}
             keyExtractor={(item) => item.id}
             contentContainerStyle={[
               styles.listContent,
-              inboxItems.length === 0 && styles.emptyListContent,
+              visibleInboxItems.length === 0 && styles.emptyListContent,
             ]}
             showsVerticalScrollIndicator={false}
             onRefresh={handleRefresh}

--- a/apps/mobile/lib/inbox-optimistic-dismissal.test.ts
+++ b/apps/mobile/lib/inbox-optimistic-dismissal.test.ts
@@ -1,0 +1,58 @@
+import {
+  addPendingDismissedId,
+  removePendingDismissedId,
+  filterPendingDismissedItems,
+  pruneResolvedPendingDismissedIds,
+} from './inbox-optimistic-dismissal';
+
+describe('inbox optimistic dismissal helpers', () => {
+  it('adds a pending id without mutating the original set', () => {
+    const pendingIds = new Set<string>(['item-1']);
+
+    const next = addPendingDismissedId(pendingIds, 'item-2');
+
+    expect([...pendingIds]).toEqual(['item-1']);
+    expect([...next]).toEqual(['item-1', 'item-2']);
+  });
+
+  it('returns the same set when adding a duplicate pending id', () => {
+    const pendingIds = new Set<string>(['item-1']);
+
+    const next = addPendingDismissedId(pendingIds, 'item-1');
+
+    expect(next).toBe(pendingIds);
+  });
+
+  it('removes a pending id without mutating the original set', () => {
+    const pendingIds = new Set<string>(['item-1', 'item-2']);
+
+    const next = removePendingDismissedId(pendingIds, 'item-1');
+
+    expect([...pendingIds]).toEqual(['item-1', 'item-2']);
+    expect([...next]).toEqual(['item-2']);
+  });
+
+  it('filters dismissed items out of the rendered inbox list', () => {
+    const items = [{ id: 'item-1' }, { id: 'item-2' }, { id: 'item-3' }];
+    const pendingIds = new Set<string>(['item-2']);
+
+    expect(filterPendingDismissedItems(items, pendingIds)).toEqual([
+      { id: 'item-1' },
+      { id: 'item-3' },
+    ]);
+  });
+
+  it('prunes pending ids once the backing query no longer contains the item', () => {
+    const pendingIds = new Set<string>(['item-1', 'item-2']);
+    const items = [{ id: 'item-2' }, { id: 'item-3' }];
+
+    expect([...pruneResolvedPendingDismissedIds(pendingIds, items)]).toEqual(['item-2']);
+  });
+
+  it('returns the same set when all pending ids are still present', () => {
+    const pendingIds = new Set<string>(['item-1']);
+    const items = [{ id: 'item-1' }, { id: 'item-2' }];
+
+    expect(pruneResolvedPendingDismissedIds(pendingIds, items)).toBe(pendingIds);
+  });
+});

--- a/apps/mobile/lib/inbox-optimistic-dismissal.ts
+++ b/apps/mobile/lib/inbox-optimistic-dismissal.ts
@@ -1,0 +1,58 @@
+type ItemWithId = {
+  id: string;
+};
+
+export function addPendingDismissedId(pendingIds: Set<string>, id: string): Set<string> {
+  if (pendingIds.has(id)) {
+    return pendingIds;
+  }
+
+  const next = new Set(pendingIds);
+  next.add(id);
+  return next;
+}
+
+export function removePendingDismissedId(pendingIds: Set<string>, id: string): Set<string> {
+  if (!pendingIds.has(id)) {
+    return pendingIds;
+  }
+
+  const next = new Set(pendingIds);
+  next.delete(id);
+  return next;
+}
+
+export function filterPendingDismissedItems<T extends ItemWithId>(
+  items: T[],
+  pendingIds: ReadonlySet<string>
+): T[] {
+  if (pendingIds.size === 0) {
+    return items;
+  }
+
+  return items.filter((item) => !pendingIds.has(item.id));
+}
+
+export function pruneResolvedPendingDismissedIds<T extends ItemWithId>(
+  pendingIds: Set<string>,
+  items: T[]
+): Set<string> {
+  if (pendingIds.size === 0) {
+    return pendingIds;
+  }
+
+  const visibleIds = new Set(items.map((item) => item.id));
+  let didChange = false;
+  const next = new Set<string>();
+
+  pendingIds.forEach((id) => {
+    if (visibleIds.has(id)) {
+      next.add(id);
+      return;
+    }
+
+    didChange = true;
+  });
+
+  return didChange ? next : pendingIds;
+}


### PR DESCRIPTION
## Summary
- remove inbox rows immediately on swipe by tracking pending dismissals in the screen layer
- keep the network mutation in the background and only restore the row if the mutation fails
- add focused helper coverage for optimistic dismissal filtering and cleanup

## Testing
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

## Notes
- Did not run the iOS simulator in this pass.