### PR TITLE
Add haptic feedback to filter chips

### DIFF
--- a/apps/mobile/components/filter-chip.test.tsx
+++ b/apps/mobile/components/filter-chip.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { FilterChip } from './filter-chip';
+
+jest.mock('expo-haptics', () => ({
+  selectionAsync: jest.fn(),
+}));
+
+const { selectionAsync: mockSelectionAsync } = jest.requireMock('expo-haptics') as {
+  selectionAsync: jest.Mock;
+};
+
+jest.mock('react-native', () => ({
+  __esModule: true,
+  Platform: {
+    select: (options: Record<string, unknown>) => options.ios ?? options.default,
+  },
+  Pressable: ({
+    children,
+    onPress,
+  }: {
+    children?: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
+    onPress?: () => void;
+  }) =>
+    React.createElement(
+      'button',
+      { onClick: onPress, onPress },
+      typeof children === 'function' ? children({ pressed: false }) : children
+    ),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+  },
+  View: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+jest.mock('@/hooks/use-app-theme', () => ({
+  useAppTheme: () => ({
+    colors: {
+      surfaceRaised: '#222222',
+      surfaceSubtle: '#111111',
+      borderDefault: '#666666',
+      borderSubtle: '#444444',
+      textPrimary: '#ffffff',
+      textSubheader: '#bbbbbb',
+    },
+    motion: {
+      opacity: {
+        pressed: 0.8,
+      },
+    },
+  }),
+}));
+
+jest.mock('@/components/primitives/text', () => ({
+  Text: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('span', null, children),
+}));
+
+describe('FilterChip', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectionAsync.mockResolvedValue(undefined);
+  });
+
+  it('triggers selection haptics and calls onPress', () => {
+    const onPress = jest.fn();
+    let renderer: ReturnType<typeof TestRenderer.create>;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(FilterChip, {
+          label: 'Articles',
+          isSelected: false,
+          onPress,
+        })
+      );
+    });
+
+    act(() => {
+      renderer.root.findByType('button').props.onPress();
+    });
+
+    expect(mockSelectionAsync).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -6,6 +6,8 @@
  */
 
 import type { ComponentType } from 'react';
+
+import * as Haptics from 'expo-haptics';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { Radius, Spacing, Typography } from '@/constants/theme';
@@ -103,10 +105,14 @@ export function FilterChip({
   const sizeStyles = size === 'small' ? styles.chipSmall : styles.chipMedium;
   const textStyles = size === 'small' ? styles.textSmall : styles.textMedium;
   const iconSize = size === 'small' ? 12 : 14;
+  const handlePress = () => {
+    void Haptics.selectionAsync();
+    onPress();
+  };
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       style={({ pressed }) => [
         styles.chip,
         sizeStyles,


### PR DESCRIPTION
## Summary
- add shared selection haptics inside `FilterChip` so all filter chip presses get consistent tactile feedback
- add a focused `FilterChip` component test covering the haptic call and existing press handler
- keep screen-level behavior unchanged outside chip presses

## Testing
- `bun run design-system:check`
- `bun x jest apps/mobile/components/filter-chip.test.tsx --config apps/mobile/jest.config.js --runInBand`
- `bun x jest apps/mobile/lib/home-screen.test.tsx --config apps/mobile/jest.config.js --runInBand`