### PR TITLE
web: reuse provider icons in bookmark fab buttons

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "lucide-react": "^1.8.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-icons": "^5.6.0",
     "react-router-dom": "^7.14.0",
     "superjson": "^2.2.0",
     "tailwind-merge": "^3.5.0"

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -4,14 +4,12 @@ import {
   ChevronLeft,
   ChevronRight,
   Ellipsis,
-  Globe2,
-  Mail,
-  Music2,
-  Play,
-  Rss,
   Settings,
   Share2,
 } from 'lucide-react';
+import { FaSpotify } from 'react-icons/fa';
+import { FaXTwitter } from 'react-icons/fa6';
+import { IoGlobeOutline, IoLogoYoutube, IoNewspaperOutline } from 'react-icons/io5';
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Link, NavLink, useNavigate, useParams } from 'react-router-dom';
 
@@ -101,37 +99,37 @@ function getBookmarkFabConfig(provider: Provider | string): {
     case Provider.SPOTIFY:
       return {
         label: 'Open in Spotify',
-        icon: <Music2 size={20} strokeWidth={2.2} />,
+        icon: <FaSpotify size={22} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--spotify',
       };
     case Provider.YOUTUBE:
       return {
         label: 'Open in YouTube',
-        icon: <Play size={20} strokeWidth={2.2} />,
+        icon: <IoLogoYoutube size={22} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--youtube',
       };
     case Provider.GMAIL:
       return {
         label: 'Open source newsletter',
-        icon: <Mail size={20} strokeWidth={2.2} />,
+        icon: <IoNewspaperOutline size={22} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--gmail',
       };
     case Provider.SUBSTACK:
       return {
         label: 'Open in Substack',
-        icon: <Rss size={20} strokeWidth={2.2} />,
+        icon: <IoGlobeOutline size={22} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--substack',
       };
     case Provider.X:
       return {
         label: 'Open on X',
-        icon: <span className="new-page-bookmark-view__fab-x">X</span>,
+        icon: <FaXTwitter size={20} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--x',
       };
     default:
       return {
         label: 'Open source',
-        icon: <Globe2 size={20} strokeWidth={2.2} />,
+        icon: <IoGlobeOutline size={22} aria-hidden="true" />,
         toneClassName: 'new-page-bookmark-view__fab--default',
       };
   }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -793,11 +793,6 @@ img {
   background: #1a1a1a;
 }
 
-.new-page-bookmark-view__fab-x {
-  font-size: 1.1rem;
-  font-weight: 800;
-}
-
 .new-page-bookmark-view__section {
   display: grid;
   gap: 0.75rem;

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
         "lucide-react": "^1.8.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-icons": "^5.6.0",
         "react-router-dom": "^7.14.0",
         "superjson": "^2.2.0",
         "tailwind-merge": "^3.5.0",
@@ -2519,6 +2520,8 @@
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 
     "react-freeze": ["react-freeze@1.0.4", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA=="],
+
+    "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
 
     "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
 


### PR DESCRIPTION
Replaces the web bookmark/detail FAB icons with web-native equivalents that match the mobile provider buttons more closely.

- Uses react-icons for Spotify, YouTube, newsletter/article, and web/default variants
- Switches X to a Font Awesome X/Twitter icon so it renders reliably on the web
- Keeps the existing button colors, labels, and layout intact

This keeps the web app aligned with the mobile icon set without depending on Expo-only icon packages.