### PR TITLE
fix(web): separate bookmark hero parallax layers

### DIFF
--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -634,8 +634,10 @@ export function BookmarksPage() {
                     ) : (
                       <div className="new-page-bookmark-view__hero-placeholder" />
                     )}
+                  </div>
 
-                    <div className="new-page-bookmark-view__hero-content">
+                  <div className="new-page-bookmark-view__body">
+                    <div className="new-page-bookmark-view__header">
                       <div className="new-page-bookmark-view__badges">
                         <Badge>{mapProvider(displayBookmark.provider)}</Badge>
                         <Badge>{mapContentType(displayBookmark.contentType)}</Badge>
@@ -643,9 +645,6 @@ export function BookmarksPage() {
 
                       <h2 className="new-page-bookmark-view__title">{displayBookmark.title}</h2>
                     </div>
-                  </div>
-
-                  <div className="new-page-bookmark-view__body">
                     <div className="new-page-bookmark-view__creator-block">
                       <div className="new-page-bookmark-view__creator">
                         {displayBookmark.creatorImageUrl ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -588,6 +588,7 @@ img {
   --bookmark-hero-translate-y: 0px;
   --bookmark-hero-scale: 1;
   --bookmark-hero-opacity: 1;
+  --bookmark-header-overlap: clamp(2.75rem, 7vw, 4.5rem);
   position: relative;
   width: 100%;
   display: flex;
@@ -649,15 +650,6 @@ img {
     linear-gradient(90deg, rgba(18, 18, 18, 0.08), rgba(18, 18, 18, 0.22));
 }
 
-.new-page-bookmark-view__hero-content {
-  position: absolute;
-  inset: auto 0 0 0;
-  z-index: 1;
-  display: grid;
-  gap: 0.9rem;
-  padding: 1.5rem;
-}
-
 .new-page-bookmark-view__back {
   position: absolute;
   top: 1rem;
@@ -680,6 +672,14 @@ img {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.new-page-bookmark-view__header {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: calc(-1 * var(--bookmark-header-overlap));
+  position: relative;
+  z-index: 1;
 }
 
 .new-page-bookmark-view__title {
@@ -2528,7 +2528,6 @@ input:focus {
     height: 40%;
   }
 
-  .new-page-bookmark-view__hero-content,
   .new-page-bookmark-view__body {
     padding-inline: 1rem;
   }


### PR DESCRIPTION
## Summary
- move the bookmark title and metadata chips out of the parallax hero layer
- keep the header visually overlapping the bottom edge of the cover image
- limit the parallax motion and fade effect to the cover image itself

## Why
The bookmark detail view treated the cover image and the overlaid title/chips as one moving sheet. This caused the title and chips to translate and fade with the cover image during parallax. The change keeps the intended overlap while separating the image layer from the content layer.

## Validation
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:worker:ci`