### PR TITLE
Add native collapsing headers across iOS screens

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/_layout.tsx
+++ b/apps/mobile/app/(tabs)/inbox/_layout.tsx
@@ -1,15 +1,16 @@
+import { Stack } from 'expo-router';
+
 import {
   createNativeLargeTitleScreenOptions,
   nativeLargeTitleStackScreenOptions,
 } from '@/lib/native-large-title-header';
-import { Stack } from 'expo-router';
 
-export default function SearchLayout() {
+export default function InboxLayout() {
   return (
     <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
       <Stack.Screen
         name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Search' })}
+        options={createNativeLargeTitleScreenOptions({ title: 'Inbox' })}
       />
     </Stack>
   );

--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -3,7 +3,6 @@ import { Surface, useToast } from 'heroui-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, View, Text, StyleSheet, type ListRenderItemInfo } from 'react-native';
 import Animated, { FadeOut, LinearTransition } from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { InboxArrowIcon } from '@/components/icons';
 import { type ItemCardData } from '@/components/item-card';
@@ -30,17 +29,8 @@ import { useNetworkStatus } from '@/hooks/use-network-status';
 import { showSuccess, showWarning, showError } from '@/lib/toast-utils';
 import type { ContentType, Provider } from '@/lib/content-utils';
 
-// =============================================================================
-// Constants
-// =============================================================================
-
-/** How long to wait before clearing reappeared state (ms) */
 const REENTRY_CLEANUP_DELAY = 500;
 const INBOX_PAGE_SIZE = 20;
-
-// =============================================================================
-// Custom Empty State for Inbox
-// =============================================================================
 
 function InboxEmptyState({ colors }: { colors: (typeof Colors)['light'] }) {
   return (
@@ -62,10 +52,6 @@ function InboxEmptyState({ colors }: { colors: (typeof Colors)['light'] }) {
   );
 }
 
-// =============================================================================
-// Main Screen
-// =============================================================================
-
 export default function InboxScreen() {
   const navigation = useNavigation();
   const colorScheme = useColorScheme();
@@ -77,23 +63,15 @@ export default function InboxScreen() {
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteInboxItems({ limit: INBOX_PAGE_SIZE });
 
-  // Track items that should animate in after a failed mutation (rollback)
-  // Maps item ID to the direction they should enter from
   const [reappearingItems, setReappearingItems] = useState<Map<string, EnterDirection>>(new Map());
   const [pendingDismissedItemIds, setPendingDismissedItemIds] = useState<Set<string>>(new Set());
   const listRef = useRef<Animated.FlatList<ItemCardData>>(null);
 
-  // Action mutations for swipeable items with rollback handling
   const archiveMutation = useArchiveItem();
   const bookmarkMutation = useBookmarkItem();
 
-  /**
-   * Mark an item as reappearing with a specific enter direction.
-   * Auto-clears after animation completes.
-   */
   const markAsReappearing = useCallback((id: string, enterFrom: EnterDirection) => {
     setReappearingItems((prev) => new Map(prev).set(id, enterFrom));
-    // Clear after animation completes
     setTimeout(() => {
       setReappearingItems((prev) => {
         const next = new Map(prev);
@@ -111,7 +89,6 @@ export default function InboxScreen() {
         {
           onError: () => {
             setPendingDismissedItemIds((prev) => removePendingDismissedId(prev, id));
-            // Archive exits left, so reappear from left
             markAsReappearing(id, 'left');
             showError(toast, new Error('Archive failed'), 'Failed to archive item', 'archive');
           },
@@ -129,7 +106,6 @@ export default function InboxScreen() {
         {
           onError: () => {
             setPendingDismissedItemIds((prev) => removePendingDismissedId(prev, id));
-            // Bookmark exits right, so reappear from right
             markAsReappearing(id, 'right');
             showError(toast, new Error('Bookmark failed'), 'Failed to save item', 'bookmark');
           },
@@ -139,7 +115,6 @@ export default function InboxScreen() {
     [bookmarkMutation, markAsReappearing, toast]
   );
 
-  // Sync hooks
   const { syncAll, isLoading: isSyncing, progress: syncProgress, lastResult } = useSyncAll();
   const { isConnected, isInternetReachable } = useNetworkStatus();
   const isOffline = !isConnected || isInternetReachable === false;
@@ -152,38 +127,28 @@ export default function InboxScreen() {
     syncAll();
   }, [syncAll, isOffline, toast]);
 
-  // Toast for sync results - use ref to prevent duplicate toasts
-  // Handles partial failures gracefully with nuanced messaging:
-  // - Full success: green success toast
-  // - Partial success (some failures): yellow warning toast
-  // - Complete failure: red error toast
   const lastToastResultRef = useRef<typeof lastResult>(null);
   useEffect(() => {
     if (!lastResult) return;
-    // Skip if we've already shown a toast for this exact result
     if (lastResult === lastToastResultRef.current) return;
     lastToastResultRef.current = lastResult;
 
     const { success, synced, total, itemsFound, errors, message } = lastResult;
     const failedCount = errors.length;
 
-    // No subscriptions to sync - don't show toast
     if (total === 0 && synced === 0) {
       return;
     }
 
-    // Full success (no failures)
     if (success) {
       if (itemsFound > 0) {
         showSuccess(toast, message);
       } else if (synced > 0) {
-        showSuccess(toast, message); // "All caught up!"
+        showSuccess(toast, message);
       }
       return;
     }
 
-    // Partial success: some synced, some failed
-    // Use warning tone - lead with success, mention failures
     if (synced > 0 && failedCount > 0) {
       const failedText =
         failedCount === 1 ? '1 source had issues' : `${failedCount} sources had issues`;
@@ -191,19 +156,16 @@ export default function InboxScreen() {
       return;
     }
 
-    // Complete failure: nothing synced
     if (synced === 0 && total > 0) {
       showError(toast, new Error(message || 'Sync failed'), 'Sync failed', 'sync');
       return;
     }
 
-    // Fallback for edge cases (e.g., rate limit errors before sync started)
     if (!success) {
       showError(toast, new Error(message || 'Sync failed'), 'Sync failed', 'sync');
     }
   }, [lastResult, toast]);
 
-  // Transform API response to ItemCardData format
   const inboxItems: ItemCardData[] = useMemo(
     () =>
       (data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
@@ -268,13 +230,37 @@ export default function InboxScreen() {
     });
   }, [navigation]);
 
+  if (isLoading) {
+    return (
+      <Surface style={[styles.container, { backgroundColor: colors.background }]}>
+        <LoadingState />
+      </Surface>
+    );
+  }
+
+  if (error) {
+    return (
+      <Surface style={[styles.container, { backgroundColor: colors.background }]}>
+        <ErrorState message={error.message} />
+      </Surface>
+    );
+  }
+
   return (
-    <Surface style={[styles.container, { backgroundColor: colors.background }]}>
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
-        {/* Header */}
-        <View style={styles.header}>
-          <View style={styles.headerTextContainer}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Animated.FlatList
+        ref={listRef}
+        style={styles.list}
+        data={visibleInboxItems}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+        onRefresh={handleRefresh}
+        refreshing={isSyncing}
+        ListHeaderComponent={
+          <View style={styles.listHeader}>
             {syncProgress && syncProgress.total > 0 ? (
               <Animated.View exiting={FadeOut.duration(200)}>
                 <Text style={[styles.headerSubtitle, { color: colors.primary }]}>
@@ -287,86 +273,46 @@ export default function InboxScreen() {
               </Text>
             )}
           </View>
-        </View>
-
-        {/* Content */}
-        {isLoading ? (
-          <LoadingState />
-        ) : error ? (
-          <ErrorState message={error.message} />
-        ) : (
-          <Animated.FlatList
-            ref={listRef}
-            data={visibleInboxItems}
-            renderItem={renderItem}
-            keyExtractor={(item) => item.id}
-            contentContainerStyle={[
-              styles.listContent,
-              visibleInboxItems.length === 0 && styles.emptyListContent,
-            ]}
-            showsVerticalScrollIndicator={false}
-            onRefresh={handleRefresh}
-            refreshing={isSyncing}
-            ListEmptyComponent={<InboxEmptyState colors={colors} />}
-            itemLayoutAnimation={LinearTransition.springify().damping(15).stiffness(100)}
-            onEndReached={handleEndReached}
-            onEndReachedThreshold={0.6}
-            ListFooterComponent={
-              isFetchingNextPage ? (
-                <View style={styles.loadingFooter}>
-                  <ActivityIndicator size="small" color={colors.primary} />
-                </View>
-              ) : null
-            }
-          />
-        )}
-      </SafeAreaView>
+        }
+        ListEmptyComponent={<InboxEmptyState colors={colors} />}
+        itemLayoutAnimation={LinearTransition.springify().damping(15).stiffness(100)}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.6}
+        ListFooterComponent={
+          isFetchingNextPage ? (
+            <View style={styles.loadingFooter}>
+              <ActivityIndicator size="small" color={colors.primary} />
+            </View>
+          ) : null
+        }
+      />
     </Surface>
   );
 }
-
-// =============================================================================
-// Styles
-// =============================================================================
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  safeArea: {
+  list: {
     flex: 1,
   },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  listHeader: {
     paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.lg,
+    paddingTop: Spacing.sm,
     paddingBottom: Spacing.md,
-  },
-  headerTextContainer: {
-    flex: 1,
-  },
-  headerTitle: {
-    ...Typography.displayMedium,
-    marginBottom: Spacing.xs,
   },
   headerSubtitle: {
     ...Typography.bodyMedium,
   },
-  // List
   listContent: {
+    flexGrow: 1,
     paddingBottom: Spacing['3xl'],
   },
   loadingFooter: {
     paddingVertical: Spacing.lg,
     alignItems: 'center',
   },
-  emptyListContent: {
-    flexGrow: 1,
-    justifyContent: 'center',
-  },
-  // Empty state (custom for inbox)
   emptyState: {
     flex: 1,
     alignItems: 'center',

--- a/apps/mobile/app/(tabs)/index/_layout.tsx
+++ b/apps/mobile/app/(tabs)/index/_layout.tsx
@@ -1,16 +1,14 @@
+import { Stack } from 'expo-router';
+
 import {
   createNativeLargeTitleScreenOptions,
   nativeLargeTitleStackScreenOptions,
 } from '@/lib/native-large-title-header';
-import { Stack } from 'expo-router';
 
-export default function SearchLayout() {
+export default function HomeLayout() {
   return (
     <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Search' })}
-      />
+      <Stack.Screen name="index" options={createNativeLargeTitleScreenOptions({ title: 'Home' })} />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -14,7 +14,6 @@ import {
   type NativeSyntheticEvent,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
 
 import { FilterChip } from '@/components/filter-chip';
@@ -43,10 +42,6 @@ import { useSubscriptions } from '@/hooks/use-subscriptions-query';
 import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
 import type { ContentType, Provider, UIContentType } from '@/lib/content-utils';
 
-// =============================================================================
-// Icons
-// =============================================================================
-
 function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; color?: string }) {
   return (
     <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
@@ -54,10 +49,6 @@ function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; col
     </Svg>
   );
 }
-
-// =============================================================================
-// Utility Functions
-// =============================================================================
 
 const INBOX_PAGE_SIZE = 20;
 const HOME_TOP_THRESHOLD = 4;
@@ -111,10 +102,6 @@ const contentTypeFilters: {
   },
 ];
 
-// =============================================================================
-// Components
-// =============================================================================
-
 function SectionHeader({
   title,
   count,
@@ -139,10 +126,6 @@ function SectionHeader({
   );
 }
 
-// =============================================================================
-// Main Screen
-// =============================================================================
-
 type HomeTabNavigation = {
   addListener: (event: 'tabPress', listener: () => void) => () => void;
   isFocused: () => boolean;
@@ -162,7 +145,6 @@ export default function HomeScreen() {
 
   useTabPrefetch('home');
 
-  // Data hooks
   const { data: inboxPages, isLoading: isInboxLoading } = useInfiniteInboxItems({
     limit: INBOX_PAGE_SIZE,
   });
@@ -175,7 +157,6 @@ export default function HomeScreen() {
     [connections, subscriptionsData?.items]
   );
 
-  // Transform to ItemCardData format for use with ItemCard component
   const jumpBackInItems = useMemo((): ItemCardData[] => {
     return (homeData?.jumpBackIn ?? []).map((item) => ({
       id: item.id,
@@ -262,7 +243,6 @@ export default function HomeScreen() {
     }));
   }, [homeData?.byContentType.articles]);
 
-  // Category counts
   const categoryCounts = useMemo(() => {
     const items = libraryData?.items ?? [];
     return {
@@ -324,250 +304,222 @@ export default function HomeScreen() {
   }, [contentTypeFilter, navigation]);
 
   return (
-    <Surface style={[styles.container, { backgroundColor: colors.background }]}>
-      <Stack.Screen options={{ headerShown: false }} />
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
-        <ScrollView
-          ref={scrollViewRef}
-          style={styles.scrollView}
-          contentContainerStyle={styles.content}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          showsVerticalScrollIndicator={false}
-        >
-          {/* Header */}
-          <Animated.View style={styles.header}>
-            <View style={styles.headerTopRow}>
-              <View style={styles.headerTitleWrap}>
-                <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
-                <Text style={[styles.headerTitle, { color: colors.text }]}>Home</Text>
-              </View>
-              <Pressable
-                onPress={handleOpenSettings}
-                style={({ pressed }) => [
-                  styles.settingsButton,
-                  { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
-                  pressed && { opacity: 0.75 },
-                ]}
-                accessibilityLabel={
-                  hasSettingsAlert
-                    ? 'Open settings. Subscription integrations need attention'
-                    : 'Open settings'
-                }
-                accessibilityRole="button"
-              >
-                <SettingsIcon size={20} color={colors.text} />
-                {hasSettingsAlert ? (
-                  <View
-                    testID="home-settings-alert-dot"
-                    pointerEvents="none"
-                    style={[
-                      styles.settingsAlertDot,
-                      {
-                        backgroundColor: colors.warning,
-                        borderColor: colors.backgroundSecondary,
-                      },
-                    ]}
-                  />
-                ) : null}
-              </Pressable>
-            </View>
-          </Animated.View>
-
-          <Animated.View>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.filterContainer}
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={{
+          headerRight: () => (
+            <Pressable
+              onPress={handleOpenSettings}
+              style={({ pressed }) => [
+                styles.settingsButton,
+                { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
+                pressed && { opacity: 0.75 },
+              ]}
+              accessibilityLabel={
+                hasSettingsAlert
+                  ? 'Open settings. Subscription integrations need attention'
+                  : 'Open settings'
+              }
+              accessibilityRole="button"
             >
-              {contentTypeFilters.map((filter) => (
-                <FilterChip
-                  key={filter.id}
-                  label={filter.label}
-                  isSelected={contentTypeFilter === filter.id}
-                  onPress={() =>
-                    setContentTypeFilter((current) => (current === filter.id ? null : filter.id))
-                  }
-                  icon={filter.icon}
-                  dotColor={filter.dotColor}
-                  selectedColor={filter.selectedColor}
-                  selectedSurfaceColor={filter.selectedSurfaceColor}
-                  count={categoryCounts[filter.id]}
+              <SettingsIcon size={20} color={colors.text} />
+              {hasSettingsAlert ? (
+                <View
+                  testID="home-settings-alert-dot"
+                  pointerEvents="none"
+                  style={[
+                    styles.settingsAlertDot,
+                    {
+                      backgroundColor: colors.warning,
+                      borderColor: colors.backgroundSecondary,
+                    },
+                  ]}
                 />
-              ))}
-            </ScrollView>
-          </Animated.View>
-          {isLoading ? (
-            <View style={styles.loadingState}>
-              <ActivityIndicator size="large" color={colors.primary} />
-            </View>
-          ) : (
-            <>
-              {/* Jump Back In - Recently Opened Bookmarks */}
-              {filteredJumpBackInItems.length > 0 && (
-                <Animated.View>
-                  <SectionHeader
-                    title="Jump Back In"
-                    count={filteredJumpBackInItems.length}
-                    colors={colors}
-                  />
-                  <View style={styles.jumpBackInGrid}>
-                    {filteredJumpBackInItems.map((item) => (
-                      <View
-                        key={item.id}
-                        style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
-                      >
-                        <ItemCard item={item} shape="row" rowStyle="featured" />
-                      </View>
-                    ))}
-                  </View>
-                </Animated.View>
-              )}
+              ) : null}
+            </Pressable>
+          ),
+        }}
+      />
 
-              {/* Recently Bookmarked - Horizontal Cards */}
-              {filteredRecentlyBookmarked.length > 0 && (
-                <Animated.View>
-                  <SectionHeader
-                    title="Recently Bookmarked"
-                    count={filteredRecentlyBookmarked.length}
-                    colors={colors}
-                  />
-                  <FlatList
-                    horizontal
-                    data={filteredRecentlyBookmarked}
-                    renderItem={({ item, index }) => (
-                      <ItemCard item={item} shape="stack" index={index} />
-                    )}
-                    keyExtractor={(item) => item.id}
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={styles.horizontalList}
-                  />
-                </Animated.View>
-              )}
+      <ScrollView
+        ref={scrollViewRef}
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+      >
+        <Animated.View style={styles.header}>
+          <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
+        </Animated.View>
 
-              {/* Inbox Section - Condensed List using compact ItemCard */}
-              {filteredInboxItems.length > 0 && (
-                <Animated.View style={styles.section}>
-                  <SectionHeader
-                    title="Inbox"
-                    count={filteredInboxItems.length}
-                    colors={colors}
-                    onPress={() => router.push('/(tabs)/inbox')}
-                  />
-                  <View
-                    style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
-                  >
-                    {filteredInboxItems.map((item, index) => (
-                      <ItemCard key={item.id} item={item} shape="row" index={index} />
-                    ))}
-                  </View>
-                </Animated.View>
-              )}
+        <Animated.View>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.filterContainer}
+          >
+            {contentTypeFilters.map((filter) => (
+              <FilterChip
+                key={filter.id}
+                label={filter.label}
+                isSelected={contentTypeFilter === filter.id}
+                onPress={() =>
+                  setContentTypeFilter((current) => (current === filter.id ? null : filter.id))
+                }
+                icon={filter.icon}
+                dotColor={filter.dotColor}
+                selectedColor={filter.selectedColor}
+                selectedSurfaceColor={filter.selectedSurfaceColor}
+                count={categoryCounts[filter.id]}
+              />
+            ))}
+          </ScrollView>
+        </Animated.View>
+        {isLoading ? (
+          <View style={styles.loadingState}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        ) : (
+          <>
+            {filteredJumpBackInItems.length > 0 && (
+              <Animated.View>
+                <SectionHeader
+                  title="Jump Back In"
+                  count={filteredJumpBackInItems.length}
+                  colors={colors}
+                />
+                <View style={styles.jumpBackInGrid}>
+                  {filteredJumpBackInItems.map((item) => (
+                    <View
+                      key={item.id}
+                      style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                    >
+                      <ItemCard item={item} shape="row" rowStyle="featured" />
+                    </View>
+                  ))}
+                </View>
+              </Animated.View>
+            )}
 
-              {/* Category Collection - Large Cards with overlay */}
-              {showPodcastsSection && podcasts.length > 0 && (
-                <Animated.View>
-                  <SectionHeader title="Podcasts" count={podcasts.length} colors={colors} />
-                  <FlatList
-                    horizontal
-                    data={podcasts.slice(0, 5)}
-                    renderItem={({ item, index }) => (
-                      <ItemCard item={item} shape="cover" index={index} />
-                    )}
-                    keyExtractor={(item) => item.id}
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={styles.horizontalList}
-                  />
-                </Animated.View>
-              )}
+            {filteredRecentlyBookmarked.length > 0 && (
+              <Animated.View>
+                <SectionHeader
+                  title="Recently Bookmarked"
+                  count={filteredRecentlyBookmarked.length}
+                  colors={colors}
+                />
+                <FlatList
+                  horizontal
+                  data={filteredRecentlyBookmarked}
+                  renderItem={({ item, index }) => (
+                    <ItemCard item={item} shape="stack" index={index} />
+                  )}
+                  keyExtractor={(item) => item.id}
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.horizontalList}
+                />
+              </Animated.View>
+            )}
 
-              {showArticlesSection && articles.length > 0 && (
-                <Animated.View>
-                  <SectionHeader title="Articles" count={articles.length} colors={colors} />
-                  <FlatList
-                    horizontal
-                    data={articles}
-                    renderItem={({ item, index }) => (
-                      <ItemCard item={item} shape="stack" index={index} />
-                    )}
-                    keyExtractor={(item) => item.id}
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={styles.horizontalList}
-                  />
-                </Animated.View>
-              )}
+            {filteredInboxItems.length > 0 && (
+              <Animated.View style={styles.section}>
+                <SectionHeader
+                  title="Inbox"
+                  count={filteredInboxItems.length}
+                  colors={colors}
+                  onPress={() => router.push('/(tabs)/inbox')}
+                />
+                <View
+                  style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
+                >
+                  {filteredInboxItems.map((item, index) => (
+                    <ItemCard key={item.id} item={item} shape="row" index={index} />
+                  ))}
+                </View>
+              </Animated.View>
+            )}
 
-              {/* Videos - Horizontal Cards */}
-              {showVideosSection && videos.length > 0 && (
-                <Animated.View>
-                  <SectionHeader title="Videos" count={videos.length} colors={colors} />
-                  <FlatList
-                    horizontal
-                    data={videos}
-                    renderItem={({ item, index }) => (
-                      <ItemCard item={item} shape="stack" index={index} />
-                    )}
-                    keyExtractor={(item) => item.id}
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={styles.horizontalList}
-                  />
-                </Animated.View>
-              )}
-            </>
-          )}
+            {showPodcastsSection && podcasts.length > 0 && (
+              <Animated.View>
+                <SectionHeader title="Podcasts" count={podcasts.length} colors={colors} />
+                <FlatList
+                  horizontal
+                  data={podcasts.slice(0, 5)}
+                  renderItem={({ item, index }) => (
+                    <ItemCard item={item} shape="cover" index={index} />
+                  )}
+                  keyExtractor={(item) => item.id}
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.horizontalList}
+                />
+              </Animated.View>
+            )}
 
-          {/* Bottom spacing for tab bar */}
-          <View style={styles.bottomSpacer} />
-        </ScrollView>
-      </SafeAreaView>
+            {showArticlesSection && articles.length > 0 && (
+              <Animated.View>
+                <SectionHeader title="Articles" count={articles.length} colors={colors} />
+                <FlatList
+                  horizontal
+                  data={articles}
+                  renderItem={({ item, index }) => (
+                    <ItemCard item={item} shape="stack" index={index} />
+                  )}
+                  keyExtractor={(item) => item.id}
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.horizontalList}
+                />
+              </Animated.View>
+            )}
+
+            {showVideosSection && videos.length > 0 && (
+              <Animated.View>
+                <SectionHeader title="Videos" count={videos.length} colors={colors} />
+                <FlatList
+                  horizontal
+                  data={videos}
+                  renderItem={({ item, index }) => (
+                    <ItemCard item={item} shape="stack" index={index} />
+                  )}
+                  keyExtractor={(item) => item.id}
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.horizontalList}
+                />
+              </Animated.View>
+            )}
+          </>
+        )}
+
+        <View style={styles.bottomSpacer} />
+      </ScrollView>
     </Surface>
   );
 }
 
-// =============================================================================
-// Styles
-// =============================================================================
-
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-  },
-  safeArea: {
     flex: 1,
   },
   scrollView: {
     flex: 1,
   },
   content: {
+    flexGrow: 1,
     paddingBottom: 32,
   },
-
-  // Header
   header: {
     paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.lg,
+    paddingTop: Spacing.sm,
     paddingBottom: Spacing.xl,
-  },
-  headerTopRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: Spacing.md,
-  },
-  headerTitleWrap: {
-    flex: 1,
   },
   greeting: {
     ...Typography.labelMedium,
-    marginBottom: Spacing.xs,
-  },
-  headerTitle: {
-    ...Typography.displayMedium,
   },
   settingsButton: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
@@ -575,8 +527,8 @@ const styles = StyleSheet.create({
   },
   settingsAlertDot: {
     position: 'absolute',
-    top: 7,
-    right: 7,
+    top: 5,
+    right: 5,
     width: 10,
     height: 10,
     borderRadius: Radius.full,
@@ -587,8 +539,6 @@ const styles = StyleSheet.create({
     gap: Spacing.sm,
     marginBottom: Spacing.lg,
   },
-
-  // Section
   section: {
     marginBottom: Spacing.xl,
   },
@@ -610,15 +560,11 @@ const styles = StyleSheet.create({
   sectionCount: {
     ...Typography.bodySmall,
   },
-
-  // Horizontal List
   horizontalList: {
     paddingHorizontal: Spacing.md,
     gap: Spacing.md,
     marginBottom: Spacing.xl,
   },
-
-  // Jump Back In Grid
   jumpBackInGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
@@ -629,23 +575,17 @@ const styles = StyleSheet.create({
   jumpBackInGridItem: {
     minWidth: 0,
   },
-
-  // Inbox Container
   inboxContainer: {
     marginHorizontal: Spacing.md,
     borderRadius: Radius.lg,
     overflow: 'hidden',
   },
-
-  // Loading state
   loadingState: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: Spacing['5xl'],
   },
-
-  // Bottom spacer
   bottomSpacer: {
     height: 40,
   },

--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -1,15 +1,16 @@
+import { Stack } from 'expo-router';
+
 import {
   createNativeLargeTitleScreenOptions,
   nativeLargeTitleStackScreenOptions,
 } from '@/lib/native-large-title-header';
-import { Stack } from 'expo-router';
 
-export default function SearchLayout() {
+export default function LibraryLayout() {
   return (
     <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
       <Stack.Screen
         name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Search' })}
+        options={createNativeLargeTitleScreenOptions({ title: 'Library' })}
       />
     </Stack>
   );

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef, type ComponentType }
 
 import * as Haptics from 'expo-haptics';
 import { Surface } from 'heroui-native';
-import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { Stack, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import {
   ActivityIndicator,
   View,
@@ -17,7 +17,6 @@ import {
   type ListRenderItemInfo,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import Svg, { Path } from 'react-native-svg';
 import { ContentType as ApiContentType } from '@zine/shared';
 
@@ -44,10 +43,6 @@ import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
 import type { UIContentType, UIProvider } from '@/lib/content-utils';
 
-// =============================================================================
-// Icons
-// =============================================================================
-
 function SearchIcon({ size = 20, color = '#94A3B8' }: { size?: number; color?: string }) {
   return (
     <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
@@ -67,10 +62,6 @@ function PlusIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: str
     </Svg>
   );
 }
-
-// =============================================================================
-// Filter Options
-// =============================================================================
 
 const LIBRARY_PAGE_SIZE = 20;
 const LIBRARY_TOP_THRESHOLD = 4;
@@ -123,10 +114,6 @@ const filterOptions: {
   },
 ];
 
-// =============================================================================
-// Main Screen
-// =============================================================================
-
 type LibraryTabNavigation = {
   addListener: (event: 'tabPress', listener: () => void) => () => void;
   isFocused: () => boolean;
@@ -163,7 +150,6 @@ export default function LibraryScreen() {
     return matchedOption ? matchedOption.contentType : undefined;
   }, [contentTypeParam]);
 
-  // Filter state
   const [contentTypeFilter, setContentTypeFilter] = useState<ApiContentType | null>(
     () => preselectedContentType ?? null
   );
@@ -184,13 +170,11 @@ export default function LibraryScreen() {
     return () => clearTimeout(handle);
   }, [searchQuery]);
 
-  // Handle add bookmark
   const handleAddBookmark = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     router.push('/add-link');
   }, [router]);
 
-  // Memoize filter to prevent unnecessary query key changes
   const filter = useMemo(
     () => ({
       contentType: contentTypeFilter ?? undefined,
@@ -199,7 +183,6 @@ export default function LibraryScreen() {
     [contentTypeFilter, showCompletedOnly]
   );
 
-  // Fetch library items from tRPC with memoized filter
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteLibraryItems({
       filter,
@@ -207,7 +190,6 @@ export default function LibraryScreen() {
       limit: LIBRARY_PAGE_SIZE,
     });
 
-  // Transform API response to ItemCardData format
   const libraryItems: ItemCardData[] = useMemo(
     () =>
       (data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
@@ -268,13 +250,22 @@ export default function LibraryScreen() {
     });
   }, [contentTypeFilter, navigation, showCompletedOnly]);
 
+  const listEmptyComponent = (
+    <EmptyState
+      title={searchQuery.trim() ? 'No matches found' : 'No bookmarked items'}
+      message={
+        searchQuery.trim()
+          ? 'Try a different title or creator name.'
+          : 'Bookmark content from your inbox to save it here for later.'
+      }
+    />
+  );
+
   return (
-    <Surface style={[styles.container, { backgroundColor: colors.background }]}>
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
-        {/* Header */}
-        <View style={styles.header}>
-          <View style={styles.headerTitleRow}>
-            <Text style={[styles.headerTitle, { color: colors.text }]}>Library</Text>
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={{
+          headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}
               style={[styles.addButton, { backgroundColor: colors.backgroundSecondary }]}
@@ -283,146 +274,122 @@ export default function LibraryScreen() {
             >
               <PlusIcon size={22} color={colors.text} />
             </Pressable>
-          </View>
-          <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-            {libraryCountLabel}
-          </Text>
-        </View>
+          ),
+        }}
+      />
 
-        {/* Search Bar */}
-        <Animated.View style={styles.searchContainer}>
-          <View
-            style={[
-              styles.searchBar,
-              {
-                backgroundColor: colors.backgroundSecondary,
-                borderColor: colors.border,
-              },
-            ]}
-          >
-            <SearchIcon size={18} color={colors.textTertiary} />
-            <TextInput
-              placeholder="Search your library..."
-              placeholderTextColor={colors.textTertiary}
-              style={[styles.searchInput, { color: colors.text }]}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-            />
-          </View>
-        </Animated.View>
+      {isLoading ? (
+        <LoadingState />
+      ) : error ? (
+        <ErrorState message={error.message} />
+      ) : (
+        <FlatList
+          ref={listScrollRef}
+          data={libraryItems}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          style={styles.listContainer}
+          contentContainerStyle={styles.listContent}
+          contentInsetAdjustmentBehavior="automatic"
+          showsVerticalScrollIndicator={false}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.6}
+          ListHeaderComponent={
+            <View style={styles.listHeader}>
+              <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
+                {libraryCountLabel}
+              </Text>
 
-        {/* Filter Chips */}
-        <Animated.View>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.filterContainer}
-          >
-            <FilterChip
-              label="Completed"
-              isSelected={showCompletedOnly}
-              onPress={() => setShowCompletedOnly((prev) => !prev)}
-              icon={CheckOutlineIcon}
-              selectedColor={FilterChipPalette.completed.accent}
-              selectedSurfaceColor={FilterChipPalette.completed.surface}
-            />
-            {filterOptions.map((option) => (
-              <FilterChip
-                key={option.id}
-                label={option.label}
-                isSelected={contentTypeFilter === option.contentType}
-                onPress={() =>
-                  setContentTypeFilter((current) =>
-                    current === option.contentType ? null : option.contentType
-                  )
-                }
-                icon={option.icon}
-                dotColor={option.color}
-                selectedColor={option.selectedColor}
-                selectedSurfaceColor={option.selectedSurfaceColor}
-              />
-            ))}
-          </ScrollView>
-        </Animated.View>
+              <Animated.View style={styles.searchContainer}>
+                <View
+                  style={[
+                    styles.searchBar,
+                    {
+                      backgroundColor: colors.backgroundSecondary,
+                      borderColor: colors.border,
+                    },
+                  ]}
+                >
+                  <SearchIcon size={18} color={colors.textTertiary} />
+                  <TextInput
+                    placeholder="Search your library..."
+                    placeholderTextColor={colors.textTertiary}
+                    style={[styles.searchInput, { color: colors.text }]}
+                    value={searchQuery}
+                    onChangeText={setSearchQuery}
+                  />
+                </View>
+              </Animated.View>
 
-        {/* Content */}
-        {isLoading ? (
-          <LoadingState />
-        ) : error ? (
-          <ErrorState message={error.message} />
-        ) : libraryItems.length === 0 ? (
-          <EmptyState
-            title={searchQuery.trim() ? 'No matches found' : 'No bookmarked items'}
-            message={
-              searchQuery.trim()
-                ? 'Try a different title or creator name.'
-                : 'Bookmark content from your inbox to save it here for later.'
-            }
-          />
-        ) : (
-          <FlatList
-            ref={listScrollRef}
-            data={libraryItems}
-            keyExtractor={(item) => item.id}
-            renderItem={renderItem}
-            style={styles.listContainer}
-            contentContainerStyle={styles.listContent}
-            showsVerticalScrollIndicator={false}
-            onScroll={handleScroll}
-            scrollEventThrottle={16}
-            onEndReached={handleEndReached}
-            onEndReachedThreshold={0.6}
-            ListFooterComponent={
-              <View style={styles.listFooter}>
-                {isFetchingNextPage ? (
-                  <ActivityIndicator size="small" color={colors.primary} />
-                ) : null}
-              </View>
-            }
-          />
-        )}
-      </SafeAreaView>
+              <Animated.View>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.filterContainer}
+                >
+                  <FilterChip
+                    label="Completed"
+                    isSelected={showCompletedOnly}
+                    onPress={() => setShowCompletedOnly((prev) => !prev)}
+                    icon={CheckOutlineIcon}
+                    selectedColor={FilterChipPalette.completed.accent}
+                    selectedSurfaceColor={FilterChipPalette.completed.surface}
+                  />
+                  {filterOptions.map((option) => (
+                    <FilterChip
+                      key={option.id}
+                      label={option.label}
+                      isSelected={contentTypeFilter === option.contentType}
+                      onPress={() =>
+                        setContentTypeFilter((current) =>
+                          current === option.contentType ? null : option.contentType
+                        )
+                      }
+                      icon={option.icon}
+                      dotColor={option.color}
+                      selectedColor={option.selectedColor}
+                      selectedSurfaceColor={option.selectedSurfaceColor}
+                    />
+                  ))}
+                </ScrollView>
+              </Animated.View>
+            </View>
+          }
+          ListEmptyComponent={listEmptyComponent}
+          ListFooterComponent={
+            <View style={styles.listFooter}>
+              {isFetchingNextPage ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : null}
+            </View>
+          }
+        />
+      )}
     </Surface>
   );
 }
-
-// =============================================================================
-// Styles
-// =============================================================================
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  safeArea: {
-    flex: 1,
-  },
-  header: {
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.lg,
-    paddingBottom: Spacing.md,
-  },
-  headerTitleRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: Spacing.xs,
-  },
-  headerTitle: {
-    ...Typography.displayMedium,
+  listHeader: {
+    paddingTop: Spacing.sm,
   },
   headerSubtitle: {
     ...Typography.bodyMedium,
+    paddingHorizontal: Spacing.md,
+    marginBottom: Spacing.md,
   },
   addButton: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
   },
-
-  // Search
   searchContainer: {
     paddingHorizontal: Spacing.md,
     marginBottom: Spacing.md,
@@ -441,19 +408,16 @@ const styles = StyleSheet.create({
     ...Typography.bodyMedium,
     paddingVertical: 0,
   },
-
-  // Filters
   filterContainer: {
     paddingHorizontal: Spacing.md,
     gap: Spacing.sm,
     marginBottom: Spacing.md,
   },
-
-  // List
   listContainer: {
     flex: 1,
   },
   listContent: {
+    flexGrow: 1,
     paddingBottom: Spacing['3xl'],
   },
   listFooter: {

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -2,12 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Stack, useNavigation } from 'expo-router';
 import { Surface } from 'heroui-native';
-import { FlatList, type ListRenderItemInfo, StyleSheet, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { FlatList, type ListRenderItemInfo, StyleSheet, View } from 'react-native';
 
 import { type ItemCardData, ItemCard } from '@/components/item-card';
 import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
-import { Colors, Spacing, Typography } from '@/constants/theme';
+import { Colors, Spacing } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { mapContentType, mapProvider, useLibraryItems } from '@/hooks/use-items-trpc';
 import type { ContentType, Provider } from '@/lib/content-utils';
@@ -85,10 +84,9 @@ export default function SearchTabScreen() {
   );
 
   return (
-    <Surface style={[styles.container, { backgroundColor: colors.background }]}>
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
         options={{
-          title: '',
           headerSearchBarOptions: {
             placement: 'automatic',
             placeholder: 'Search your library',
@@ -100,25 +98,20 @@ export default function SearchTabScreen() {
         }}
       />
 
-      <SafeAreaView style={styles.safeArea} edges={['top']}>
-        <View style={styles.header}>
-          <Text style={[styles.headerTitle, { color: colors.text }]}>Search</Text>
-        </View>
-
-        <FlatList
-          ref={listScrollRef}
-          data={isShowingState ? [] : libraryItems}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          style={styles.listContainer}
-          contentContainerStyle={[styles.listContent, isShowingState && styles.emptyListContent]}
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-          ListEmptyComponent={listEmptyComponent}
-          ListFooterComponent={!isShowingState ? <View style={styles.bottomSpacer} /> : null}
-        />
-      </SafeAreaView>
+      <FlatList
+        ref={listScrollRef}
+        data={isShowingState ? [] : libraryItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        style={styles.listContainer}
+        contentContainerStyle={[styles.listContent, isShowingState && styles.emptyListContent]}
+        contentInsetAdjustmentBehavior="automatic"
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={!isShowingState ? <View style={styles.bottomSpacer} /> : null}
+      />
     </Surface>
   );
 }
@@ -126,17 +119,6 @@ export default function SearchTabScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  safeArea: {
-    flex: 1,
-  },
-  header: {
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.lg,
-    paddingBottom: Spacing.md,
-  },
-  headerTitle: {
-    ...Typography.displayMedium,
   },
   listContainer: {
     flex: 1,

--- a/apps/mobile/app/onboarding/connect.tsx
+++ b/apps/mobile/app/onboarding/connect.tsx
@@ -171,12 +171,12 @@ export default function OnboardingConnectScreen() {
 
   const handleSkip = useCallback(() => {
     // Navigate to main app (tabs)
-    router.replace('/(tabs)');
+    router.replace('/index');
   }, [router]);
 
   const handleContinue = useCallback(() => {
     // Navigate to main app (tabs)
-    router.replace('/(tabs)');
+    router.replace('/index');
   }, [router]);
 
   return (

--- a/apps/mobile/app/onboarding/select-channels.tsx
+++ b/apps/mobile/app/onboarding/select-channels.tsx
@@ -146,7 +146,7 @@ export default function SelectChannelsScreen() {
 
       // Navigate to tabs after a short delay to allow subscriptions to process
       setTimeout(() => {
-        router.replace('/(tabs)');
+        router.replace('/index');
       }, 500);
     } catch (err) {
       showError(toast, err, 'Failed to subscribe', 'SelectChannels');
@@ -157,7 +157,7 @@ export default function SelectChannelsScreen() {
 
   // Skip and go to tabs without subscribing
   const handleSkip = useCallback(() => {
-    router.replace('/(tabs)');
+    router.replace('/index');
   }, [router]);
 
   // If provider is invalid, redirect to onboarding connect screen

--- a/apps/mobile/app/settings/_layout.tsx
+++ b/apps/mobile/app/settings/_layout.tsx
@@ -7,20 +7,20 @@
  * @see features/subscriptions/frontend-spec.md Section 2.1 (Settings Stack)
  */
 
+import {
+  createNativeLargeTitleScreenOptions,
+  nativeLargeTitleStackScreenOptions,
+} from '@/lib/native-large-title-header';
 import { Stack } from 'expo-router';
 
 export default function SettingsLayout() {
   return (
-    <Stack
-      screenOptions={{
-        headerBackButtonDisplayMode: 'minimal',
-      }}
-    >
+    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
       <Stack.Screen
         name="index"
-        options={{
+        options={createNativeLargeTitleScreenOptions({
           title: 'Settings',
-        }}
+        })}
       />
       <Stack.Screen
         name="connections"

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -12,7 +12,6 @@
 import { useMemo } from 'react';
 import { View, Text, ScrollView, Pressable, StyleSheet, Linking, Share } from 'react-native';
 import { useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import { useClerk } from '@clerk/clerk-expo';
 import Constants from 'expo-constants';
 
@@ -194,8 +193,13 @@ function SettingsScreenContent({
   };
 
   return (
-    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={[]}>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+    <View style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
         <View style={[styles.section, { backgroundColor: colors.card }]}>
           <SettingsRow
             title="Subscriptions"
@@ -269,7 +273,7 @@ function SettingsScreenContent({
           </>
         )}
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -281,7 +285,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   scrollContent: {
+    flexGrow: 1,
     padding: Spacing.lg,
     paddingBottom: Spacing['3xl'],
   },

--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -318,8 +318,9 @@ export default function ProviderDetailScreen() {
   return (
     <>
       <Stack.Screen options={{ title: sourceConfig.name }} />
-      <Surface tone="canvas" style={styles.container}>
+      <Surface tone="canvas" style={styles.container} collapsable={false}>
         <FlatList
+          style={styles.list}
           data={provider === 'GMAIL' ? newsletterFeeds : filteredSubscriptions}
           keyExtractor={(item) => item.id}
           keyboardShouldPersistTaps="handled"
@@ -572,7 +573,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  list: {
+    flex: 1,
+  },
   content: {
+    flexGrow: 1,
     padding: Spacing.lg,
     gap: Spacing.md,
     paddingBottom: Spacing['3xl'],

--- a/apps/mobile/app/subscriptions/_layout.tsx
+++ b/apps/mobile/app/subscriptions/_layout.tsx
@@ -6,35 +6,27 @@
  */
 
 import { Stack } from 'expo-router';
+import {
+  createNativeLargeTitleScreenOptions,
+  nativeLargeTitleStackScreenOptions,
+} from '@/lib/native-large-title-header';
 
 export default function SubscriptionsLayout() {
   return (
-    <Stack
-      screenOptions={{
-        headerBackButtonDisplayMode: 'minimal',
-        headerLargeTitleShadowVisible: false,
-      }}
-    >
+    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
       <Stack.Screen
         name="index"
-        options={{
+        options={createNativeLargeTitleScreenOptions({
           title: 'Subscriptions',
-          headerLargeTitle: true,
-        }}
+        })}
       />
       <Stack.Screen
         name="rss"
-        options={{
+        options={createNativeLargeTitleScreenOptions({
           title: 'RSS',
-          headerLargeTitle: true,
-        }}
+        })}
       />
-      <Stack.Screen
-        name="[provider]"
-        options={{
-          headerLargeTitle: true,
-        }}
-      />
+      <Stack.Screen name="[provider]" options={createNativeLargeTitleScreenOptions()} />
       <Stack.Screen
         name="connect"
         options={{

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -110,6 +110,7 @@ export default function SubscriptionsScreen() {
       <Stack.Screen options={{ headerLeft }} />
       <Surface tone="canvas" style={styles.container} collapsable={false}>
         <ScrollView
+          style={styles.scrollView}
           contentContainerStyle={styles.content}
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
@@ -141,7 +142,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  scrollView: {
+    flex: 1,
+  },
   content: {
+    flexGrow: 1,
     paddingHorizontal: Spacing.lg,
     gap: Spacing.md,
     paddingBottom: Spacing['3xl'],

--- a/apps/mobile/app/subscriptions/rss.tsx
+++ b/apps/mobile/app/subscriptions/rss.tsx
@@ -145,8 +145,9 @@ export default function RssSubscriptionsScreen() {
   return (
     <>
       <Stack.Screen options={{ title: sourceConfig.name }} />
-      <Surface tone="canvas" style={styles.container}>
+      <Surface tone="canvas" style={styles.container} collapsable={false}>
         <FlatList
+          style={styles.list}
           data={filteredFeeds}
           keyExtractor={(item) => item.id}
           keyboardShouldPersistTaps="handled"
@@ -285,7 +286,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  list: {
+    flex: 1,
+  },
   content: {
+    flexGrow: 1,
     padding: Spacing.lg,
     gap: Spacing.md,
     paddingBottom: Spacing['3xl'],

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -65,7 +65,13 @@ jest.mock('expo-router', () => ({
   }),
   useNavigation: () => mockNavigation,
   Stack: {
-    Screen: () => null,
+    Screen: ({
+      options,
+    }: {
+      options?: {
+        headerRight?: () => React.ReactNode;
+      };
+    }) => React.createElement(React.Fragment, null, options?.headerRight?.()),
   },
 }));
 

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -49,6 +49,15 @@ jest.mock('expo-router', () => ({
   }),
   useNavigation: () => mockNavigation,
   useLocalSearchParams: () => ({}),
+  Stack: {
+    Screen: ({
+      options,
+    }: {
+      options?: {
+        headerRight?: () => React.ReactNode;
+      };
+    }) => React.createElement(React.Fragment, null, options?.headerRight?.()),
+  },
 }));
 
 jest.mock('react-native', () => ({
@@ -90,10 +99,14 @@ jest.mock('react-native', () => ({
       {
         data,
         renderItem,
+        ListHeaderComponent,
+        ListFooterComponent,
         ...props
       }: {
         data?: unknown[];
         renderItem?: (args: { item: unknown; index: number }) => React.ReactNode;
+        ListHeaderComponent?: React.ReactNode;
+        ListFooterComponent?: React.ReactNode;
       },
       ref: React.ForwardedRef<{ scrollToOffset: typeof mockScrollToOffset }>
     ) => {
@@ -104,9 +117,11 @@ jest.mock('react-native', () => ({
       return React.createElement(
         'flat-list',
         props,
+        ListHeaderComponent,
         data?.map((item, index) =>
           React.createElement(React.Fragment, { key: index }, renderItem?.({ item, index }))
-        )
+        ),
+        ListFooterComponent
       );
     }
   ),

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -1,0 +1,34 @@
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+
+import { Colors } from '@/constants/theme';
+
+export const nativeLargeTitleStackScreenOptions: NativeStackNavigationOptions = {
+  headerBackButtonDisplayMode: 'minimal',
+  headerLargeTitleShadowVisible: false,
+};
+
+export const nativeLargeTitleHeaderAppearance: NativeStackNavigationOptions = {
+  headerTintColor: Colors.dark.text,
+  headerStyle: {
+    backgroundColor: Colors.dark.background,
+  },
+  headerLargeStyle: {
+    backgroundColor: 'transparent',
+  },
+  headerTitleStyle: {
+    color: Colors.dark.text,
+  },
+  headerLargeTitleStyle: {
+    color: Colors.dark.text,
+  },
+};
+
+export function createNativeLargeTitleScreenOptions(
+  options: NativeStackNavigationOptions = {}
+): NativeStackNavigationOptions {
+  return {
+    ...nativeLargeTitleHeaderAppearance,
+    headerLargeTitle: true,
+    ...options,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared native large-title header helper for iOS stack screens
- apply the collapsing transparent-to-black header treatment to subscriptions, provider pages, rss, settings, search, inbox, library, and home
- refactor the inbox, library, and home tabs into nested stack routes so they can use native large-title headers while preserving existing screen behavior

## Validation
- bun run design-system:check
- bun run typecheck
- git push hook: prettier --check
- git push hook: worker vitest suite (1416 tests passed)