### PR TITLE
Fix home and library tab reselection

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -129,6 +129,11 @@ function SectionHeader({
 
 type HomeTabNavigation = {
   addListener: (event: 'tabPress', listener: () => void) => () => void;
+};
+
+type HomeScreenNavigation = {
+  addListener: HomeTabNavigation['addListener'];
+  getParent?: () => HomeTabNavigation | undefined;
   isFocused: () => boolean;
 };
 
@@ -164,7 +169,7 @@ type HomeSectionItem =
 
 export default function HomeScreen() {
   const router = useRouter();
-  const navigation = useNavigation() as HomeTabNavigation;
+  const navigation = useNavigation() as HomeScreenNavigation;
   const listRef = useRef<FlatList<HomeSectionItem>>(null);
   const scrollOffsetYRef = useRef(0);
   const colorScheme = useColorScheme();
@@ -527,7 +532,9 @@ export default function HomeScreen() {
   );
 
   useEffect(() => {
-    return navigation.addListener('tabPress', () => {
+    const tabNavigation = navigation.getParent?.() ?? navigation;
+
+    return tabNavigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
 
       const isAtTop = scrollOffsetYRef.current <= HOME_TOP_THRESHOLD;

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -117,12 +117,17 @@ const filterOptions: {
 
 type LibraryTabNavigation = {
   addListener: (event: 'tabPress', listener: () => void) => () => void;
+};
+
+type LibraryScreenNavigation = {
+  addListener: LibraryTabNavigation['addListener'];
+  getParent?: () => LibraryTabNavigation | undefined;
   isFocused: () => boolean;
 };
 
 export default function LibraryScreen() {
   const router = useRouter();
-  const navigation = useNavigation() as LibraryTabNavigation;
+  const navigation = useNavigation() as LibraryScreenNavigation;
   const listScrollRef = useRef<FlatList<ItemCardData>>(null);
   const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
@@ -232,7 +237,9 @@ export default function LibraryScreen() {
       : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`;
 
   useEffect(() => {
-    return navigation.addListener('tabPress', () => {
+    const tabNavigation = navigation.getParent?.() ?? navigation;
+
+    return tabNavigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
 
       const isAtTop = scrollOffsetYRef.current <= LIBRARY_TOP_THRESHOLD;

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -11,9 +11,18 @@ const mockRemoveListener = jest.fn();
 let mockConnections: Array<{ provider: string; status: string }> = [];
 let mockSubscriptionsData: { items: Array<{ provider: string; status: string }> } = { items: [] };
 
-const mockNavigation = {
+const mockNavigation: {
+  addListener: typeof mockAddListener;
+  isFocused: typeof mockIsFocused;
+  getParent: () => typeof mockTabNavigation | undefined;
+} = {
   addListener: mockAddListener,
   isFocused: mockIsFocused,
+  getParent: () => mockTabNavigation,
+};
+
+const mockTabNavigation = {
+  addListener: mockAddListener,
 };
 
 let tabPressListener: (() => void) | undefined;
@@ -368,5 +377,25 @@ describe('HomeScreen', () => {
 
     expect(mockScrollTo).toHaveBeenCalledWith({ offset: 0, animated: true });
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
+  });
+
+  it('handles home tab reselection when the screen navigation emits tabPress directly', () => {
+    mockNavigation.getParent = () => undefined;
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    act(() => {
+      pressHomeTab();
+    });
+
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
+    expect(mockScrollTo).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -7,9 +7,18 @@ const mockIsFocused = jest.fn();
 const mockScrollToOffset = jest.fn();
 const mockRemoveListener = jest.fn();
 
-const mockNavigation = {
+const mockTabNavigation = {
+  addListener: mockAddListener,
+};
+
+const mockNavigation: {
+  addListener: typeof mockAddListener;
+  isFocused: typeof mockIsFocused;
+  getParent: () => typeof mockTabNavigation | undefined;
+} = {
   addListener: mockAddListener,
   isFocused: mockIsFocused,
+  getParent: () => mockTabNavigation,
 };
 
 let tabPressListener: (() => void) | undefined;
@@ -316,5 +325,25 @@ describe('LibraryScreen', () => {
 
     expect(mockScrollToOffset).toHaveBeenCalledWith({ offset: 0, animated: true });
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
+  });
+
+  it('handles library tab reselection when the screen navigation emits tabPress directly', () => {
+    mockNavigation.getParent = () => undefined;
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<LibraryScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    act(() => {
+      pressLibraryTab();
+    });
+
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
+    expect(mockScrollToOffset).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- make Home tab reselection listen to the active tabPress source in nested navigator setups
- make Library tab reselection use the same resilient listener path
- add regression coverage for the direct-navigation tabPress fallback on both screens

## Testing
- bun run test -- lib/home-screen.test.tsx --runInBand
- bun run test -- lib/library-screen.test.tsx --runInBand