### PR TITLE
Fix X/Twitter bookmark parsing for mobile-host share URLs

### DIFF
--- a/apps/worker/src/lib/fxtwitter.test.ts
+++ b/apps/worker/src/lib/fxtwitter.test.ts
@@ -55,6 +55,13 @@ describe('fxtwitter', () => {
       expect(result).toEqual({ username: 'user', tweetId: '12345' });
     });
 
+    it('parses mobile x.com URL with query params', () => {
+      const result = parseTwitterUrl(
+        'https://mobile.x.com/saranormous/status/2035080458304987603?s=12'
+      );
+      expect(result).toEqual({ username: 'saranormous', tweetId: '2035080458304987603' });
+    });
+
     it('returns null for invalid domain', () => {
       const result = parseTwitterUrl('https://google.com');
       expect(result).toBeNull();

--- a/apps/worker/src/lib/fxtwitter.ts
+++ b/apps/worker/src/lib/fxtwitter.ts
@@ -233,10 +233,6 @@ export const FXTWITTER_API_BASE = 'https://api.fxtwitter.com';
 /** Request timeout in milliseconds (10s for Worker environment reliability) */
 const FETCH_TIMEOUT_MS = 10000;
 
-/** Regex pattern for Twitter/X URLs */
-const TWITTER_URL_PATTERN =
-  /^https?:\/\/(?:www\.)?(?:twitter\.com|x\.com)\/([^/]+)\/status\/(\d+)/i;
-
 // ============================================================================
 // Logger
 // ============================================================================
@@ -293,16 +289,31 @@ async function fetchWithTimeout(
  * ```
  */
 export function parseTwitterUrl(url: string): ParsedTwitterUrl | null {
-  const match = url.match(TWITTER_URL_PATTERN);
+  try {
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname.toLowerCase().replace(/^www\./, '');
+    const baseHostname = hostname.replace(/^(?:mobile\.|m\.)/, '');
 
-  if (!match || !match[1] || !match[2]) {
+    if (baseHostname !== 'twitter.com' && baseHostname !== 'x.com') {
+      return null;
+    }
+
+    const pathParts = parsedUrl.pathname.split('/').filter(Boolean);
+    if (pathParts.length < 3 || pathParts[1] !== 'status') {
+      return null;
+    }
+
+    const username = pathParts[0];
+    const tweetId = pathParts[2] ?? '';
+
+    if (!username || !/^\d+$/.test(tweetId)) {
+      return null;
+    }
+
+    return { username, tweetId };
+  } catch {
     return null;
   }
-
-  return {
-    username: match[1],
-    tweetId: match[2],
-  };
 }
 
 // ============================================================================

--- a/apps/worker/src/lib/link-parser.test.ts
+++ b/apps/worker/src/lib/link-parser.test.ts
@@ -326,6 +326,19 @@ describe('parseLink', () => {
         expect(result?.provider).toBe(Provider.X);
         expect(result?.providerId).toBe('1234567890123456789');
       });
+
+      it('handles mobile x.com host with query parameters', () => {
+        const result = parseLink(
+          'https://mobile.x.com/saranormous/status/2035080458304987603?s=12'
+        );
+
+        expect(result).toEqual({
+          provider: Provider.X,
+          contentType: ContentType.POST,
+          providerId: '2035080458304987603',
+          canonicalUrl: 'https://x.com/saranormous/status/2035080458304987603',
+        });
+      });
     });
 
     describe('tracking parameter stripping', () => {

--- a/apps/worker/src/lib/link-parser.ts
+++ b/apps/worker/src/lib/link-parser.ts
@@ -227,9 +227,10 @@ function parseSubstack(url: URL): ParsedLink | null {
  *
  */
 function parseTwitter(url: URL): ParsedLink | null {
-  const hostname = url.hostname.toLowerCase().replace('www.', '');
+  const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
+  const baseHostname = hostname.replace(/^(?:mobile\.|m\.)/, '');
 
-  if (hostname !== 'twitter.com' && hostname !== 'x.com') {
+  if (baseHostname !== 'twitter.com' && baseHostname !== 'x.com') {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- fix X/Twitter URL parsing to normalize host variants (`mobile.` / `m.` + `www.`) in both link parsing and FxTwitter URL parsing
- switch `parseTwitterUrl` to URL-based parsing instead of a permissive regex
- add regression tests including the reported URL pattern (`.../status/...?...`) on mobile host variants

## Root cause
Bookmark parsing only accepted bare `x.com` / `twitter.com` hosts. Some shared X links (especially from mobile contexts) can use `mobile.x.com`/`m.twitter.com`, which caused provider parsing to fall through and bookmark creation to fail in the X-specific metadata path.

## Validation
- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker test:run -- src/lib/link-parser.test.ts src/lib/fxtwitter.test.ts`
- pre-push quality gates (auto): prettier check, mobile design-system check, turbo typecheck, worker test suite (`51 files / 1403 tests`)
