### PR TITLE
fix(web): truncate bookmark breadcrumb titles

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -358,7 +358,9 @@ img {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-width: 0;
   min-height: 4.5rem;
+  overflow: hidden;
   padding: 0 1rem 0 0;
   background: var(--background, #000);
 }
@@ -366,6 +368,7 @@ img {
 .new-page-inset__header-actions {
   margin-left: auto;
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: flex-end;
   gap: 0.75rem;
@@ -380,9 +383,15 @@ img {
   display: flex;
   align-items: center;
   gap: 0.375rem;
+  flex: 1 1 0%;
   min-width: 0;
+  overflow: hidden;
   font-size: 0.875rem;
   color: var(--text-dim);
+}
+
+.new-page-breadcrumb > svg {
+  flex-shrink: 0;
 }
 
 .new-page-breadcrumb__link {
@@ -400,6 +409,9 @@ img {
 }
 
 .new-page-breadcrumb__title {
+  display: block;
+  flex: 1 1 0%;
+  max-width: 100%;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- allow the bookmark detail header to shrink its breadcrumb row inside the sticky header
- keep breadcrumb chevrons and header actions from collapsing while letting the title take the remaining space
- ellipsize long bookmark titles instead of letting them overflow the breadcrumb bar

## Why
Long bookmark names were spilling across the breadcrumb/header area on bookmark detail pages instead of truncating with an ellipsis.

## Notes
- This PR only includes the web breadcrumb CSS fix.
- An unrelated local Storybook-generated mobile file remains uncommitted and is not part of this PR.