### PR TITLE
Add settings alerts for disconnected integrations

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -38,6 +38,9 @@ import {
   mapContentType,
   mapProvider,
 } from '@/hooks/use-items-trpc';
+import { useConnections } from '@/hooks/use-connections';
+import { useSubscriptions } from '@/hooks/use-subscriptions-query';
+import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
 import type { ContentType, Provider, UIContentType } from '@/lib/content-utils';
 
 // =============================================================================
@@ -165,6 +168,12 @@ export default function HomeScreen() {
   });
   const { data: homeData, isLoading: isHomeLoading } = useHomeData();
   const { data: libraryData } = useLibraryItems();
+  const { data: connections } = useConnections();
+  const { data: subscriptionsData } = useSubscriptions();
+  const { hasAttention: hasSettingsAlert } = useMemo(
+    () => getSubscriptionIntegrationAttention(connections, subscriptionsData?.items),
+    [connections, subscriptionsData?.items]
+  );
 
   // Transform to ItemCardData format for use with ItemCard component
   const jumpBackInItems = useMemo((): ItemCardData[] => {
@@ -340,10 +349,27 @@ export default function HomeScreen() {
                   { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
                   pressed && { opacity: 0.75 },
                 ]}
-                accessibilityLabel="Open settings"
+                accessibilityLabel={
+                  hasSettingsAlert
+                    ? 'Open settings. Subscription integrations need attention'
+                    : 'Open settings'
+                }
                 accessibilityRole="button"
               >
                 <SettingsIcon size={20} color={colors.text} />
+                {hasSettingsAlert ? (
+                  <View
+                    testID="home-settings-alert-dot"
+                    pointerEvents="none"
+                    style={[
+                      styles.settingsAlertDot,
+                      {
+                        backgroundColor: colors.warning,
+                        borderColor: colors.backgroundSecondary,
+                      },
+                    ]}
+                  />
+                ) : null}
               </Pressable>
             </View>
           </Animated.View>
@@ -542,9 +568,19 @@ const styles = StyleSheet.create({
     width: 44,
     height: 44,
     borderRadius: 22,
+    position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 1,
+  },
+  settingsAlertDot: {
+    position: 'absolute',
+    top: 7,
+    right: 7,
+    width: 10,
+    height: 10,
+    borderRadius: Radius.full,
+    borderWidth: 2,
   },
   filterContainer: {
     paddingHorizontal: Spacing.md,

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -9,6 +9,7 @@
  * @see features/subscriptions/frontend-spec.md Section 3 (Settings Screen)
  */
 
+import { useMemo } from 'react';
 import { View, Text, ScrollView, Pressable, StyleSheet, Linking, Share } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -19,9 +20,9 @@ import { Colors, Spacing, Radius } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useConnections } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions-query';
-import { isReconnectRequired } from '@/lib/connection-status';
 import { buildMobileDiagnosticBundle } from '@/lib/diagnostics';
 import { settingsLogger } from '@/lib/logger';
+import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
 import { buildSubscriptionsSummary } from '@/lib/subscription-sources';
 import { trpc } from '@/lib/trpc';
 import { useAuthAvailability } from '@/providers/auth-provider';
@@ -38,6 +39,8 @@ interface SettingsRowProps {
   rightTextColor?: string;
   onPress?: () => void;
   titleColor?: string;
+  showAlertDot?: boolean;
+  alertDotTestID?: string;
 }
 
 // ============================================================================
@@ -55,6 +58,8 @@ function SettingsRow({
   rightTextColor,
   onPress,
   titleColor,
+  showAlertDot,
+  alertDotTestID,
 }: SettingsRowProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -70,8 +75,18 @@ function SettingsRow({
           )}
         </View>
       </View>
-      {rightText && (
-        <Text style={{ color: rightTextColor ?? colors.textTertiary }}>{rightText}</Text>
+      {(showAlertDot || rightText) && (
+        <View style={styles.rowRight}>
+          {showAlertDot ? (
+            <View
+              testID={alertDotTestID}
+              style={[styles.alertDot, { backgroundColor: colors.warning }]}
+            />
+          ) : null}
+          {rightText ? (
+            <Text style={{ color: rightTextColor ?? colors.textTertiary }}>{rightText}</Text>
+          ) : null}
+        </View>
       )}
     </View>
   );
@@ -135,8 +150,10 @@ function SettingsScreenContent({
     (rssStatsQuery.data?.active ?? 0);
   const activeIntegrationCount =
     connections?.filter((connection) => connection.status === 'ACTIVE')?.length ?? 0;
-  const needsAttentionCount =
-    connections?.filter((connection) => isReconnectRequired(connection.status))?.length ?? 0;
+  const { attentionCount: needsAttentionCount, hasAttention: hasSubscriptionsAlert } = useMemo(
+    () => getSubscriptionIntegrationAttention(connections, subscriptionsData?.items),
+    [connections, subscriptionsData?.items]
+  );
 
   // Get app version from expo-constants
   const appVersion = Constants.expoConfig?.version ?? '1.0.0';
@@ -192,6 +209,8 @@ function SettingsScreenContent({
                 : 'Manage your subscriptions and integrations'
             }
             rightText="→"
+            showAlertDot={hasSubscriptionsAlert}
+            alertDotTestID="settings-subscriptions-alert-dot"
             onPress={() => router.push('/subscriptions')}
           />
         </View>
@@ -298,8 +317,18 @@ const styles = StyleSheet.create({
   rowTextContainer: {
     flex: 1,
   },
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
   providerIcon: {
     fontSize: 24,
+  },
+  alertDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radius.full,
   },
   rowTitle: {
     fontSize: 16,

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -8,6 +8,8 @@ const mockAddListener = jest.fn();
 const mockIsFocused = jest.fn();
 const mockScrollTo = jest.fn();
 const mockRemoveListener = jest.fn();
+let mockConnections: Array<{ provider: string; status: string }> = [];
+let mockSubscriptionsData: { items: Array<{ provider: string; status: string }> } = { items: [] };
 
 const mockNavigation = {
   addListener: mockAddListener,
@@ -72,10 +74,10 @@ jest.mock('react-native', () => ({
   Platform: {
     select: (options: Record<string, unknown>) => options.ios ?? options.default,
   },
-  View: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('div', null, children),
-  Text: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('span', null, children),
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('span', props, children),
   ScrollView: React.forwardRef(
     (
       { children, ...props }: { children?: React.ReactNode; horizontal?: boolean },
@@ -94,13 +96,14 @@ jest.mock('react-native', () => ({
   Pressable: ({
     children,
     onPress,
+    ...props
   }: {
     children: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
     onPress?: () => void;
   }) =>
     React.createElement(
       'button',
-      { onClick: onPress, onPress },
+      { onClick: onPress, onPress, ...props },
       typeof children === 'function' ? children({ pressed: false }) : children
     ),
   FlatList: ({
@@ -189,6 +192,14 @@ jest.mock('@/hooks/use-prefetch', () => ({
   useTabPrefetch: jest.fn(),
 }));
 
+jest.mock('@/hooks/use-connections', () => ({
+  useConnections: () => ({ data: mockConnections }),
+}));
+
+jest.mock('@/hooks/use-subscriptions-query', () => ({
+  useSubscriptions: () => ({ data: mockSubscriptionsData }),
+}));
+
 jest.mock('@/lib/home-layout', () => ({
   getFeaturedGridItemWidth: () => 160,
   getVisibleFeaturedGridItems: (items: unknown[]) => items,
@@ -223,6 +234,8 @@ describe('HomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     tabPressListener = undefined;
+    mockConnections = [];
+    mockSubscriptionsData = { items: [] };
     mockIsFocused.mockReturnValue(true);
     mockAddListener.mockImplementation((event: 'tabPress', listener: () => void) => {
       if (event === 'tabPress') {
@@ -253,6 +266,19 @@ describe('HomeScreen', () => {
     });
 
     expect(mockPush).toHaveBeenCalledWith('/settings');
+  });
+
+  it('shows an alert dot on the settings button when an integration is disconnected', () => {
+    mockSubscriptionsData = {
+      items: [{ provider: 'YOUTUBE', status: 'DISCONNECTED' }],
+    };
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    expect(() => renderer!.root.findByProps({ testID: 'home-settings-alert-dot' })).not.toThrow();
   });
 
   it('clears the active filter when the home tab is reselected at the top', () => {

--- a/apps/mobile/lib/settings-screen.test.tsx
+++ b/apps/mobile/lib/settings-screen.test.tsx
@@ -31,22 +31,23 @@ jest.mock('react-native', () => ({
   Platform: {
     select: (options: Record<string, unknown>) => options.ios ?? options.default,
   },
-  View: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('div', null, children),
-  Text: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('span', null, children),
-  ScrollView: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('div', null, children),
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('span', props, children),
+  ScrollView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
   Pressable: ({
     children,
     onPress,
+    ...props
   }: {
     children: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
     onPress?: () => void;
   }) =>
     React.createElement(
       'button',
-      { onClick: onPress, onPress },
+      { onClick: onPress, onPress, ...props },
       typeof children === 'function' ? children({ pressed: false }) : children
     ),
   StyleSheet: {
@@ -176,6 +177,19 @@ describe('SettingsScreen subscriptions entrypoint', () => {
     });
 
     expect(mockPush).toHaveBeenCalledWith('/subscriptions');
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('shows an alert dot on the subscriptions row when an integration needs attention', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<SettingsScreen />);
+    });
+
+    expect(() =>
+      renderer!.root.findByProps({ testID: 'settings-subscriptions-alert-dot' })
+    ).not.toThrow();
     consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/mobile/lib/subscription-integration-attention.test.ts
+++ b/apps/mobile/lib/subscription-integration-attention.test.ts
@@ -1,0 +1,36 @@
+import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
+
+describe('getSubscriptionIntegrationAttention', () => {
+  it('counts reconnect-required integrations', () => {
+    expect(
+      getSubscriptionIntegrationAttention([{ provider: 'SPOTIFY', status: 'EXPIRED' }], [])
+    ).toEqual({
+      attentionCount: 1,
+      hasAttention: true,
+      providers: ['SPOTIFY'],
+    });
+  });
+
+  it('counts disconnected subscriptions when the provider is no longer actively connected', () => {
+    expect(
+      getSubscriptionIntegrationAttention([], [{ provider: 'YOUTUBE', status: 'DISCONNECTED' }])
+    ).toEqual({
+      attentionCount: 1,
+      hasAttention: true,
+      providers: ['YOUTUBE'],
+    });
+  });
+
+  it('ignores disconnected subscriptions when the integration is still connected', () => {
+    expect(
+      getSubscriptionIntegrationAttention(
+        [{ provider: 'YOUTUBE', status: 'ACTIVE' }],
+        [{ provider: 'YOUTUBE', status: 'DISCONNECTED' }]
+      )
+    ).toEqual({
+      attentionCount: 0,
+      hasAttention: false,
+      providers: [],
+    });
+  });
+});

--- a/apps/mobile/lib/subscription-integration-attention.ts
+++ b/apps/mobile/lib/subscription-integration-attention.ts
@@ -1,0 +1,49 @@
+import { isReconnectRequired } from '@/lib/connection-status';
+import type { ConnectionProvider, ConnectionStatus } from '@/hooks/use-connections';
+import type { SubscriptionProvider, SubscriptionStatus } from '@/hooks/use-subscriptions-query';
+
+type IntegrationProvider = ConnectionProvider | SubscriptionProvider;
+
+type IntegrationConnection = {
+  provider: IntegrationProvider;
+  status: ConnectionStatus;
+};
+
+type IntegrationSubscription = {
+  provider: SubscriptionProvider;
+  status: SubscriptionStatus;
+};
+
+export function getSubscriptionIntegrationAttention(
+  connections: readonly IntegrationConnection[] | undefined,
+  subscriptions: readonly IntegrationSubscription[] | undefined
+) {
+  const providersNeedingAttention = new Set<IntegrationProvider>();
+  const connectionStatusByProvider = new Map<IntegrationProvider, ConnectionStatus>();
+
+  for (const connection of connections ?? []) {
+    connectionStatusByProvider.set(connection.provider, connection.status);
+
+    if (isReconnectRequired(connection.status)) {
+      providersNeedingAttention.add(connection.provider);
+    }
+  }
+
+  for (const subscription of subscriptions ?? []) {
+    if (subscription.status !== 'DISCONNECTED') {
+      continue;
+    }
+
+    if (connectionStatusByProvider.get(subscription.provider) === 'ACTIVE') {
+      continue;
+    }
+
+    providersNeedingAttention.add(subscription.provider);
+  }
+
+  return {
+    attentionCount: providersNeedingAttention.size,
+    hasAttention: providersNeedingAttention.size > 0,
+    providers: Array.from(providersNeedingAttention),
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared helper to detect subscription integrations that need attention from reconnect-required connections or disconnected subscriptions
- show an alert dot on the Home settings button and on the Settings > Subscriptions row when an integration is disconnected
- cover the new attention logic and both screen entry points with tests

## Testing
- bun run --cwd apps/mobile test -- lib/home-screen.test.tsx lib/settings-screen.test.tsx lib/subscription-integration-attention.test.ts
- bun run format:check
- bun run design-system:check
- bun run typecheck
- pre-push worker vitest subset via git push