### PR TITLE
worker: validate sync KV payloads before use

### DIFF
--- a/apps/worker/src/sync/dlq-consumer.test.ts
+++ b/apps/worker/src/sync/dlq-consumer.test.ts
@@ -131,6 +131,32 @@ const TEST_USER_ID = 'user_test_123';
 const TEST_JOB_ID = '01HQXYZ123456789ABCDEFGHIJ';
 const MOCK_NOW = 1705320000000;
 
+function createDLQEntry(
+  id: string,
+  overrides?: Partial<{
+    deadLetteredAt: number;
+    attempts: number;
+    environment: string;
+    message: Partial<SyncQueueMessage>;
+  }>
+) {
+  return {
+    id,
+    message: {
+      jobId: TEST_JOB_ID,
+      userId: TEST_USER_ID,
+      subscriptionId: `sub_${id}`,
+      provider: 'YOUTUBE' as const,
+      providerChannelId: 'UC123',
+      enqueuedAt: MOCK_NOW - 60000,
+      ...(overrides?.message ?? {}),
+    },
+    deadLetteredAt: overrides?.deadLetteredAt ?? MOCK_NOW,
+    attempts: overrides?.attempts ?? 3,
+    environment: overrides?.environment ?? 'development',
+  };
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -429,20 +455,12 @@ describe('getDLQEntries', () => {
   });
 
   it('should return stored DLQ entries', async () => {
-    const entry1 = {
-      id: 'entry_1',
+    const entry1 = createDLQEntry('entry_1', {
       message: {
-        jobId: TEST_JOB_ID,
-        userId: TEST_USER_ID,
         subscriptionId: 'sub_1',
-        provider: 'YOUTUBE',
-        providerChannelId: 'UC123',
         enqueuedAt: MOCK_NOW,
       },
-      deadLetteredAt: MOCK_NOW,
-      attempts: 3,
-      environment: 'development',
-    };
+    });
 
     const kv = createMockKV({
       [getDLQIndexKey()]: JSON.stringify(['entry_1']),
@@ -458,9 +476,9 @@ describe('getDLQEntries', () => {
   it('should respect limit parameter', async () => {
     const kv = createMockKV({
       [getDLQIndexKey()]: JSON.stringify(['entry_1', 'entry_2', 'entry_3']),
-      [getDLQEntryKey('entry_1')]: JSON.stringify({ id: 'entry_1' }),
-      [getDLQEntryKey('entry_2')]: JSON.stringify({ id: 'entry_2' }),
-      [getDLQEntryKey('entry_3')]: JSON.stringify({ id: 'entry_3' }),
+      [getDLQEntryKey('entry_1')]: JSON.stringify(createDLQEntry('entry_1')),
+      [getDLQEntryKey('entry_2')]: JSON.stringify(createDLQEntry('entry_2')),
+      [getDLQEntryKey('entry_3')]: JSON.stringify(createDLQEntry('entry_3')),
     });
 
     const entries = await getDLQEntries(kv, 2);
@@ -473,8 +491,8 @@ describe('getDLQEntries', () => {
   it('should handle missing entries gracefully', async () => {
     const kv = createMockKV({
       [getDLQIndexKey()]: JSON.stringify(['entry_1', 'missing_entry', 'entry_2']),
-      [getDLQEntryKey('entry_1')]: JSON.stringify({ id: 'entry_1' }),
-      [getDLQEntryKey('entry_2')]: JSON.stringify({ id: 'entry_2' }),
+      [getDLQEntryKey('entry_1')]: JSON.stringify(createDLQEntry('entry_1')),
+      [getDLQEntryKey('entry_2')]: JSON.stringify(createDLQEntry('entry_2')),
       // 'missing_entry' doesn't exist in KV
     });
 
@@ -483,6 +501,23 @@ describe('getDLQEntries', () => {
     // Should filter out null entries
     expect(entries).toHaveLength(2);
     expect(entries.map((e) => e.id)).toEqual(['entry_1', 'entry_2']);
+  });
+
+  it('should skip invalid entry payloads and warn', async () => {
+    const kv = createMockKV({
+      [getDLQIndexKey()]: JSON.stringify(['entry_1', 'entry_2']),
+      [getDLQEntryKey('entry_1')]: JSON.stringify(createDLQEntry('entry_1')),
+      [getDLQEntryKey('entry_2')]: JSON.stringify({ id: 'entry_2' }),
+    });
+
+    const entries = await getDLQEntries(kv, 10);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe('entry_1');
+    expect(mockLogger.warn).toHaveBeenCalledWith('DLQ entry data invalid; skipping', {
+      operation: 'list',
+      entryId: 'entry_2',
+    });
   });
 
   it('should return empty array when index JSON is corrupted', async () => {
@@ -503,7 +538,7 @@ describe('getDLQEntries', () => {
   it('should return empty array and warn when index data has invalid shape', async () => {
     const kv = createMockKV({
       [getDLQIndexKey()]: JSON.stringify(['entry_1', 42]),
-      [getDLQEntryKey('entry_1')]: JSON.stringify({ id: 'entry_1' }),
+      [getDLQEntryKey('entry_1')]: JSON.stringify(createDLQEntry('entry_1')),
     });
 
     await expect(getDLQEntries(kv)).resolves.toEqual([]);
@@ -534,21 +569,15 @@ describe('getDLQSummary', () => {
   });
 
   it('should return summary with count and recent entries', async () => {
-    const entry1 = {
-      id: 'entry_1',
-      message: { jobId: 'job1' },
+    const entry1 = createDLQEntry('entry_1', {
       deadLetteredAt: MOCK_NOW - 60000,
-      attempts: 3,
-      environment: 'development',
-    };
+      message: { jobId: 'job1' },
+    });
 
-    const entry2 = {
-      id: 'entry_2',
-      message: { jobId: 'job2' },
+    const entry2 = createDLQEntry('entry_2', {
       deadLetteredAt: MOCK_NOW,
-      attempts: 3,
-      environment: 'development',
-    };
+      message: { jobId: 'job2' },
+    });
 
     const kv = createMockKV({
       [getDLQIndexKey()]: JSON.stringify(['entry_2', 'entry_1']),
@@ -572,10 +601,11 @@ describe('getDLQSummary', () => {
     };
 
     for (let i = 0; i < 15; i++) {
-      kvData[getDLQEntryKey(`entry_${i}`)] = JSON.stringify({
-        id: `entry_${i}`,
-        deadLetteredAt: MOCK_NOW - i * 1000,
-      });
+      kvData[getDLQEntryKey(`entry_${i}`)] = JSON.stringify(
+        createDLQEntry(`entry_${i}`, {
+          deadLetteredAt: MOCK_NOW - i * 1000,
+        })
+      );
     }
 
     const kv = createMockKV(kvData);
@@ -583,6 +613,24 @@ describe('getDLQSummary', () => {
 
     expect(summary.count).toBe(15);
     expect(summary.recent).toHaveLength(10);
+  });
+
+  it('should skip invalid recent entry payloads and warn', async () => {
+    const kv = createMockKV({
+      [getDLQIndexKey()]: JSON.stringify(['entry_1', 'entry_2']),
+      [getDLQEntryKey('entry_1')]: JSON.stringify(createDLQEntry('entry_1')),
+      [getDLQEntryKey('entry_2')]: JSON.stringify({ id: 'entry_2' }),
+    });
+
+    const summary = await getDLQSummary(kv);
+
+    expect(summary.count).toBe(2);
+    expect(summary.recent).toHaveLength(1);
+    expect(summary.recent[0]?.id).toBe('entry_1');
+    expect(mockLogger.warn).toHaveBeenCalledWith('DLQ entry data invalid; skipping', {
+      operation: 'summary',
+      entryId: 'entry_2',
+    });
   });
 
   it('should return empty summary when index JSON is corrupted', async () => {

--- a/apps/worker/src/sync/dlq-consumer.ts
+++ b/apps/worker/src/sync/dlq-consumer.ts
@@ -20,6 +20,7 @@ import {
   getDLQEntryKey,
   getDLQIndexKey,
   DLQ_ENTRY_TTL_SECONDS,
+  parseDLQEntry,
 } from './types';
 import { updateJobProgress } from './service';
 
@@ -48,6 +49,28 @@ function parseDLQIndex(indexData: string | null, operation: string): string[] {
     });
     return [];
   }
+}
+
+async function getStoredDLQEntry(
+  id: string,
+  kv: KVNamespace,
+  operation: 'list' | 'summary'
+): Promise<DLQEntry | null> {
+  const data = await kv.get(getDLQEntryKey(id));
+  if (!data) {
+    return null;
+  }
+
+  const entry = parseDLQEntry(data);
+  if (!entry) {
+    dlqLogger.warn('DLQ entry data invalid; skipping', {
+      operation,
+      entryId: id,
+    });
+    return null;
+  }
+
+  return entry;
 }
 
 /**
@@ -242,15 +265,7 @@ export async function getDLQEntries(kv: KVNamespace, limit: number = 20): Promis
   const idsToFetch = entryIds.slice(0, limit);
 
   // Fetch entries in parallel
-  const entryPromises = idsToFetch.map(async (id) => {
-    const data = await kv.get(getDLQEntryKey(id));
-    if (!data) return null;
-    try {
-      return JSON.parse(data) as DLQEntry;
-    } catch {
-      return null;
-    }
-  });
+  const entryPromises = idsToFetch.map((id) => getStoredDLQEntry(id, kv, 'list'));
 
   const entries = await Promise.all(entryPromises);
   return entries.filter((e): e is DLQEntry => e !== null);
@@ -285,15 +300,7 @@ export async function getDLQSummary(kv: KVNamespace): Promise<{
 
   // Fetch recent entries (last 10)
   const recentIds = entryIds.slice(0, 10);
-  const entryPromises = recentIds.map(async (id) => {
-    const data = await kv.get(getDLQEntryKey(id));
-    if (!data) return null;
-    try {
-      return JSON.parse(data) as DLQEntry;
-    } catch {
-      return null;
-    }
-  });
+  const entryPromises = recentIds.map((id) => getStoredDLQEntry(id, kv, 'summary'));
 
   const recent = (await Promise.all(entryPromises)).filter((e): e is DLQEntry => e !== null);
 

--- a/apps/worker/src/sync/service.test.ts
+++ b/apps/worker/src/sync/service.test.ts
@@ -230,6 +230,21 @@ describe('getJobStatus', () => {
     expect(result).toBeNull();
   });
 
+  it('should return null for invalid job status shape', async () => {
+    mockKV._store.set(
+      getJobStatusKey(TEST_JOB_ID),
+      JSON.stringify({
+        jobId: TEST_JOB_ID,
+        userId: TEST_USER_ID,
+        status: 'processing',
+      })
+    );
+
+    const result = await getJobStatus(TEST_JOB_ID, mockKV);
+
+    expect(result).toBeNull();
+  });
+
   it('should use correct key format', async () => {
     await getJobStatus(TEST_JOB_ID, mockKV);
 
@@ -485,6 +500,24 @@ describe('updateJobProgress', () => {
     // Should not have called put (only get)
     expect(mockKV.put).not.toHaveBeenCalled();
     expect(mockLogger.warn).toHaveBeenCalledWith('Job status not found for update', {
+      jobId: TEST_JOB_ID,
+      subscriptionId: 'sub_1',
+    });
+  });
+
+  it('should return early when job status payload is invalid', async () => {
+    mockKV._store.set(
+      getJobStatusKey(TEST_JOB_ID),
+      JSON.stringify({
+        jobId: TEST_JOB_ID,
+        userId: TEST_USER_ID,
+      })
+    );
+
+    await updateJobProgress(TEST_JOB_ID, 'sub_1', true, 5, null, mockKV);
+
+    expect(mockKV.put).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith('Job status payload invalid; skipping update', {
       jobId: TEST_JOB_ID,
       subscriptionId: 'sub_1',
     });

--- a/apps/worker/src/sync/service.ts
+++ b/apps/worker/src/sync/service.ts
@@ -31,6 +31,7 @@ import {
   getJobStatusKey,
   JOB_STATUS_TTL_SECONDS,
   ACTIVE_JOB_TTL_SECONDS,
+  parseSyncJobStatus,
 } from './types';
 // Note: Provider and polling imports are done dynamically in processSyncFallback
 // to avoid loading googleapis at module init time (breaks workerd test environment)
@@ -315,13 +316,7 @@ export async function initiateSyncJob(
  */
 export async function getJobStatus(jobId: string, kv: KVNamespace): Promise<SyncJobStatus | null> {
   const data = await kv.get(getJobStatusKey(jobId));
-  if (!data) return null;
-
-  try {
-    return JSON.parse(data) as SyncJobStatus;
-  } catch {
-    return null;
-  }
+  return parseSyncJobStatus(data);
 }
 
 /**
@@ -417,7 +412,11 @@ export async function updateJobProgress(
     return;
   }
 
-  const status: SyncJobStatus = JSON.parse(data);
+  const status = parseSyncJobStatus(data);
+  if (!status) {
+    syncLogger.warn('Job status payload invalid; skipping update', { jobId, subscriptionId });
+    return;
+  }
 
   // Update counters
   status.completed++;

--- a/apps/worker/src/sync/types.ts
+++ b/apps/worker/src/sync/types.ts
@@ -125,6 +125,24 @@ export const SyncJobStatusSchema = z.object({
   telemetry: SyncJobTelemetrySchema.optional(),
 });
 
+function parseStoredJson(value: string | null | undefined, schema: z.ZodTypeAny): unknown | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseSyncJobStatus(value: string | null | undefined): SyncJobStatus | null {
+  return parseStoredJson(value, SyncJobStatusSchema) as SyncJobStatus | null;
+}
+
 // ============================================================================
 // API Response Types
 // ============================================================================
@@ -250,6 +268,10 @@ export const DLQEntrySchema = z.object({
   attempts: z.number(),
   environment: z.string(),
 });
+
+export function parseDLQEntry(value: string | null | undefined): DLQEntry | null {
+  return parseStoredJson(value, DLQEntrySchema) as DLQEntry | null;
+}
 
 /**
  * DLQ summary for monitoring dashboard


### PR DESCRIPTION
## Summary
- add shared schema-backed helpers to parse stored sync job status and DLQ entries from KV
- replace direct  call sites in sync service and DLQ consumer with safe parsing
- log and skip invalid persisted payloads instead of operating on malformed shapes
- add regression tests covering invalid-shape payload handling in service and DLQ flows

## Validation
- bun run --cwd apps/worker test:run src/sync/service.test.ts src/sync/dlq-consumer.test.ts
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- pre-push hook also ran Checking formatting...
All matched files use Prettier code style!, mobile-design-system: OK, , and 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/lct-2026-03-31-01/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...
