### PR TITLE
Improve Home screen performance and header behavior

### DIFF
--- a/apps/mobile/app/(tabs)/index/_layout.tsx
+++ b/apps/mobile/app/(tabs)/index/_layout.tsx
@@ -1,14 +1,9 @@
 import { Stack } from 'expo-router';
 
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
-
 export default function HomeLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen name="index" options={createNativeLargeTitleScreenOptions({ title: 'Home' })} />
+    <Stack>
+      <Stack.Screen name="index" options={{ title: 'Home' }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -40,7 +40,6 @@ import {
 import { useConnections } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions-query';
 import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
-import { createNativeLargeTitleScreenOptions } from '@/lib/native-large-title-header';
 import type { ContentType, Provider, UIContentType } from '@/lib/content-utils';
 
 function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; color?: string }) {
@@ -53,6 +52,7 @@ function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; col
 
 const INBOX_PAGE_SIZE = 20;
 const HOME_TOP_THRESHOLD = 4;
+const HOME_COLLAPSED_TITLE_THRESHOLD = 44;
 
 function getGreeting(): string {
   const hour = new Date().getHours();
@@ -172,6 +172,7 @@ export default function HomeScreen() {
   const { width: windowWidth } = useWindowDimensions();
   const greeting = useMemo(() => getGreeting(), []);
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
+  const [showCollapsedTitle, setShowCollapsedTitle] = useState(false);
   const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
 
   useTabPrefetch('home');
@@ -289,7 +290,13 @@ export default function HomeScreen() {
   }, [router]);
 
   const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    scrollOffsetYRef.current = event.nativeEvent.contentOffset.y;
+    const offsetY = event.nativeEvent.contentOffset.y;
+    scrollOffsetYRef.current = offsetY;
+
+    const shouldShowCollapsedTitle = offsetY > HOME_COLLAPSED_TITLE_THRESHOLD;
+    setShowCollapsedTitle((current) =>
+      current === shouldShowCollapsedTitle ? current : shouldShowCollapsedTitle
+    );
   }, []);
 
   const isLoading = isInboxLoading || isHomeLoading;
