### PR TITLE
fix(mobile): only count explicit bookmark opens

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 apps/mobile/expo-env.d.ts
+apps/mobile/.rnstorybook/storybook.requires.ts
+apps/mobile/uniwind-types.d.ts
 apps/mobile/ios/
 .opencode/

--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -1,7 +1,7 @@
 import * as Haptics from 'expo-haptics';
 import * as WebBrowser from 'expo-web-browser';
 import { useToast } from 'heroui-native';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { Linking, Share } from 'react-native';
 
 import {
@@ -25,21 +25,6 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
   const unbookmarkMutation = useUnbookmarkItem();
   const toggleFinishedMutation = useToggleFinished();
   const markOpenedMutation = useMarkItemOpened();
-  const lastMarkedItemIdRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (!item?.id) {
-      lastMarkedItemIdRef.current = null;
-      return;
-    }
-
-    if (lastMarkedItemIdRef.current === item.id) {
-      return;
-    }
-
-    lastMarkedItemIdRef.current = item.id;
-    markOpenedMutation.mutate({ id: item.id });
-  }, [item?.id, markOpenedMutation]);
 
   const handleOpenLink = useCallback(async () => {
     if (!item?.canonicalUrl) return;
@@ -71,7 +56,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
         }
       }
 
-      if (didOpen) {
+      if (didOpen && item.state === UserItemState.BOOKMARKED) {
         markOpenedMutation.mutate({ id: item.id });
       }
     } catch (err) {

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -5,6 +5,6 @@ const expoConfig = require('eslint-config-expo/flat');
 module.exports = defineConfig([
   expoConfig,
   {
-    ignores: ['dist/*'],
+    ignores: ['dist/*', '.rnstorybook/storybook.requires.ts', 'uniwind-types.d.ts'],
   },
 ]);

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -123,20 +123,18 @@ describe('useItemDetailActions', () => {
     expect(mockToggleFinishedMutation.mutate).not.toHaveBeenCalled();
   });
 
-  it('marks an item opened when the detail view loads', () => {
+  it('does not mark an item opened when the detail view loads', () => {
     let currentItem: ItemDetailItem | undefined = baseItem;
     const { rerender } = renderHook(() => useItemDetailActions(currentItem));
 
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledTimes(1);
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: baseItem.id });
+    expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
 
     rerender();
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledTimes(1);
+    expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
 
     currentItem = { ...baseItem, id: 'item-2' } as unknown as ItemDetailItem;
     rerender();
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledTimes(2);
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenLastCalledWith({ id: 'item-2' });
+    expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
   });
 
   it('opens in-app browser for articles and marks opened for bookmarked items', async () => {
@@ -216,15 +214,14 @@ describe('useItemDetailActions', () => {
     });
   });
 
-  it('marks opened after a successful open even when the item is not bookmarked', async () => {
+  it('does not mark opened after a successful open when the item is not bookmarked', async () => {
     const { result } = renderHook(() => useItemDetailActions(baseItem));
-    mockMarkOpenedMutation.mutate.mockClear();
 
     await act(async () => {
       await result.current.handleOpenLink();
     });
 
-    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: baseItem.id });
+    expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
   });
 
   it('logs errors when link opening fails', async () => {

--- a/apps/worker/src/trpc/routers/items.test.ts
+++ b/apps/worker/src/trpc/routers/items.test.ts
@@ -281,7 +281,13 @@ function createMockItemsCaller(options: {
           message: `Item ${input.id} not found`,
         });
       }
-      return { success: true as const, updated: item.state === UserItemState.BOOKMARKED };
+
+      if (item.state === UserItemState.BOOKMARKED) {
+        item.lastOpenedAt = new Date().toISOString();
+        return { success: true as const, updated: true };
+      }
+
+      return { success: true as const, updated: false };
     },
 
     updateProgress: async (input: { id: string; position: number; duration: number }) => {
@@ -1217,6 +1223,27 @@ describe('Items Router', () => {
       const result = await caller.markOpened({ id: 'ui-002' });
 
       expect(result).toEqual({ success: true, updated: false });
+    });
+
+    it('should not add inbox items to jumpBackIn after markOpened', async () => {
+      const item = createMockItemView({
+        id: 'ui-inbox-opened',
+        state: UserItemState.INBOX,
+        lastOpenedAt: null,
+      });
+      const itemsMap = new Map<string, ItemView>();
+      itemsMap.set(item.id, item);
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        libraryItems: [item],
+        allItems: itemsMap,
+      });
+
+      await caller.markOpened({ id: item.id });
+      const home = await caller.home();
+
+      expect(home.jumpBackIn).toEqual([]);
     });
 
     it('should throw NOT_FOUND when item does not exist', async () => {

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -1024,6 +1024,10 @@ export const itemsRouter = router({
         });
       }
 
+      if (existing[0].state !== UserItemState.BOOKMARKED) {
+        return { success: true as const, updated: false };
+      }
+
       await ctx.db
         .update(userItems)
         .set({


### PR DESCRIPTION
## Summary
- stop item detail navigation from recording a bookmark open before the user actually taps the open link action
- only persist `lastOpenedAt` for bookmarked items, so inbox and other non-bookmarked opens never affect Jump Back In
- add regression tests for the mobile detail flow and the worker mark-opened behavior, and manually verify in the iOS simulator