### PR TITLE
Harden worker rate limiter parsing

### DIFF
--- a/apps/worker/src/lib/rate-limiter.test.ts
+++ b/apps/worker/src/lib/rate-limiter.test.ts
@@ -151,6 +151,31 @@ describe('isRateLimited', () => {
 
     expect(mockKV.get).toHaveBeenCalledWith('rate:SPOTIFY:user_test');
   });
+
+  it('should ignore malformed stored state and clear it', async () => {
+    mockKV._store.set('rate:SPOTIFY:user_bad_json', '{not-json');
+
+    const result = await isRateLimited('SPOTIFY', 'user_bad_json', mockKV);
+
+    expect(result).toEqual({ limited: false });
+    expect(mockKV.delete).toHaveBeenCalledWith('rate:SPOTIFY:user_bad_json');
+  });
+
+  it('should ignore invalid stored state shapes and clear them', async () => {
+    mockKV._store.set(
+      'rate:YOUTUBE:user_bad_shape',
+      JSON.stringify({
+        retryAfter: 'soon',
+        consecutiveFailures: 1,
+        lastRequest: MOCK_NOW,
+      })
+    );
+
+    const result = await isRateLimited('YOUTUBE', 'user_bad_shape', mockKV);
+
+    expect(result).toEqual({ limited: false });
+    expect(mockKV.delete).toHaveBeenCalledWith('rate:YOUTUBE:user_bad_shape');
+  });
 });
 
 // ============================================================================
@@ -220,6 +245,16 @@ describe('RateLimitedFetcher', () => {
       await fetcher.fetch('SPOTIFY', 'user_clear', mockFn);
 
       expect(mockKV.delete).toHaveBeenCalledWith('rate:SPOTIFY:user_clear');
+    });
+
+    it('should recover from malformed stored state', async () => {
+      mockKV._store.set('rate:SPOTIFY:user_corrupt', '{not-json');
+      const mockFn = vi.fn().mockResolvedValue('ok');
+
+      const result = await fetcher.fetch('SPOTIFY', 'user_corrupt', mockFn);
+
+      expect(result).toBe('ok');
+      expect(mockFn).toHaveBeenCalled();
     });
   });
 
@@ -316,6 +351,23 @@ describe('RateLimitedFetcher', () => {
       }
     });
 
