### PR TITLE
Fix missing iOS large header title

### DIFF
--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -13,7 +13,7 @@ export const nativeLargeTitleHeaderAppearance: NativeStackNavigationOptions = {
     backgroundColor: Colors.dark.background,
   },
   headerLargeStyle: {
-    backgroundColor: Colors.dark.background,
+    backgroundColor: 'transparent',
   },
   headerTitleStyle: {
     color: Colors.dark.text,


### PR DESCRIPTION
## Summary
- restore the native large-title header background to transparent
- fix the missing expanded header text on iOS screens that use large titles
- keep the change scoped to the shared mobile header helper

## Testing
- bun run format:check
- bun run typecheck
- pre-push worker CI suite (triggered by git push)
