### PR TITLE
fix(web): make add bookmark button icon-only

### DIFF
--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -14,7 +14,7 @@ import { IoGlobeOutline, IoLogoYoutube, IoNewspaperOutline } from 'react-icons/i
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Link, NavLink, useNavigate, useParams } from 'react-router-dom';
 
-import { getButtonMetrics } from '@zine/design-system';
+import { Colors, getButtonMetrics } from '@zine/design-system';
 import { ContentType, Provider } from '@zine/shared';
 
 import { Badge, Button, EmptyState, cn } from './components';
@@ -535,9 +535,18 @@ export function BookmarksPage() {
               <span className="new-page-inset__header-note">{manualBookmarkNotice}</span>
             ) : null}
 
-            <Button type="button" onClick={() => setManualBookmarkOpen(true)}>
+            <Button
+              type="button"
+              size="icon"
+              variant="secondary"
+              aria-label="Add bookmark"
+              style={{
+                backgroundColor: Colors.dark.overlayForeground,
+                color: Colors.dark.accentForeground,
+              }}
+              onClick={() => setManualBookmarkOpen(true)}
+            >
               <Plus size={16} strokeWidth={2.2} />
-              Add bookmark
             </Button>
           </div>
         </header>


### PR DESCRIPTION
## Summary
- Convert the Add bookmark action to an icon-only button
- Use a white background with a dark icon for the header action

## Why
- Keeps the control compact in the bookmarks header while preserving contrast and readability

## Notes
- The change is limited to `apps/web/src/bookmarks-page.tsx`