### PR TITLE
mobile: harden duration formatting edge cases

### DIFF
--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -63,6 +63,7 @@ import {
   useBookmarkItem,
   useArchiveItem,
   useToggleFinished,
+  formatDuration,
 } from './use-items-trpc';
 
 function createMockItem(overrides: Record<string, unknown> = {}) {
@@ -337,6 +338,27 @@ function createToggleUtils(initial?: {
     },
   };
 }
+
+describe('formatDuration', () => {
+  it('formats minute and hour durations', () => {
+    expect(formatDuration(45)).toBe('0:45');
+    expect(formatDuration(125)).toBe('2:05');
+    expect(formatDuration(3661)).toBe('1:01:01');
+  });
+
+  it('floors fractional seconds to avoid decimal output', () => {
+    expect(formatDuration(125.9)).toBe('2:05');
+    expect(formatDuration(59.999)).toBe('0:59');
+  });
+
+  it('returns undefined for invalid durations', () => {
+    expect(formatDuration(undefined)).toBeUndefined();
+    expect(formatDuration(null)).toBeUndefined();
+    expect(formatDuration(Number.NaN)).toBeUndefined();
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(formatDuration(-1)).toBeUndefined();
+  });
+});
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -305,10 +305,12 @@ export function mapProvider(provider: Provider): UIProvider {
  */
 export function formatDuration(seconds?: number | null): string | undefined {
   if (seconds === undefined || seconds === null) return undefined;
+  if (!Number.isFinite(seconds) || seconds < 0) return undefined;
 
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
 
   if (hours > 0) {
     return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- harden `formatDuration` to return `undefined` for invalid inputs (`NaN`, `Infinity`, negative values)
- normalize fractional durations by flooring to whole seconds before formatting
- add focused unit tests covering valid formatting, fractional input handling, and invalid inputs

## Why
This is a small tech-debt cleanup that makes duration formatting behavior deterministic and safer around unexpected numeric inputs, preventing odd UI strings like decimal seconds.

## Validation
- `cd apps/mobile && bunx jest hooks/use-items-trpc.test.ts`
- `bun run --cwd apps/mobile lint`
- `bun run typecheck`
- pre-push hook also ran worker test suite successfully
