### PR TITLE
Web: adopt left-rail shell and split-pane inbox

### DIFF
--- a/apps/web/src/components/item-card.tsx
+++ b/apps/web/src/components/item-card.tsx
@@ -4,7 +4,13 @@ import type { ReactNode } from 'react';
 import { Radius, Typography } from '@zine/design-system';
 import type { ContentType, Provider } from '@zine/shared';
 
-import { formatDuration, formatRelativeDate, mapContentType, mapProvider } from '@/lib/format';
+import {
+  formatDuration,
+  formatPlainText,
+  formatRelativeDate,
+  mapContentType,
+  mapProvider,
+} from '@/lib/format';
 import { typographyStyle } from '@/lib/utils';
 
 import { Surface } from '@/components';
@@ -154,7 +160,8 @@ export function ItemCardView({
   const sourceLabel = item.canonicalUrl
     ? new URL(item.canonicalUrl).hostname.replace(/^www\./, '')
     : 'original source';
-  const summary = item.summary ?? item.creator ?? item.publisher ?? 'Untitled source';
+  const summary =
+    formatPlainText(item.summary) ?? item.creator ?? item.publisher ?? 'Untitled source';
   const creatorLabel = item.creator || item.publisher || 'Unknown creator';
   const href = `/item/${item.id}`;
   const inlineLengthLabel = getLengthLabel(item);

--- a/apps/web/src/home-page.tsx
+++ b/apps/web/src/home-page.tsx
@@ -134,7 +134,7 @@ export function HomePage() {
     filteredJumpBackIn.length > 0 || filteredRecentBookmarks.length > 0 || filteredInbox.length > 0;
 
   return (
-    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-10">
+    <div className="flex w-full max-w-[1180px] flex-col gap-10">
       <header className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
         <div className="space-y-2">
           <h1 className="text-[3.35rem] font-semibold leading-none tracking-[-0.06em] text-foreground sm:text-[4.5rem]">

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -8,6 +8,27 @@ export function mapProvider(provider: Provider | string) {
   return provider.toString().toLowerCase();
 }
 
+export function formatPlainText(value?: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  const plainText = value
+    .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&(nbsp|#160);/gi, ' ')
+    .replace(/&(amp|#38);/gi, '&')
+    .replace(/&(quot|#34);/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return plainText.length > 0 ? plainText : null;
+}
+
 export function formatDuration(seconds?: number | null): string | undefined {
   if (seconds === undefined || seconds === null || !Number.isFinite(seconds) || seconds < 0) {
     return undefined;

--- a/apps/web/src/pages.tsx
+++ b/apps/web/src/pages.tsx
@@ -1,6 +1,19 @@
 import { SignIn, SignUp, UserButton } from '@clerk/clerk-react';
-import { BookOpen, House, Inbox, Rss, Settings, type LucideIcon } from 'lucide-react';
-import { useEffect, useState, useTransition, type ReactNode } from 'react';
+import {
+  Archive,
+  BookOpen,
+  BookmarkCheck,
+  ChevronRight,
+  ExternalLink,
+  House,
+  Inbox,
+  Link2,
+  Plus,
+  Rss,
+  Settings,
+  type LucideIcon,
+} from 'lucide-react';
+import { useEffect, useMemo, useState, useTransition, type ReactNode } from 'react';
 import {
   Link,
   NavLink,
@@ -9,6 +22,7 @@ import {
   useLocation,
   useNavigate,
   useParams,
+  useSearchParams,
 } from 'react-router-dom';
 
 import { ContentType, Provider, UserItemState } from '@zine/shared';
@@ -33,8 +47,10 @@ import {
   formatDeltaLabel,
   formatDuration,
   formatEstimatedMinutes,
+  formatPlainText,
   formatRelativeDate,
   isValidUrl,
+  mapContentType,
   mapProvider,
 } from './lib/format';
 import { completeOAuthFlow, connectProvider, type OAuthProvider } from './lib/oauth';
@@ -76,11 +92,70 @@ const SHELL_NAV_ITEMS: Array<{ to: string; label: string; icon: LucideIcon }> = 
   { to: '/subscriptions', label: 'Subscriptions', icon: Rss },
 ];
 
-function AppWordmark() {
+type ShellSection = {
+  parentLabel: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+function getShellSection(pathname: string): ShellSection {
+  if (pathname === '/') {
+    return { parentLabel: 'All spaces', label: 'Home', icon: House };
+  }
+
+  if (pathname.startsWith('/inbox')) {
+    return { parentLabel: 'All inboxes', label: 'Inbox', icon: Inbox };
+  }
+
+  if (pathname.startsWith('/library') || pathname.startsWith('/item/')) {
+    return { parentLabel: 'Saved shelf', label: 'Library', icon: BookOpen };
+  }
+
+  if (pathname.startsWith('/subscriptions')) {
+    return { parentLabel: 'Source view', label: 'Subscriptions', icon: Rss };
+  }
+
+  if (pathname.startsWith('/add-link')) {
+    return { parentLabel: 'Capture', label: 'Add link', icon: Link2 };
+  }
+
+  if (pathname.startsWith('/settings')) {
+    return { parentLabel: 'Account', label: 'Settings', icon: Settings };
+  }
+
+  if (pathname.startsWith('/recap/')) {
+    return { parentLabel: 'Insights', label: 'Weekly recap', icon: BookOpen };
+  }
+
+  return { parentLabel: 'Workspace', label: 'Browse', icon: House };
+}
+
+function getInboxSummary(item: InboxItem) {
+  return formatPlainText(item.summary) ?? item.creator ?? 'No preview available yet.';
+}
+
+function getInboxSearchValue(item: InboxItem) {
+  return [
+    item.title,
+    formatPlainText(item.summary),
+    item.creator,
+    mapProvider(item.provider),
+    item.contentType,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+function getInboxLengthLabel(item: InboxItem) {
+  return item.duration ? formatDuration(item.duration) : null;
+}
+
+function AppWordmark({ compact = false }: { compact?: boolean }) {
   return (
-    <div className="wordmark">
+    <div className={cn('wordmark', compact && 'wordmark--compact')}>
       <span className="wordmark__disc" />
-      <div>
+      <div className="wordmark__text">
         <p>Zine</p>
         <small>editorial browser</small>
       </div>
@@ -175,46 +250,88 @@ export function ProtectedRoute({ children }: { children: ReactNode }) {
 
 function ShellChrome() {
   const { mode } = useAuthAvailability();
+  const location = useLocation();
+  const shellSection = getShellSection(location.pathname);
+  const SectionIcon = shellSection.icon;
 
   return (
     <div className="app-shell">
-      <header className="shell-header">
-        <Link to="/" className="shell-header__brand" aria-label="Go to home">
-          <AppWordmark />
-        </Link>
-        <div className="shell-header__actions">
-          <Link className="shell-icon-button" to="/settings" aria-label="Open settings">
-            <Settings size={18} strokeWidth={2.1} />
+      <aside className="shell-rail" aria-label="Workspace navigation">
+        <div className="shell-rail__top">
+          <Link to="/" className="shell-rail__brand" aria-label="Go to home">
+            <AppWordmark compact />
           </Link>
+
+          <nav className="shell-rail__nav" aria-label="Primary">
+            {SHELL_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
+              <NavLink
+                key={to}
+                to={to}
+                end={to === '/'}
+                aria-label={label}
+                title={label}
+                className={({ isActive }) =>
+                  cn('shell-rail__link', isActive && 'shell-rail__link--active')
+                }
+              >
+                <Icon size={18} strokeWidth={2.15} />
+                <span className="shell-rail__link-label">{label}</span>
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+
+        <div className="shell-rail__bottom">
+          <Link
+            className={cn(
+              'shell-rail__link',
+              location.pathname.startsWith('/settings') && 'shell-rail__link--active'
+            )}
+            to="/settings"
+            aria-label="Open settings"
+            title="Settings"
+          >
+            <Settings size={18} strokeWidth={2.1} />
+            <span className="shell-rail__link-label">Settings</span>
+          </Link>
+
           {mode === 'clerk' ? (
             <div className="shell-user-button">
               <UserButton />
             </div>
           ) : (
-            <Badge tone="warning">Dev mode</Badge>
+            <Badge className="shell-rail__badge" tone="warning">
+              Dev
+            </Badge>
           )}
         </div>
-      </header>
+      </aside>
 
-      <main className="page-frame">
-        <Outlet />
-      </main>
+      <div className="shell-main">
+        <header className="shell-topbar">
+          <div className="shell-topbar__crumbs">
+            <span>{shellSection.parentLabel}</span>
+            <ChevronRight className="shell-topbar__separator" size={14} strokeWidth={2.2} />
+            <span className="shell-topbar__current">
+              <SectionIcon size={15} strokeWidth={2.2} />
+              {shellSection.label}
+            </span>
+          </div>
+          <div className="shell-topbar__actions">
+            {!location.pathname.startsWith('/add-link') ? (
+              <LinkButton className="shell-topbar__shortcut" to="/add-link" tone="ghost">
+                <Plus size={16} strokeWidth={2.15} />
+                Add link
+              </LinkButton>
+            ) : null}
+            <p className="topbar__note">v{WEB_APP_VERSION}</p>
+          </div>
+        </header>
 
-      <nav className="shell-dock" aria-label="Primary">
-        {SHELL_NAV_ITEMS.map(({ to, label, icon: Icon }) => (
-          <NavLink
-            key={to}
-            to={to}
-            end={to === '/'}
-            className={({ isActive }) =>
-              cn('shell-dock__link', isActive && 'shell-dock__link--active')
-            }
-          >
-            <Icon size={18} strokeWidth={2.15} />
-            <span className="shell-dock__label">{label}</span>
-          </NavLink>
-        ))}
-      </nav>
+        <main className="page-frame">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }
@@ -231,6 +348,8 @@ export function InboxPage() {
   const utils = trpc.useUtils();
   const inboxQuery = trpc.items.inbox.useQuery({ limit: 50 });
   const [pendingId, setPendingId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const bookmarkMutation = trpc.items.bookmark.useMutation({
     onSettled: () => {
@@ -250,15 +369,24 @@ export function InboxPage() {
   });
 
   const inboxItems: InboxItem[] = inboxQuery.data?.items ?? [];
+  const filteredItems = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    if (!query) {
+      return inboxItems;
+    }
+
+    return inboxItems.filter((item) => getInboxSearchValue(item).includes(query));
+  }, [inboxItems, search]);
+  const selectedItemId = searchParams.get('item');
+  const selectedItem = filteredItems.find((item) => item.id === selectedItemId) ?? filteredItems[0];
+  const selectedLengthLabel = selectedItem
+    ? (getInboxLengthLabel(selectedItem) ??
+      (selectedItem.readingTimeMinutes ? `${selectedItem.readingTimeMinutes} min read` : null))
+    : null;
 
   return (
     <div className="page-stack">
-      <PageHeader
-        eyebrow="Inbox"
-        title="Decisions first."
-        description="Treat new items like a finite queue: save what matters, archive the rest, move on cleanly."
-      />
-
       <QueryBoundary
         isLoading={inboxQuery.isLoading}
         error={inboxQuery.error}
@@ -270,37 +398,159 @@ export function InboxPage() {
           />
         }
       >
-        <div className="item-list">
-          {inboxItems.map((item) => (
-            <ItemCard
-              key={item.id}
-              item={item}
-              actionSlot={
-                <div className="button-row">
-                  <Button
-                    tone="ghost"
-                    disabled={pendingId === item.id}
-                    onClick={() => {
-                      setPendingId(item.id);
-                      archiveMutation.mutate({ id: item.id });
-                    }}
-                  >
-                    Archive
-                  </Button>
-                  <Button
-                    disabled={pendingId === item.id}
-                    onClick={() => {
-                      setPendingId(item.id);
-                      bookmarkMutation.mutate({ id: item.id });
-                    }}
-                  >
-                    Keep
-                  </Button>
+        {filteredItems.length === 0 ? (
+          <Surface className="inbox-empty-search">
+            <p className="eyebrow">No matches</p>
+            <h2>Nothing in the inbox matches that search.</h2>
+            <p>Try a different title, source, or creator.</p>
+          </Surface>
+        ) : (
+          <div className="inbox-workspace">
+            <Surface className="inbox-sidebar">
+              <div className="inbox-sidebar__header">
+                <div>
+                  <p className="eyebrow">Inbox</p>
+                  <h2>Decisions first.</h2>
+                  <p>
+                    Treat new items like a finite queue: save what matters, archive the rest, and
+                    move on cleanly.
+                  </p>
                 </div>
-              }
-            />
-          ))}
-        </div>
+                <Badge>{filteredItems.length}</Badge>
+              </div>
+
+              <Field label="Search" hint="Title, creator, or source">
+                <input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search inbox"
+                />
+              </Field>
+
+              <div className="inbox-list" role="list">
+                {filteredItems.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={cn(
+                      'inbox-list-item',
+                      selectedItem?.id === item.id && 'inbox-list-item--active'
+                    )}
+                    onClick={() => {
+                      setSearchParams((current) => {
+                        const next = new URLSearchParams(current);
+                        next.set('item', item.id);
+                        return next;
+                      });
+                    }}
+                  >
+                    <div className="inbox-list-item__meta">
+                      <span>{item.creator || mapProvider(item.provider)}</span>
+                      <span>{formatRelativeDate(item.publishedAt ?? item.ingestedAt)}</span>
+                    </div>
+                    <p className="inbox-list-item__title">{item.title}</p>
+                    <p className="inbox-list-item__summary">{getInboxSummary(item)}</p>
+                  </button>
+                ))}
+              </div>
+            </Surface>
+
+            {selectedItem ? (
+              <Surface className="inbox-detail">
+                <div className="inbox-detail__header">
+                  <div>
+                    <div className="inbox-detail__eyebrow">
+                      <Badge tone="warning">In inbox</Badge>
+                      <span>{mapProvider(selectedItem.provider)}</span>
+                      <span>{mapContentType(selectedItem.contentType)}</span>
+                    </div>
+                    <h2>{selectedItem.title}</h2>
+                    <p className="inbox-detail__summary">{getInboxSummary(selectedItem)}</p>
+                  </div>
+
+                  <div className="button-row button-row--wrap">
+                    <Button
+                      tone="ghost"
+                      disabled={pendingId === selectedItem.id}
+                      onClick={() => {
+                        setPendingId(selectedItem.id);
+                        archiveMutation.mutate({ id: selectedItem.id });
+                      }}
+                    >
+                      <Archive size={16} strokeWidth={2.15} />
+                      Archive
+                    </Button>
+                    <Button
+                      disabled={pendingId === selectedItem.id}
+                      onClick={() => {
+                        setPendingId(selectedItem.id);
+                        bookmarkMutation.mutate({ id: selectedItem.id });
+                      }}
+                    >
+                      <BookmarkCheck size={16} strokeWidth={2.15} />
+                      Keep
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="inbox-detail__body">
+                  <div className="inbox-detail__content">
+                    <div className="inbox-detail__meta">
+                      <span>{selectedItem.creator || 'Unknown creator'}</span>
+                      {selectedLengthLabel ? <span>{selectedLengthLabel}</span> : null}
+                      <span>
+                        {formatRelativeDate(selectedItem.publishedAt ?? selectedItem.ingestedAt)}
+                      </span>
+                    </div>
+
+                    <div className="inbox-detail__context-grid">
+                      <div className="inbox-detail__context">
+                        <strong>Creator</strong>
+                        <span>{selectedItem.creator || 'Unknown creator'}</span>
+                      </div>
+                      <div className="inbox-detail__context">
+                        <strong>Source</strong>
+                        <span>{mapProvider(selectedItem.provider)}</span>
+                      </div>
+                      <div className="inbox-detail__context">
+                        <strong>Saved</strong>
+                        <span>{formatAbsoluteDate(selectedItem.ingestedAt)}</span>
+                      </div>
+                      <div className="inbox-detail__context">
+                        <strong>Length</strong>
+                        <span>{selectedLengthLabel ?? 'Open item for details'}</span>
+                      </div>
+                    </div>
+
+                    <div className="inbox-detail__footer">
+                      <LinkButton to={`/item/${selectedItem.id}`} tone="ghost">
+                        Open detail
+                      </LinkButton>
+                      {selectedItem.canonicalUrl ? (
+                        <AnchorButton
+                          href={selectedItem.canonicalUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open original
+                          <ExternalLink size={16} strokeWidth={2.15} />
+                        </AnchorButton>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="inbox-detail__media">
+                    {selectedItem.thumbnailUrl ? (
+                      <img src={selectedItem.thumbnailUrl} alt="" />
+                    ) : (
+                      <div className="inbox-detail__placeholder" />
+                    )}
+                  </div>
+                </div>
+              </Surface>
+            ) : null}
+          </div>
+        )}
       </QueryBoundary>
     </div>
   );
@@ -479,7 +729,7 @@ export function AddLinkPage() {
           <Surface className="preview-panel">
             <p className="eyebrow">Preview</p>
             <h2>{preview?.title}</h2>
-            <p>{preview?.description ?? preview?.creator}</p>
+            <p>{formatPlainText(preview?.description) ?? preview?.creator}</p>
             <div className="meta-row">
               <Badge>{preview?.provider.toLowerCase()}</Badge>
               <span>{preview?.contentType.toLowerCase()}</span>
@@ -570,7 +820,10 @@ export function ItemDetailPage() {
               eyebrow="Item detail"
               title={item.title}
               description={
-                item.summary ?? item.creator ?? item.publisher ?? 'Saved from the original source.'
+                formatPlainText(item.summary) ??
+                item.creator ??
+                item.publisher ??
+                'Saved from the original source.'
               }
               actions={<div className="button-row">{stateBadge(item.state)}</div>}
             />
@@ -634,7 +887,7 @@ export function ItemDetailPage() {
               <Surface className="preview-panel">
                 <p className="eyebrow">Context</p>
                 <h2>{item.title}</h2>
-                <p>{item.summary ?? 'No summary available for this item yet.'}</p>
+                <p>{formatPlainText(item.summary) ?? 'No summary available for this item yet.'}</p>
                 {item.thumbnailUrl ? (
                   <img className="preview-panel__image" src={item.thumbnailUrl} alt="" />
                 ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -55,6 +55,14 @@ img {
   gap: 0.8rem;
 }
 
+.wordmark__text {
+  min-width: 0;
+}
+
+.wordmark--compact .wordmark__text {
+  display: none;
+}
+
 .wordmark p {
   margin: 0;
   font-family: var(--font-sans);
@@ -79,6 +87,10 @@ img {
   border-radius: 999px;
   background: #ffffff;
   box-shadow: 0 0 0 7px rgba(255, 255, 255, 0.08);
+}
+
+.wordmark--compact .wordmark__disc {
+  box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.05);
 }
 
 .shell-loading,
@@ -197,29 +209,113 @@ img {
 
 .app-shell {
   min-height: 100vh;
-  padding: 1.2rem 1.2rem 7.5rem;
-}
-
-.shell-header,
-.page-frame {
-  width: min(100%, var(--frame-width));
-  margin: 0 auto;
-}
-
-.shell-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 5.75rem minmax(0, 1fr);
   gap: 1rem;
-  margin-bottom: 1.4rem;
-  padding: 0.35rem 0;
+  padding: 1rem;
 }
 
-.shell-header__brand {
+.shell-main {
+  min-width: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shell-rail,
+.page-frame {
   min-width: 0;
 }
 
-.shell-header__actions,
+.shell-rail {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: calc(100vh - 2rem);
+  padding: 1rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 1.8rem;
+  background: rgba(6, 6, 6, 0.86);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    var(--shadow);
+  backdrop-filter: blur(20px);
+}
+
+.shell-rail__top,
+.shell-rail__bottom {
+  display: grid;
+  gap: 0.8rem;
+  justify-items: center;
+  width: 100%;
+}
+
+.shell-rail__brand {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.4rem 0;
+}
+
+.shell-rail__nav {
+  display: grid;
+  gap: 0.7rem;
+  justify-items: center;
+  width: 100%;
+}
+
+.shell-rail__link,
+.shell-user-button,
+.shell-rail__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.35rem;
+  min-height: 3.35rem;
+  padding: 0.2rem;
+  border: 1px solid transparent;
+  border-radius: 1.15rem;
+  color: var(--text-subheader);
+  background: transparent;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
+}
+
+.shell-rail__link:hover,
+.shell-rail__link--active,
+.shell-user-button:hover {
+  transform: translateY(-1px);
+  background: var(--surface-subtle);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.shell-rail__link--active {
+  background: var(--surface-raised);
+}
+
+.shell-rail__link-label {
+  display: none;
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.shell-user-button {
+  overflow: hidden;
+}
+
+.shell-rail__badge {
+  padding-inline: 0.5rem;
+}
+
+.shell-topbar,
 .page-header__actions,
 .button-row {
   display: flex;
@@ -227,80 +323,40 @@ img {
   align-items: center;
 }
 
-.shell-icon-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 3rem;
-  height: 3rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface-subtle);
-  color: var(--text-subheader);
-  transition:
-    background 180ms ease,
-    color 180ms ease,
-    border-color 180ms ease;
+.shell-topbar {
+  justify-content: space-between;
+  min-height: 3.5rem;
+  padding: 0.35rem 0.35rem 0;
 }
 
-.shell-icon-button:hover {
-  background: var(--surface-raised);
-  color: var(--text);
-}
-
-.shell-user-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 3rem;
-  min-height: 3rem;
-  padding: 0.2rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface-subtle);
-}
-
-.shell-dock {
-  position: fixed;
-  left: 50%;
-  bottom: 1.2rem;
-  z-index: 30;
+.shell-topbar__crumbs,
+.shell-topbar__current,
+.shell-topbar__actions {
   display: flex;
-  width: min(calc(100vw - 2rem), 30rem);
-  padding: 0.45rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: rgba(20, 20, 20, 0.94);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(20px);
-  transform: translateX(-50%);
-}
-
-.shell-dock__link {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 0.28rem;
-  min-height: 3.65rem;
-  border-radius: 999px;
-  color: var(--text-subheader);
-  transition:
-    background 180ms ease,
-    color 180ms ease;
+  gap: 0.6rem;
 }
 
-.shell-dock__link:hover,
-.shell-dock__link--active {
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text);
-}
-
-.shell-dock__label {
-  font-size: 0.78rem;
+.shell-topbar__crumbs {
+  color: var(--text-tertiary);
+  font-size: 0.76rem;
   font-weight: 600;
-  letter-spacing: -0.01em;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.shell-topbar__current {
+  color: var(--text);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.shell-topbar__separator {
+  color: var(--text-dim);
+}
+
+.shell-topbar__shortcut {
+  min-height: 2.65rem;
 }
 
 .button-row--wrap {
@@ -308,13 +364,13 @@ img {
 }
 
 .page-frame {
-  min-height: 100vh;
-  padding-bottom: 1.5rem;
+  min-height: calc(100vh - 4.25rem);
+  padding-bottom: 1rem;
 }
 
 .page-stack {
   display: grid;
-  gap: 1.35rem;
+  gap: 1.5rem;
 }
 
 .page-header {
@@ -397,6 +453,227 @@ img {
 
 .split-layout {
   grid-template-columns: 1.05fr 0.95fr;
+}
+
+.inbox-workspace {
+  display: grid;
+  grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.inbox-sidebar,
+.inbox-detail {
+  display: grid;
+  gap: 1rem;
+  padding: 1.1rem;
+}
+
+.inbox-sidebar {
+  position: sticky;
+  top: 5.5rem;
+  max-height: calc(100vh - 6.5rem);
+}
+
+.inbox-sidebar__header,
+.inbox-detail__header,
+.inbox-detail__footer,
+.inbox-list-item__meta,
+.inbox-detail__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+}
+
+.inbox-sidebar__header {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.inbox-sidebar__header h2,
+.inbox-detail__header h2 {
+  margin: 0.25rem 0 0.55rem;
+  font-family: var(--font-sans);
+  letter-spacing: -0.04em;
+}
+
+.inbox-sidebar__header h2 {
+  font-size: 1.65rem;
+}
+
+.inbox-sidebar__header p:last-child {
+  color: var(--text-dim);
+  line-height: 1.65;
+}
+
+.inbox-list {
+  display: grid;
+  gap: 0.6rem;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 0.15rem;
+}
+
+.inbox-list-item {
+  width: 100%;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--surface-subtle);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease;
+}
+
+.inbox-list-item:hover,
+.inbox-list-item--active {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+  background: var(--surface-raised);
+}
+
+.inbox-list-item__meta {
+  justify-content: space-between;
+  color: var(--text-tertiary);
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.inbox-list-item__meta span:last-child {
+  flex-shrink: 0;
+}
+
+.inbox-list-item__title,
+.inbox-list-item__summary,
+.inbox-detail__summary {
+  margin: 0;
+}
+
+.inbox-list-item__title {
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.inbox-list-item__summary {
+  color: var(--text-dim);
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+
+.inbox-detail {
+  min-height: calc(100vh - 6.5rem);
+}
+
+.inbox-detail__header {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.inbox-detail__header h2 {
+  max-width: 14ch;
+  font-size: clamp(2rem, 5vw, 3.45rem);
+  line-height: 0.94;
+}
+
+.inbox-detail__eyebrow,
+.inbox-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--text-subheader);
+}
+
+.inbox-detail__summary {
+  max-width: 54rem;
+  color: var(--text-subheader);
+  line-height: 1.72;
+}
+
+.inbox-detail__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(15rem, 0.9fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.inbox-detail__content,
+.inbox-detail__context-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.inbox-detail__context-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.inbox-detail__context {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--surface-subtle);
+}
+
+.inbox-detail__context strong {
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.inbox-detail__context span {
+  color: var(--text);
+}
+
+.inbox-detail__footer {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.inbox-detail__media {
+  min-height: 20rem;
+  border: 1px solid var(--border);
+  border-radius: 1.2rem;
+  overflow: hidden;
+  background: var(--surface-subtle);
+}
+
+.inbox-detail__media img,
+.inbox-detail__placeholder {
+  width: 100%;
+  height: 100%;
+}
+
+.inbox-detail__media img {
+  object-fit: cover;
+}
+
+.inbox-detail__placeholder {
+  min-height: 20rem;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.01));
+}
+
+.inbox-empty-search {
+  padding: 1.4rem;
 }
 
 .field {
@@ -630,37 +907,86 @@ input:focus {
 
 @media (max-width: 1120px) {
   .split-layout,
+  .inbox-workspace,
+  .inbox-detail__body,
+  .inbox-detail__context-grid,
   .group-grid,
   .source-grid,
   .stats-grid,
   .auth-screen {
     grid-template-columns: 1fr;
   }
+
+  .inbox-sidebar {
+    position: static;
+    max-height: none;
+    min-height: 0;
+  }
 }
 
-@media (max-width: 760px) {
-  .shell-header,
+@media (max-width: 700px) {
+  .app-shell {
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  .shell-rail {
+    min-height: 0;
+    flex-direction: row;
+    align-items: center;
+    padding: 0.75rem;
+    border-radius: 1.4rem;
+  }
+
+  .shell-rail__top,
+  .shell-rail__bottom,
+  .shell-rail__nav {
+    display: flex;
+    align-items: center;
+    justify-items: unset;
+  }
+
+  .shell-rail__top {
+    flex: 1;
+    gap: 0.75rem;
+  }
+
+  .shell-rail__bottom,
+  .shell-rail__nav {
+    gap: 0.55rem;
+  }
+
+  .shell-rail__link,
+  .shell-user-button,
+  .shell-rail__badge {
+    width: auto;
+    min-height: 3rem;
+    padding-inline: 0.9rem;
+    border-radius: 999px;
+  }
+
+  .shell-rail__link-label,
+  .wordmark--compact .wordmark__text {
+    display: inline;
+  }
+
+  .shell-topbar,
   .page-header {
     flex-direction: column;
     align-items: start;
   }
 
-  .shell-header__actions {
+  .shell-topbar__actions {
     width: 100%;
     justify-content: space-between;
   }
 
-  .shell-dock {
-    width: calc(100vw - 1.2rem);
-    bottom: 0.8rem;
+  .shell-topbar__crumbs {
+    flex-wrap: wrap;
   }
 
-  .shell-dock__label {
-    font-size: 0.72rem;
-  }
-
-  .app-shell {
-    padding: 1rem 0.6rem 7.25rem;
+  .inbox-detail__header h2 {
+    max-width: none;
   }
 
   .auth-hero,


### PR DESCRIPTION
## Summary
- rework the web app into a left-rail workspace shell inspired by the referenced sidebar layout while keeping Zine's existing design-system tokens and surfaces
- turn Inbox into a split-pane workspace with a searchable secondary list and a live detail preview for the selected item
- normalize HTML-heavy summaries into readable plain text so cards, inbox previews, and detail views do not leak raw markup

## Validation
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web build
- bun run --cwd apps/web lint
- git push -u origin web-parity (repo hooks ran prettier check, mobile design-system check, turbo typecheck, and worker tests)
- manual browser verification of the shell, left-rail navigation, inbox selection, and detail-pane updates on localhost

## Notes
- Vite still reports the existing chunk-size warning during build, but the build succeeds
- left the unrelated autogenerated mobile Storybook file out of this PR