### PR TITLE
feat(web): add settings subnavigation stub

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -116,7 +116,7 @@ describe('BookmarksPage', () => {
       route: '/bookmarks',
       path: '/bookmarks',
     });
-    expect(screen.getByText('Loading bookmarks')).toBeVisible();
+    expect(loadingView.getByText('Loading bookmarks')).toBeVisible();
     loadingView.unmount();
 
     hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({
@@ -128,8 +128,8 @@ describe('BookmarksPage', () => {
       route: '/bookmarks',
       path: '/bookmarks',
     });
-    expect(screen.getByText('Could not load bookmarks')).toBeVisible();
-    expect(screen.getByText('Network down')).toBeVisible();
+    expect(errorView.getByText('Could not load bookmarks')).toBeVisible();
+    expect(errorView.getByText('Network down')).toBeVisible();
     errorView.unmount();
 
     hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({

--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -1,6 +1,6 @@
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { ContentType, Provider } from '@zine/shared';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -9,6 +9,7 @@ import { renderRoute } from './test/render-router';
 vi.mock('./lib/trpc', () => import('./test/mocks/trpc'));
 
 import { BookmarksPage } from './bookmarks-page';
+import { SettingsPage } from './settings-page';
 import { createCreator, createLibraryItem } from './test/fixtures';
 import { hookSpies, invalidateSpies, mutationSpies, resetTrpcMocks } from './test/mocks/trpc';
 
@@ -44,7 +45,12 @@ const libraryItems = [articleItem, videoItem, podcastItem];
 function LocationProbe() {
   const location = useLocation();
 
-  return <output data-testid="location-search">{location.search}</output>;
+  return (
+    <>
+      <output data-testid="location-pathname">{location.pathname}</output>
+      <output data-testid="location-search">{location.search}</output>
+    </>
+  );
 }
 
 function installDefaultBookmarkMocks() {
@@ -189,6 +195,40 @@ describe('BookmarksPage', () => {
     expect(screen.getByText(articleItem.title)).toBeVisible();
     expect(screen.getByText(videoItem.title)).toBeVisible();
     expect(screen.getByText(podcastItem.title)).toBeVisible();
+  });
+
+  test('navigates to the settings page from the sidebar', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter initialEntries={['/bookmarks']}>
+        <Routes>
+          <Route
+            path="/bookmarks"
+            element={
+              <>
+                <BookmarksPage />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <>
+                <SettingsPage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Settings' }));
+
+    expect(await screen.findByRole('heading', { name: 'Settings' })).toBeVisible();
+    expect(screen.getByTestId('location-pathname')).toHaveTextContent('/settings');
   });
 
   test('keeps the page shell visible while bookmark data is refreshing', () => {

--- a/apps/web/src/settings-page.test.tsx
+++ b/apps/web/src/settings-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -14,34 +14,101 @@ describe('SettingsPage', () => {
     resetTrpcMocks();
   });
 
-  test('always links back to bookmarks', () => {
-    renderRoute(<SettingsPage />);
+  test('renders the bookmarks shell with a settings breadcrumb and a single card', () => {
+    const { container } = renderRoute(<SettingsPage />, {
+      route: '/settings',
+      path: '/settings',
+    });
 
-    expect(screen.getByRole('link', { name: 'Back to bookmarks' })).toHaveAttribute(
-      'href',
-      '/bookmarks'
+    expect(screen.getByRole('link', { name: 'Bookmarks' })).toHaveAttribute('href', '/bookmarks');
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveClass(
+      'new-page-sidebar__rail-btn--active'
     );
+    expect(screen.getByLabelText('Current page location')).toHaveTextContent('Library');
+    expect(screen.getByLabelText('Current page location')).toHaveTextContent('Settings');
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    expect(container.querySelectorAll('.new-page-column-card')).toHaveLength(1);
+    expect(container.querySelector('.new-page-column-card--full')).not.toBeNull();
+    expect(container.querySelector('.new-page-inset__content')).toBeNull();
   });
 
-  test('shows sign out controls only for clerk mode', () => {
-    setAuthAvailability({ mode: 'development-bypass', isEnabled: true });
+  describe('two-column layout', () => {
+    test('has a settings nav on the left and a content area on the right', () => {
+      const { container } = renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
 
-    renderRoute(<SettingsPage />);
+      const nav = screen.getByRole('navigation', { name: 'Settings sections' });
+      expect(nav).toBeVisible();
+      expect(container.querySelector('.settings-page__layout')).not.toBeNull();
+      expect(container.querySelector('.settings-page__nav')).not.toBeNull();
+      expect(container.querySelector('.settings-page__content')).not.toBeNull();
+    });
 
-    expect(screen.queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
-  });
+    test('nav contains Subscriptions item that is active by default', () => {
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
 
-  test('signs out through the app session in clerk mode', async () => {
-    const user = userEvent.setup();
-    const signOut = vi.fn(async () => {});
+      const nav = screen.getByRole('navigation', { name: 'Settings sections' });
+      const subscriptionsBtn = within(nav).getByRole('button', { name: 'Subscriptions' });
+      expect(subscriptionsBtn).toBeVisible();
+      expect(subscriptionsBtn).toHaveAttribute('aria-current', 'true');
+    });
 
-    setAuthAvailability({ mode: 'clerk', isEnabled: true });
-    setSessionState({ signOut });
+    test('shows subscriptions content by default', () => {
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
 
-    renderRoute(<SettingsPage />);
+      expect(screen.getByRole('heading', { name: 'Subscriptions' })).toBeVisible();
+      expect(screen.getByText(/manage your subscriptions/i)).toBeVisible();
+    });
 
-    await user.click(screen.getByRole('button', { name: 'Sign out' }));
+    test('nav contains a sign out button in clerk mode', () => {
+      setAuthAvailability({ mode: 'clerk', isEnabled: true });
 
-    expect(signOut).toHaveBeenCalledWith({ redirectUrl: '/sign-in' });
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Settings sections' });
+      const signOutBtn = within(nav).getByRole('button', { name: 'Sign out' });
+      expect(signOutBtn).toBeVisible();
+    });
+
+    test('hides sign out button in development-bypass mode', () => {
+      setAuthAvailability({ mode: 'development-bypass', isEnabled: true });
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Settings sections' });
+      expect(within(nav).queryByRole('button', { name: 'Sign out' })).not.toBeInTheDocument();
+    });
+
+    test('sign out button triggers signOut in clerk mode', async () => {
+      const user = userEvent.setup();
+      const signOut = vi.fn(async () => {});
+
+      setAuthAvailability({ mode: 'clerk', isEnabled: true });
+      setSessionState({ signOut });
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      const nav = screen.getByRole('navigation', { name: 'Settings sections' });
+      await user.click(within(nav).getByRole('button', { name: 'Sign out' }));
+
+      expect(signOut).toHaveBeenCalledWith({ redirectUrl: '/sign-in' });
+    });
   });
 });

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -1,35 +1,119 @@
-import { Button, LinkButton, Surface } from './components';
+import { BookmarkCheck, ChevronRight, LogOut, Newspaper, Settings } from 'lucide-react';
+import { Link, NavLink } from 'react-router-dom';
+
+import { AppWordmark } from './app-wordmark';
+import { cn } from './components';
 import { useAppSession, useAuthAvailability } from './lib/trpc';
+
+function SubscriptionsSection() {
+  return (
+    <div className="settings-page__section">
+      <h2 className="settings-page__section-title">Subscriptions</h2>
+      <p className="settings-page__section-copy">
+        Manage your subscriptions here. Subscription controls are coming soon.
+      </p>
+    </div>
+  );
+}
 
 export function SettingsPage() {
   const { mode } = useAuthAvailability();
   const { signOut } = useAppSession();
 
   return (
-    <main className="shell-loading">
-      <Surface className="empty-state">
-        <p className="eyebrow">Settings</p>
-        <h2>Settings are pared back in this web pass.</h2>
-        <p>
-          Use the bookmarks desk for now. Account controls can come back once the browser channel
-          expands.
-        </p>
-        <div className="button-row">
-          <LinkButton to="/bookmarks" tone="ghost">
-            Back to bookmarks
-          </LinkButton>
-          {mode === 'clerk' ? (
-            <Button
-              tone="danger"
-              onClick={() => {
-                void signOut({ redirectUrl: '/sign-in' });
-              }}
+    <main className="new-page-screen">
+      <div className="new-page-sidebar">
+        <div className="new-page-sidebar__rail">
+          <div className="new-page-sidebar__rail-top">
+            <div className="new-page-sidebar__rail-header">
+              <Link
+                to="/bookmarks"
+                className="new-page-sidebar__brand"
+                aria-label="Go to bookmarks"
+              >
+                <div className="new-page-sidebar__brand-icon">
+                  <AppWordmark compact />
+                </div>
+              </Link>
+            </div>
+
+            <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
+              <NavLink
+                to="/bookmarks"
+                end
+                className={({ isActive }) =>
+                  cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+                }
+                aria-label="Bookmarks"
+                title="Bookmarks"
+              >
+                <BookmarkCheck size={18} strokeWidth={2.15} />
+                <span>Bookmarks</span>
+              </NavLink>
+            </nav>
+          </div>
+
+          <div className="new-page-sidebar__rail-footer">
+            <NavLink
+              to="/settings"
+              className={({ isActive }) =>
+                cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+              }
+              aria-label="Settings"
+              title="Settings"
             >
-              Sign out
-            </Button>
-          ) : null}
+              <Settings size={18} strokeWidth={2.15} />
+              <span>Settings</span>
+            </NavLink>
+          </div>
         </div>
-      </Surface>
+      </div>
+
+      <div className="new-page-inset">
+        <header className="new-page-inset__header">
+          <nav className="new-page-breadcrumb" aria-label="Current page location">
+            <span>Library</span>
+            <ChevronRight size={14} strokeWidth={2.2} />
+            <strong>Settings</strong>
+          </nav>
+        </header>
+
+        <div className="new-page-inset__body">
+          <section className="new-page-column-card new-page-column-card--full">
+            <div className="new-page-column-card__header">
+              <h1 className="new-page-column-card__title">Settings</h1>
+            </div>
+
+            <div className="settings-page__layout">
+              <nav className="settings-page__nav" aria-label="Settings sections">
+                <button
+                  className="settings-page__nav-item settings-page__nav-item--active"
+                  aria-current="true"
+                >
+                  <Newspaper size={16} strokeWidth={2} />
+                  Subscriptions
+                </button>
+
+                {mode === 'clerk' ? (
+                  <button
+                    className="settings-page__nav-item settings-page__nav-item--danger"
+                    onClick={() => {
+                      void signOut({ redirectUrl: '/sign-in' });
+                    }}
+                  >
+                    <LogOut size={16} strokeWidth={2} />
+                    Sign out
+                  </button>
+                ) : null}
+              </nav>
+
+              <div className="settings-page__content">
+                <SubscriptionsSection />
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -85,6 +85,7 @@ export function SettingsPage() {
             </div>
 
             <div className="settings-page__layout">
+              {/* Keep the settings nav fixed on the left while the content pane changes on the right. */}
               <nav className="settings-page__nav" aria-label="Settings sections">
                 <button
                   className="settings-page__nav-item settings-page__nav-item--active"

--- a/apps/web/src/storybook/layout-web-app-states.stories.tsx
+++ b/apps/web/src/storybook/layout-web-app-states.stories.tsx
@@ -1,8 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  BookmarkCheck,
+  ChevronRight,
+  LogOut,
+  Newspaper,
+  Settings as SettingsIcon,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 import { ContentType } from '@zine/shared';
 
-import { Badge, Button, EmptyState, LinkButton, StatCard, Surface } from '@/components';
+import { Badge, Button, EmptyState, StatCard, Surface } from '@/components';
 import { AppWordmark } from '@/app-wordmark';
 import { FilterChip } from '@/components/ui/filter-chip';
 
@@ -224,21 +232,82 @@ function BookmarkEmptyReference() {
 
 function SettingsReference() {
   return (
-    <main className="shell-loading">
-      <Surface className="empty-state">
-        <p className="eyebrow">Settings</p>
-        <h2>Settings are pared back in this web pass.</h2>
-        <p>
-          Use the bookmarks desk for now. Account controls can come back once the browser channel
-          expands.
-        </p>
-        <div className="button-row">
-          <LinkButton to="/bookmarks" tone="ghost">
-            Back to bookmarks
-          </LinkButton>
-          <Button tone="ghost">Sign out</Button>
+    <main className="new-page-screen">
+      <div className="new-page-sidebar">
+        <div className="new-page-sidebar__rail">
+          <div className="new-page-sidebar__rail-top">
+            <div className="new-page-sidebar__rail-header">
+              <Link
+                to="/bookmarks"
+                className="new-page-sidebar__brand"
+                aria-label="Go to bookmarks"
+              >
+                <div className="new-page-sidebar__brand-icon">
+                  <AppWordmark compact />
+                </div>
+              </Link>
+            </div>
+
+            <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
+              <Link to="/bookmarks" className="new-page-sidebar__rail-btn" aria-label="Bookmarks">
+                <BookmarkCheck size={18} strokeWidth={2.15} />
+                <span>Bookmarks</span>
+              </Link>
+            </nav>
+          </div>
+
+          <div className="new-page-sidebar__rail-footer">
+            <Link
+              to="/settings"
+              className="new-page-sidebar__rail-btn new-page-sidebar__rail-btn--active"
+              aria-label="Settings"
+            >
+              <SettingsIcon size={18} strokeWidth={2.15} />
+              <span>Settings</span>
+            </Link>
+          </div>
         </div>
-      </Surface>
+      </div>
+
+      <div className="new-page-inset">
+        <header className="new-page-inset__header">
+          <nav className="new-page-breadcrumb" aria-label="Current page location">
+            <span>Library</span>
+            <ChevronRight size={14} strokeWidth={2.2} />
+            <strong>Settings</strong>
+          </nav>
+        </header>
+
+        <div className="new-page-inset__body">
+          <section className="new-page-column-card new-page-column-card--full">
+            <div className="new-page-column-card__header">
+              <h1 className="new-page-column-card__title">Settings</h1>
+            </div>
+
+            <div className="settings-page__layout">
+              <nav className="settings-page__nav" aria-label="Settings sections">
+                <button className="settings-page__nav-item settings-page__nav-item--active">
+                  <Newspaper size={16} strokeWidth={2} />
+                  Subscriptions
+                </button>
+                <button className="settings-page__nav-item settings-page__nav-item--danger">
+                  <LogOut size={16} strokeWidth={2} />
+                  Sign out
+                </button>
+              </nav>
+
+              <div className="settings-page__content">
+                <div className="settings-page__section">
+                  <h2 className="settings-page__section-title">Subscriptions</h2>
+                  <p className="settings-page__section-copy">
+                    Manage your subscriptions here. Subscription controls are coming soon.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -510,6 +510,11 @@ img {
   overflow: hidden;
 }
 
+.new-page-column-card--full {
+  width: 100%;
+  min-width: 0;
+}
+
 .new-page-column-card__header {
   display: flex;
   flex-direction: column;
@@ -556,6 +561,81 @@ img {
   font-size: 0.8125rem;
   color: var(--text-dim);
   text-align: center;
+}
+
+.settings-page__layout {
+  display: grid;
+  grid-template-columns: 12rem 1fr;
+  gap: 0;
+  min-height: 20rem;
+}
+
+.settings-page__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem;
+  border-right: 1px solid var(--border);
+}
+
+.settings-page__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.settings-page__nav-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+}
+
+.settings-page__nav-item--active {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.settings-page__nav-item--danger {
+  margin-top: auto;
+  color: var(--danger, #ef4444);
+}
+
+.settings-page__nav-item--danger:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--danger, #ef4444);
+}
+
+.settings-page__content {
+  padding: 1rem 1.5rem;
+}
+
+.settings-page__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-page__section-title {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-page__section-copy {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text-dim);
 }
 
 /* ── Bookmark row (flat) ── */


### PR DESCRIPTION
Add a two-column settings card in the web app with section navigation for Subscriptions and Sign out.

- keeps the existing bookmarks-style page shell and breadcrumbs
- stubs Subscriptions content in the right-hand panel
- shows Sign out only in clerk mode and wires it to the app session
- updates tests, styles, and Storybook coverage

Manually verified in the browser against the local dev server.