### PR TITLE
fix(web): make bookmark chips update instantly

### DIFF
--- a/apps/web/e2e/app.smoke.spec.ts
+++ b/apps/web/e2e/app.smoke.spec.ts
@@ -19,7 +19,7 @@ test('loads the bookmarks desk, filters content, opens detail, and navigates to 
   await expect(page.getByText('Design systems at scale')).toBeVisible();
 
   await page.getByRole('button', { name: /Design systems at scale/ }).click();
-  await expect(page).toHaveURL(/\/bookmarks\/video-1$/);
+  await expect(page).toHaveURL(/\/bookmarks\/video-1\?contentType=video$/);
   await expect(page.getByRole('heading', { name: 'Design systems at scale' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Open in YouTube' })).toHaveAttribute(
     'href',

--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router-dom';
 import { ContentType, Provider } from '@zine/shared';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -39,6 +40,12 @@ const podcastItem = createLibraryItem({
 });
 
 const libraryItems = [articleItem, videoItem, podcastItem];
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <output data-testid="location-search">{location.search}</output>;
+}
 
 function installDefaultBookmarkMocks() {
   hookSpies.itemsLibraryUseQuery.mockImplementation((input) => ({
@@ -133,30 +140,72 @@ describe('BookmarksPage', () => {
     ).toBeVisible();
   });
 
-  test('filters the bookmark list by content type', async () => {
+  test('filters locally and syncs the selected filter to the URL', async () => {
     const user = userEvent.setup();
+
+    renderRoute(
+      <>
+        <BookmarksPage />
+        <LocationProbe />
+      </>,
+      {
+        route: '/bookmarks?contentType=video',
+        path: '/bookmarks',
+      }
+    );
+
+    expect(screen.queryByText(articleItem.title)).not.toBeInTheDocument();
+    expect(screen.getByText(videoItem.title)).toBeVisible();
+    expect(screen.queryByText(podcastItem.title)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Videos' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-search')).toHaveTextContent('?contentType=video');
+    expect(
+      hookSpies.itemsLibraryUseQuery.mock.calls.some(
+        ([input]) => input.filter.contentType === ContentType.VIDEO
+      )
+    ).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'Articles' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search')).toHaveTextContent('?contentType=article');
+    });
+
+    expect(screen.getByText(articleItem.title)).toBeVisible();
+    expect(screen.queryByText(videoItem.title)).not.toBeInTheDocument();
+    expect(screen.queryByText(podcastItem.title)).not.toBeInTheDocument();
+    expect(
+      hookSpies.itemsLibraryUseQuery.mock.calls.some(
+        ([input]) => input.filter.contentType === ContentType.ARTICLE
+      )
+    ).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-search')).toHaveTextContent('');
+    });
+
+    expect(screen.getByText(articleItem.title)).toBeVisible();
+    expect(screen.getByText(videoItem.title)).toBeVisible();
+    expect(screen.getByText(podcastItem.title)).toBeVisible();
+  });
+
+  test('keeps the page shell visible while bookmark data is refreshing', () => {
+    hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({
+      data: { items: libraryItems },
+      isLoading: true,
+      error: null,
+    });
 
     renderRoute(<BookmarksPage />, {
       route: '/bookmarks',
       path: '/bookmarks',
     });
 
+    expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
     expect(screen.getByText(articleItem.title)).toBeVisible();
-    expect(screen.getByText(videoItem.title)).toBeVisible();
-    expect(screen.getByText(podcastItem.title)).toBeVisible();
-
-    await user.click(screen.getByRole('button', { name: 'Videos' }));
-
-    await waitFor(() => {
-      expect(hookSpies.itemsLibraryUseQuery).toHaveBeenLastCalledWith({
-        limit: 50,
-        filter: { contentType: ContentType.VIDEO },
-      });
-    });
-
-    expect(screen.queryByText(articleItem.title)).not.toBeInTheDocument();
-    expect(screen.getByText(videoItem.title)).toBeVisible();
-    expect(screen.queryByText(podcastItem.title)).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading bookmarks')).not.toBeInTheDocument();
   });
 
   test('recovers to the list when a selected bookmark cannot be loaded', async () => {

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -12,7 +12,7 @@ import { FaSpotify } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
 import { IoGlobeOutline, IoLogoYoutube, IoNewspaperOutline } from 'react-icons/io5';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { Link, NavLink, useNavigate, useParams } from 'react-router-dom';
+import { Link, NavLink, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { getButtonMetrics } from '@zine/design-system';
 import { ContentType, Provider } from '@zine/shared';
@@ -38,6 +38,7 @@ const CONTENT_FILTERS: Array<{ label: string; value?: ContentType }> = [
   { label: 'Videos', value: ContentType.VIDEO },
   { label: 'Posts', value: ContentType.POST },
 ];
+const CONTENT_FILTER_SEARCH_PARAM = 'contentType';
 
 const BOOKMARK_ACTION_BUTTON_SIZE = 56;
 const BOOKMARK_ACTION_ICON_SIZE = 22;
@@ -72,6 +73,43 @@ function getLibraryLengthLabel(
   }
 
   return null;
+}
+
+function parseBookmarkFilter(rawValue: string | null): ContentType | undefined {
+  switch (rawValue?.toLowerCase()) {
+    case 'article':
+      return ContentType.ARTICLE;
+    case 'podcast':
+      return ContentType.PODCAST;
+    case 'video':
+      return ContentType.VIDEO;
+    case 'post':
+      return ContentType.POST;
+    default:
+      return undefined;
+  }
+}
+
+function serializeBookmarkFilter(value: ContentType | undefined): string | null {
+  switch (value) {
+    case ContentType.ARTICLE:
+      return 'article';
+    case ContentType.PODCAST:
+      return 'podcast';
+    case ContentType.VIDEO:
+      return 'video';
+    case ContentType.POST:
+      return 'post';
+    default:
+      return null;
+  }
+}
+
+function buildBookmarksLocation(bookmarkId: string | null | undefined, search: string) {
+  return {
+    pathname: bookmarkId ? `/bookmarks/${bookmarkId}` : '/bookmarks',
+    search,
+  };
 }
 
 type BookmarkDetailItem = Pick<
@@ -333,15 +371,28 @@ export function BookmarksPage() {
   const utils = trpc.useUtils();
   const navigate = useNavigate();
   const { bookmarkId } = useParams<{ bookmarkId?: string }>();
-  const [bookmarkFilter, setBookmarkFilter] = useState<ContentType | undefined>();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [manualBookmarkOpen, setManualBookmarkOpen] = useState(false);
   const [manualBookmarkNotice, setManualBookmarkNotice] = useState<string | null>(null);
+  const bookmarkFilter = parseBookmarkFilter(searchParams.get(CONTENT_FILTER_SEARCH_PARAM));
+  const bookmarkSearch = searchParams.toString();
+  const bookmarkSearchString = bookmarkSearch ? `?${bookmarkSearch}` : '';
 
-  const bookmarksQuery = trpc.items.library.useQuery({
-    limit: 50,
-    filter: { contentType: bookmarkFilter },
-  });
+  const bookmarksQuery = trpc.items.library.useQuery(
+    {
+      limit: 50,
+      filter: {},
+    },
+    {
+      placeholderData: (previousData) => previousData,
+    }
+  );
   const bookmarks = bookmarksQuery.data?.items ?? [];
+  const filteredBookmarks = useMemo(
+    () =>
+      bookmarkFilter ? bookmarks.filter((item) => item.contentType === bookmarkFilter) : bookmarks,
+    [bookmarkFilter, bookmarks]
+  );
   const selectedBookmarkId = bookmarkId ?? null;
   const selectedBookmark = useMemo(
     () => bookmarks.find((item) => item.id === bookmarkId) ?? null,
@@ -365,8 +416,9 @@ export function BookmarksPage() {
       return;
     }
 
-    navigate('/bookmarks', { replace: true });
+    navigate(buildBookmarksLocation(null, bookmarkSearchString), { replace: true });
   }, [
+    bookmarkSearchString,
     bookmarkId,
     navigate,
     selectedBookmark,
@@ -395,7 +447,19 @@ export function BookmarksPage() {
   const { articleRef: bookmarkDetailRef, heroRef: bookmarkHeroRef } = useBookmarkDetailParallax(
     displayBookmark?.id ?? null
   );
-  const libraryIsEmpty = bookmarks.length === 0;
+  const bookmarkFilterLabel = CONTENT_FILTERS.find(
+    (filter) => filter.value === bookmarkFilter
+  )?.label;
+  const libraryIsEmpty = filteredBookmarks.length === 0;
+  const hasBookmarkData = Boolean(bookmarksQuery.data);
+  const bookmarksAreRefreshing = bookmarksQuery.isFetching;
+  const showInitialBookmarksLoadingState = !hasBookmarkData && bookmarksQuery.isLoading;
+  const refreshNotice = bookmarksQuery.error
+    ? (bookmarksQuery.error.message ?? 'Could not refresh bookmarks.')
+    : bookmarksAreRefreshing
+      ? 'Refreshing bookmarks...'
+      : null;
+  const headerNotice = manualBookmarkNotice ?? refreshNotice;
 
   const invalidateSelectedBookmark = () => {
     if (!selectedBookmarkId) {
@@ -439,12 +503,12 @@ export function BookmarksPage() {
         utils.items.get.invalidate({ id: result.userItemId }),
       ]);
 
-      navigate(`/bookmarks/${result.userItemId}`);
+      navigate(buildBookmarksLocation(result.userItemId, bookmarkSearchString));
     },
-    [navigate, utils.items.get, utils.items.home, utils.items.library]
+    [bookmarkSearchString, navigate, utils.items.get, utils.items.home, utils.items.library]
   );
 
-  if (bookmarksQuery.isLoading) {
+  if (showInitialBookmarksLoadingState) {
     return (
       <main className="new-page-screen">
         <EmptyState title="Loading bookmarks" message="Pulling your saved items into the desk." />
@@ -452,7 +516,7 @@ export function BookmarksPage() {
     );
   }
 
-  if (bookmarksQuery.error) {
+  if (bookmarksQuery.error && !hasBookmarkData) {
     return (
       <main className="new-page-screen">
         <EmptyState
@@ -470,7 +534,7 @@ export function BookmarksPage() {
           <div className="new-page-sidebar__rail-top">
             <div className="new-page-sidebar__rail-header">
               <Link
-                to="/bookmarks"
+                to={buildBookmarksLocation(null, bookmarkSearchString)}
                 className="new-page-sidebar__brand"
                 aria-label="Go to bookmarks"
               >
@@ -482,7 +546,7 @@ export function BookmarksPage() {
 
             <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
               <NavLink
-                to="/bookmarks"
+                to={buildBookmarksLocation(null, bookmarkSearchString)}
                 end
                 className={({ isActive }) =>
                   cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
@@ -519,7 +583,10 @@ export function BookmarksPage() {
             <ChevronRight size={14} strokeWidth={2.2} />
             {displayBookmark ? (
               <>
-                <Link to="/bookmarks" className="new-page-breadcrumb__link">
+                <Link
+                  to={buildBookmarksLocation(null, bookmarkSearchString)}
+                  className="new-page-breadcrumb__link"
+                >
                   Bookmarks
                 </Link>
                 <ChevronRight size={14} strokeWidth={2.2} />
@@ -531,8 +598,8 @@ export function BookmarksPage() {
           </nav>
 
           <div className="new-page-inset__header-actions">
-            {manualBookmarkNotice ? (
-              <span className="new-page-inset__header-note">{manualBookmarkNotice}</span>
+            {headerNotice ? (
+              <span className="new-page-inset__header-note">{headerNotice}</span>
             ) : null}
 
             <Button type="button" onClick={() => setManualBookmarkOpen(true)}>
@@ -554,7 +621,18 @@ export function BookmarksPage() {
                     size="small"
                     selected={bookmarkFilter === filter.value}
                     tone={filter.value ?? 'default'}
-                    onClick={() => setBookmarkFilter(filter.value)}
+                    onClick={() => {
+                      const nextSearchParams = new URLSearchParams(searchParams);
+                      const nextFilter = serializeBookmarkFilter(filter.value);
+
+                      if (nextFilter) {
+                        nextSearchParams.set(CONTENT_FILTER_SEARCH_PARAM, nextFilter);
+                      } else {
+                        nextSearchParams.delete(CONTENT_FILTER_SEARCH_PARAM);
+                      }
+
+                      setSearchParams(nextSearchParams);
+                    }}
                   />
                 ))}
               </div>
@@ -563,10 +641,14 @@ export function BookmarksPage() {
             <div className="new-page-column-card__list">
               {libraryIsEmpty ? (
                 <p className="new-page-column-card__empty">
-                  Add a bookmark to start building your library.
+                  {bookmarks.length === 0
+                    ? 'Add a bookmark to start building your library.'
+                    : bookmarkFilterLabel
+                      ? `No ${bookmarkFilterLabel.toLowerCase()} bookmarks match this filter.`
+                      : 'No bookmarks match this filter.'}
                 </p>
               ) : (
-                bookmarks.map((item) => (
+                filteredBookmarks.map((item) => (
                   <button
                     key={item.id}
                     type="button"
@@ -575,7 +657,7 @@ export function BookmarksPage() {
                       'bookmark-row',
                       selectedBookmark?.id === item.id && 'bookmark-row--selected'
                     )}
-                    onClick={() => navigate(`/bookmarks/${item.id}`)}
+                    onClick={() => navigate(buildBookmarksLocation(item.id, bookmarkSearchString))}
                   >
                     {item.thumbnailUrl ? (
                       <img
@@ -618,7 +700,7 @@ export function BookmarksPage() {
                   <button
                     type="button"
                     className="new-page-bookmark-view__back"
-                    onClick={() => navigate('/bookmarks')}
+                    onClick={() => navigate(buildBookmarksLocation(null, bookmarkSearchString))}
                     aria-label="Back to bookmarks list"
                     title="Back"
                   >


### PR DESCRIPTION
## Summary
- keep the bookmarks split view mounted while the library query refreshes so chip clicks do not flash the full-page loading state
- filter the loaded bookmark list locally and sync the selected chip to `?contentType=...` for near-instant updates
- preserve the active filter while navigating into and back out of bookmark detail, and add test coverage for URL sync and non-blocking refreshes

## Why
Bookmark filter chips were causing a jarring full-page reload effect in the web app. This keeps the interaction responsive and makes the filter state shareable and back-button friendly.

## Validation
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web`
- `bun run build`
- manual browser verification of bookmark chip interactions and detail navigation

## Notes
- left the existing unrelated change in `apps/mobile/.rnstorybook/storybook.requires.ts` out of this PR