### PR TITLE
web: add manual bookmark dialog

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.61.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.60.0",
     "@trpc/client": "^11.0.0",

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -4,19 +4,21 @@ import {
   ChevronLeft,
   ChevronRight,
   Ellipsis,
+  Plus,
   Settings,
   Share2,
 } from 'lucide-react';
 import { FaSpotify } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
 import { IoGlobeOutline, IoLogoYoutube, IoNewspaperOutline } from 'react-icons/io5';
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Link, NavLink, useNavigate, useParams } from 'react-router-dom';
 
 import { getButtonMetrics } from '@zine/design-system';
 import { ContentType, Provider } from '@zine/shared';
 
 import { Badge, Button, EmptyState, cn } from './components';
+import { ManualBookmarkDialog } from './components/manual-bookmark-dialog';
 import { FilterChip } from './components/ui/filter-chip';
 import { AppWordmark } from './app-wordmark';
 import {
@@ -315,11 +317,25 @@ function useBookmarkDetailParallax(scrollKey: string | null) {
   return { articleRef, heroRef };
 }
 
+function getManualBookmarkNotice(status: 'created' | 'already_bookmarked' | 'rebookmarked') {
+  switch (status) {
+    case 'already_bookmarked':
+      return 'Already in your library';
+    case 'rebookmarked':
+      return 'Added back to library';
+    case 'created':
+    default:
+      return 'Saved to library';
+  }
+}
+
 export function BookmarksPage() {
   const utils = trpc.useUtils();
   const navigate = useNavigate();
   const { bookmarkId } = useParams<{ bookmarkId?: string }>();
   const [bookmarkFilter, setBookmarkFilter] = useState<ContentType | undefined>();
+  const [manualBookmarkOpen, setManualBookmarkOpen] = useState(false);
+  const [manualBookmarkNotice, setManualBookmarkNotice] = useState<string | null>(null);
 
   const bookmarksQuery = trpc.items.library.useQuery({
     limit: 50,
@@ -379,6 +395,7 @@ export function BookmarksPage() {
   const { articleRef: bookmarkDetailRef, heroRef: bookmarkHeroRef } = useBookmarkDetailParallax(
     displayBookmark?.id ?? null
   );
+  const libraryIsEmpty = bookmarks.length === 0;
 
   const invalidateSelectedBookmark = () => {
     if (!selectedBookmarkId) {
@@ -399,6 +416,34 @@ export function BookmarksPage() {
     onSuccess: invalidateSelectedBookmark,
   });
 
+  useEffect(() => {
+    if (!manualBookmarkNotice) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setManualBookmarkNotice(null);
+    }, 4000);
+
+    return () => window.clearTimeout(timeout);
+  }, [manualBookmarkNotice]);
+
+  const handleManualBookmarkSaved = useCallback(
+    (result: { userItemId: string; status: 'created' | 'already_bookmarked' | 'rebookmarked' }) => {
+      setManualBookmarkOpen(false);
+      setManualBookmarkNotice(getManualBookmarkNotice(result.status));
+
+      void Promise.all([
+        utils.items.library.invalidate(),
+        utils.items.home.invalidate(),
+        utils.items.get.invalidate({ id: result.userItemId }),
+      ]);
+
+      navigate(`/bookmarks/${result.userItemId}`);
+    },
+    [navigate, utils.items.get, utils.items.home, utils.items.library]
+  );
+
   if (bookmarksQuery.isLoading) {
     return (
       <main className="new-page-screen">
@@ -413,17 +458,6 @@ export function BookmarksPage() {
         <EmptyState
           title="Could not load bookmarks"
           message={bookmarksQuery.error.message ?? 'Please refresh and try again.'}
-        />
-      </main>
-    );
-  }
-
-  if (bookmarks.length === 0) {
-    return (
-      <main className="new-page-screen">
-        <EmptyState
-          title="No bookmarks yet"
-          message="Save a few items first, then this desk becomes the main web surface for browsing them."
         />
       </main>
     );
@@ -495,6 +529,17 @@ export function BookmarksPage() {
               <strong>Bookmarks</strong>
             )}
           </nav>
+
+          <div className="new-page-inset__header-actions">
+            {manualBookmarkNotice ? (
+              <span className="new-page-inset__header-note">{manualBookmarkNotice}</span>
+            ) : null}
+
+            <Button type="button" onClick={() => setManualBookmarkOpen(true)}>
+              <Plus size={16} strokeWidth={2.2} />
+              Add bookmark
+            </Button>
+          </div>
         </header>
 
         <div className="new-page-inset__body">
@@ -516,44 +561,50 @@ export function BookmarksPage() {
             </div>
 
             <div className="new-page-column-card__list">
-              {bookmarks.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  aria-pressed={selectedBookmark?.id === item.id}
-                  className={cn(
-                    'bookmark-row',
-                    selectedBookmark?.id === item.id && 'bookmark-row--selected'
-                  )}
-                  onClick={() => navigate(`/bookmarks/${item.id}`)}
-                >
-                  {item.thumbnailUrl ? (
-                    <img
-                      className="bookmark-row__cover"
-                      src={item.thumbnailUrl}
-                      alt=""
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="bookmark-row__cover bookmark-row__cover--empty" />
-                  )}
-                  <div className="bookmark-row__info">
-                    <span className="bookmark-row__title">{item.title}</span>
-                    <div className="bookmark-row__author">
-                      {item.creatorImageUrl ? (
-                        <img className="bookmark-row__avatar" src={item.creatorImageUrl} alt="" />
-                      ) : (
-                        <div className="bookmark-row__avatar bookmark-row__avatar--fallback">
-                          {(item.creator || item.publisher || 'U')[0]}
-                        </div>
-                      )}
-                      <span className="bookmark-row__name">
-                        {item.creator || item.publisher || 'Unknown'}
-                      </span>
+              {libraryIsEmpty ? (
+                <p className="new-page-column-card__empty">
+                  Add a bookmark to start building your library.
+                </p>
+              ) : (
+                bookmarks.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    aria-pressed={selectedBookmark?.id === item.id}
+                    className={cn(
+                      'bookmark-row',
+                      selectedBookmark?.id === item.id && 'bookmark-row--selected'
+                    )}
+                    onClick={() => navigate(`/bookmarks/${item.id}`)}
+                  >
+                    {item.thumbnailUrl ? (
+                      <img
+                        className="bookmark-row__cover"
+                        src={item.thumbnailUrl}
+                        alt=""
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="bookmark-row__cover bookmark-row__cover--empty" />
+                    )}
+                    <div className="bookmark-row__info">
+                      <span className="bookmark-row__title">{item.title}</span>
+                      <div className="bookmark-row__author">
+                        {item.creatorImageUrl ? (
+                          <img className="bookmark-row__avatar" src={item.creatorImageUrl} alt="" />
+                        ) : (
+                          <div className="bookmark-row__avatar bookmark-row__avatar--fallback">
+                            {(item.creator || item.publisher || 'U')[0]}
+                          </div>
+                        )}
+                        <span className="bookmark-row__name">
+                          {item.creator || item.publisher || 'Unknown'}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                </button>
-              ))}
+                  </button>
+                ))
+              )}
             </div>
           </aside>
 
@@ -754,9 +805,13 @@ export function BookmarksPage() {
               ) : (
                 <div className="new-page-bookmark-pane__empty">
                   <div>
-                    <p className="eyebrow">Bookmark view</p>
-                    <h2>Select a bookmark</h2>
-                    <p>Pick something from the list and its detail view will open here.</p>
+                    <p className="eyebrow">{libraryIsEmpty ? 'Your library' : 'Bookmark view'}</p>
+                    <h2>{libraryIsEmpty ? 'Add your first bookmark' : 'Select a bookmark'}</h2>
+                    <p>
+                      {libraryIsEmpty
+                        ? 'Use the add button in the header to save a link manually and start this shelf.'
+                        : 'Pick something from the list and its detail view will open here.'}
+                    </p>
                   </div>
                 </div>
               )}
@@ -764,6 +819,12 @@ export function BookmarksPage() {
           </div>
         </div>
       </div>
+
+      <ManualBookmarkDialog
+        open={manualBookmarkOpen}
+        onOpenChange={setManualBookmarkOpen}
+        onSaved={handleManualBookmarkSaved}
+      />
     </main>
   );
 }

