### PR TITLE
Remove weekly recap teaser card from Home

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -17,7 +17,6 @@ import Svg, { Path } from 'react-native-svg';
 
 import { FilterChip } from '@/components/filter-chip';
 import { ArticleIcon, HeadphonesIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
-import { WeeklyRecapCard } from '@/components/insights/weekly-recap-card';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import {
   Colors,
@@ -37,9 +36,7 @@ import {
   mapContentType,
   mapProvider,
 } from '@/hooks/use-items-trpc';
-import { useWeeklyRecapEntryState, useWeeklyRecapTeaser } from '@/hooks/use-insights-trpc';
 import type { ContentType, Provider, UIContentType } from '@/lib/content-utils';
-import { useAuthAvailability } from '@/providers/auth-provider';
 
 // =============================================================================
 // Icons
@@ -153,9 +150,6 @@ export default function HomeScreen() {
   const greeting = useMemo(() => getGreeting(), []);
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
   const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
-  const { isEnabled: isAuthEnabled } = useAuthAvailability();
-  const { shouldShowEntry: shouldShowWeeklyRecapTeaser, weekAnchorDate } =
-    useWeeklyRecapEntryState();
 
   useTabPrefetch('home');
 
@@ -163,10 +157,6 @@ export default function HomeScreen() {
   const { data: inboxData, isLoading: isInboxLoading } = useInboxItems();
   const { data: homeData, isLoading: isHomeLoading } = useHomeData();
   const { data: libraryData } = useLibraryItems();
-  const { data: weeklyRecapTeaser, isLoading: isWeeklyRecapLoading } = useWeeklyRecapTeaser({
-    enabled: isAuthEnabled && shouldShowWeeklyRecapTeaser,
-    weekAnchorDate,
-  });
 
   // Transform to ItemCardData format for use with ItemCard component
   const jumpBackInItems = useMemo((): ItemCardData[] => {
@@ -358,19 +348,6 @@ export default function HomeScreen() {
               ))}
             </ScrollView>
           </Animated.View>
-
-          {isAuthEnabled &&
-            shouldShowWeeklyRecapTeaser &&
-            (weeklyRecapTeaser || isWeeklyRecapLoading) && (
-              <Animated.View style={styles.recapCardSection}>
-                <WeeklyRecapCard
-                  recap={weeklyRecapTeaser}
-                  isLoading={isWeeklyRecapLoading}
-                  onPress={() => router.push('/recap/weekly')}
-                />
-              </Animated.View>
-            )}
-
           {isLoading ? (
             <View style={styles.loadingState}>
               <ActivityIndicator size="large" color={colors.primary} />
@@ -550,10 +527,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md,
     gap: Spacing.sm,
     marginBottom: Spacing.lg,
-  },
-  recapCardSection: {
-    paddingHorizontal: Spacing.md,
-    marginBottom: Spacing.xl,
   },
 
   // Section

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -6,7 +6,6 @@ import HomeScreen from '@/app/(tabs)/index';
 const mockPush = jest.fn();
 const mockUseWeeklyRecapTeaser = jest.fn();
 const mockUseWeeklyRecapEntryState = jest.fn();
-const mockUseAuthAvailability = jest.fn(() => ({ isEnabled: true }));
 
 type Renderer = ReturnType<typeof TestRenderer.create>;
 type TestNode = Renderer['root'];
@@ -116,13 +115,12 @@ jest.mock('@/components/icons', () => ({
   ArticleIcon: () => null,
   HeadphonesIcon: () => null,
   PostIcon: () => null,
-  SettingsIcon: () => null,
+  SettingsIcon: () => React.createElement('span', null, 'Settings icon'),
   VideoIcon: () => null,
 }));
 
 jest.mock('@/components/insights/weekly-recap-card', () => ({
-  WeeklyRecapCard: ({ onPress }: { onPress?: () => void }) =>
-    React.createElement('button', { onClick: onPress, onPress }, 'Weekly recap card'),
+  WeeklyRecapCard: () => React.createElement('button', null, 'Weekly recap card'),
 }));
 
 jest.mock('@/components/item-card', () => ({
@@ -166,11 +164,7 @@ jest.mock('@/hooks/use-insights-trpc', () => ({
   useWeeklyRecapEntryState: () => mockUseWeeklyRecapEntryState(),
 }));
 
-jest.mock('@/providers/auth-provider', () => ({
-  useAuthAvailability: () => mockUseAuthAvailability(),
-}));
-
-describe('HomeScreen weekly recap entry', () => {
+describe('HomeScreen weekly recap behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseWeeklyRecapTeaser.mockReturnValue({
@@ -181,58 +175,29 @@ describe('HomeScreen weekly recap entry', () => {
       shouldShowEntry: true,
       weekAnchorDate: '2026-03-15',
     });
-    mockUseAuthAvailability.mockReturnValue({ isEnabled: true });
   });
 
-  it('shows the recap teaser on the home screen during the Sunday/Monday window', () => {
-    let renderer: Renderer;
-    act(() => {
-      renderer = TestRenderer.create(<HomeScreen />);
-    });
-
-    expect(getTextContent(renderer!.root)).toContain('Weekly recap card');
-    expect(mockUseWeeklyRecapTeaser).toHaveBeenCalledWith({
-      enabled: true,
-      weekAnchorDate: '2026-03-15',
-    });
-
-    act(() => {
-      findButtonByText(renderer!, 'Weekly recap card').props.onPress();
-    });
-
-    expect(mockPush).toHaveBeenCalledWith('/recap/weekly');
-  });
-
-  it('hides the recap teaser outside the Sunday/Monday window', () => {
-    mockUseWeeklyRecapEntryState.mockReturnValue({
-      shouldShowEntry: false,
-      weekAnchorDate: '2026-03-15',
-    });
-
+  it('does not render a weekly recap card on Home and does not query teaser data', () => {
     let renderer: Renderer;
     act(() => {
       renderer = TestRenderer.create(<HomeScreen />);
     });
 
     expect(getTextContent(renderer!.root)).not.toContain('Weekly recap card');
-    expect(mockUseWeeklyRecapTeaser).toHaveBeenCalledWith({
-      enabled: false,
-      weekAnchorDate: '2026-03-15',
-    });
+    expect(mockUseWeeklyRecapEntryState).not.toHaveBeenCalled();
+    expect(mockUseWeeklyRecapTeaser).not.toHaveBeenCalled();
   });
 
-  it('disables the recap teaser query when auth is unavailable', () => {
-    mockUseAuthAvailability.mockReturnValue({ isEnabled: false });
-
+  it('keeps settings navigation on the Home screen', () => {
     let renderer: Renderer;
     act(() => {
       renderer = TestRenderer.create(<HomeScreen />);
     });
 
-    expect(getTextContent(renderer!.root)).not.toContain('Weekly recap card');
-    expect(mockUseWeeklyRecapTeaser).toHaveBeenCalledWith({
-      enabled: false,
-      weekAnchorDate: '2026-03-15',
+    act(() => {
+      findButtonByText(renderer!, 'Settings icon').props.onPress();
     });
+
+    expect(mockPush).toHaveBeenCalledWith('/settings');
   });
 });


### PR DESCRIPTION
## Summary\n- remove weekly recap teaser card rendering from Home tab\n- remove Home-specific weekly recap teaser query wiring\n- update Home screen tests to assert recap card is not shown and Settings navigation remains\n\n## Validation\n- bun run --cwd apps/mobile test lib/home-screen.test.tsx\n- bun run --cwd apps/mobile lint\n- bun run typecheck\n