### PR TITLE
perf(mobile): simplify scroll headers outside home

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/_layout.tsx
+++ b/apps/mobile/app/(tabs)/inbox/_layout.tsx
@@ -1,17 +1,11 @@
 import { Stack } from 'expo-router';
 
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
 
 export default function InboxLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Inbox' })}
-      />
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
+      <Stack.Screen name="index" />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from 'expo-router';
+import { Stack, useNavigation } from 'expo-router';
 import { Surface, useToast } from 'heroui-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, View, Text, StyleSheet, type ListRenderItemInfo } from 'react-native';
@@ -27,6 +27,10 @@ import {
 } from '@/lib/inbox-optimistic-dismissal';
 import { useNetworkStatus } from '@/hooks/use-network-status';
 import { showSuccess, showWarning, showError } from '@/lib/toast-utils';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 import type { ContentType, Provider } from '@/lib/content-utils';
 
 const REENTRY_CLEANUP_DELAY = 500;
@@ -57,6 +61,7 @@ export default function InboxScreen() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const { toast } = useToast();
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
 
   useTabPrefetch('inbox');
 
@@ -230,37 +235,40 @@ export default function InboxScreen() {
     });
   }, [navigation]);
 
-  if (isLoading) {
-    return (
-      <Surface style={[styles.container, { backgroundColor: colors.background }]}>
-        <LoadingState />
-      </Surface>
-    );
-  }
-
-  if (error) {
-    return (
-      <Surface style={[styles.container, { backgroundColor: colors.background }]}>
-        <ErrorState message={error.message} />
-      </Surface>
-    );
-  }
+  const listEmptyComponent = isLoading ? (
+    <LoadingState />
+  ) : error ? (
+    <ErrorState message={error.message} />
+  ) : (
+    <InboxEmptyState colors={colors} />
+  );
 
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: 'Inbox',
+          showScreenTitle: isLoading || showCollapsedTitle,
+        })}
+      />
       <Animated.FlatList
         ref={listRef}
         style={styles.list}
-        data={visibleInboxItems}
+        data={isLoading || error ? [] : visibleInboxItems}
         renderItem={renderItem}
         keyExtractor={(item) => item.id}
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
         onRefresh={handleRefresh}
         refreshing={isSyncing}
         ListHeaderComponent={
           <View style={styles.listHeader}>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
             {syncProgress && syncProgress.total > 0 ? (
               <Animated.View exiting={FadeOut.duration(200)}>
                 <Text style={[styles.headerSubtitle, { color: colors.primary }]}>
@@ -274,12 +282,12 @@ export default function InboxScreen() {
             )}
           </View>
         }
-        ListEmptyComponent={<InboxEmptyState colors={colors} />}
+        ListEmptyComponent={listEmptyComponent}
         itemLayoutAnimation={LinearTransition.springify().damping(15).stiffness(100)}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.6}
         ListFooterComponent={
-          isFetchingNextPage ? (
+          !isLoading && !error && isFetchingNextPage ? (
             <View style={styles.loadingFooter}>
               <ActivityIndicator size="small" color={colors.primary} />
             </View>
@@ -301,6 +309,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacing.md,
     paddingTop: Spacing.sm,
     paddingBottom: Spacing.md,
+  },
+  headerTitle: {
+    ...Typography.displayMedium,
+    marginBottom: Spacing.xs,
   },
   headerSubtitle: {
     ...Typography.bodyMedium,

--- a/apps/mobile/app/(tabs)/library/_layout.tsx
+++ b/apps/mobile/app/(tabs)/library/_layout.tsx
@@ -1,17 +1,11 @@
 import { Stack } from 'expo-router';
 
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
 
 export default function LibraryLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Library' })}
-      />
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
+      <Stack.Screen name="index" />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -12,8 +12,6 @@ import {
   Pressable,
   TextInput,
   FlatList,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   type ListRenderItemInfo,
 } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
@@ -40,7 +38,10 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteLibraryItems, mapContentType, mapProvider } from '@/hooks/use-items-trpc';
-import { createNativeLargeTitleScreenOptions } from '@/lib/native-large-title-header';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 import type { UIContentType, UIProvider } from '@/lib/content-utils';
 
 function SearchIcon({ size = 20, color = '#94A3B8' }: { size?: number; color?: string }) {
@@ -123,10 +124,10 @@ export default function LibraryScreen() {
   const router = useRouter();
   const navigation = useNavigation() as LibraryTabNavigation;
   const listScrollRef = useRef<FlatList<ItemCardData>>(null);
-  const scrollOffsetYRef = useRef(0);
   const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { handleScroll, scrollOffsetYRef, showCollapsedTitle } = useCollapsedHeaderTitle();
 
   useTabPrefetch('library');
 
@@ -217,10 +218,6 @@ export default function LibraryScreen() {
     void fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    scrollOffsetYRef.current = event.nativeEvent.contentOffset.y;
-  }, []);
-
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
       <ItemCard item={item} shape="row" index={index} />
@@ -250,7 +247,11 @@ export default function LibraryScreen() {
     });
   }, [contentTypeFilter, navigation, showCompletedOnly]);
 
