### PR TITLE
Improve large-title header scroll performance

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -306,6 +306,8 @@ export default function HomeScreen() {
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
         options={{
+          title: 'Home',
+          headerLargeTitle: true,
           headerRight: () => (
             <Pressable
               onPress={handleOpenSettings}

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -13,7 +13,6 @@ import {
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
 
 import { FilterChip } from '@/components/filter-chip';
@@ -347,36 +346,34 @@ export default function HomeScreen() {
         contentContainerStyle={styles.content}
         contentInsetAdjustmentBehavior="automatic"
         onScroll={handleScroll}
-        scrollEventThrottle={16}
+        scrollEventThrottle={32}
         showsVerticalScrollIndicator={false}
       >
-        <Animated.View style={styles.header}>
+        <View style={styles.header}>
           <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
-        </Animated.View>
+        </View>
 
-        <Animated.View>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.filterContainer}
-          >
-            {contentTypeFilters.map((filter) => (
-              <FilterChip
-                key={filter.id}
-                label={filter.label}
-                isSelected={contentTypeFilter === filter.id}
-                onPress={() =>
-                  setContentTypeFilter((current) => (current === filter.id ? null : filter.id))
-                }
-                icon={filter.icon}
-                dotColor={filter.dotColor}
-                selectedColor={filter.selectedColor}
-                selectedSurfaceColor={filter.selectedSurfaceColor}
-                count={categoryCounts[filter.id]}
-              />
-            ))}
-          </ScrollView>
-        </Animated.View>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.filterContainer}
+        >
+          {contentTypeFilters.map((filter) => (
+            <FilterChip
+              key={filter.id}
+              label={filter.label}
+              isSelected={contentTypeFilter === filter.id}
+              onPress={() =>
+                setContentTypeFilter((current) => (current === filter.id ? null : filter.id))
+              }
+              icon={filter.icon}
+              dotColor={filter.dotColor}
+              selectedColor={filter.selectedColor}
+              selectedSurfaceColor={filter.selectedSurfaceColor}
+              count={categoryCounts[filter.id]}
+            />
+          ))}
+        </ScrollView>
         {isLoading ? (
           <View style={styles.loadingState}>
             <ActivityIndicator size="large" color={colors.primary} />
@@ -384,7 +381,7 @@ export default function HomeScreen() {
         ) : (
           <>
             {filteredJumpBackInItems.length > 0 && (
-              <Animated.View>
+              <>
                 <SectionHeader
                   title="Jump Back In"
                   count={filteredJumpBackInItems.length}
@@ -400,11 +397,11 @@ export default function HomeScreen() {
                     </View>
                   ))}
                 </View>
-              </Animated.View>
+              </>
             )}
 
             {filteredRecentlyBookmarked.length > 0 && (
-              <Animated.View>
+              <>
                 <SectionHeader
                   title="Recently Bookmarked"
                   count={filteredRecentlyBookmarked.length}
@@ -420,11 +417,11 @@ export default function HomeScreen() {
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.horizontalList}
                 />
-              </Animated.View>
+              </>
             )}
 
             {filteredInboxItems.length > 0 && (
-              <Animated.View style={styles.section}>
+              <View style={styles.section}>
                 <SectionHeader
                   title="Inbox"
                   count={filteredInboxItems.length}
@@ -438,11 +435,11 @@ export default function HomeScreen() {
                     <ItemCard key={item.id} item={item} shape="row" index={index} />
                   ))}
                 </View>
-              </Animated.View>
+              </View>
             )}
 
             {showPodcastsSection && podcasts.length > 0 && (
-              <Animated.View>
+              <>
                 <SectionHeader title="Podcasts" count={podcasts.length} colors={colors} />
                 <FlatList
                   horizontal
@@ -454,11 +451,11 @@ export default function HomeScreen() {
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.horizontalList}
                 />
-              </Animated.View>
+              </>
             )}
 
             {showArticlesSection && articles.length > 0 && (
-              <Animated.View>
+              <>
                 <SectionHeader title="Articles" count={articles.length} colors={colors} />
                 <FlatList
                   horizontal
@@ -470,11 +467,11 @@ export default function HomeScreen() {
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.horizontalList}
                 />
-              </Animated.View>
+              </>
             )}
 
             {showVideosSection && videos.length > 0 && (
-              <Animated.View>
+              <>
                 <SectionHeader title="Videos" count={videos.length} colors={colors} />
                 <FlatList
                   horizontal
@@ -486,7 +483,7 @@ export default function HomeScreen() {
                   showsHorizontalScrollIndicator={false}
                   contentContainerStyle={styles.horizontalList}
                 />
-              </Animated.View>
+              </>
             )}
           </>
         )}

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -39,6 +39,7 @@ import {
 import { useConnections } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions-query';
 import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
+import { createNativeLargeTitleScreenOptions } from '@/lib/native-large-title-header';
 import type { ContentType, Provider, UIContentType } from '@/lib/content-utils';
 
 function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; color?: string }) {
@@ -305,9 +306,8 @@ export default function HomeScreen() {
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
-        options={{
+        options={createNativeLargeTitleScreenOptions({
           title: 'Home',
-          headerLargeTitle: true,
           headerRight: () => (
             <Pressable
               onPress={handleOpenSettings}
@@ -339,7 +339,7 @@ export default function HomeScreen() {
               ) : null}
             </Pressable>
           ),
-        }}
+        })}
       />
 
       <ScrollView

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -16,7 +16,6 @@ import {
   type NativeSyntheticEvent,
   type ListRenderItemInfo,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
 import { ContentType as ApiContentType } from '@zine/shared';
 
@@ -293,7 +292,7 @@ export default function LibraryScreen() {
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
           onScroll={handleScroll}
-          scrollEventThrottle={16}
+          scrollEventThrottle={32}
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.6}
           ListHeaderComponent={
@@ -302,7 +301,7 @@ export default function LibraryScreen() {
                 {libraryCountLabel}
               </Text>
 
-              <Animated.View style={styles.searchContainer}>
+              <View style={styles.searchContainer}>
                 <View
                   style={[
                     styles.searchBar,
@@ -321,40 +320,38 @@ export default function LibraryScreen() {
                     onChangeText={setSearchQuery}
                   />
                 </View>
-              </Animated.View>
+              </View>
 
-              <Animated.View>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.filterContainer}
-                >
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filterContainer}
+              >
+                <FilterChip
+                  label="Completed"
+                  isSelected={showCompletedOnly}
+                  onPress={() => setShowCompletedOnly((prev) => !prev)}
+                  icon={CheckOutlineIcon}
+                  selectedColor={FilterChipPalette.completed.accent}
+                  selectedSurfaceColor={FilterChipPalette.completed.surface}
+                />
+                {filterOptions.map((option) => (
                   <FilterChip
-                    label="Completed"
-                    isSelected={showCompletedOnly}
-                    onPress={() => setShowCompletedOnly((prev) => !prev)}
-                    icon={CheckOutlineIcon}
-                    selectedColor={FilterChipPalette.completed.accent}
-                    selectedSurfaceColor={FilterChipPalette.completed.surface}
+                    key={option.id}
+                    label={option.label}
+                    isSelected={contentTypeFilter === option.contentType}
+                    onPress={() =>
+                      setContentTypeFilter((current) =>
+                        current === option.contentType ? null : option.contentType
+                      )
+                    }
+                    icon={option.icon}
+                    dotColor={option.color}
+                    selectedColor={option.selectedColor}
+                    selectedSurfaceColor={option.selectedSurfaceColor}
                   />
-                  {filterOptions.map((option) => (
-                    <FilterChip
-                      key={option.id}
-                      label={option.label}
-                      isSelected={contentTypeFilter === option.contentType}
-                      onPress={() =>
-                        setContentTypeFilter((current) =>
-                          current === option.contentType ? null : option.contentType
-                        )
-                      }
-                      icon={option.icon}
-                      dotColor={option.color}
-                      selectedColor={option.selectedColor}
-                      selectedSurfaceColor={option.selectedSurfaceColor}
-                    />
-                  ))}
-                </ScrollView>
-              </Animated.View>
+                ))}
+              </ScrollView>
             </View>
           }
           ListEmptyComponent={listEmptyComponent}

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -264,6 +264,8 @@ export default function LibraryScreen() {
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
         options={{
+          title: 'Library',
+          headerLargeTitle: true,
           headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -40,6 +40,7 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
+import { createNativeLargeTitleScreenOptions } from '@/lib/native-large-title-header';
 import type { UIContentType, UIProvider } from '@/lib/content-utils';
 
 function SearchIcon({ size = 20, color = '#94A3B8' }: { size?: number; color?: string }) {
@@ -263,9 +264,8 @@ export default function LibraryScreen() {
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
-        options={{
+        options={createNativeLargeTitleScreenOptions({
           title: 'Library',
-          headerLargeTitle: true,
           headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}
@@ -276,7 +276,7 @@ export default function LibraryScreen() {
               <PlusIcon size={22} color={colors.text} />
             </Pressable>
           ),
-        }}
+        })}
       />
 
       {isLoading ? (

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -262,8 +262,8 @@ export function ItemCard({
       <Pressable
         onPress={handlePress}
         style={({ pressed }) => [
-          styles.rowFeaturedWrapper,
           styles.rowFeaturedCard,
+          styles.rowFeaturedWrapper,
           { backgroundColor: colors.surfaceElevated, borderColor: colors.borderDefault },
           pressed && { opacity: motion.opacity.pressed },
         ]}

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -11,7 +11,6 @@ import { useEffect, useState } from 'react';
 import { Image } from 'expo-image';
 import { useRouter, type Href } from 'expo-router';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import Animated from 'react-native-reanimated';
 
 import { Typography, Spacing, Radius, IconSizes } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
@@ -155,113 +154,104 @@ export function ItemCard({
 
   if (shape === 'cover') {
     return (
-      <Animated.View>
-        <Pressable
-          onPress={handlePress}
-          style={({ pressed }) => [styles.coverCard, pressed && { opacity: 0.95 }]}
-        >
-          {mediaImageUrl ? (
-            <Image
-              source={{ uri: mediaImageUrl }}
-              style={styles.coverImage}
-              contentFit="cover"
-              transition={mediaTransition}
-              onError={handleMediaImageError}
-            />
-          ) : (
-            <View style={[styles.coverImage, { backgroundColor: colors.surfaceRaised }]} />
-          )}
+      <Pressable
+        onPress={handlePress}
+        style={({ pressed }) => [styles.coverCard, pressed && { opacity: 0.95 }]}
+      >
+        {mediaImageUrl ? (
+          <Image
+            source={{ uri: mediaImageUrl }}
+            style={styles.coverImage}
+            contentFit="cover"
+            transition={mediaTransition}
+            onError={handleMediaImageError}
+          />
+        ) : (
+          <View style={[styles.coverImage, { backgroundColor: colors.surfaceRaised }]} />
+        )}
 
-          <View style={[styles.coverContent, { backgroundColor: colors.overlaySoft }]}>
-            <Text style={[styles.coverCreator, { color: colors.overlayForegroundSubtle }]}>
-              {item.creator}
+        <View style={[styles.coverContent, { backgroundColor: colors.overlaySoft }]}>
+          <Text style={[styles.coverCreator, { color: colors.overlayForegroundSubtle }]}>
+            {item.creator}
+          </Text>
+          <Text style={[styles.coverTitle, { color: colors.overlayForeground }]} numberOfLines={2}>
+            {item.title}
+          </Text>
+          {durationText && (
+            <Text style={[styles.coverDuration, { color: colors.overlayForegroundMuted }]}>
+              {durationText}
             </Text>
-            <Text
-              style={[styles.coverTitle, { color: colors.overlayForeground }]}
-              numberOfLines={2}
-            >
-              {item.title}
-            </Text>
-            {durationText && (
-              <Text style={[styles.coverDuration, { color: colors.overlayForegroundMuted }]}>
-                {durationText}
-              </Text>
-            )}
-          </View>
-        </Pressable>
-      </Animated.View>
+          )}
+        </View>
+      </Pressable>
     );
   }
 
   if (shape === 'stack') {
     return (
-      <Animated.View>
-        <Pressable
-          onPress={handlePress}
-          style={({ pressed }) => [
-            styles.stackCard,
-            { backgroundColor: colors.surfaceSubtle },
-            pressed && { opacity: 0.7 },
-          ]}
-        >
-          {mediaImageUrl ? (
-            <Image
-              source={{ uri: mediaImageUrl }}
-              style={styles.stackImage}
-              contentFit="cover"
-              transition={mediaTransition}
-              onError={handleMediaImageError}
-            />
-          ) : (
-            <View style={[styles.stackImage, { backgroundColor: colors.surfaceRaised }]} />
-          )}
+      <Pressable
+        onPress={handlePress}
+        style={({ pressed }) => [
+          styles.stackCard,
+          { backgroundColor: colors.surfaceSubtle },
+          pressed && { opacity: 0.7 },
+        ]}
+      >
+        {mediaImageUrl ? (
+          <Image
+            source={{ uri: mediaImageUrl }}
+            style={styles.stackImage}
+            contentFit="cover"
+            transition={mediaTransition}
+            onError={handleMediaImageError}
+          />
+        ) : (
+          <View style={[styles.stackImage, { backgroundColor: colors.surfaceRaised }]} />
+        )}
 
-          <View style={styles.stackContent}>
-            <Text style={[styles.stackTitle, { color: colors.text }]} numberOfLines={1}>
-              {item.title}
-            </Text>
-            <View style={styles.stackMeta}>
-              <View style={styles.stackMetaIcon}>{renderSubtitleLeadingVisual()}</View>
-              <View style={styles.stackMetaTextGroup}>
-                <View
+        <View style={styles.stackContent}>
+          <Text style={[styles.stackTitle, { color: colors.text }]} numberOfLines={1}>
+            {item.title}
+          </Text>
+          <View style={styles.stackMeta}>
+            <View style={styles.stackMetaIcon}>{renderSubtitleLeadingVisual()}</View>
+            <View style={styles.stackMetaTextGroup}>
+              <View
+                style={[
+                  styles.stackMetaCreatorContainer,
+                  inlineLengthText ? styles.stackMetaCreatorContainerWithLength : null,
+                ]}
+              >
+                <Text
                   style={[
-                    styles.stackMetaCreatorContainer,
-                    inlineLengthText ? styles.stackMetaCreatorContainerWithLength : null,
+                    styles.stackSource,
+                    styles.stackMetaCreator,
+                    { color: colors.textSubheader },
                   ]}
+                  numberOfLines={1}
                 >
+                  {item.creator}
+                </Text>
+              </View>
+              {inlineLengthText ? (
+                <>
+                  <View style={[styles.stackTypeDot, { backgroundColor: colors.textSubheader }]} />
                   <Text
                     style={[
                       styles.stackSource,
-                      styles.stackMetaCreator,
+                      styles.stackMetaLength,
                       { color: colors.textSubheader },
                     ]}
                     numberOfLines={1}
                   >
-                    {item.creator}
+                    {inlineLengthText}
                   </Text>
-                </View>
-                {inlineLengthText ? (
-                  <>
-                    <View
-                      style={[styles.stackTypeDot, { backgroundColor: colors.textSubheader }]}
-                    />
-                    <Text
-                      style={[
-                        styles.stackSource,
-                        styles.stackMetaLength,
-                        { color: colors.textSubheader },
-                      ]}
-                      numberOfLines={1}
-                    >
-                      {inlineLengthText}
-                    </Text>
-                  </>
-                ) : null}
-              </View>
+                </>
+              ) : null}
             </View>
           </View>
-        </Pressable>
-      </Animated.View>
+        </View>
+      </Pressable>
     );
   }
 
@@ -269,100 +259,92 @@ export function ItemCard({
 
   if (isFeaturedRow) {
     return (
-      <Animated.View style={styles.rowFeaturedWrapper}>
-        <Pressable
-          onPress={handlePress}
-          style={({ pressed }) => [
-            styles.rowFeaturedCard,
-            { backgroundColor: colors.surfaceElevated, borderColor: colors.borderDefault },
-            pressed && { opacity: motion.opacity.pressed },
-          ]}
-        >
-          <View
-            style={[
-              styles.rowFeaturedThumbnailContainer,
-              { backgroundColor: colors.surfaceRaised },
-            ]}
-          >
-            {mediaImageUrl ? (
-              <Image
-                source={{ uri: mediaImageUrl }}
-                style={styles.rowFeaturedThumbnailImage}
-                contentFit="cover"
-                transition={mediaTransition}
-                onError={handleMediaImageError}
-              />
-            ) : null}
-          </View>
-          <View style={styles.rowFeaturedContent}>
-            <Text style={[styles.rowFeaturedTitle, { color: colors.text }]} numberOfLines={2}>
-              {item.title}
-            </Text>
-          </View>
-        </Pressable>
-      </Animated.View>
-    );
-  }
-
-  return (
-    <Animated.View>
       <Pressable
         onPress={handlePress}
-        style={({ pressed }) => [styles.rowCompactCard, pressed && { opacity: 0.7 }]}
+        style={({ pressed }) => [
+          styles.rowFeaturedWrapper,
+          styles.rowFeaturedCard,
+          { backgroundColor: colors.surfaceElevated, borderColor: colors.borderDefault },
+          pressed && { opacity: motion.opacity.pressed },
+        ]}
       >
-        <View style={styles.rowCompactThumbnailContainer}>
+        <View
+          style={[styles.rowFeaturedThumbnailContainer, { backgroundColor: colors.surfaceRaised }]}
+        >
           {mediaImageUrl ? (
             <Image
               source={{ uri: mediaImageUrl }}
-              style={styles.rowCompactThumbnailImage}
+              style={styles.rowFeaturedThumbnailImage}
               contentFit="cover"
               transition={mediaTransition}
               onError={handleMediaImageError}
             />
-          ) : (
-            <View
-              style={[styles.rowCompactThumbnailImage, { backgroundColor: colors.surfaceRaised }]}
-            />
-          )}
+          ) : null}
         </View>
-
-        <View style={styles.rowCompactContent}>
-          <Text style={[styles.rowCompactTitle, { color: colors.text }]} numberOfLines={1}>
+        <View style={styles.rowFeaturedContent}>
+          <Text style={[styles.rowFeaturedTitle, { color: colors.text }]} numberOfLines={2}>
             {item.title}
           </Text>
-          <View style={styles.rowCompactMeta}>
-            <View style={styles.rowCompactMetaIcon}>{renderSubtitleLeadingVisual()}</View>
-            <Text
-              style={[
-                styles.rowCompactMetaText,
-                styles.rowCompactMetaCreator,
-                { color: colors.textSubheader },
-              ]}
-              numberOfLines={1}
-            >
-              {item.creator}
-            </Text>
-            {inlineLengthText ? (
-              <>
-                <View
-                  style={[styles.rowCompactMetaDot, { backgroundColor: colors.textSubheader }]}
-                />
-                <Text
-                  style={[
-                    styles.rowCompactMetaText,
-                    styles.rowCompactMetaLength,
-                    { color: colors.textSubheader },
-                  ]}
-                  numberOfLines={1}
-                >
-                  {inlineLengthText}
-                </Text>
-              </>
-            ) : null}
-          </View>
         </View>
       </Pressable>
-    </Animated.View>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={({ pressed }) => [styles.rowCompactCard, pressed && { opacity: 0.7 }]}
+    >
+      <View style={styles.rowCompactThumbnailContainer}>
+        {mediaImageUrl ? (
+          <Image
+            source={{ uri: mediaImageUrl }}
+            style={styles.rowCompactThumbnailImage}
+            contentFit="cover"
+            transition={mediaTransition}
+            onError={handleMediaImageError}
+          />
+        ) : (
+          <View
+            style={[styles.rowCompactThumbnailImage, { backgroundColor: colors.surfaceRaised }]}
+          />
+        )}
+      </View>
+
+      <View style={styles.rowCompactContent}>
+        <Text style={[styles.rowCompactTitle, { color: colors.text }]} numberOfLines={1}>
+          {item.title}
+        </Text>
+        <View style={styles.rowCompactMeta}>
+          <View style={styles.rowCompactMetaIcon}>{renderSubtitleLeadingVisual()}</View>
+          <Text
+            style={[
+              styles.rowCompactMetaText,
+              styles.rowCompactMetaCreator,
+              { color: colors.textSubheader },
+            ]}
+            numberOfLines={1}
+          >
+            {item.creator}
+          </Text>
+          {inlineLengthText ? (
+            <>
+              <View style={[styles.rowCompactMetaDot, { backgroundColor: colors.textSubheader }]} />
+              <Text
+                style={[
+                  styles.rowCompactMetaText,
+                  styles.rowCompactMetaLength,
+                  { color: colors.textSubheader },
+                ]}
+                numberOfLines={1}
+              >
+                {inlineLengthText}
+              </Text>
+            </>
+          ) : null}
+        </View>
+      </View>
+    </Pressable>
   );
 }
 

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -13,7 +13,7 @@ export const nativeLargeTitleHeaderAppearance: NativeStackNavigationOptions = {
     backgroundColor: Colors.dark.background,
   },
   headerLargeStyle: {
-    backgroundColor: 'transparent',
+    backgroundColor: Colors.dark.background,
   },
   headerTitleStyle: {
     color: Colors.dark.text,


### PR DESCRIPTION
## Summary
- remove avoidable large-title header compositing work by giving the large header a solid background
- trim unnecessary Reanimated wrappers from Home, Library, and shared item cards
- reduce JS scroll callback frequency on Home and Library where scroll position is only used for tab-press behavior

## Validation
- bun run format:check
- bun run design-system:check
- bun run typecheck
- bun run test
- bun run build
