### PR TITLE
Fix development CORS for worktree web app

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -21,6 +21,7 @@ import { handleSyncQueue } from './sync/consumer';
 import { handleSyncDLQ } from './sync/dlq-consumer';
 import type { SyncQueueMessage } from './sync/types';
 import { logger } from './lib/logger';
+import { resolveCorsOrigin } from './lib/cors';
 import { createWorkerRequestTelemetry, getWorkerRelease } from './lib/telemetry';
 import { authMiddleware } from './middleware/auth';
 import authRoutes from './routes/auth';
@@ -89,22 +90,7 @@ app.use('*', async (c, next) => {
 app.use(
   '*',
   cors({
-    origin: (origin) => {
-      // Development: Allow any localhost port (for worktree isolation)
-      // This covers Expo dev server, any webpack dev server, etc.
-      if (origin?.match(/^http:\/\/localhost:\d+$/)) return origin;
-
-      // Android emulator: 10.0.2.2 is the special alias for host machine
-      // This is only needed for Expo web running in Android emulator's Chrome
-      if (origin?.match(/^http:\/\/10\.0\.2\.2:\d+$/)) return origin;
-
-      // Production: Explicit allowlist
-      if (origin === 'https://myzine.app') return origin;
-      if (origin === 'https://www.myzine.app') return origin;
-
-      // Reject all other origins
-      return null;
-    },
+    origin: (origin, c) => resolveCorsOrigin(origin, c.env.ENVIRONMENT),
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: [
       'Content-Type',

--- a/apps/worker/src/lib/cors.test.ts
+++ b/apps/worker/src/lib/cors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isDevelopmentOrigin, resolveCorsOrigin } from './cors';
+
+describe('CORS origin resolution', () => {
+  it('accepts Tailscale worktree origins in development', () => {
+    const origin = 'http://100.92.242.50:8224';
+
+    expect(isDevelopmentOrigin(origin)).toBe(true);
+    expect(resolveCorsOrigin(origin, 'development')).toBe(origin);
+  });
+
+  it('accepts loopback and private LAN development origins', () => {
+    expect(isDevelopmentOrigin('http://127.0.0.1:5173')).toBe(true);
+    expect(isDevelopmentOrigin('http://192.168.1.20:8224')).toBe(true);
+    expect(isDevelopmentOrigin('http://app.local:8224')).toBe(true);
+  });
+
+  it('keeps non-development environments on the explicit production allowlist', () => {
+    expect(resolveCorsOrigin('http://100.92.242.50:8224', 'production')).toBeNull();
+    expect(resolveCorsOrigin('https://myzine.app', 'production')).toBe('https://myzine.app');
+  });
+
+  it('rejects malformed or public origins in development', () => {
+    expect(isDevelopmentOrigin('not-a-url')).toBe(false);
+    expect(isDevelopmentOrigin('https://example.com')).toBe(false);
+    expect(resolveCorsOrigin('https://example.com', 'development')).toBeNull();
+  });
+});

--- a/apps/worker/src/lib/cors.ts
+++ b/apps/worker/src/lib/cors.ts
@@ -1,0 +1,66 @@
+function isPrivateOrLoopbackIpv4(hostname: string): boolean {
+  const octets = hostname.split('.').map((segment) => Number.parseInt(segment, 10));
+
+  if (octets.length !== 4 || octets.some((octet) => Number.isNaN(octet))) {
+    return false;
+  }
+
+  const [first, second] = octets;
+
+  if (first === 10 || first === 127) return true;
+  if (first === 169 && second === 254) return true;
+  if (first === 172 && second >= 16 && second <= 31) return true;
+  if (first === 192 && second === 168) return true;
+
+  // Tailscale uses CGNAT space (100.64.0.0/10).
+  if (first === 100 && second >= 64 && second <= 127) return true;
+
+  return false;
+}
+
+export function isDevelopmentOrigin(origin: string): boolean {
+  let url: URL;
+
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== 'http:') {
+    return false;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '10.0.2.2') {
+    return true;
+  }
+
+  if (hostname === '::1' || hostname === '[::1]') {
+    return true;
+  }
+
+  if (
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.ts.net')
+  ) {
+    return true;
+  }
+
+  return isPrivateOrLoopbackIpv4(hostname);
+}
+
+export function resolveCorsOrigin(origin: string, environment?: string): string | null {
+  const resolvedEnvironment = environment || 'development';
+
+  if (resolvedEnvironment === 'development' && isDevelopmentOrigin(origin)) {
+    return origin;
+  }
+
+  if (origin === 'https://myzine.app') return origin;
+  if (origin === 'https://www.myzine.app') return origin;
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- extract worker CORS origin resolution into a dedicated helper
- allow development requests from loopback, private-network, and Tailscale worktree origins
- add regression coverage for the development and production allowlists

## Testing
- bun run test:run src/lib/cors.test.ts
- pre-push checks via git push (format check, design-system check, typecheck, worker test suite)