-  const listEmptyComponent = (
+  const listEmptyComponent = isLoading ? (
+    <LoadingState />
+  ) : error ? (
+    <ErrorState message={error.message} />
+  ) : (
     <EmptyState
       title={searchQuery.trim() ? 'No matches found' : 'No bookmarked items'}
       message={
@@ -264,8 +265,11 @@ export default function LibraryScreen() {
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
-        options={createNativeLargeTitleScreenOptions({
-          title: 'Library',
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: 'Library',
+          showScreenTitle: isLoading || Boolean(error) || showCollapsedTitle,
           headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}
@@ -279,93 +283,88 @@ export default function LibraryScreen() {
         })}
       />
 
-      {isLoading ? (
-        <LoadingState />
-      ) : error ? (
-        <ErrorState message={error.message} />
-      ) : (
-        <FlatList
-          ref={listScrollRef}
-          data={libraryItems}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          style={styles.listContainer}
-          contentContainerStyle={styles.listContent}
-          contentInsetAdjustmentBehavior="automatic"
-          showsVerticalScrollIndicator={false}
-          onScroll={handleScroll}
-          scrollEventThrottle={32}
-          onEndReached={handleEndReached}
-          onEndReachedThreshold={0.6}
-          ListHeaderComponent={
-            <View style={styles.listHeader}>
-              <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-                {libraryCountLabel}
-              </Text>
+      <FlatList
+        ref={listScrollRef}
+        data={isLoading || error ? [] : libraryItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        style={styles.listContainer}
+        contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.6}
+        ListHeaderComponent={
+          <View style={styles.listHeader}>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>Library</Text>
+            <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
+              {libraryCountLabel}
+            </Text>
 
-              <View style={styles.searchContainer}>
-                <View
-                  style={[
-                    styles.searchBar,
-                    {
-                      backgroundColor: colors.backgroundSecondary,
-                      borderColor: colors.border,
-                    },
-                  ]}
-                >
-                  <SearchIcon size={18} color={colors.textTertiary} />
-                  <TextInput
-                    placeholder="Search your library..."
-                    placeholderTextColor={colors.textTertiary}
-                    style={[styles.searchInput, { color: colors.text }]}
-                    value={searchQuery}
-                    onChangeText={setSearchQuery}
-                  />
-                </View>
-              </View>
-
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.filterContainer}
+            <View style={styles.searchContainer}>
+              <View
+                style={[
+                  styles.searchBar,
+                  {
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: colors.border,
+                  },
+                ]}
               >
-                <FilterChip
-                  label="Completed"
-                  isSelected={showCompletedOnly}
-                  onPress={() => setShowCompletedOnly((prev) => !prev)}
-                  icon={CheckOutlineIcon}
-                  selectedColor={FilterChipPalette.completed.accent}
-                  selectedSurfaceColor={FilterChipPalette.completed.surface}
+                <SearchIcon size={18} color={colors.textTertiary} />
+                <TextInput
+                  placeholder="Search your library..."
+                  placeholderTextColor={colors.textTertiary}
+                  style={[styles.searchInput, { color: colors.text }]}
+                  value={searchQuery}
+                  onChangeText={setSearchQuery}
                 />
-                {filterOptions.map((option) => (
-                  <FilterChip
-                    key={option.id}
-                    label={option.label}
-                    isSelected={contentTypeFilter === option.contentType}
-                    onPress={() =>
-                      setContentTypeFilter((current) =>
-                        current === option.contentType ? null : option.contentType
-                      )
-                    }
-                    icon={option.icon}
-                    dotColor={option.color}
-                    selectedColor={option.selectedColor}
-                    selectedSurfaceColor={option.selectedSurfaceColor}
-                  />
-                ))}
-              </ScrollView>
+              </View>
             </View>
-          }
-          ListEmptyComponent={listEmptyComponent}
-          ListFooterComponent={
-            <View style={styles.listFooter}>
-              {isFetchingNextPage ? (
-                <ActivityIndicator size="small" color={colors.primary} />
-              ) : null}
-            </View>
-          }
-        />
-      )}
+
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.filterContainer}
+            >
+              <FilterChip
+                label="Completed"
+                isSelected={showCompletedOnly}
+                onPress={() => setShowCompletedOnly((prev) => !prev)}
+                icon={CheckOutlineIcon}
+                selectedColor={FilterChipPalette.completed.accent}
+                selectedSurfaceColor={FilterChipPalette.completed.surface}
+              />
+              {filterOptions.map((option) => (
+                <FilterChip
+                  key={option.id}
+                  label={option.label}
+                  isSelected={contentTypeFilter === option.contentType}
+                  onPress={() =>
+                    setContentTypeFilter((current) =>
+                      current === option.contentType ? null : option.contentType
+                    )
+                  }
+                  icon={option.icon}
+                  dotColor={option.color}
+                  selectedColor={option.selectedColor}
+                  selectedSurfaceColor={option.selectedSurfaceColor}
+                />
+              ))}
+            </ScrollView>
+          </View>
+        }
+        ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={
+          <View style={styles.listFooter}>
+            {!isLoading && !error && isFetchingNextPage ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : null}
+          </View>
+        }
+      />
     </Surface>
   );
 }
