### PR TITLE
fix(web): match bookmark header to mobile

### DIFF
--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -23,12 +23,11 @@ import { AppWordmark } from './app-wordmark';
 import {
   formatDuration,
   formatPlainText,
-  formatRelativeDate,
   isValidUrl,
   mapContentType,
   mapProvider,
 } from './lib/format';
-import type { LibraryItem } from './lib/router-types';
+import type { LibraryItem, RouterOutputs } from './lib/router-types';
 import { trpc } from './lib/trpc';
 
 const CONTENT_FILTERS: Array<{ label: string; value?: ContentType }> = [
@@ -66,16 +65,126 @@ function getLibraryLengthLabel(
   return null;
 }
 
-function getLibrarySourceHost(url?: string | null) {
-  if (!url || !isValidUrl(url)) {
+type BookmarkDetailItem = Pick<
+  LibraryItem,
+  | 'provider'
+  | 'duration'
+  | 'readingTimeMinutes'
+  | 'publishedAt'
+  | 'bookmarkedAt'
+  | 'ingestedAt'
+  | 'canonicalUrl'
+>;
+type CreatorProfile = RouterOutputs['creators']['get'];
+
+function formatBookmarkRelativeTime(value?: string | number | null) {
+  if (!value) {
+    return 'Just now';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Just now';
+  }
+
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+
+  if (diffMs < 0) {
+    return 'Just now';
+  }
+
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+  const diffWeeks = Math.floor(diffDays / 7);
+
+  if (diffMinutes < 1) {
+    return 'Just now';
+  }
+
+  if (diffHours < 1) {
+    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  }
+
+  if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+
+  if (diffDays === 1) {
+    return 'Yesterday';
+  }
+
+  if (diffDays < 7) {
+    return `${diffDays} days ago`;
+  }
+
+  if (diffDays < 30) {
+    return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`;
+  }
+
+  const sameYear = date.getFullYear() === now.getFullYear();
+
+  return new Intl.DateTimeFormat(
+    'en',
+    sameYear
+      ? { month: 'short', day: 'numeric' }
+      : {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        }
+  ).format(date);
+}
+
+function extractPodcastHosts(description?: string | null) {
+  if (!description) {
     return null;
   }
 
-  try {
-    return new URL(url).hostname.replace(/^www\./, '');
-  } catch {
+  const patterns = [
+    /(?:from|by|hosted by|with)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*(?:\s+and\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)+)/i,
+    /(?:from|by|hosted by|with)\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = description.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+}
+
+function extractXHandle(url?: string | null) {
+  if (!url) {
     return null;
   }
+
+  const match = url.match(/(?:x\.com|twitter\.com)\/([^/]+)\//);
+  return match ? match[1] : null;
+}
+
+function getBookmarkSubtextBits(
+  item: BookmarkDetailItem,
+  creator: CreatorProfile | undefined
+): string[] {
+  const bits: Array<string | null> = [];
+
+  if (item.provider === Provider.SPOTIFY) {
+    bits.push(extractPodcastHosts(creator?.description));
+  }
+
+  if (item.provider === Provider.YOUTUBE || item.provider === Provider.X) {
+    bits.push(creator?.handle ?? extractXHandle(item.canonicalUrl));
+  }
+
+  bits.push(formatBookmarkRelativeTime(item.publishedAt ?? item.bookmarkedAt ?? item.ingestedAt));
+  bits.push(getLibraryLengthLabel(item));
+
+  return bits.filter((bit): bit is string => Boolean(bit));
 }
 
 function getBookmarkAboutLabel(contentType: ContentType) {
@@ -182,17 +291,15 @@ export function BookmarksPage() {
   ]);
 
   const displayBookmark = selectedBookmarkDetailQuery.data ?? selectedBookmark;
-  const selectedBookmarkLength = displayBookmark ? getLibraryLengthLabel(displayBookmark) : null;
-  const selectedBookmarkSource = displayBookmark
-    ? (getLibrarySourceHost(displayBookmark.canonicalUrl) ?? mapProvider(displayBookmark.provider))
-    : null;
+  const selectedBookmarkCreatorQuery = trpc.creators.get.useQuery(
+    { creatorId: displayBookmark?.creatorId ?? '' },
+    {
+      enabled: Boolean(displayBookmark?.creatorId),
+      staleTime: 5 * 60 * 1000,
+    }
+  );
   const selectedBookmarkMeta = displayBookmark
-    ? [
-        formatRelativeDate(
-          displayBookmark.publishedAt ?? displayBookmark.bookmarkedAt ?? displayBookmark.ingestedAt
-        ),
-        selectedBookmarkLength,
-      ].filter(Boolean)
+    ? getBookmarkSubtextBits(displayBookmark, selectedBookmarkCreatorQuery.data)
     : [];
   const selectedBookmarkSourceUrl =
     displayBookmark?.canonicalUrl && isValidUrl(displayBookmark.canonicalUrl)
@@ -413,30 +520,33 @@ export function BookmarksPage() {
                   </div>
 
                   <div className="new-page-bookmark-view__body">
-                    <div className="new-page-bookmark-view__creator">
-                      {displayBookmark.creatorImageUrl ? (
-                        <img
-                          className="new-page-bookmark-view__creator-avatar"
-                          src={displayBookmark.creatorImageUrl}
-                          alt=""
-                        />
-                      ) : (
-                        <div className="new-page-bookmark-view__creator-avatar new-page-bookmark-view__creator-avatar--fallback">
-                          {getLibraryCreatorLabel(displayBookmark).slice(0, 1).toUpperCase()}
-                        </div>
-                      )}
+                    <div className="new-page-bookmark-view__creator-block">
+                      <div className="new-page-bookmark-view__creator">
+                        {displayBookmark.creatorImageUrl ? (
+                          <img
+                            className="new-page-bookmark-view__creator-avatar"
+                            src={displayBookmark.creatorImageUrl}
+                            alt=""
+                          />
+                        ) : (
+                          <div className="new-page-bookmark-view__creator-avatar new-page-bookmark-view__creator-avatar--fallback">
+                            {getLibraryCreatorLabel(displayBookmark).slice(0, 1).toUpperCase()}
+                          </div>
+                        )}
 
-                      <div className="new-page-bookmark-view__creator-copy">
-                        <strong>{getLibraryCreatorLabel(displayBookmark)}</strong>
-                        <span>{selectedBookmarkSource ?? 'Unknown source'}</span>
+                        <div className="new-page-bookmark-view__creator-copy">
+                          <strong>{getLibraryCreatorLabel(displayBookmark)}</strong>
+                        </div>
                       </div>
                     </div>
 
-                    <div className="new-page-bookmark-view__meta" aria-label="Bookmark metadata">
-                      {selectedBookmarkMeta.map((bit) => (
-                        <span key={bit}>{bit}</span>
-                      ))}
-                    </div>
+                    {selectedBookmarkMeta.length > 0 ? (
+                      <div className="new-page-bookmark-view__meta" aria-label="Bookmark metadata">
+                        {selectedBookmarkMeta.map((bit, index) => (
+                          <span key={`${bit}-${index}`}>{bit}</span>
+                        ))}
+                      </div>
+                    ) : null}
 
                     <div className="new-page-bookmark-view__actions">
                       <div className="new-page-bookmark-view__actions-left">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -686,13 +686,19 @@ img {
   align-items: center;
 }
 
+.new-page-bookmark-view__creator-block {
+  display: grid;
+  gap: 0.35rem;
+}
+
 .new-page-bookmark-view__creator {
-  gap: 0.875rem;
+  min-width: 0;
+  gap: 0.625rem;
 }
 
 .new-page-bookmark-view__creator-avatar {
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 1.75rem;
+  height: 1.75rem;
   flex-shrink: 0;
   border-radius: 999px;
   object-fit: cover;
@@ -710,12 +716,12 @@ img {
 
 .new-page-bookmark-view__creator-copy {
   min-width: 0;
-  display: grid;
-  gap: 0.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .new-page-bookmark-view__creator-copy strong,
-.new-page-bookmark-view__creator-copy span,
 .new-page-bookmark-view__meta span,
 .new-page-bookmark-view__summary,
 .new-page-bookmark-view__empty p:last-child {
@@ -724,24 +730,22 @@ img {
 
 .new-page-bookmark-view__creator-copy strong {
   color: var(--text);
-  font-size: 1rem;
+  font-size: 1.02rem;
   font-weight: 600;
-}
-
-.new-page-bookmark-view__creator-copy span {
-  font-size: 0.875rem;
+  line-height: 1.2;
 }
 
 .new-page-bookmark-view__meta {
   flex-wrap: wrap;
-  gap: 0.55rem;
-  font-size: 0.82rem;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  line-height: 1.25;
 }
 
 .new-page-bookmark-view__meta span {
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.45rem;
 }
 
 .new-page-bookmark-view__meta span:not(:first-child)::before {
@@ -2155,7 +2159,7 @@ input:focus {
     font-size: 1.95rem;
   }
 
-  .new-page-bookmark-view__creator,
+  .new-page-bookmark-view__creator-block,
   .new-page-bookmark-view__actions {
     align-items: stretch;
   }


### PR DESCRIPTION
## Summary
- tighten the web bookmark creator row to match the mobile avatar/name treatment
- swap the creator subtext from source-host copy to mobile-style metadata bits
- align spacing and typography in the header block to the mobile feel

## Notes
- scoped to the bookmark detail creator header and subtext only
- leaves the existing unrelated Storybook worktree change untouched