+    it('should parse Retry-After HTTP-date values', async () => {
+      const retryAfter = new Date(MOCK_NOW + 90000).toUTCString();
+      const mockFn = vi.fn().mockRejectedValue({
+        status: 429,
+        headers: {
+          get: (name: string) => (name === 'Retry-After' ? retryAfter : null),
+        },
+      });
+
+      try {
+        await fetcher.fetch('SPOTIFY', 'user_http_date', mockFn);
+      } catch (error) {
+        expect(error).toBeInstanceOf(RateLimitError);
+        expect((error as RateLimitError).retryInMs).toBe(90000);
+      }
+    });
+
     it('should parse Retry-After from response.headers style', async () => {
       const mockFn = vi.fn().mockRejectedValue({
         status: 429,
@@ -331,6 +383,24 @@ describe('RateLimitedFetcher', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(RateLimitError);
         expect((error as RateLimitError).retryInMs).toBeCloseTo(45000, -2);
+      }
+    });
+
+    it('should parse case-insensitive Retry-After header keys', async () => {
+      const mockFn = vi.fn().mockRejectedValue({
+        status: 429,
+        response: {
+          headers: {
+            'Retry-After': '15',
+          },
+        },
+      });
+
+      try {
+        await fetcher.fetch('YOUTUBE', 'user_case_header', mockFn);
+      } catch (error) {
+        expect(error).toBeInstanceOf(RateLimitError);
+        expect((error as RateLimitError).retryInMs).toBeCloseTo(15000, -2);
       }
     });
 

--- a/apps/worker/src/lib/rate-limiter.ts
+++ b/apps/worker/src/lib/rate-limiter.ts
@@ -13,6 +13,102 @@
 import { logger } from './logger';
 
 const rateLimitLogger = logger.child('rate-limiter');
+const DEFAULT_RETRY_AFTER_MS = 30 * 1000;
+
+function createDefaultRateLimitState(): RateLimitState {
+  return {
+    retryAfter: null,
+    consecutiveFailures: 0,
+    lastRequest: 0,
+  };
+}
+
+function isValidRateLimitState(value: unknown): value is RateLimitState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const state = value as Record<string, unknown>;
+  const retryAfterIsValid =
+    state.retryAfter === null ||
+    (typeof state.retryAfter === 'number' &&
+      Number.isFinite(state.retryAfter) &&
+      state.retryAfter >= 0);
+
+  return (
+    retryAfterIsValid &&
+    typeof state.consecutiveFailures === 'number' &&
+    Number.isFinite(state.consecutiveFailures) &&
+    state.consecutiveFailures >= 0 &&
+    typeof state.lastRequest === 'number' &&
+    Number.isFinite(state.lastRequest) &&
+    state.lastRequest >= 0
+  );
+}
+
+async function readStoredRateLimitState(
+  key: string,
+  kv: Pick<KVNamespace, 'delete'>,
+  stored: string | null
+): Promise<RateLimitState> {
+  if (!stored) {
+    return createDefaultRateLimitState();
+  }
+
+  try {
+    const parsed = JSON.parse(stored);
+    if (isValidRateLimitState(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    rateLimitLogger.warn('Failed to parse stored rate limit state', { key, error });
+    await kv.delete(key);
+    return createDefaultRateLimitState();
+  }
+
+  rateLimitLogger.warn('Ignoring invalid stored rate limit state shape', { key });
+  await kv.delete(key);
+  return createDefaultRateLimitState();
+}
+
+function readHeaderValue(headers: unknown, headerName: string): string | undefined {
+  if (!headers || typeof headers !== 'object') {
+    return undefined;
+  }
+
+  const headersWithGet = headers as { get?: (name: string) => string | null };
+  if (typeof headersWithGet.get === 'function') {
+    return headersWithGet.get(headerName) ?? undefined;
+  }
+
+  const lowerHeaderName = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === lowerHeaderName && typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function parseRetryAfterHeader(retryAfterHeader: string, now: number): number | null {
+  const trimmed = retryAfterHeader.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const retryAfterSeconds = Number(trimmed);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return now + retryAfterSeconds * 1000;
+  }
+
+  const retryAfterDate = Date.parse(trimmed);
+  if (Number.isFinite(retryAfterDate) && retryAfterDate > now) {
+    return retryAfterDate;
+  }
+
+  return null;
+}
 
 /**
  * State tracked per provider/user combination
@@ -158,39 +254,29 @@ export class RateLimitedFetcher {
    * - Default fallback of 30 seconds
    */
   private parseRetryAfter(error: unknown): number {
+    const now = Date.now();
+
     if (!error || typeof error !== 'object') {
-      return Date.now() + 30 * 1000;
+      return now + DEFAULT_RETRY_AFTER_MS;
     }
 
     const err = error as Record<string, unknown>;
 
-    // Try to extract Retry-After from headers
-    let retryAfterHeader: string | undefined;
-
-    // Check error.headers.get() (fetch Response style)
-    if (err.headers && typeof (err.headers as Record<string, unknown>).get === 'function') {
-      const headers = err.headers as { get: (name: string) => string | null };
-      retryAfterHeader = headers.get('Retry-After') ?? undefined;
-    }
-
-    // Check error.response.headers['retry-after'] (axios style)
-    if (!retryAfterHeader && err.response && typeof err.response === 'object') {
-      const response = err.response as Record<string, unknown>;
-      if (response.headers && typeof response.headers === 'object') {
-        const headers = response.headers as Record<string, string>;
-        retryAfterHeader = headers['retry-after'];
-      }
-    }
+    const retryAfterHeader =
+      readHeaderValue(err.headers, 'Retry-After') ??
+      (err.response && typeof err.response === 'object'
+        ? readHeaderValue((err.response as Record<string, unknown>).headers, 'Retry-After')
+        : undefined);
 
     if (retryAfterHeader) {
-      const seconds = parseInt(retryAfterHeader, 10);
-      if (!isNaN(seconds)) {
-        return Date.now() + seconds * 1000;
+      const retryAfter = parseRetryAfterHeader(retryAfterHeader, now);
+      if (retryAfter !== null) {
+        return retryAfter;
       }
     }
 
     // Default: 30 seconds
-    return Date.now() + 30 * 1000;
+    return now + DEFAULT_RETRY_AFTER_MS;
   }
 
   /**
@@ -217,9 +303,7 @@ export class RateLimitedFetcher {
     if (cached) return cached;
 
     const stored = await this.kv.get(key);
-    const state: RateLimitState = stored
-      ? JSON.parse(stored)
-      : { retryAfter: null, consecutiveFailures: 0, lastRequest: 0 };
+    const state = await readStoredRateLimitState(key, this.kv, stored);
 
     this.memoryState.set(key, state);
     return state;
@@ -295,7 +379,7 @@ export async function isRateLimited(
 
   if (!stored) return { limited: false };
 
-  const state: RateLimitState = JSON.parse(stored);
+  const state = await readStoredRateLimitState(key, kv, stored);
   if (!state.retryAfter || Date.now() >= state.retryAfter) {
     return { limited: false };
   }


### PR DESCRIPTION
## Summary
- validate and safely recover from malformed persisted KV rate-limit state
- clear invalid/corrupt stored entries instead of throwing during reads
- improve Retry-After parsing to support numeric seconds, HTTP-date values, and case-insensitive header keys
- add focused tests for malformed state handling and header parsing edge cases

## Validation
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/worker test -- src/lib/rate-limiter.test.ts
- pre-push hooks (prettier + mobile design-system check + turbo typecheck + worker test suite)
