### PR TITLE
Fix mobile shell background flashes

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "zine",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "dark",
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "app.zine.mobile",
@@ -61,7 +61,7 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,
           "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
+          "backgroundColor": "#000000",
           "dark": {
             "backgroundColor": "#000000"
           }

--- a/apps/mobile/app/(auth)/_layout.tsx
+++ b/apps/mobile/app/(auth)/_layout.tsx
@@ -6,6 +6,8 @@
 
 import { useAuth } from '@clerk/clerk-expo';
 import { Redirect, Stack } from 'expo-router';
+
+import { Colors } from '@/constants/theme';
 import { useAuthAvailability } from '@/providers/auth-provider';
 
 export default function AuthLayout() {
@@ -35,7 +37,7 @@ function ClerkAuthLayout() {
     <Stack
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: 'transparent' },
+        contentStyle: { backgroundColor: Colors.dark.background },
       }}
     >
       <Stack.Screen name="sign-in" />

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,12 +1,14 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, ThemeProvider, type Theme } from '@react-navigation/native';
+import * as SystemUI from 'expo-system-ui';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { HeroUINativeProvider, ToastProvider } from 'heroui-native';
+import { useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
-import { useColorScheme } from '@/hooks/use-color-scheme';
+import { Colors } from '@/constants/theme';
 import { AuthProvider } from '@/providers/auth-provider';
 import { TRPCProvider } from '@/providers/trpc-provider';
 import { useBaselinePrefetchOnFocus } from '@/hooks/use-prefetch';
@@ -21,18 +23,43 @@ function PrefetchManager() {
   return null;
 }
 
+const navigationTheme: Theme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    primary: Colors.dark.tint,
+    background: Colors.dark.background,
+    card: Colors.dark.background,
+    text: Colors.dark.text,
+    border: Colors.dark.borderSubtle,
+    notification: Colors.dark.tint,
+  },
+};
+
+const rootStackScreenOptions = {
+  contentStyle: {
+    backgroundColor: Colors.dark.background,
+  },
+  headerStyle: {
+    backgroundColor: Colors.dark.background,
+  },
+  headerTintColor: Colors.dark.text,
+};
+
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
+  useEffect(() => {
+    void SystemUI.setBackgroundColorAsync(Colors.dark.background);
+  }, []);
 
   return (
     <GestureHandlerRootView style={styles.root}>
       <AuthProvider>
         <TRPCProvider>
           <PrefetchManager />
-          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <ThemeProvider value={navigationTheme}>
             <HeroUINativeProvider>
               <ToastProvider defaultProps={{ placement: 'bottom' }} maxVisibleToasts={3}>
-                <Stack>
+                <Stack screenOptions={rootStackScreenOptions}>
                   <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
                   <Stack.Screen name="(auth)" options={{ headerShown: false }} />
                   <Stack.Screen name="settings" options={{ headerShown: false }} />
@@ -69,7 +96,7 @@ export default function RootLayout() {
                     }}
                   />
                 </Stack>
-                <StatusBar style="auto" />
+                <StatusBar style="light" />
               </ToastProvider>
             </HeroUINativeProvider>
           </ThemeProvider>
@@ -82,5 +109,6 @@ export default function RootLayout() {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
+    backgroundColor: Colors.dark.background,
   },
 });

--- a/apps/mobile/app/onboarding/_layout.tsx
+++ b/apps/mobile/app/onboarding/_layout.tsx
@@ -19,6 +19,9 @@ export default function OnboardingLayout() {
   return (
     <Stack
       screenOptions={{
+        contentStyle: {
+          backgroundColor: colors.background,
+        },
         headerStyle: {
           backgroundColor: colors.background,
         },

--- a/apps/mobile/app/subscriptions/connect/_layout.tsx
+++ b/apps/mobile/app/subscriptions/connect/_layout.tsx
@@ -16,6 +16,9 @@ export default function ConnectLayout() {
   return (
     <Stack
       screenOptions={{
+        contentStyle: {
+          backgroundColor: colors.background,
+        },
         headerStyle: {
           backgroundColor: colors.background,
         },

--- a/apps/mobile/app/subscriptions/discover/_layout.tsx
+++ b/apps/mobile/app/subscriptions/discover/_layout.tsx
@@ -20,6 +20,9 @@ export default function DiscoverLayout() {
   return (
     <Stack
       screenOptions={{
+        contentStyle: {
+          backgroundColor: colors.background,
+        },
         headerStyle: {
           backgroundColor: colors.background,
         },

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -2,11 +2,23 @@ import { useCallback, useRef, useState } from 'react';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
+import { Colors } from '@/constants/theme';
+
 const COLLAPSED_TITLE_THRESHOLD = 44;
 
 export const lightweightHeaderStackScreenOptions: NativeStackNavigationOptions = {
   headerBackButtonDisplayMode: 'minimal',
   headerShadowVisible: false,
+  contentStyle: {
+    backgroundColor: Colors.dark.background,
+  },
+  headerStyle: {
+    backgroundColor: Colors.dark.background,
+  },
+  headerTintColor: Colors.dark.text,
+  headerTitleStyle: {
+    color: Colors.dark.text,
+  },
 };
 
 export function createLightweightHeaderScreenOptions({


### PR DESCRIPTION
## Summary
- set the app shell and React Navigation theme backgrounds to black so transitions do not reveal a light surface
- align nested stack content backgrounds and auth layout content styling with the app's dark-only theme
- force Expo appearance and splash defaults to dark/black to avoid native white flashes during launch and navigation

## Validation
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- bun run design-system:check