@@ -399,6 +406,7 @@ export default function HomeScreen() {
     () => (
       <>
         <View style={styles.header}>
+          <Text style={[styles.homeTitle, { color: colors.text }]}>Home</Text>
           <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
         </View>
 
@@ -425,7 +433,7 @@ export default function HomeScreen() {
         </ScrollView>
       </>
     ),
-    [categoryCounts, colors.textSubheader, contentTypeFilter, greeting]
+    [categoryCounts, colors.text, colors.textSubheader, contentTypeFilter, greeting]
   );
 
   const renderSection = useCallback(
@@ -536,8 +544,18 @@ export default function HomeScreen() {
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
-        options={createNativeLargeTitleScreenOptions({
-          title: 'Home',
+        options={{
+          title: showCollapsedTitle ? 'Home' : '',
+          headerLargeTitle: false,
+          headerTransparent: false,
+          headerShadowVisible: false,
+          headerTintColor: colors.text,
+          headerStyle: {
+            backgroundColor: colors.background,
+          },
+          headerTitleStyle: {
+            color: colors.text,
+          },
           headerRight: () => (
             <Pressable
               onPress={handleOpenSettings}
@@ -569,7 +587,7 @@ export default function HomeScreen() {
               ) : null}
             </Pressable>
           ),
-        })}
+        }}
       />
 
       <FlatList
@@ -616,6 +634,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md,
     paddingTop: Spacing.sm,
     paddingBottom: Spacing.xl,
+  },
+  homeTitle: {
+    ...Typography.displayMedium,
+    marginBottom: Spacing.xs,
   },
   greeting: {
     ...Typography.labelMedium,

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -7,7 +7,7 @@
  * - cover: full-bleed image with text overlay
  */
 
-import { useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Image } from 'expo-image';
 import { useRouter, type Href } from 'expo-router';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
@@ -79,11 +79,35 @@ export interface ItemCardProps {
   onPress?: () => void;
 }
 
+function areItemCardItemsEqual(previous: ItemCardData, next: ItemCardData): boolean {
+  return (
+    previous.id === next.id &&
+    previous.title === next.title &&
+    previous.creator === next.creator &&
+    previous.creatorImageUrl === next.creatorImageUrl &&
+    previous.thumbnailUrl === next.thumbnailUrl &&
+    previous.contentType === next.contentType &&
+    previous.provider === next.provider &&
+    previous.duration === next.duration &&
+    previous.readingTimeMinutes === next.readingTimeMinutes
+  );
+}
+
+function areItemCardPropsEqual(previous: ItemCardProps, next: ItemCardProps): boolean {
+  return (
+    previous.shape === next.shape &&
+    previous.rowStyle === next.rowStyle &&
+    previous.index === next.index &&
+    previous.onPress === next.onPress &&
+    areItemCardItemsEqual(previous.item, next.item)
+  );
+}
+
 // ============================================================================
 // Component
 // ============================================================================
 
-export function ItemCard({
+function ItemCardComponent({
   item,
   shape = 'row',
   rowStyle = 'compact',
@@ -94,17 +118,26 @@ export function ItemCard({
   const { colors, motion } = useAppTheme();
   const prefetchItemDetail = usePrefetchItemDetail();
   const mediaTransition = motion.duration.normal;
-  const creatorImageUrl = normalizeItemCardImageUrl(item.creatorImageUrl);
-  const mediaImageCandidates = getItemCardImageCandidates({
-    thumbnailUrl: item.thumbnailUrl,
-    creatorImageUrl: item.creatorImageUrl,
-  });
+  const creatorImageUrl = useMemo(
+    () => normalizeItemCardImageUrl(item.creatorImageUrl),
+    [item.creatorImageUrl]
+  );
+  const mediaImageCandidates = useMemo(
+    () =>
+      getItemCardImageCandidates({
+        thumbnailUrl: item.thumbnailUrl,
+        creatorImageUrl: item.creatorImageUrl,
+      }),
+    [item.creatorImageUrl, item.thumbnailUrl]
+  );
   const [mediaImageCandidateIndex, setMediaImageCandidateIndex] = useState(0);
   const [subtitleAvatarFailed, setSubtitleAvatarFailed] = useState(false);
 
-  const durationText = formatDuration(item.duration) || null;
-  const readingTimeText =
-    item.readingTimeMinutes && !item.duration ? `${item.readingTimeMinutes} min` : null;
+  const durationText = useMemo(() => formatDuration(item.duration) || null, [item.duration]);
+  const readingTimeText = useMemo(
+    () => (item.readingTimeMinutes && !item.duration ? `${item.readingTimeMinutes} min` : null),
+    [item.duration, item.readingTimeMinutes]
+  );
   const inlineLengthText = durationText ?? readingTimeText;
   const mediaImageUrl = mediaImageCandidates[mediaImageCandidateIndex] ?? null;
 
@@ -116,7 +149,11 @@ export function ItemCard({
     setSubtitleAvatarFailed(false);
   }, [item.id, creatorImageUrl]);
 
-  const handleMediaImageError = () => {
+  const handleSubtitleAvatarError = useCallback(() => {
+    setSubtitleAvatarFailed(true);
+  }, []);
+
+  const handleMediaImageError = useCallback(() => {
     if (mediaImageUrl === creatorImageUrl) {
       setSubtitleAvatarFailed(true);
     }
@@ -124,7 +161,7 @@ export function ItemCard({
     setMediaImageCandidateIndex((currentIndex) =>
       Math.min(currentIndex + 1, mediaImageCandidates.length)
     );
-  };
+  }, [creatorImageUrl, mediaImageCandidates.length, mediaImageUrl]);
 
   const renderSubtitleLeadingVisual = () => {
     if (creatorImageUrl && !subtitleAvatarFailed) {
@@ -134,7 +171,7 @@ export function ItemCard({
           style={styles.subtitleAvatar}
           contentFit="cover"
           transition={mediaTransition}
-          onError={() => setSubtitleAvatarFailed(true)}
+          onError={handleSubtitleAvatarError}
         />
       );
     }
@@ -142,7 +179,7 @@ export function ItemCard({
     return getContentIcon(item.contentType, IconSizes.xs, colors.textSubheader);
   };
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     if (onPress) {
       onPress();
       return;
@@ -150,7 +187,7 @@ export function ItemCard({
 
     prefetchItemDetail(item.id);
     router.push(`/item/${item.id}` as Href);
-  };
+  }, [item.id, onPress, prefetchItemDetail, router]);
 
   if (shape === 'cover') {
     return (
@@ -347,6 +384,8 @@ export function ItemCard({
     </Pressable>
   );
 }
+
+export const ItemCard = memo(ItemCardComponent, areItemCardPropsEqual);
 
 // ============================================================================
 // Styles

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -87,6 +87,21 @@ export type ItemView = {
   tags: ItemTag[];
 };
 
+type HomeItemView = Pick<
+  ItemView,
+  | 'id'
+  | 'title'
+  | 'thumbnailUrl'
+  | 'contentType'
+  | 'provider'
+  | 'creator'
+  | 'creatorImageUrl'
+  | 'publisher'
+  | 'duration'
+  | 'readingTimeMinutes'
+  | 'lastOpenedAt'
+>;
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -296,6 +311,32 @@ async function toItemViewsWithTags(
   const tagsByItemId = await getTagsForUserItems(ctx, userItemIds);
 
   return rows.map((row) => toItemView(row, tagsByItemId.get(row.user_items.id) ?? []));
+}
+
+function toHomeItemViews(
+  rows: Array<{
+    user_items: typeof userItems.$inferSelect;
+    items: typeof items.$inferSelect;
+    creators: typeof creators.$inferSelect | null;
+  }>
+): HomeItemView[] {
+  return rows.map((row) => {
+    const itemView = toItemView(row);
+
+    return {
+      id: itemView.id,
+      title: itemView.title,
+      thumbnailUrl: itemView.thumbnailUrl,
+      contentType: itemView.contentType,
+      provider: itemView.provider,
+      creator: itemView.creator,
+      creatorImageUrl: itemView.creatorImageUrl,
+      publisher: itemView.publisher,
+      duration: itemView.duration,
+      readingTimeMinutes: itemView.readingTimeMinutes,
+      lastOpenedAt: itemView.lastOpenedAt,
+    };
+  });
 }
 
 type ConsumptionEventType = 'OPENED' | 'FINISHED' | 'UNFINISHED' | 'PROGRESS_DELTA';
@@ -606,14 +647,11 @@ export const itemsRouter = router({
       articlesQuery,
     ]);
 
-    const [recentBookmarksViews, jumpBackInViews, videosViews, podcastsViews, articlesViews] =
-      await Promise.all([
-        toItemViewsWithTags(ctx, recentBookmarks),
-        toItemViewsWithTags(ctx, jumpBackIn),
-        toItemViewsWithTags(ctx, videos),
-        toItemViewsWithTags(ctx, podcasts),
-        toItemViewsWithTags(ctx, articles),
-      ]);
+    const recentBookmarksViews = toHomeItemViews(recentBookmarks);
+    const jumpBackInViews = toHomeItemViews(jumpBackIn);
+    const videosViews = toHomeItemViews(videos);
+    const podcastsViews = toHomeItemViews(podcasts);
+    const articlesViews = toHomeItemViews(articles);
 
     return {
       recentBookmarks: recentBookmarksViews,


### PR DESCRIPTION
## Summary
- trim the Home API payload so Home only fetches card fields it actually renders
- memoize ItemCard work to reduce repeat render cost across Home and other lists
- move Home off the native collapsing large-title header path and replace it with a lightweight in-content large title

## Testing
- bun run format:check
- bun run lint
- bun run typecheck
- bun run --cwd apps/worker test:run -- items.test.ts
- bun run --cwd apps/mobile test use-items-trpc.test.ts item-card-compact-metadata.test.ts --runInBand
- bun run --cwd apps/mobile test home-screen.test.tsx --runInBand