### PR TITLE
Fix duplicate mobile header button backgrounds

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -566,11 +566,7 @@ export default function HomeScreen() {
           headerRight: () => (
             <Pressable
               onPress={handleOpenSettings}
-              style={({ pressed }) => [
-                styles.settingsButton,
-                { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
-                pressed && { opacity: 0.75 },
-              ]}
+              style={styles.settingsButton}
               accessibilityLabel={
                 hasSettingsAlert
                   ? 'Open settings. Subscription integrations need attention'
@@ -587,7 +583,7 @@ export default function HomeScreen() {
                     styles.settingsAlertDot,
                     {
                       backgroundColor: colors.warning,
-                      borderColor: colors.backgroundSecondary,
+                      borderColor: colors.background,
                     },
                   ]}
                 />
@@ -656,7 +652,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
+    backgroundColor: 'transparent',
   },
   settingsAlertDot: {
     position: 'absolute',

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -280,7 +280,7 @@ export default function LibraryScreen() {
           headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}
-              style={[styles.addButton, { backgroundColor: colors.backgroundSecondary }]}
+              style={styles.addButton}
               accessibilityLabel="Add bookmark"
               accessibilityRole="button"
             >
@@ -399,6 +399,7 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
+    backgroundColor: 'transparent',
   },
   searchContainer: {
     paddingHorizontal: Spacing.md,

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -318,6 +318,19 @@ describe('HomeScreen', () => {
     expect(mockPush).toHaveBeenCalledWith('/settings');
   });
 
+  it('keeps the home settings button background transparent without custom press feedback', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    const settingsButton = renderer!.root.findByProps({ accessibilityLabel: 'Open settings' });
+
+    expect(settingsButton.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: 'transparent' })
+    );
+  });
+
   it('shows an alert dot on the settings button when an integration is disconnected', () => {
     mockSubscriptionsData = {
       items: [{ provider: 'YOUTUBE', status: 'DISCONNECTED' }],

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -86,13 +86,14 @@ jest.mock('react-native', () => ({
   Pressable: ({
     children,
     onPress,
+    ...props
   }: {
     children: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
     onPress?: () => void;
   }) =>
     React.createElement(
       'button',
-      { onClick: onPress, onPress },
+      { onClick: onPress, onPress, ...props },
       typeof children === 'function' ? children({ pressed: false }) : children
     ),
   TextInput: ({
@@ -257,6 +258,19 @@ describe('LibraryScreen', () => {
 
       return mockRemoveListener;
     });
+  });
+
+  it('keeps the library add bookmark button background transparent', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<LibraryScreen />);
+    });
+
+    const addBookmarkButton = renderer!.root.findByProps({ accessibilityLabel: 'Add bookmark' });
+
+    expect(addBookmarkButton.props.style).toEqual(
+      expect.objectContaining({ backgroundColor: 'transparent' })
+    );
   });
 
   it('clears the active filter when the library tab is reselected at the top', () => {


### PR DESCRIPTION
## Summary
- remove the custom filled/pressed header button styling from the Home settings action
- make the Library add-bookmark header action transparent so native header chrome owns the circle
- add regression tests for both header buttons

## Testing
- bun run --cwd apps/mobile test -- --runInBand home-screen.test.tsx
- bun run --cwd apps/mobile test -- --runInBand library-screen.test.tsx
- bun run lint && bun run typecheck && bun run test && bun run build && bun run design-system:check