### PR TITLE
fix(web): use skeleton loading state for bookmarks

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -99,7 +99,7 @@ describe('BookmarksPage', () => {
     });
   });
 
-  test('renders loading, error, and empty states from the library query', () => {
+  test('renders skeleton loading, error, and empty states from the library query', () => {
     hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({
       data: undefined,
       isLoading: true,
@@ -110,7 +110,10 @@ describe('BookmarksPage', () => {
       route: '/bookmarks',
       path: '/bookmarks',
     });
-    expect(screen.getByText('Loading bookmarks')).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
+    expect(screen.getByTestId('bookmark-detail-skeleton')).toBeVisible();
+    expect(screen.getAllByTestId('bookmark-row-skeleton')).toHaveLength(6);
+    expect(screen.queryByText('Loading bookmarks')).not.toBeInTheDocument();
     loadingView.unmount();
 
     hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({
@@ -206,6 +209,28 @@ describe('BookmarksPage', () => {
     expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
     expect(screen.getByText(articleItem.title)).toBeVisible();
     expect(screen.queryByText('Loading bookmarks')).not.toBeInTheDocument();
+  });
+
+  test('shows the detail skeleton while a routed bookmark is still loading', () => {
+    hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({
+      data: { items: [] },
+      isLoading: false,
+      error: null,
+    });
+    hookSpies.itemsGetUseQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    renderRoute(<BookmarksPage />, {
+      route: '/bookmarks/video-1',
+      path: '/bookmarks/:bookmarkId',
+      redirects: [{ path: '/bookmarks', element: <div>Bookmarks fallback</div> }],
+    });
+
+    expect(screen.getByTestId('bookmark-detail-skeleton')).toBeVisible();
+    expect(screen.queryByText('Select a bookmark')).not.toBeInTheDocument();
   });
 
   test('recovers to the list when a selected bookmark cannot be loaded', async () => {

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -741,6 +741,27 @@ export function BookmarksPage() {
               aria-busy={showInitialBookmarksLoadingState}
             >
               {showInitialBookmarksLoadingState ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  style={{
+                    position: 'absolute',
+                    width: '1px',
+                    height: '1px',
+                    padding: 0,
+                    margin: '-1px',
+                    overflow: 'hidden',
+                    clip: 'rect(0, 0, 0, 0)',
+                    whiteSpace: 'nowrap',
+                    border: 0,
+                  }}
+                >
+                  Loading bookmarks
+                </div>
+              ) : null}
+
+              {showInitialBookmarksLoadingState ? (
                 Array.from({ length: BOOKMARK_LOADING_ROW_COUNT }, (_, index) => (
                   <BookmarkRowSkeleton key={index} />
                 ))

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -367,6 +367,100 @@ function getManualBookmarkNotice(status: 'created' | 'already_bookmarked' | 'reb
   }
 }
 
+const BOOKMARK_LOADING_ROW_COUNT = 6;
+
+function BookmarkRowSkeleton() {
+  return (
+    <div
+      className="bookmark-row bookmark-row--skeleton"
+      aria-hidden="true"
+      data-testid="bookmark-row-skeleton"
+    >
+      <div className="bookmark-row__cover bookmark-skeleton-block" />
+      <div className="bookmark-row__info">
+        <span
+          className="bookmark-skeleton-line bookmark-skeleton-line--title"
+          style={{ width: '78%' }}
+        />
+        <div className="bookmark-row__author">
+          <span className="bookmark-skeleton-circle bookmark-skeleton-circle--row-avatar" />
+          <span className="bookmark-skeleton-line" style={{ width: '42%' }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BookmarkDetailSkeleton() {
+  return (
+    <div
+      className="new-page-bookmark-view new-page-bookmark-view--pane new-page-bookmark-view--skeleton"
+      aria-hidden="true"
+      data-testid="bookmark-detail-skeleton"
+    >
+      <div className="new-page-bookmark-view__hero">
+        <div className="new-page-bookmark-view__hero-placeholder new-page-bookmark-view__hero-placeholder--skeleton" />
+      </div>
+
+      <div className="new-page-bookmark-view__body">
+        <div className="new-page-bookmark-view__header">
+          <div className="new-page-bookmark-view__badges">
+            <span className="bookmark-skeleton-pill" />
+            <span className="bookmark-skeleton-pill" style={{ width: '4rem' }} />
+          </div>
+
+          <span
+            className="bookmark-skeleton-line bookmark-skeleton-line--display"
+            style={{ width: '74%' }}
+          />
+          <span
+            className="bookmark-skeleton-line bookmark-skeleton-line--display"
+            style={{ width: '56%' }}
+          />
+        </div>
+
+        <div className="new-page-bookmark-view__creator-block">
+          <div className="new-page-bookmark-view__creator">
+            <span className="bookmark-skeleton-circle bookmark-skeleton-circle--detail-avatar" />
+            <div className="new-page-bookmark-view__creator-copy new-page-bookmark-view__creator-copy--skeleton">
+              <span className="bookmark-skeleton-line" style={{ width: '10rem' }} />
+            </div>
+          </div>
+        </div>
+
+        <div className="new-page-bookmark-view__meta new-page-bookmark-view__meta--skeleton">
+          <span className="bookmark-skeleton-line" style={{ width: '5rem' }} />
+          <span className="bookmark-skeleton-line" style={{ width: '4.5rem' }} />
+          <span className="bookmark-skeleton-line" style={{ width: '3.75rem' }} />
+        </div>
+
+        <div className="new-page-bookmark-view__actions">
+          <div className="new-page-bookmark-view__actions-left">
+            {Array.from({ length: 4 }, (_, index) => (
+              <span key={index} className="bookmark-skeleton-action" />
+            ))}
+          </div>
+
+          <span className="bookmark-skeleton-circle bookmark-skeleton-circle--fab" />
+        </div>
+
+        <section className="new-page-bookmark-view__section">
+          <span className="bookmark-skeleton-line" style={{ width: '7rem', height: '0.7rem' }} />
+          <span className="bookmark-skeleton-line bookmark-skeleton-line--summary" />
+          <span
+            className="bookmark-skeleton-line bookmark-skeleton-line--summary"
+            style={{ width: '84%' }}
+          />
+          <span
+            className="bookmark-skeleton-line bookmark-skeleton-line--summary"
+            style={{ width: '68%' }}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
 export function BookmarksPage() {
   const utils = trpc.useUtils();
   const navigate = useNavigate();
@@ -454,6 +548,9 @@ export function BookmarksPage() {
   const hasBookmarkData = Boolean(bookmarksQuery.data);
   const bookmarksAreRefreshing = bookmarksQuery.isFetching;
   const showInitialBookmarksLoadingState = !hasBookmarkData && bookmarksQuery.isLoading;
+  const showBookmarkDetailSkeleton =
+    showInitialBookmarksLoadingState ||
+    Boolean(selectedBookmarkId && !displayBookmark && selectedBookmarkDetailQuery.isLoading);
   const refreshNotice = bookmarksQuery.error
     ? (bookmarksQuery.error.message ?? 'Could not refresh bookmarks.')
     : bookmarksAreRefreshing
@@ -507,14 +604,6 @@ export function BookmarksPage() {
     },
     [bookmarkSearchString, navigate, utils.items.get, utils.items.home, utils.items.library]
   );
-
-  if (showInitialBookmarksLoadingState) {
-    return (
-      <main className="new-page-screen">
-        <EmptyState title="Loading bookmarks" message="Pulling your saved items into the desk." />
-      </main>
-    );
-  }
 
   if (bookmarksQuery.error && !hasBookmarkData) {
     return (
@@ -647,8 +736,15 @@ export function BookmarksPage() {
               </div>
             </div>
 
-            <div className="new-page-column-card__list">
-              {libraryIsEmpty ? (
+            <div
+              className="new-page-column-card__list"
+              aria-busy={showInitialBookmarksLoadingState}
+            >
+              {showInitialBookmarksLoadingState ? (
+                Array.from({ length: BOOKMARK_LOADING_ROW_COUNT }, (_, index) => (
+                  <BookmarkRowSkeleton key={index} />
+                ))
+              ) : libraryIsEmpty ? (
                 <p className="new-page-column-card__empty">
                   {bookmarks.length === 0
                     ? 'Add a bookmark to start building your library.'
@@ -700,8 +796,13 @@ export function BookmarksPage() {
           </aside>
 
           <div className="new-page-inset__content">
-            <section className="new-page-column-card new-page-bookmark-pane">
-              {displayBookmark ? (
+            <section
+              className="new-page-column-card new-page-bookmark-pane"
+              aria-busy={showBookmarkDetailSkeleton}
+            >
+              {showBookmarkDetailSkeleton ? (
+                <BookmarkDetailSkeleton />
+              ) : displayBookmark ? (
                 <article
                   ref={bookmarkDetailRef}
                   className="new-page-bookmark-view new-page-bookmark-view--pane"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -544,10 +544,105 @@ img {
   display: none;
 }
 
+@keyframes bookmark-skeleton-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 .new-page-column-card__skeleton {
   height: 3.5rem;
   border-radius: 0.5rem;
   background: rgba(255, 255, 255, 0.04);
+}
+
+.new-page-column-card__skeleton,
+.bookmark-skeleton-block,
+.bookmark-skeleton-line,
+.bookmark-skeleton-pill,
+.bookmark-skeleton-circle,
+.bookmark-skeleton-action,
+.new-page-bookmark-view__hero-placeholder--skeleton {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.new-page-column-card__skeleton::after,
+.bookmark-skeleton-block::after,
+.bookmark-skeleton-line::after,
+.bookmark-skeleton-pill::after,
+.bookmark-skeleton-circle::after,
+.bookmark-skeleton-action::after,
+.new-page-bookmark-view__hero-placeholder--skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.16) 45%,
+    transparent 100%
+  );
+  animation: bookmark-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.bookmark-skeleton-line,
+.bookmark-skeleton-pill,
+.bookmark-skeleton-circle,
+.bookmark-skeleton-action {
+  display: block;
+}
+
+.bookmark-skeleton-line {
+  height: 0.75rem;
+  border-radius: 999px;
+}
+
+.bookmark-skeleton-line--title {
+  height: 0.9rem;
+}
+
+.bookmark-skeleton-line--display {
+  height: 1.15rem;
+}
+
+.bookmark-skeleton-line--summary {
+  height: 0.95rem;
+}
+
+.bookmark-skeleton-pill {
+  width: 4.75rem;
+  height: 1.5rem;
+  border-radius: 999px;
+}
+
+.bookmark-skeleton-circle {
+  border-radius: 999px;
+}
+
+.bookmark-skeleton-circle--row-avatar {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.bookmark-skeleton-circle--detail-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+}
+
+.bookmark-skeleton-circle--fab {
+  width: 3.5rem;
+  height: 3.5rem;
+  flex-shrink: 0;
+}
+
+.bookmark-skeleton-action {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 1rem;
 }
 
 .new-page-column-card__empty {
@@ -583,6 +678,15 @@ img {
 
 .bookmark-row--selected {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.bookmark-row--skeleton {
+  cursor: default;
+  pointer-events: none;
+}
+
+.bookmark-row--skeleton:hover {
+  background: transparent;
 }
 
 .bookmark-row__cover {
@@ -705,6 +809,10 @@ img {
     linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.01));
 }
 
+.new-page-bookmark-view__hero-placeholder--skeleton {
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .new-page-bookmark-view__hero::after {
   content: '';
   position: absolute;
@@ -809,6 +917,10 @@ img {
   gap: 0.25rem;
 }
 
+.new-page-bookmark-view__creator-copy--skeleton {
+  width: min(12rem, 100%);
+}
+
 .new-page-bookmark-view__creator-copy strong,
 .new-page-bookmark-view__meta span,
 .new-page-bookmark-view__summary,
@@ -839,6 +951,10 @@ img {
 .new-page-bookmark-view__meta span:not(:first-child)::before {
   content: '•';
   color: var(--text-tertiary);
+}
+
+.new-page-bookmark-view__meta--skeleton span:not(:first-child)::before {
+  content: none;
 }
 
 .new-page-bookmark-view__actions {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -588,6 +588,17 @@ img {
   animation: bookmark-skeleton-shimmer 1.4s ease-in-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .new-page-column-card__skeleton::after,
+  .bookmark-skeleton-block::after,
+  .bookmark-skeleton-line::after,
+  .bookmark-skeleton-pill::after,
+  .bookmark-skeleton-circle::after,
+  .bookmark-skeleton-action::after,
+  .new-page-bookmark-view__hero-placeholder--skeleton::after {
+    animation: none;
+  }
+}
 .bookmark-skeleton-line,
 .bookmark-skeleton-pill,
 .bookmark-skeleton-circle,


### PR DESCRIPTION
## Summary
- keep the bookmarks web shell mounted during initial library loading
- replace the flashing empty-state screen with in-place skeleton rows and a detail-pane skeleton
- add coverage for both the initial list load and routed bookmark detail loading

## Why
The bookmarks route briefly rendered a different empty/loading view before the real layout appeared, which caused a noticeable flash and snap-in. This keeps loading inside the existing page chrome so the transition feels stable.

## Notes
- left the unrelated `apps/mobile/.rnstorybook/storybook.requires.ts` worktree change out of this PR