### PR TITLE
refactor: use shared timestamp helpers in worker

### DIFF
--- a/apps/worker/src/ingestion/processor/creators.ts
+++ b/apps/worker/src/ingestion/processor/creators.ts
@@ -11,6 +11,7 @@ import {
   generateSyntheticCreatorId,
   type CreatorParams,
 } from '../../db/helpers/creators';
+import { nowIso } from '../../lib/timestamps';
 
 // ============================================================================
 // Creator Extraction Helpers
@@ -138,7 +139,7 @@ export async function backfillCreatorIdIfMissing<T>(
     // Update the canonical item with the creatorId
     await db
       .update(items)
-      .set({ creatorId, updatedAt: new Date().toISOString() })
+      .set({ creatorId, updatedAt: nowIso() })
       .where(eq(items.id, existing[0].id));
 
     ingestionLogger.info('Backfilled creatorId for item', {

--- a/apps/worker/src/ingestion/processor/items.ts
+++ b/apps/worker/src/ingestion/processor/items.ts
@@ -3,24 +3,7 @@ import { and, eq } from 'drizzle-orm';
 import type { Database } from '../../db';
 import { items } from '../../db/schema';
 import type { NewItem } from '../transformers';
-
-// ============================================================================
-// Timestamp Conversion Helpers
-// ============================================================================
-
-/**
- * Convert Unix milliseconds to ISO8601 string.
- *
- * CRITICAL: This function bridges the timestamp gap between:
- * - New tables (subscriptions, subscription_items): Unix milliseconds (INTEGER)
- * - Existing tables (items, user_items, provider_items_seen): ISO8601 strings (TEXT)
- *
- * @param timestamp - Unix timestamp in milliseconds
- * @returns ISO8601 formatted string (e.g., "2024-01-15T10:00:00.000Z")
- */
-function toISO8601(timestamp: number): string {
-  return new Date(timestamp).toISOString();
-}
+import { nowIso, unixToIso } from '../../lib/timestamps';
 
 // ============================================================================
 // Canonical Item Helpers
@@ -62,7 +45,7 @@ export async function findOrCreateCanonicalItem(
     if (!existing[0].creatorId && creatorId) {
       await db
         .update(items)
-        .set({ creatorId, updatedAt: new Date().toISOString() })
+        .set({ creatorId, updatedAt: nowIso() })
         .where(eq(items.id, existing[0].id));
     }
     return { id: existing[0].id };
@@ -70,8 +53,8 @@ export async function findOrCreateCanonicalItem(
 
   // Create new canonical item
   // Convert timestamps to ISO8601 for existing items table
-  const now = new Date().toISOString();
-  const publishedAtISO = newItem.publishedAt ? toISO8601(newItem.publishedAt) : null;
+  const now = nowIso();
+  const publishedAtISO = newItem.publishedAt ? unixToIso(newItem.publishedAt) : null;
 
   // Use onConflictDoNothing() to handle race conditions where another worker
   // creates the same canonical item concurrently. The unique constraint on

--- a/apps/worker/src/ingestion/processor/prepare.ts
+++ b/apps/worker/src/ingestion/processor/prepare.ts
@@ -10,6 +10,7 @@ import { serializeError } from '../../utils/error-utils';
 import { backfillCreatorIdIfMissing, getOrCreateCreator } from './creators';
 import { storeToDLQ } from './dlq';
 import type { IngestContext, PreparedItem, PreparedResult } from './types';
+import { nowIso } from '../../lib/timestamps';
 
 // ============================================================================
 // Preparation Helpers
@@ -75,7 +76,7 @@ export async function prepareItem<T>({
   if (existingCanonical.length > 0 && !existingCanonical[0].creatorId && creatorId) {
     await db
       .update(items)
-      .set({ creatorId, updatedAt: new Date().toISOString() })
+      .set({ creatorId, updatedAt: nowIso() })
       .where(eq(items.id, existingCanonical[0].id));
   }
 

--- a/apps/worker/src/ingestion/processor/write.ts
+++ b/apps/worker/src/ingestion/processor/write.ts
@@ -4,14 +4,7 @@ import { UserItemState } from '@zine/shared';
 import type { Database } from '../../db';
 import { items, providerItemsSeen, subscriptionItems, userItems } from '../../db/schema';
 import type { PreparedItem, WriteContext } from './types';
-
-// ============================================================================
-// Write Helpers
-// ============================================================================
-
-function toISO8601(timestamp: number): string {
-  return new Date(timestamp).toISOString();
-}
+import { unixToIso } from '../../lib/timestamps';
 
 /**
  * Build the ingestion statements for a prepared item.
@@ -22,7 +15,7 @@ export function buildIngestionStatements(prepared: PreparedItem, context: WriteC
 
   if (!prepared.canonicalItemExists) {
     const publishedAtISO = prepared.newItem.publishedAt
-      ? toISO8601(prepared.newItem.publishedAt)
+      ? unixToIso(prepared.newItem.publishedAt)
       : null;
 
     statements.push(

--- a/apps/worker/src/lib/timestamps.test.ts
+++ b/apps/worker/src/lib/timestamps.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for timestamp utilities
+ *
+ * Verifies shared helpers used across ingestion, polling, and router layers.
+ * Focused on parseSpotifyDate which replaced local copies in multiple files.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSpotifyDate } from './timestamps';
+
+describe('parseSpotifyDate', () => {
+  it('parses YYYY-MM-DD (full date) as UTC midnight', () => {
+    expect(parseSpotifyDate('2024-01-15')).toBe(new Date('2024-01-15T00:00:00Z').getTime());
+  });
+
+  it('parses YYYY-MM (month precision) as first of month UTC midnight', () => {
+    expect(parseSpotifyDate('2024-06')).toBe(new Date('2024-06-01T00:00:00Z').getTime());
+  });
+
+  it('parses YYYY (year only) as January 1st UTC midnight', () => {
+    expect(parseSpotifyDate('2024')).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+  });
+
+  it('returns fallback for null', () => {
+    const fallback = 1704067200000;
+    expect(parseSpotifyDate(null, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for undefined', () => {
+    const fallback = 1704067200000;
+    expect(parseSpotifyDate(undefined, fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for empty string', () => {
+    const fallback = 1704067200000;
+    expect(parseSpotifyDate('', fallback)).toBe(fallback);
+  });
+
+  it('returns fallback for an invalid date string', () => {
+    const fallback = 1704067200000;
+    expect(parseSpotifyDate('not-a-date', fallback)).toBe(fallback);
+  });
+});

--- a/apps/worker/src/trpc/routers/creators.ts
+++ b/apps/worker/src/trpc/routers/creators.ts
@@ -28,6 +28,7 @@ import {
 } from '../../db/schema';
 import { UserItemState, YOUTUBE_SHORTS_MAX_DURATION_SECONDS } from '@zine/shared';
 import { decodeCursor, encodeCursor } from '../../lib/pagination';
+import { parseSpotifyDate } from '../../lib/timestamps';
 import { toItemView, type ItemView } from './items';
 import { getLatestContentItemContentType } from './latest-content-content-type';
 import {
@@ -1372,27 +1373,6 @@ async function fetchSpotifyContent(
       externalUrl: episode.externalUrl,
       duration: Math.round(episode.durationMs / 1000),
     }));
-}
-
-/**
- * Parse Spotify date string to Unix milliseconds
- *
- * Spotify dates can be in various formats:
- * - YYYY-MM-DD (full date)
- * - YYYY-MM (month precision)
- * - YYYY (year precision)
- */
-function parseSpotifyDate(dateStr: string): number {
-  // Handle YYYY-MM-DD, YYYY-MM, or YYYY formats
-  if (dateStr.length === 4) {
-    // YYYY -> January 1st
-    return new Date(`${dateStr}-01-01`).getTime();
-  } else if (dateStr.length === 7) {
-    // YYYY-MM -> 1st of month
-    return new Date(`${dateStr}-01`).getTime();
-  }
-  // YYYY-MM-DD
-  return new Date(dateStr).getTime();
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace duplicated ingestion timestamp helpers with shared `lib/timestamps` utilities
- switch the creators router to the shared Spotify date parser
- add focused tests for shared Spotify date parsing behavior

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- bun run design-system:check