@@ -376,6 +375,11 @@ const styles = StyleSheet.create({
   },
   listHeader: {
     paddingTop: Spacing.sm,
+  },
+  headerTitle: {
+    ...Typography.displayMedium,
+    paddingHorizontal: Spacing.md,
+    marginBottom: Spacing.xs,
   },
   headerSubtitle: {
     ...Typography.bodyMedium,

--- a/apps/mobile/app/(tabs)/search/_layout.tsx
+++ b/apps/mobile/app/(tabs)/search/_layout.tsx
@@ -1,16 +1,10 @@
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
 import { Stack } from 'expo-router';
 
 export default function SearchLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({ title: 'Search' })}
-      />
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
+      <Stack.Screen name="index" />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -9,6 +9,7 @@ import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
 import { Colors, Spacing } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { mapContentType, mapProvider, useLibraryItems } from '@/hooks/use-items-trpc';
+import { createLightweightHeaderScreenOptions } from '@/lib/native-large-title-header';
 import type { ContentType, Provider } from '@/lib/content-utils';
 
 export default function SearchTabScreen() {
@@ -86,7 +87,10 @@ export default function SearchTabScreen() {
   return (
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
-        options={{
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: 'Search',
           headerSearchBarOptions: {
             placement: 'automatic',
             placeholder: 'Search your library',
@@ -95,7 +99,7 @@ export default function SearchTabScreen() {
               setSearchQuery(event.nativeEvent.text);
             },
           },
-        }}
+        })}
       />
 
       <FlatList

--- a/apps/mobile/app/settings/_layout.tsx
+++ b/apps/mobile/app/settings/_layout.tsx
@@ -7,21 +7,13 @@
  * @see features/subscriptions/frontend-spec.md Section 2.1 (Settings Stack)
  */
 
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
 import { Stack } from 'expo-router';
 
 export default function SettingsLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({
-          title: 'Settings',
-        })}
-      />
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
+      <Stack.Screen name="index" />
       <Stack.Screen
         name="connections"
         options={{

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -11,15 +11,19 @@
 
 import { useMemo } from 'react';
 import { View, Text, ScrollView, Pressable, StyleSheet, Linking, Share } from 'react-native';
-import { useRouter } from 'expo-router';
+import { Stack, useRouter } from 'expo-router';
 import { useClerk } from '@clerk/clerk-expo';
 import Constants from 'expo-constants';
 
-import { Colors, Spacing, Radius } from '@/constants/theme';
+import { Colors, Spacing, Radius, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useConnections } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions-query';
 import { buildMobileDiagnosticBundle } from '@/lib/diagnostics';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 import { settingsLogger } from '@/lib/logger';
 import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
 import { buildSubscriptionsSummary } from '@/lib/subscription-sources';
@@ -130,6 +134,7 @@ function SettingsScreenContent({
   const router = useRouter();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
   const isStorybookEnabled = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
   const isDeveloperDiagnosticsEnabled = __DEV__ || isStorybookEnabled;
 
@@ -194,12 +199,26 @@ function SettingsScreenContent({
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: 'Settings',
+          showScreenTitle: showCollapsedTitle,
+        })}
+      />
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         contentInsetAdjustmentBehavior="automatic"
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
         showsVerticalScrollIndicator={false}
       >
+        <View style={styles.screenHeader}>
+          <Text style={[styles.screenTitle, { color: colors.text }]}>Settings</Text>
+        </View>
+
         <View style={[styles.section, { backgroundColor: colors.card }]}>
           <SettingsRow
             title="Subscriptions"
@@ -292,6 +311,12 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     padding: Spacing.lg,
     paddingBottom: Spacing['3xl'],
+  },
+  screenHeader: {
+    marginBottom: Spacing.sm,
+  },
+  screenTitle: {
+    ...Typography.displayMedium,
   },
   sectionTitle: {
     fontSize: 12,

--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -13,8 +13,13 @@ import {
   SourceSubscriptionRow,
 } from '@/components/subscriptions';
 import { Spacing } from '@/constants/theme';
+import { useAppTheme } from '@/hooks/use-app-theme';
 import { useConnections, useDisconnectConnection, type Connection } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 import { validateAndConvertProvider } from '@/lib/route-validation';
 import {
   formatSourceCount,
@@ -43,6 +48,8 @@ export default function ProviderDetailScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{ provider: string }>();
   const utils = trpc.useUtils();
+  const { colors } = useAppTheme();
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
 
   const providerValidation = validateAndConvertProvider(params.provider);
   const provider: Provider = providerValidation.success ? providerValidation.data : 'YOUTUBE';
@@ -293,32 +300,21 @@ export default function ProviderDetailScreen() {
     newslettersSyncMutation.mutate();
   }, [isConnected, newslettersSyncMutation]);
 
-  if (!providerValidation.success) {
-    return (
-      <>
-        <Stack.Screen options={{ title: 'Invalid source' }} />
-        <Surface tone="canvas" style={styles.container}>
-          <ErrorState title="Invalid source" message={providerValidation.message} />
-        </Surface>
-      </>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <>
-        <Stack.Screen options={{ title: sourceConfig.name }} />
-        <Surface tone="canvas" style={styles.container}>
-          <LoadingState message={`Loading ${sourceConfig.name.toLowerCase()}...`} />
-        </Surface>
-      </>
-    );
-  }
-
   return (
-    <>
-      <Stack.Screen options={{ title: sourceConfig.name }} />
-      <Surface tone="canvas" style={styles.container} collapsable={false}>
+    <Surface tone="canvas" style={styles.container} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.surfaceCanvas,
+          tintColor: colors.textPrimary,
+          screenTitle: providerValidation.success ? sourceConfig.name : 'Invalid source',
+          showScreenTitle: !providerValidation.success || isLoading || showCollapsedTitle,
+        })}
+      />
+      {!providerValidation.success ? (
+        <ErrorState title="Invalid source" message={providerValidation.message} />
+      ) : isLoading ? (
+        <LoadingState message={`Loading ${sourceConfig.name.toLowerCase()}...`} />
+      ) : (
         <FlatList
           style={styles.list}
           data={provider === 'GMAIL' ? newsletterFeeds : filteredSubscriptions}
@@ -327,6 +323,8 @@ export default function ProviderDetailScreen() {
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.content}
           contentInsetAdjustmentBehavior="automatic"
+          onScroll={handleScroll}
+          scrollEventThrottle={32}
           ListHeaderComponent={
             <View style={styles.header}>
               <SourceHero source={provider} summary={hubSummary} />
@@ -417,8 +415,8 @@ export default function ProviderDetailScreen() {
           }
           ItemSeparatorComponent={() => <View style={styles.separator} />}
         />
-      </Surface>
-    </>
+      )}
+    </Surface>
   );
 }
 

