### PR TITLE
Facelift subscriptions hub: branded icons & streamlined layout

### DIFF
--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -1,18 +1,16 @@
 import { useMemo } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { Stack, useNavigation, useRouter } from 'expo-router';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { LoadingState } from '@/components/list-states';
-import { IconButton, Surface, Text } from '@/components/primitives';
+import { Surface } from '@/components/primitives';
 import { SourceListRow } from '@/components/subscriptions';
-import { Radius, Spacing } from '@/constants/theme';
-import { useAppTheme } from '@/hooks/use-app-theme';
+import { Spacing } from '@/constants/theme';
 import { useConnections, type Connection } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
-import { isReconnectRequired, type ConnectionStatus } from '@/lib/connection-status';
+import { type ConnectionStatus } from '@/lib/connection-status';
 import {
-  buildSubscriptionsSummary,
   getHubStatusText,
   getIntegrationState,
   getSubscriptionSourceConfig,
@@ -25,22 +23,17 @@ const SUBSCRIPTION_SOURCES: SubscriptionSource[] = ['YOUTUBE', 'SPOTIFY', 'GMAIL
 export default function SubscriptionsScreen() {
   const navigation = useNavigation();
   const router = useRouter();
-  const { colors } = useAppTheme();
   const canGoBack = navigation.canGoBack();
   const headerLeft = canGoBack
     ? () => (
-        <View style={styles.headerLeftWrapper}>
-          <IconButton
-            size="sm"
-            variant="subtle"
-            colors={colors}
-            style={[styles.headerBackButton, { backgroundColor: colors.backgroundSecondary }]}
-            accessibilityLabel="Go back"
-            onPress={() => router.back()}
-          >
-            <Ionicons name="chevron-back" size={20} color={colors.text} />
-          </IconButton>
-        </View>
+        <Pressable
+          accessibilityLabel="Go back"
+          onPress={() => router.back()}
+          hitSlop={8}
+          style={styles.headerBack}
+        >
+          <Ionicons name="chevron-back" size={28} color="#FFFFFF" />
+        </Pressable>
       )
     : undefined;
 
@@ -71,13 +64,6 @@ export default function SubscriptionsScreen() {
   ).length;
   const gmailCount = newsletterStatsQuery.data?.active ?? 0;
   const rssCount = rssStatsQuery.data?.active ?? 0;
-
-  const totalActiveCount = youtubeCount + spotifyCount + gmailCount + rssCount;
-  const connectedIntegrations =
-    connections?.filter((connection: Connection) => connection.status === 'ACTIVE').length ?? 0;
-  const attentionCount =
-    connections?.filter((connection: Connection) => isReconnectRequired(connection.status))
-      .length ?? 0;
 
   const sourceRows = useMemo(
     () =>
@@ -111,11 +97,7 @@ export default function SubscriptionsScreen() {
   if (isLoading) {
     return (
       <>
-        <Stack.Screen
-          options={{
-            headerLeft,
-          }}
-        />
+        <Stack.Screen options={{ headerLeft }} />
         <Surface tone="canvas" style={styles.container}>
           <LoadingState />
         </Surface>
@@ -125,27 +107,13 @@ export default function SubscriptionsScreen() {
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          headerLeft,
-        }}
-      />
+      <Stack.Screen options={{ headerLeft }} />
       <Surface tone="canvas" style={styles.container} collapsable={false}>
         <ScrollView
           contentContainerStyle={styles.content}
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
         >
-          <Surface tone="elevated" border="subtle" radius="xl" style={styles.hero}>
-            <Text variant="labelSmallPlain" tone="tertiary" transform="uppercase">
-              Subscriptions
-            </Text>
-            <Text variant="headlineSmall">Manage each source in one place</Text>
-            <Text variant="bodyMedium" tone="subheader">
-              {buildSubscriptionsSummary(totalActiveCount, connectedIntegrations, attentionCount)}
-            </Text>
-          </Surface>
-
           <View style={styles.rows}>
             {sourceRows.map((row) => (
               <SourceListRow
@@ -175,26 +143,14 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: Spacing.lg,
-    gap: Spacing.lg,
+    gap: Spacing.md,
     paddingBottom: Spacing['3xl'],
+    paddingTop: Spacing.sm,
   },
-  headerBackButton: {
-    width: 40,
-    height: 40,
-    borderRadius: Radius.full,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerLeftWrapper: {
-    marginLeft: Spacing.md,
-    marginTop: Spacing.xs,
-  },
-  hero: {
-    gap: Spacing.sm,
-    marginTop: Spacing.sm,
-    padding: Spacing.lg,
+  headerBack: {
+    marginLeft: -Spacing.xs,
   },
   rows: {
-    gap: Spacing.md,
+    gap: Spacing.sm,
   },
 });

--- a/apps/mobile/components/subscriptions/source-ui.test.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.test.tsx
@@ -40,6 +40,11 @@ jest.mock('react-native', () => ({
   },
 }));
 
+jest.mock('@expo/vector-icons', () => {
+  const Icon = (props: Record<string, unknown>) => React.createElement('svg', props);
+  return { Ionicons: Icon, FontAwesome5: Icon };
+});
+
 jest.mock('lucide-react-native', () => {
   const Icon = ({ children }: { children?: React.ReactNode }) =>
     React.createElement('svg', null, children);

--- a/apps/mobile/components/subscriptions/source-ui.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.tsx
@@ -1,5 +1,6 @@
+import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import { View, Image, Pressable, StyleSheet, TextInput } from 'react-native';
-import { FileText, Headphones, Play, Rss } from 'lucide-react-native';
+import { Rss } from 'lucide-react-native';
 
 import { Badge, Button, Surface, Text } from '@/components/primitives';
 import { ChevronRightIcon, SearchIcon } from '@/components/icons';
@@ -12,24 +13,28 @@ import {
   getSubscriptionSourceConfig,
 } from '@/lib/subscription-sources';
 
+// design-system-exception: brand colors matching FAB config in item-detail-helpers.tsx
+const SOURCE_BRAND: Record<SubscriptionSource, { bg: string; icon: React.ReactNode }> = {
+  YOUTUBE: {
+    bg: '#FF0000', // design-system-exception: YouTube brand color
+    icon: <Ionicons name="logo-youtube" size={22} color="#FFFFFF" />, // design-system-exception: white on brand
+  },
+  SPOTIFY: {
+    bg: '#1DB954', // design-system-exception: Spotify brand color
+    icon: <FontAwesome5 name="spotify" size={22} color="#FFFFFF" />, // design-system-exception: white on brand
+  },
+  GMAIL: {
+    bg: '#1A73E8', // design-system-exception: Gmail brand color
+    icon: <Ionicons name="newspaper-outline" size={22} color="#FFFFFF" />, // design-system-exception: white on brand
+  },
+  RSS: {
+    bg: '#F59E0B', // design-system-exception: RSS accent color
+    icon: <Rss size={20} color="#FFFFFF" strokeWidth={2.5} />, // design-system-exception: white on brand
+  },
+};
+
 function SourceGlyph({ source }: { source: SubscriptionSource }) {
-  const { colors } = useAppTheme();
-  const iconColor = source === 'GMAIL' ? colors.statusInfo : colors.textPrimary;
-  const iconSize = 20;
-
-  if (source === 'YOUTUBE') {
-    return <Play size={iconSize} color={iconColor} fill={iconColor} strokeWidth={0} />;
-  }
-
-  if (source === 'SPOTIFY') {
-    return <Headphones size={iconSize} color={iconColor} fill={iconColor} strokeWidth={0} />;
-  }
-
-  if (source === 'GMAIL') {
-    return <FileText size={iconSize} color={iconColor} fill={iconColor} strokeWidth={0} />;
-  }
-
-  return <Rss size={iconSize} color={iconColor} strokeWidth={2} />;
+  return SOURCE_BRAND[source].icon;
 }
 
 function getBadgeTone(state: IntegrationState): 'subtle' | 'success' | 'warning' | 'info' {
@@ -84,7 +89,7 @@ export function SourceListRow({
       style={({ pressed }) => [pressed && { opacity: motion.opacity.pressed }]}
     >
       <Surface tone="elevated" border="subtle" radius="xl" style={styles.sourceRow}>
-        <View style={[styles.glyphContainer, { backgroundColor: colors.surfaceRaised }]}>
+        <View style={[styles.glyphContainer, { backgroundColor: SOURCE_BRAND[source].bg }]}>
           <SourceGlyph source={source} />
         </View>
         <View style={styles.sourceRowCopy}>
@@ -108,12 +113,11 @@ export function SourceHero({
   title?: string;
   summary: string;
 }) {
-  const { colors } = useAppTheme();
   const config = getSubscriptionSourceConfig(source);
 
   return (
     <Surface tone="elevated" border="subtle" radius="xl" style={styles.hero}>
-      <View style={[styles.heroGlyph, { backgroundColor: colors.surfaceRaised }]}>
+      <View style={[styles.heroGlyph, { backgroundColor: SOURCE_BRAND[source].bg }]}>
         <SourceGlyph source={source} />
       </View>
       <View style={styles.heroCopy}>
@@ -401,7 +405,7 @@ const styles = StyleSheet.create({
   glyphContainer: {
     width: 48,
     height: 48,
-    borderRadius: Radius.lg,
+    borderRadius: Radius.full,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -418,7 +422,7 @@ const styles = StyleSheet.create({
   heroGlyph: {
     width: 56,
     height: 56,
-    borderRadius: Radius.xl,
+    borderRadius: Radius.full,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/apps/mobile/lib/subscriptions-screen.test.tsx
+++ b/apps/mobile/lib/subscriptions-screen.test.tsx
@@ -41,6 +41,15 @@ jest.mock('react-native', () => ({
   Platform: {
     select: (options: Record<string, unknown>) => options.ios ?? options.default,
   },
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => React.createElement('button', { onClick: onPress, onPress, accessibilityLabel }, children),
   View: ({ children }: { children?: React.ReactNode }) =>
     React.createElement('div', null, children),
   ScrollView: ({ children }: { children?: React.ReactNode }) =>
@@ -161,13 +170,10 @@ describe('SubscriptionsScreen header', () => {
     expect(stackScreenProps.options.headerLeft).toBeDefined();
 
     const headerLeft = stackScreenProps.options.headerLeft!;
-    const backButtonWrapper = headerLeft({ tintColor: '#111111' }) as React.ReactElement<{
-      children: React.ReactElement<{
-        onPress: () => void;
-        accessibilityLabel?: string;
-      }>;
+    const backButton = headerLeft({ tintColor: '#111111' }) as React.ReactElement<{
+      onPress: () => void;
+      accessibilityLabel?: string;
     }>;
-    const backButton = backButtonWrapper.props.children;
 
     expect(backButton.props.accessibilityLabel).toBe('Go back');
 


### PR DESCRIPTION
Gives the subscriptions hub screen a visual refresh:

- Removed the "Manage each source in one place" summary card at the top
- Branded provider icons: each source row now uses the same icons and brand colors as the FAB buttons elsewhere (YouTube red, Spotify green, Gmail blue, RSS amber) with circular glyph backgrounds
- Native-style back button: replaced the custom circular IconButton chevron with a simple Pressable chevron matching the native iOS header style
- Applied the same brand-colored glyphs to SourceHero on provider detail pages

Files changed:
- apps/mobile/app/subscriptions/index.tsx
- apps/mobile/components/subscriptions/source-ui.tsx
- apps/mobile/lib/subscriptions-screen.test.tsx