--- a/apps/web/src/components/manual-bookmark-dialog-view.tsx
+++ b/apps/web/src/components/manual-bookmark-dialog-view.tsx
@@ -1,0 +1,313 @@
+import { AlertCircle, Clipboard, Link2, LoaderCircle, Plus, RefreshCcw, X } from 'lucide-react';
+
+import type { BookmarkPreview } from '../lib/router-types';
+import { cn } from '../lib/utils';
+import {
+  formatDuration,
+  formatPlainText,
+  isValidUrl,
+  mapContentType,
+  mapProvider,
+} from '../lib/format';
+
+function getPreviewLengthLabel(preview: NonNullable<BookmarkPreview>) {
+  if (preview.duration) {
+    return formatDuration(preview.duration) ?? null;
+  }
+
+  if (preview.readingTimeMinutes) {
+    return `${preview.readingTimeMinutes} min read`;
+  }
+
+  return null;
+}
+
+function getPreviewSourceLabel(preview: NonNullable<BookmarkPreview>) {
+  if (preview.siteName) {
+    return preview.siteName;
+  }
+
+  if (isValidUrl(preview.canonicalUrl)) {
+    try {
+      return new URL(preview.canonicalUrl).hostname.replace(/^www\./, '');
+    } catch {
+      return mapProvider(preview.provider);
+    }
+  }
+
+  return mapProvider(preview.provider);
+}
+
+function BadgePill({
+  children,
+  tone,
+}: {
+  children: string;
+  tone?: 'success' | 'warning' | 'danger';
+}) {
+  return <span className={cn('badge', tone && `badge--${tone}`)}>{children}</span>;
+}
+
+function ManualBookmarkPreviewCard({ preview }: { preview: NonNullable<BookmarkPreview> }) {
+  const previewSummary = formatPlainText(preview.description);
+  const previewLength = getPreviewLengthLabel(preview);
+  const previewSource = getPreviewSourceLabel(preview);
+
+  return (
+    <section className="manual-bookmark-preview-card" data-testid="manual-bookmark-preview-card">
+      <div className="manual-bookmark-preview-card__media">
+        {preview.thumbnailUrl ? (
+          <img src={preview.thumbnailUrl} alt="" loading="lazy" />
+        ) : (
+          <div className="manual-bookmark-preview-card__placeholder" aria-hidden="true">
+            <Link2 size={28} strokeWidth={1.9} />
+          </div>
+        )}
+        <div className="manual-bookmark-preview-card__media-badges">
+          <BadgePill>{mapContentType(preview.contentType)}</BadgePill>
+          <BadgePill>{mapProvider(preview.provider)}</BadgePill>
+          {preview.source === 'provider_api' ? (
+            <BadgePill tone="success">Connected</BadgePill>
+          ) : null}
+        </div>
+        {previewLength ? (
+          <div className="manual-bookmark-preview-card__length">{previewLength}</div>
+        ) : null}
+      </div>
+
+      <div className="manual-bookmark-preview-card__body">
+        <div className="manual-bookmark-preview-card__creator">
+          {preview.creatorImageUrl ? (
+            <img
+              className="manual-bookmark-preview-card__avatar"
+              src={preview.creatorImageUrl}
+              alt=""
+            />
+          ) : (
+            <div className="manual-bookmark-preview-card__avatar manual-bookmark-preview-card__avatar--fallback">
+              {(preview.creator || 'Z').slice(0, 1).toUpperCase()}
+            </div>
+          )}
+
+          <div className="manual-bookmark-preview-card__creator-copy">
+            <strong>{preview.creator}</strong>
+            <span>{previewSource}</span>
+          </div>
+        </div>
+
+        <div className="manual-bookmark-preview-card__copy">
+          <h3>{preview.title}</h3>
+          {previewSummary ? <p>{previewSummary}</p> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export type ManualBookmarkDialogViewProps = {
+  url: string;
+  isUrlValid: boolean;
+  preview: BookmarkPreview | null;
+  isLoadingPreview: boolean;
+  isFetchingPreview: boolean;
+  previewErrorMessage: string | null;
+  saveErrorMessage?: string | null;
+  isSaving: boolean;
+  onClose: () => void;
+  onUrlChange: (value: string) => void;
+  onPaste: () => void;
+  onClear: () => void;
+  onRetry: () => void;
+  onSave: () => void;
+};
+
+export function ManualBookmarkDialogView({
+  url,
+  isUrlValid,
+  preview,
+  isLoadingPreview,
+  isFetchingPreview,
+  previewErrorMessage,
+  saveErrorMessage = null,
+  isSaving,
+  onClose,
+  onUrlChange,
+  onPaste,
+  onClear,
+  onRetry,
+  onSave,
+}: ManualBookmarkDialogViewProps) {
+  const hasInput = url.trim().length > 0;
+  const resolvedPreview = preview ?? null;
+  const resolvedErrorMessage = saveErrorMessage ?? previewErrorMessage;
+  const showEmptyState = !hasInput || !isUrlValid;
+  const showLoadingState = hasInput && isUrlValid && isLoadingPreview && !resolvedPreview;
+  const showErrorState =
+    hasInput &&
+    isUrlValid &&
+    Boolean(resolvedErrorMessage) &&
+    !showLoadingState &&
+    !resolvedPreview;
+  const showPreviewState =
+    hasInput && isUrlValid && (Boolean(resolvedPreview) || isFetchingPreview) && !showLoadingState;
+  const canSave = Boolean(resolvedPreview) && !isFetchingPreview && !isSaving;
+
+  return (
+    <div className="manual-bookmark-dialog" data-testid="manual-bookmark-dialog">
+      <div className="manual-bookmark-dialog__header">
+        <div className="manual-bookmark-dialog__header-copy">
+          <h2 id="manual-bookmark-dialog-title" className="manual-bookmark-dialog__title">
+            Add bookmark
+          </h2>
+          <p
+            id="manual-bookmark-dialog-description"
+            className="manual-bookmark-dialog__description"
+          >
+            Paste a link, review the preview, and save it straight into your library.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          className="button button--ghost manual-bookmark-dialog__icon-button manual-bookmark-dialog__close"
+          aria-label="Close add bookmark dialog"
+          onClick={onClose}
+        >
+          <X size={16} strokeWidth={2.2} />
+        </button>
+      </div>
+
+      <div className="manual-bookmark-dialog__body">
+        <label className="field manual-bookmark-dialog__field">
+          <span className="field__label">Link</span>
+          <span className="field__hint">Paste a full http:// or https:// URL.</span>
+          <div
+            className="manual-bookmark-dialog__input-row"
+            data-invalid={hasInput && !isUrlValid ? 'true' : undefined}
+          >
+            <input
+              autoFocus
+              type="url"
+              value={url}
+              placeholder="https://example.com/story"
+              aria-label="Bookmark URL"
+              onChange={(event) => onUrlChange(event.currentTarget.value)}
+            />
+
+            {hasInput ? (
+              <button
+                type="button"
+                className="button button--ghost manual-bookmark-dialog__icon-button"
+                aria-label="Clear URL"
+                onClick={onClear}
+              >
+                <X size={16} strokeWidth={2.2} />
+              </button>
+            ) : (
+              <button type="button" className="button button--ghost" onClick={onPaste}>
+                <Clipboard size={16} strokeWidth={2.1} />
+                Paste
+              </button>
+            )}
+          </div>
+        </label>
+
+        {hasInput && !isUrlValid ? (
+          <p className="manual-bookmark-dialog__hint manual-bookmark-dialog__hint--error">
+            Please enter a valid URL (http:// or https://)
+          </p>
+        ) : null}
+
+        <div className="manual-bookmark-dialog__preview">
+          {showEmptyState ? (
+            <section
+              className="manual-bookmark-dialog__state manual-bookmark-dialog__state--empty"
+              data-testid="manual-bookmark-empty-state"
+            >
+              <Link2 size={28} strokeWidth={1.8} />
+              <div>
+                <h3>Paste a link to get started</h3>
+                <p>We&apos;ll fetch a preview and you can save it to your library.</p>
+              </div>
+            </section>
+          ) : null}
+
+          {showLoadingState ? (
+            <section
+              className="manual-bookmark-dialog__state"
+              data-testid="manual-bookmark-loading-state"
+            >
+              <LoaderCircle
+                className="manual-bookmark-dialog__spinner"
+                size={26}
+                strokeWidth={1.9}
+              />
+              <div>
+                <h3>Fetching preview…</h3>
+                <p>Pulling in enough metadata to make the save feel trustworthy.</p>
+              </div>
+            </section>
+          ) : null}
+
+          {showErrorState ? (
+            <section
+              className="manual-bookmark-dialog__state manual-bookmark-dialog__state--error"
+              data-testid="manual-bookmark-error-state"
+            >
+              <AlertCircle size={28} strokeWidth={1.9} />
+              <div>
+                <h3>Couldn&apos;t load preview</h3>
+                <p>{resolvedErrorMessage}</p>
+              </div>
+              <button type="button" className="button button--ghost" onClick={onRetry}>
+                <RefreshCcw size={16} strokeWidth={2.1} />
+                Try again
+              </button>
+            </section>
+          ) : null}
+
+          {showPreviewState && resolvedPreview ? (
+            <div className="manual-bookmark-dialog__preview-stack">
+              <ManualBookmarkPreviewCard preview={resolvedPreview} />
+              {isFetchingPreview ? (
+                <p className="manual-bookmark-dialog__hint">Refreshing preview…</p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="manual-bookmark-dialog__footer">
+        {saveErrorMessage ? (
+          <p className="manual-bookmark-dialog__footer-note manual-bookmark-dialog__footer-note--error">
+            {saveErrorMessage}
+          </p>
+        ) : null}
+
+        <button
+          type="button"
+          className="button manual-bookmark-dialog__save"
+          data-testid="manual-bookmark-save-button"
+          disabled={!canSave}
+          onClick={onSave}
+        >
+          {isSaving ? (
+            <>
+              <LoaderCircle
+                className="manual-bookmark-dialog__spinner"
+                size={16}
+                strokeWidth={2.1}
+              />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Plus size={16} strokeWidth={2.2} />
+              Save to library
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/manual-bookmark-dialog.tsx
+++ b/apps/web/src/components/manual-bookmark-dialog.tsx
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { BookmarkSaveResult } from '../lib/router-types';
+import { trpc } from '../lib/trpc';
+import { isValidUrl } from '../lib/format';
+import { Dialog, DialogContent } from './ui/dialog';
+import { ManualBookmarkDialogView } from './manual-bookmark-dialog-view';
+
+const PREVIEW_DEBOUNCE_MS = 500;
+
+function getSaveStatusMessage(status: BookmarkSaveResult['status']) {
+  switch (status) {
+    case 'already_bookmarked':
+      return 'Already in your library';
+    case 'rebookmarked':
+      return 'Added back to library';
+    case 'created':
+    default:
+      return 'Saved to library';
+  }
+}
+
+type ManualBookmarkDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: (result: BookmarkSaveResult) => void;
+};
+
+export function ManualBookmarkDialog({ open, onOpenChange, onSaved }: ManualBookmarkDialogProps) {
+  const [url, setUrl] = useState('');
+  const [debouncedUrl, setDebouncedUrl] = useState('');
+  const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(null);
+  const inputFocusFrame = useRef<number | null>(null);
+
+  const trimmedUrl = url.trim();
+  const urlIsValid = isValidUrl(trimmedUrl);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedUrl(trimmedUrl);
+    }, PREVIEW_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeout);
+  }, [trimmedUrl]);
+
+  useEffect(() => {
+    if (open) {
+      inputFocusFrame.current = window.requestAnimationFrame(() => {
+        const input = document.querySelector<HTMLInputElement>('[aria-label="Bookmark URL"]');
+        input?.focus();
+      });
+      return () => {
+        if (inputFocusFrame.current !== null) {
+          window.cancelAnimationFrame(inputFocusFrame.current);
+        }
+      };
+    }
+
+    setUrl('');
+    setDebouncedUrl('');
+    setSaveErrorMessage(null);
+    inputFocusFrame.current = null;
+  }, [open]);
+
+  const previewQuery = trpc.bookmarks.preview.useQuery(
+    { url: debouncedUrl },
+    {
+      enabled: open && debouncedUrl.length > 0 && urlIsValid,
+      placeholderData: (previousData) => previousData,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const saveMutation = trpc.bookmarks.save.useMutation();
+
+  const resolvedPreview = useMemo(() => {
+    if (!urlIsValid || !open) {
+      return null;
+    }
+
+    return previewQuery.data ?? null;
+  }, [open, previewQuery.data, urlIsValid]);
+
+  const previewErrorMessage = useMemo(() => {
+    if (!open || !urlIsValid || trimmedUrl.length === 0) {
+      return null;
+    }
+
+    if (previewQuery.error?.message) {
+      return previewQuery.error.message;
+    }
+
+    if (
+      debouncedUrl.length > 0 &&
+      !previewQuery.isLoading &&
+      !previewQuery.isFetching &&
+      previewQuery.data === null
+    ) {
+      return 'We could not build a preview for this link yet.';
+    }
+
+    return null;
+  }, [
+    debouncedUrl,
+    open,
+    previewQuery.data,
+    previewQuery.error?.message,
+    previewQuery.isFetching,
+    previewQuery.isLoading,
+    trimmedUrl.length,
+    urlIsValid,
+  ]);
+
+  const handleClose = useCallback(() => {
+    saveMutation.reset();
+    setSaveErrorMessage(null);
+    onOpenChange(false);
+  }, [onOpenChange, saveMutation]);
+
+  const handlePaste = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+      setSaveErrorMessage('Clipboard paste is not available in this browser.');
+      return;
+    }
+
+    try {
+      const clipboardText = (await navigator.clipboard.readText()).trim();
+
+      if (!clipboardText) {
+        setSaveErrorMessage('Your clipboard is empty.');
+        return;
+      }
+
+      setSaveErrorMessage(null);
+      setUrl(clipboardText);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Clipboard paste is not available right now.';
+      setSaveErrorMessage(message);
+    }
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    setSaveErrorMessage(null);
+    saveMutation.reset();
+    void previewQuery.refetch();
+  }, [previewQuery, saveMutation]);
+
+  const handleSave = useCallback(async () => {
+    if (!resolvedPreview) {
+      return;
+    }
+
+    setSaveErrorMessage(null);
+
+    try {
+      const result = await saveMutation.mutateAsync({
+        url: trimmedUrl,
+        provider: resolvedPreview.provider,
+        contentType: resolvedPreview.contentType,
+        providerId: resolvedPreview.providerId,
+        title: resolvedPreview.title,
+        creator: resolvedPreview.creator,
+        creatorImageUrl: resolvedPreview.creatorImageUrl ?? null,
+        thumbnailUrl: resolvedPreview.thumbnailUrl,
+        duration: resolvedPreview.duration,
+        canonicalUrl: resolvedPreview.canonicalUrl,
+        description: resolvedPreview.description,
+        siteName: resolvedPreview.siteName,
+        wordCount: resolvedPreview.wordCount,
+        readingTimeMinutes: resolvedPreview.readingTimeMinutes,
+        hasArticleContent: resolvedPreview.hasArticleContent,
+        publishedAt: resolvedPreview.publishedAt,
+        rawMetadata: resolvedPreview.rawMetadata,
+      });
+
+      setSaveErrorMessage(getSaveStatusMessage(result.status));
+      onSaved(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to save bookmark.';
+      setSaveErrorMessage(message);
+    }
+  }, [onSaved, resolvedPreview, saveMutation, trimmedUrl]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <DialogContent
+          className="manual-bookmark-dialog__content"
+          aria-describedby="manual-bookmark-dialog-description"
+          aria-labelledby="manual-bookmark-dialog-title"
+        >
+          <ManualBookmarkDialogView
+            url={url}
+            isUrlValid={urlIsValid}
+            preview={resolvedPreview}
+            isLoadingPreview={previewQuery.isLoading || (urlIsValid && trimmedUrl !== debouncedUrl)}
+            isFetchingPreview={previewQuery.isFetching}
+            previewErrorMessage={previewErrorMessage}
+            saveErrorMessage={saveErrorMessage}
+            isSaving={saveMutation.isPending}
+            onClose={handleClose}
+            onUrlChange={(value) => {
+              setSaveErrorMessage(null);
+              setUrl(value);
+            }}
+            onPaste={handlePaste}
+            onClear={() => {
+              setSaveErrorMessage(null);
+              saveMutation.reset();
+              setUrl('');
+              setDebouncedUrl('');
+            }}
+            onRetry={handleRetry}
+            onSave={handleSave}
+          />
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogTitle = DialogPrimitive.Title;
+const DialogDescription = DialogPrimitive.Description;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay ref={ref} className={cn('dialog-overlay', className)} {...props} />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content ref={ref} className={cn('dialog-content', className)} {...props}>
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogContent, DialogDescription, DialogTitle };

--- a/apps/web/src/lib/router-types.ts
+++ b/apps/web/src/lib/router-types.ts
@@ -13,4 +13,5 @@ export type NewsletterItem = RouterOutputs['subscriptions']['newsletters']['list
 export type RssFeed = RouterOutputs['subscriptions']['rss']['list']['items'][number];
 export type WeeklyRecap = RouterOutputs['insights']['weeklyRecap'];
 export type WeeklyRecapTeaser = RouterOutputs['insights']['weeklyRecapTeaser'];
+export type BookmarkPreview = RouterOutputs['bookmarks']['preview'];
 export type BookmarkSaveResult = RouterOutputs['bookmarks']['save'];

--- a/apps/web/src/storybook/layout-page-surfaces.stories.tsx
+++ b/apps/web/src/storybook/layout-page-surfaces.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { ItemCardFixtures } from '@zine/design-system';
-import { ContentType } from '@zine/shared';
+import { ContentType, Provider } from '@zine/shared';
 
 import { Badge, Button, EmptyState, PageHeader, StatCard, Surface } from '@/components';
 import { ItemCard, ItemCardView } from '@/components/item-card';
+import { ManualBookmarkDialogView } from '@/components/manual-bookmark-dialog-view';
 import { FilterChip } from '@/components/ui/filter-chip';
 
 import { createDarkCanvasDecorator } from './decorators';
@@ -107,6 +108,28 @@ const subscriptionSources = [
     badge: '4 feeds',
   },
 ];
+
+const manualBookmarkPreview = {
+  provider: Provider.WEB,
+  contentType: ContentType.ARTICLE,
+  providerId: 'storybook-manual-bookmark',
+  title: 'Quiet browser surfaces need the same save rhythm as mobile.',
+  creator: 'Zine Editorial',
+  creatorImageUrl: undefined,
+  thumbnailUrl:
+    'https://images.unsplash.com/photo-1515879218367-8466d910aaa4?auto=format&fit=crop&w=1400&q=80',
+  duration: null,
+  canonicalUrl: 'https://zine.example/read/manual-bookmark-flow',
+  source: 'article_extractor' as const,
+  description:
+    'The manual save flow should feel native to the web shell: immediate, calm, and trustworthy before the item lands in the library.',
+  siteName: 'zine.example',
+  wordCount: 920,
+  readingTimeMinutes: 4,
+  hasArticleContent: true,
+  publishedAt: '2026-04-11T10:00:00.000Z',
+  rawMetadata: undefined,
+};
 
 function SectionHeader({
   title,
@@ -401,6 +424,44 @@ function WeeklyRecapSurfaceReference() {
   );
 }
 
+function ManualBookmarkSurfaceReference() {
+  return (
+    <div className="page-stack">
+      <PageHeader
+        eyebrow="Bookmarks"
+        title="Manual save flow"
+        description="The web add-bookmark dialog should read like the same product as mobile: focused, editorial, and quiet under dark surfaces."
+        actions={
+          <div className="button-row">
+            <Button>Add bookmark</Button>
+          </div>
+        }
+      />
+
+      <div style={{ display: 'grid', placeItems: 'center', minHeight: 760 }}>
+        <div style={{ width: 'min(44rem, 100%)' }}>
+          <ManualBookmarkDialogView
+            url={manualBookmarkPreview.canonicalUrl}
+            isUrlValid
+            preview={manualBookmarkPreview}
+            isLoadingPreview={false}
+            isFetchingPreview={false}
+            previewErrorMessage={null}
+            saveErrorMessage={null}
+            isSaving={false}
+            onClose={() => {}}
+            onUrlChange={() => {}}
+            onPaste={() => {}}
+            onClear={() => {}}
+            onRetry={() => {}}
+            onSave={() => {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const meta = {
   title: 'Layout/Page Surfaces',
   decorators: [createDarkCanvasDecorator({ minHeight: 960, padding: 24 })],
@@ -424,4 +485,8 @@ export const SubscriptionsSurface: Story = {
 
 export const WeeklyRecapSurface: Story = {
   render: () => <WeeklyRecapSurfaceReference />,
+};
+
+export const ManualBookmarkSurface: Story = {
+  render: () => <ManualBookmarkSurfaceReference />,
 };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -363,6 +363,19 @@ img {
   background: var(--background, #000);
 }
 
+.new-page-inset__header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.new-page-inset__header-note {
+  font-size: 0.78rem;
+  color: var(--text-subheader);
+}
+
 .new-page-breadcrumb {
   display: flex;
   align-items: center;
@@ -878,6 +891,322 @@ img {
 
 .new-page-bookmark-view__empty h2 {
   margin: 0;
+}
+
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(16px);
+}
+
+.dialog-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 61;
+  width: min(44rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.35rem;
+  background: rgba(10, 10, 10, 0.96);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 24px 60px rgba(0, 0, 0, 0.4);
+  transform: translate(-50%, -50%);
+}
+
+.manual-bookmark-dialog__content {
+  padding: 0;
+}
+
+.manual-bookmark-dialog {
+  display: flex;
+  flex-direction: column;
+  min-height: min(42rem, calc(100vh - 2rem));
+  max-height: calc(100vh - 2rem);
+}
+
+.manual-bookmark-dialog__header,
+.manual-bookmark-dialog__footer {
+  flex-shrink: 0;
+}
+
+.manual-bookmark-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.25rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.manual-bookmark-dialog__header-copy {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.manual-bookmark-dialog__title {
+  margin: 0;
+  font-size: clamp(1.55rem, 2.4vw, 2.1rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+  color: var(--text);
+}
+
+.manual-bookmark-dialog__description {
+  max-width: 34rem;
+  color: var(--text-subheader);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.manual-bookmark-dialog__icon-button {
+  width: 2.9rem;
+  padding-inline: 0;
+}
+
+.manual-bookmark-dialog__body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 0.85rem;
+  padding: 1.25rem;
+  overflow: auto;
+}
+
+.manual-bookmark-dialog__input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.manual-bookmark-dialog__input-row[data-invalid='true'] {
+  border-color: var(--danger);
+}
+
+.manual-bookmark-dialog__input-row input {
+  padding: 0.8rem 0.9rem;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.manual-bookmark-dialog__input-row input:focus {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.manual-bookmark-dialog__hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-tertiary);
+}
+
+.manual-bookmark-dialog__hint--error {
+  color: var(--danger);
+}
+
+.manual-bookmark-dialog__preview {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.manual-bookmark-dialog__preview-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.manual-bookmark-dialog__state {
+  min-height: 16rem;
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.manual-bookmark-dialog__state svg {
+  color: var(--text-tertiary);
+}
+
+.manual-bookmark-dialog__state h3,
+.manual-bookmark-preview-card__copy h3 {
+  margin: 0;
+  color: var(--text);
+}
+
+.manual-bookmark-dialog__state p,
+.manual-bookmark-preview-card__copy p {
+  margin: 0;
+  color: var(--text-subheader);
+}
+
+.manual-bookmark-dialog__state--error {
+  gap: 1.1rem;
+}
+
+.manual-bookmark-dialog__state--error svg {
+  color: var(--danger);
+}
+
+.manual-bookmark-preview-card {
+  border: 1px solid var(--border);
+  border-radius: 1.2rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.015)),
+    rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+}
+
+.manual-bookmark-preview-card__media {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.manual-bookmark-preview-card__media img,
+.manual-bookmark-preview-card__placeholder {
+  width: 100%;
+  height: 100%;
+}
+
+.manual-bookmark-preview-card__media img {
+  object-fit: cover;
+}
+
+.manual-bookmark-preview-card__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}
+
+.manual-bookmark-preview-card__media-badges {
+  position: absolute;
+  top: 0.85rem;
+  left: 0.85rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.manual-bookmark-preview-card__length {
+  position: absolute;
+  right: 0.85rem;
+  bottom: 0.85rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #ffffff;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.manual-bookmark-preview-card__body {
+  display: grid;
+  gap: 0.95rem;
+  padding: 1rem;
+}
+
+.manual-bookmark-preview-card__creator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.manual-bookmark-preview-card__avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  object-fit: cover;
+}
+
+.manual-bookmark-preview-card__avatar--fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-subheader);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.manual-bookmark-preview-card__creator-copy {
+  min-width: 0;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.manual-bookmark-preview-card__creator-copy strong {
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.manual-bookmark-preview-card__creator-copy span {
+  color: var(--text-tertiary);
+  font-size: 0.82rem;
+}
+
+.manual-bookmark-preview-card__copy {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.manual-bookmark-preview-card__copy h3 {
+  font-size: 1.15rem;
+  line-height: 1.25;
+}
+
+.manual-bookmark-preview-card__copy p {
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.manual-bookmark-dialog__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.manual-bookmark-dialog__footer-note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-subheader);
+}
+
+.manual-bookmark-dialog__footer-note--error {
+  color: var(--danger);
+}
+
+.manual-bookmark-dialog__save {
+  margin-left: auto;
+}
+
+.manual-bookmark-dialog__spinner {
+  animation: manual-bookmark-spin 900ms linear infinite;
+}
+
+@keyframes manual-bookmark-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .shell-main {
@@ -2000,6 +2329,10 @@ input:focus {
     padding-right: 1rem;
   }
 
+  .new-page-inset__header-actions {
+    flex-wrap: wrap;
+  }
+
   .new-page-nav,
   .new-page-canvas {
     position: static;
@@ -2098,6 +2431,46 @@ input:focus {
   .new-page-inset__header,
   .new-page-inset__body {
     padding-right: 0.75rem;
+  }
+
+  .new-page-inset__header {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding-block: 0.75rem;
+  }
+
+  .new-page-breadcrumb {
+    width: 100%;
+  }
+
+  .new-page-inset__header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .dialog-content {
+    width: calc(100vw - 1rem);
+    max-height: calc(100vh - 1rem);
+    border-radius: 1rem;
+  }
+
+  .manual-bookmark-dialog {
+    min-height: calc(100vh - 1rem);
+    max-height: calc(100vh - 1rem);
+  }
+
+  .manual-bookmark-dialog__body {
+    padding-inline: 1rem;
+  }
+
+  .manual-bookmark-dialog__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .manual-bookmark-dialog__save {
+    width: 100%;
+    margin-left: 0;
   }
 
   .new-page-nav {

--- a/apps/web/test/manual-bookmark-dialog.test.tsx
+++ b/apps/web/test/manual-bookmark-dialog.test.tsx
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'bun:test';
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+
+import { ContentType, Provider } from '@zine/shared';
+
+import {
+  ManualBookmarkDialogView,
+  type ManualBookmarkDialogViewProps,
+} from '../src/components/manual-bookmark-dialog-view';
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function collectText(
+  node: TestRenderer.ReactTestRendererJSON | TestRenderer.ReactTestRendererJSON[] | null
+) {
+  if (!node) {
+    return '';
+  }
+
+  if (Array.isArray(node)) {
+    return node.map((child) => collectText(child)).join(' ');
+  }
+
+  const children = node.children ?? [];
+
+  return children
+    .map((child) => (typeof child === 'string' ? child : collectText(child)))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const preview = {
+  provider: Provider.WEB,
+  contentType: ContentType.ARTICLE,
+  providerId: 'preview-1',
+  title: 'A calm web modal for saving bookmarks',
+  creator: 'Zine Editorial',
+  creatorImageUrl: null,
+  thumbnailUrl: 'https://example.com/thumbnail.png',
+  duration: null,
+  canonicalUrl: 'https://example.com/story',
+  source: 'article_extractor',
+  description: 'A preview card should feel like the same product as mobile.',
+  siteName: 'Example',
+  wordCount: 850,
+  readingTimeMinutes: 4,
+  hasArticleContent: true,
+  publishedAt: '2026-04-10T12:00:00.000Z',
+  rawMetadata: undefined,
+} satisfies ManualBookmarkDialogViewProps['preview'];
+
+function createProps(
+  overrides: Partial<ManualBookmarkDialogViewProps> = {}
+): ManualBookmarkDialogViewProps {
+  return {
+    url: '',
+    isUrlValid: false,
+    preview: null,
+    isLoadingPreview: false,
+    isFetchingPreview: false,
+    previewErrorMessage: null,
+    isSaving: false,
+    onClose: () => {},
+    onUrlChange: () => {},
+    onPaste: () => {},
+    onClear: () => {},
+    onRetry: () => {},
+    onSave: () => {},
+    ...overrides,
+  };
+}
+
+describe('ManualBookmarkDialogView', () => {
+  it('renders the empty state and disables save before a URL is entered', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(<ManualBookmarkDialogView {...createProps()} />);
+    });
+
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-empty-state' })
+    ).toBeTruthy();
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-save-button' }).props.disabled
+    ).toBe(true);
+  });
+
+  it('shows the invalid URL hint before previewing', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <ManualBookmarkDialogView {...createProps({ url: 'not a url', isUrlValid: false })} />
+      );
+    });
+
+    expect(collectText(renderer.toJSON())).toContain(
+      'Please enter a valid URL (http:// or https://)'
+    );
+  });
+
+  it('renders the preview card and enables save when preview data is ready', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <ManualBookmarkDialogView
+          {...createProps({
+            url: preview.canonicalUrl,
+            isUrlValid: true,
+            preview,
+          })}
+        />
+      );
+    });
+
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-preview-card' })
+    ).toBeTruthy();
+    expect(collectText(renderer.toJSON())).toContain(preview.title);
+    expect(collectText(renderer.toJSON())).toContain(preview.creator);
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-save-button' }).props.disabled
+    ).toBe(false);
+  });
+
+  it('shows an inline error state with retry affordance when preview fails', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <ManualBookmarkDialogView
+          {...createProps({
+            url: 'https://example.com/story',
+            isUrlValid: true,
+            previewErrorMessage: 'Preview fetch failed.',
+          })}
+        />
+      );
+    });
+
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-error-state' })
+    ).toBeTruthy();
+    expect(collectText(renderer.toJSON())).toContain('Preview fetch failed.');
+    expect(collectText(renderer.toJSON())).toContain('Try again');
+  });
+
+  it('shows saving feedback while a bookmark is being created', () => {
+    let renderer!: TestRenderer.ReactTestRenderer;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <ManualBookmarkDialogView
+          {...createProps({
+            url: preview.canonicalUrl,
+            isUrlValid: true,
+            preview,
+            isSaving: true,
+          })}
+        />
+      );
+    });
+
+    expect(
+      renderer.root.findByProps({ 'data-testid': 'manual-bookmark-save-button' }).props.disabled
+    ).toBe(true);
+    expect(collectText(renderer.toJSON())).toContain('Saving...');
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@clerk/clerk-react": "^5.61.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.60.0",
         "@trpc/client": "^11.0.0",


### PR DESCRIPTION
## Summary
- add a manual bookmark entry point to the web bookmarks header, including the empty-library state
- introduce a web modal flow for manual bookmarking with preview, error, loading, and save states
- add a shared dialog primitive, a Storybook surface reference, and a red/green dialog view test

## Why
The web app was missing the manual bookmark flow that already exists on mobile. This PR brings that capability into the web shell so users can save links directly from the browser without leaving the bookmarks experience.

## Details
- reuses the existing `bookmarks.preview` and `bookmarks.save` tRPC endpoints
- keeps the new action aligned with the breadcrumb/header row
- navigates to the saved bookmark after success and shows the matching success note
- keeps the bookmarks page actionable even when the library is empty

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `cd apps/web && bun test test/manual-bookmark-dialog.test.tsx`
- manually verified the browser flow locally by opening the modal, previewing `https://example.com`, saving it, and confirming the new bookmark opened in the detail pane