### PR TITLE
Match library tab reselect behavior to home

### DIFF
--- a/apps/mobile/app/(tabs)/library.tsx
+++ b/apps/mobile/app/(tabs)/library.tsx
@@ -12,11 +12,14 @@ import {
   Pressable,
   TextInput,
   FlatList,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type ListRenderItemInfo,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
+import { ContentType as ApiContentType } from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
 import {
@@ -39,7 +42,7 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
-import type { ContentType as ApiContentType, UIContentType, Provider } from '@/lib/content-utils';
+import type { UIContentType, UIProvider } from '@/lib/content-utils';
 
 // =============================================================================
 // Icons
@@ -70,6 +73,7 @@ function PlusIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: str
 // =============================================================================
 
 const LIBRARY_PAGE_SIZE = 20;
+const LIBRARY_TOP_THRESHOLD = 4;
 
 const filterOptions: {
   id: string;
@@ -88,7 +92,7 @@ const filterOptions: {
     icon: ArticleIcon,
     selectedColor: FilterChipPalette.article.accent,
     selectedSurfaceColor: FilterChipPalette.article.surface,
-    contentType: 'ARTICLE',
+    contentType: ApiContentType.ARTICLE,
   },
   {
     id: 'podcast',
@@ -97,7 +101,7 @@ const filterOptions: {
     icon: HeadphonesIcon,
     selectedColor: FilterChipPalette.podcast.accent,
     selectedSurfaceColor: FilterChipPalette.podcast.surface,
-    contentType: 'PODCAST',
+    contentType: ApiContentType.PODCAST,
   },
   {
     id: 'video',
@@ -106,7 +110,7 @@ const filterOptions: {
     icon: VideoIcon,
     selectedColor: FilterChipPalette.video.accent,
     selectedSurfaceColor: FilterChipPalette.video.surface,
-    contentType: 'VIDEO',
+    contentType: ApiContentType.VIDEO,
   },
   {
     id: 'post',
@@ -115,7 +119,7 @@ const filterOptions: {
     icon: PostIcon,
     selectedColor: FilterChipPalette.post.accent,
     selectedSurfaceColor: FilterChipPalette.post.surface,
-    contentType: 'POST',
+    contentType: ApiContentType.POST,
   },
 ];
 
@@ -123,10 +127,16 @@ const filterOptions: {
 // Main Screen
 // =============================================================================
 
+type LibraryTabNavigation = {
+  addListener: (event: 'tabPress', listener: () => void) => () => void;
+  isFocused: () => boolean;
+};
+
 export default function LibraryScreen() {
   const router = useRouter();
-  const navigation = useNavigation();
+  const navigation = useNavigation() as LibraryTabNavigation;
   const listScrollRef = useRef<FlatList<ItemCardData>>(null);
+  const scrollOffsetYRef = useRef(0);
   const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -207,7 +217,7 @@ export default function LibraryScreen() {
         creatorImageUrl: item.creatorImageUrl ?? null,
         thumbnailUrl: item.thumbnailUrl ?? null,
         contentType: mapContentType(item.contentType) as UIContentType,
-        provider: mapProvider(item.provider) as Provider,
+        provider: mapProvider(item.provider) as UIProvider,
         duration: item.duration ?? null,
         readingTimeMinutes: item.readingTimeMinutes ?? null,
         bookmarkedAt: item.bookmarkedAt ?? null,
@@ -224,6 +234,10 @@ export default function LibraryScreen() {
 
     void fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsetYRef.current = event.nativeEvent.contentOffset.y;
+  }, []);
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
@@ -242,9 +256,17 @@ export default function LibraryScreen() {
     return navigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
 
+      const isAtTop = scrollOffsetYRef.current <= LIBRARY_TOP_THRESHOLD;
+
+      if (isAtTop && (showCompletedOnly || contentTypeFilter !== null)) {
+        setShowCompletedOnly(false);
+        setContentTypeFilter(null);
+        return;
+      }
+
       listScrollRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
-  }, [navigation]);
+  }, [contentTypeFilter, navigation, showCompletedOnly]);
 
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]}>
@@ -309,7 +331,11 @@ export default function LibraryScreen() {
                 key={option.id}
                 label={option.label}
                 isSelected={contentTypeFilter === option.contentType}
-                onPress={() => setContentTypeFilter(option.contentType)}
+                onPress={() =>
+                  setContentTypeFilter((current) =>
+                    current === option.contentType ? null : option.contentType
+                  )
+                }
                 icon={option.icon}
                 dotColor={option.color}
                 selectedColor={option.selectedColor}
@@ -342,6 +368,8 @@ export default function LibraryScreen() {
             style={styles.listContainer}
             contentContainerStyle={styles.listContent}
             showsVerticalScrollIndicator={false}
+            onScroll={handleScroll}
+            scrollEventThrottle={16}
             onEndReached={handleEndReached}
             onEndReachedThreshold={0.6}
             ListFooterComponent={

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+const mockPush = jest.fn();
+const mockAddListener = jest.fn();
+const mockIsFocused = jest.fn();
+const mockScrollToOffset = jest.fn();
+const mockRemoveListener = jest.fn();
+
+const mockNavigation = {
+  addListener: mockAddListener,
+  isFocused: mockIsFocused,
+};
+
+let tabPressListener: (() => void) | undefined;
+
+type Renderer = ReturnType<typeof TestRenderer.create>;
+type TestNode = Renderer['root'];
+
+function findFilterChip(renderer: Renderer, label: string) {
+  return renderer.root.find(
+    (node: TestNode) =>
+      node.type === 'button' && node.props.accessibilityLabel === `Filter ${label}`
+  );
+}
+
+function findLibraryList(renderer: Renderer) {
+  return renderer.root.find((node: TestNode) => node.type === 'flat-list');
+}
+
+function pressLibraryTab() {
+  if (!tabPressListener) {
+    throw new Error('Expected library tab press listener to be registered');
+  }
+
+  tabPressListener();
+}
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: {
+    Light: 'light',
+  },
+  impactAsync: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useNavigation: () => mockNavigation,
+  useLocalSearchParams: () => ({}),
+}));
+
+jest.mock('react-native', () => ({
+  __esModule: true,
+  Platform: {
+    select: (options: Record<string, unknown>) => options.ios ?? options.default,
+  },
+  View: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  Text: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('span', null, children),
+  ScrollView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('scroll-view', props, children),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+  },
+  Pressable: ({
+    children,
+    onPress,
+  }: {
+    children: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
+    onPress?: () => void;
+  }) =>
+    React.createElement(
+      'button',
+      { onClick: onPress, onPress },
+      typeof children === 'function' ? children({ pressed: false }) : children
+    ),
+  TextInput: ({
+    value,
+    onChangeText,
+    ...props
+  }: {
+    value?: string;
+    onChangeText?: (text: string) => void;
+  }) => React.createElement('input', { ...props, value, onChangeText }),
+  FlatList: React.forwardRef(
+    (
+      {
+        data,
+        renderItem,
+        ...props
+      }: {
+        data?: unknown[];
+        renderItem?: (args: { item: unknown; index: number }) => React.ReactNode;
+      },
+      ref: React.ForwardedRef<{ scrollToOffset: typeof mockScrollToOffset }>
+    ) => {
+      React.useImperativeHandle(ref, () => ({
+        scrollToOffset: mockScrollToOffset,
+      }));
+
+      return React.createElement(
+        'flat-list',
+        props,
+        data?.map((item, index) =>
+          React.createElement(React.Fragment, { key: index }, renderItem?.({ item, index }))
+        )
+      );
+    }
+  ),
+  ActivityIndicator: () => React.createElement('span', null, 'loading'),
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    View: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement('div', null, children),
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('svg', null, children),
+  Path: () => null,
+}));
+
+jest.mock('heroui-native', () => ({
+  Surface: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('section', null, children),
+}));
+
+jest.mock('@/components/filter-chip', () => ({
+  FilterChip: ({
+    label,
+    isSelected,
+    onPress,
+  }: {
+    label: string;
+    isSelected: boolean;
+    onPress: () => void;
+  }) =>
+    React.createElement(
+      'button',
+      {
+        onPress,
+        accessibilityLabel: `Filter ${label}`,
+        'data-selected': isSelected,
+      },
+      label
+    ),
+}));
+
+jest.mock('@/components/icons', () => ({
+  ArticleIcon: () => null,
+  CheckOutlineIcon: () => null,
+  HeadphonesIcon: () => null,
+  PostIcon: () => null,
+  VideoIcon: () => null,
+}));
+
+jest.mock('@/components/item-card', () => ({
+  ItemCard: () => React.createElement('div', null, 'item'),
+}));
+
+jest.mock('@/components/list-states', () => ({
+  LoadingState: () => React.createElement('div', null, 'loading'),
+  ErrorState: ({ message }: { message: string }) => React.createElement('div', null, message),
+  EmptyState: ({ title }: { title: string }) => React.createElement('div', null, title),
+}));
+
+jest.mock('@/hooks/use-color-scheme', () => ({
+  useColorScheme: () => 'light',
+}));
+
+jest.mock('@/hooks/use-prefetch', () => ({
+  useTabPrefetch: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-items-trpc', () => ({
+  useInfiniteLibraryItems: () => ({
+    data: {
+      pages: [
+        {
+          items: [
+            {
+              id: 'item-1',
+              title: 'Example article',
+              creator: 'Example creator',
+              creatorImageUrl: null,
+              thumbnailUrl: null,
+              contentType: 'ARTICLE',
+              provider: 'RSS',
+              duration: null,
+              readingTimeMinutes: 5,
+              bookmarkedAt: null,
+              publishedAt: null,
+              isFinished: false,
+            },
+          ],
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+  mapContentType: (value: string) => value.toLowerCase(),
+  mapProvider: (value: string) => value,
+}));
+
+const LibraryScreen = jest.requireActual('@/app/(tabs)/library').default;
+
+describe('LibraryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tabPressListener = undefined;
+    mockIsFocused.mockReturnValue(true);
+    mockAddListener.mockImplementation((event: 'tabPress', listener: () => void) => {
+      if (event === 'tabPress') {
+        tabPressListener = listener;
+      }
+
+      return mockRemoveListener;
+    });
+  });
+
+  it('clears the active filter when the library tab is reselected at the top', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<LibraryScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
+
+    act(() => {
+      pressLibraryTab();
+    });
+
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
+    expect(mockScrollToOffset).not.toHaveBeenCalled();
+  });
+
+  it('clears the completed filter when the library tab is reselected at the top', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<LibraryScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Completed').props.onPress();
+    });
+
+    expect(findFilterChip(renderer!, 'Completed').props['data-selected']).toBe(true);
+
+    act(() => {
+      pressLibraryTab();
+    });
+
+    expect(findFilterChip(renderer!, 'Completed').props['data-selected']).toBe(false);
+    expect(mockScrollToOffset).not.toHaveBeenCalled();
+  });
+
+  it('scrolls to the top without clearing the active filter when the library tab is reselected mid-scroll', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<LibraryScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    act(() => {
+      findLibraryList(renderer!).props.onScroll({
+        nativeEvent: {
+          contentOffset: {
+            y: 240,
+          },
+        },
+      });
+    });
+
+    act(() => {
+      pressLibraryTab();
+    });
+
+    expect(mockScrollToOffset).toHaveBeenCalledWith({ offset: 0, animated: true });
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- make the library tab mirror home tab reselect behavior by scrolling to top when the list is down and clearing active filters when already at the top
- make library content-type chips toggle off when reselected and align the screen with the shared content-type enum
- add focused Jest coverage for library tab reselect behavior, including clearing completed/article filters and preserving filters when scrolling to top

## Testing
- bun x jest lib/library-screen.test.tsx lib/home-screen.test.tsx --config jest.config.js --runInBand
- pre-push checks: format, design-system, typecheck, worker tests

## Manual Verification
- verified in the iOS simulator