--- a/apps/mobile/app/subscriptions/_layout.tsx
+++ b/apps/mobile/app/subscriptions/_layout.tsx
@@ -6,27 +6,14 @@
  */
 
 import { Stack } from 'expo-router';
-import {
-  createNativeLargeTitleScreenOptions,
-  nativeLargeTitleStackScreenOptions,
-} from '@/lib/native-large-title-header';
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
 
 export default function SubscriptionsLayout() {
   return (
-    <Stack screenOptions={nativeLargeTitleStackScreenOptions}>
-      <Stack.Screen
-        name="index"
-        options={createNativeLargeTitleScreenOptions({
-          title: 'Subscriptions',
-        })}
-      />
-      <Stack.Screen
-        name="rss"
-        options={createNativeLargeTitleScreenOptions({
-          title: 'RSS',
-        })}
-      />
-      <Stack.Screen name="[provider]" options={createNativeLargeTitleScreenOptions()} />
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="rss" />
+      <Stack.Screen name="[provider]" />
       <Stack.Screen
         name="connect"
         options={{

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -4,12 +4,17 @@ import { Stack, useNavigation, useRouter } from 'expo-router';
 import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 
 import { LoadingState } from '@/components/list-states';
-import { Surface } from '@/components/primitives';
+import { Surface, Text } from '@/components/primitives';
 import { SourceListRow } from '@/components/subscriptions';
 import { Spacing } from '@/constants/theme';
+import { useAppTheme } from '@/hooks/use-app-theme';
 import { useConnections, type Connection } from '@/hooks/use-connections';
 import { useSubscriptions } from '@/hooks/use-subscriptions';
 import { type ConnectionStatus } from '@/lib/connection-status';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 import {
   getHubStatusText,
   getIntegrationState,
@@ -23,6 +28,8 @@ const SUBSCRIPTION_SOURCES: SubscriptionSource[] = ['YOUTUBE', 'SPOTIFY', 'GMAIL
 export default function SubscriptionsScreen() {
   const navigation = useNavigation();
   const router = useRouter();
+  const { colors } = useAppTheme();
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
   const canGoBack = navigation.canGoBack();
   const headerLeft = canGoBack
     ? () => (
@@ -32,7 +39,7 @@ export default function SubscriptionsScreen() {
           hitSlop={8}
           style={styles.headerBack}
         >
-          <Ionicons name="chevron-back" size={28} color="#FFFFFF" />
+          <Ionicons name="chevron-back" size={28} color={colors.textPrimary} />
         </Pressable>
       )
     : undefined;
@@ -94,27 +101,35 @@ export default function SubscriptionsScreen() {
     [gmailCount, gmailStatus, rssCount, spotifyCount, spotifyStatus, youtubeCount, youtubeStatus]
   );
 
-  if (isLoading) {
-    return (
-      <>
-        <Stack.Screen options={{ headerLeft }} />
-        <Surface tone="canvas" style={styles.container}>
-          <LoadingState />
-        </Surface>
-      </>
-    );
-  }
-
   return (
-    <>
-      <Stack.Screen options={{ headerLeft }} />
-      <Surface tone="canvas" style={styles.container} collapsable={false}>
+    <Surface tone="canvas" style={styles.container} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.surfaceCanvas,
+          tintColor: colors.textPrimary,
+          screenTitle: 'Subscriptions',
+          showScreenTitle: isLoading || showCollapsedTitle,
+          headerLeft,
+        })}
+      />
+      {isLoading ? (
+        <LoadingState />
+      ) : (
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.content}
           contentInsetAdjustmentBehavior="automatic"
+          onScroll={handleScroll}
+          scrollEventThrottle={32}
           showsVerticalScrollIndicator={false}
         >
+          <View style={styles.screenHeader}>
+            <Text variant="displayMedium">Subscriptions</Text>
+            <Text variant="bodyMedium" tone="subheader">
+              Manage your sources and integrations.
+            </Text>
+          </View>
+
           <View style={styles.rows}>
             {sourceRows.map((row) => (
               <SourceListRow
@@ -126,8 +141,8 @@ export default function SubscriptionsScreen() {
             ))}
           </View>
         </ScrollView>
-      </Surface>
-    </>
+      )}
+    </Surface>
   );
 }
 
@@ -151,6 +166,9 @@ const styles = StyleSheet.create({
     gap: Spacing.md,
     paddingBottom: Spacing['3xl'],
     paddingTop: Spacing.sm,
+  },
+  screenHeader: {
+    gap: Spacing.xs,
   },
   headerBack: {
     marginLeft: -Spacing.xs,

--- a/apps/mobile/app/subscriptions/rss.tsx
+++ b/apps/mobile/app/subscriptions/rss.tsx
@@ -16,6 +16,10 @@ import { Spacing } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
 import { useRssFeeds, type RssFeed } from '@/hooks/use-rss-feeds';
 import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+import {
   formatSourceCount,
   getHubStatusText,
   getIntegrationCardCopy,
@@ -24,6 +28,7 @@ import {
 
 export default function RssSubscriptionsScreen() {
   const { colors } = useAppTheme();
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
   const {
     feeds,
     stats,
@@ -131,21 +136,19 @@ export default function RssSubscriptionsScreen() {
     ]);
   };
 
-  if (isLoading) {
-    return (
-      <>
-        <Stack.Screen options={{ title: sourceConfig.name }} />
-        <Surface tone="canvas" style={styles.container}>
-          <LoadingState message="Loading RSS subscriptions..." />
-        </Surface>
-      </>
-    );
-  }
-
   return (
-    <>
-      <Stack.Screen options={{ title: sourceConfig.name }} />
-      <Surface tone="canvas" style={styles.container} collapsable={false}>
+    <Surface tone="canvas" style={styles.container} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.surfaceCanvas,
+          tintColor: colors.textPrimary,
+          screenTitle: sourceConfig.name,
+          showScreenTitle: isLoading || showCollapsedTitle,
+        })}
+      />
+      {isLoading ? (
+        <LoadingState message="Loading RSS subscriptions..." />
+      ) : (
         <FlatList
           style={styles.list}
           data={filteredFeeds}
@@ -154,6 +157,8 @@ export default function RssSubscriptionsScreen() {
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.content}
           contentInsetAdjustmentBehavior="automatic"
+          onScroll={handleScroll}
+          scrollEventThrottle={32}
           ListHeaderComponent={
             <View style={styles.header}>
               <SourceHero source="RSS" summary={heroSummary} />
@@ -240,8 +245,8 @@ export default function RssSubscriptionsScreen() {
           )}
           ItemSeparatorComponent={() => <View style={styles.separator} />}
         />
-      </Surface>
-    </>
+      )}
+    </Surface>
   );
 }
 

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -1,34 +1,59 @@
+import { useCallback, useRef, useState } from 'react';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
-import { Colors } from '@/constants/theme';
+const COLLAPSED_TITLE_THRESHOLD = 44;
 
-export const nativeLargeTitleStackScreenOptions: NativeStackNavigationOptions = {
+export const lightweightHeaderStackScreenOptions: NativeStackNavigationOptions = {
   headerBackButtonDisplayMode: 'minimal',
-  headerLargeTitleShadowVisible: false,
+  headerShadowVisible: false,
 };
 
-export const nativeLargeTitleHeaderAppearance: NativeStackNavigationOptions = {
-  headerTintColor: Colors.dark.text,
-  headerStyle: {
-    backgroundColor: Colors.dark.background,
-  },
-  headerLargeStyle: {
-    backgroundColor: 'transparent',
-  },
-  headerTitleStyle: {
-    color: Colors.dark.text,
-  },
-  headerLargeTitleStyle: {
-    color: Colors.dark.text,
-  },
-};
-
-export function createNativeLargeTitleScreenOptions(
-  options: NativeStackNavigationOptions = {}
-): NativeStackNavigationOptions {
+export function createLightweightHeaderScreenOptions({
+  backgroundColor,
+  tintColor,
+  screenTitle,
+  showScreenTitle = true,
+  ...options
+}: NativeStackNavigationOptions & {
+  backgroundColor: string;
+  tintColor: string;
+  screenTitle: string;
+  showScreenTitle?: boolean;
+}): NativeStackNavigationOptions {
   return {
-    ...nativeLargeTitleHeaderAppearance,
-    headerLargeTitle: true,
     ...options,
+    title: showScreenTitle ? screenTitle : '',
+    headerLargeTitle: false,
+    headerTransparent: false,
+    headerShadowVisible: false,
+    headerTintColor: tintColor,
+    headerStyle: {
+      backgroundColor,
+    },
+    headerTitleStyle: {
+      color: tintColor,
+    },
+  };
+}
+
+export function useCollapsedHeaderTitle() {
+  const scrollOffsetYRef = useRef(0);
+  const [showCollapsedTitle, setShowCollapsedTitle] = useState(false);
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offsetY = event.nativeEvent.contentOffset.y;
+    scrollOffsetYRef.current = offsetY;
+
+    const shouldShowCollapsedTitle = offsetY > COLLAPSED_TITLE_THRESHOLD;
+    setShowCollapsedTitle((current) =>
+      current === shouldShowCollapsedTitle ? current : shouldShowCollapsedTitle
+    );
+  }, []);
+
+  return {
+    handleScroll,
+    scrollOffsetYRef,
+    showCollapsedTitle,
   };
 }

--- a/apps/mobile/lib/settings-screen.test.tsx
+++ b/apps/mobile/lib/settings-screen.test.tsx
@@ -20,6 +20,9 @@ function getTextContent(node: TestNode): string {
 }
 
 jest.mock('expo-router', () => ({
+  Stack: {
+    Screen: (props: Record<string, unknown>) => React.createElement('stack-screen', props),
+  },
   useRouter: () => ({
     push: mockPush,
     replace: jest.fn(),


### PR DESCRIPTION
## Summary
- move inbox, library, search, settings, and subscriptions screens off the native large-title collapse path
- use lightweight standard headers with in-content titles where needed
- keep primary scroll lists mounted so native tab scroll behavior stays consistent with Home where possible

## Testing
- file-level VS Code diagnostics on edited mobile files
- bun x tsc --noEmit -p apps/mobile/tsconfig.json (fails on pre-existing mobile type errors outside this change set)
- manual iOS verification still needed for header and tab-bar behavior
