### PR TITLE
feat(mobile): sticky bookmark detail header and actions

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -15,14 +15,22 @@
 
 import { Image } from 'expo-image';
 import { useRouter, type Href } from 'expo-router';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Colors } from '@/constants/theme';
+import { Colors, Spacing } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { upgradeSpotifyImageUrl, upgradeYouTubeImageUrl } from '@/lib/content-utils';
+import {
+  COLLAPSED_TITLE_THRESHOLD,
+  getCollapsedHeaderTitleThreshold,
+  getStickyActionRowThreshold,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
 
 import { XPostBookmarkView } from './item-detail-components';
 import { styles } from './item-detail-styles';
+import { ItemDetailActions } from './detail/components/ItemDetailActions';
 import { ItemDetailContent } from './detail/components/ItemDetailContent';
 import {
   ItemDetailParallaxLayout,
@@ -44,6 +52,10 @@ export default function ItemDetailScreen() {
   const colors = Colors[colorScheme ?? 'dark'];
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const [contentTopY, setContentTopY] = useState<number | null>(null);
+  const [titleOffsetY, setTitleOffsetY] = useState<number | null>(null);
+  const [actionRowStartY, setActionRowStartY] = useState<number | null>(null);
+  const [showStickyActions, setShowStickyActions] = useState(false);
 
   const { id, isValid, message } = useItemDetailParams();
   const { item, isLoading, error, refetch, creatorData } = useItemDetailData({ id, isValid });
@@ -66,6 +78,58 @@ export default function ItemDetailScreen() {
     archivePending: archiveMutation.isPending,
     toggleFinishedPending: toggleFinishedMutation.isPending,
   });
+  const collapsedTitleThreshold = useMemo(() => {
+    if (contentTopY === null || titleOffsetY === null) {
+      return COLLAPSED_TITLE_THRESHOLD;
+    }
+
+    return getCollapsedHeaderTitleThreshold(contentTopY + titleOffsetY);
+  }, [contentTopY, titleOffsetY]);
+  const stickyActionsTop = insets.top + 56 + Spacing.sm;
+  const stickyBackdropHeight = stickyActionsTop + 56 + Spacing.sm;
+  const stickyActionRowThreshold = useMemo(() => {
+    if (actionRowStartY === null) {
+      return Number.POSITIVE_INFINITY;
+    }
+
+    return getStickyActionRowThreshold(actionRowStartY, stickyActionsTop);
+  }, [actionRowStartY, stickyActionsTop]);
+  const {
+    handleScroll: handleTitleScroll,
+    showCollapsedTitle,
+    scrollOffsetYRef,
+  } = useCollapsedHeaderTitle({
+    threshold: collapsedTitleThreshold,
+  });
+  const handleScroll = useCallback(
+    (event: Parameters<typeof handleTitleScroll>[0]) => {
+      handleTitleScroll(event);
+
+      const shouldShowStickyActions = event.nativeEvent.contentOffset.y > stickyActionRowThreshold;
+      setShowStickyActions((current) =>
+        current === shouldShowStickyActions ? current : shouldShowStickyActions
+      );
+    },
+    [handleTitleScroll, stickyActionRowThreshold]
+  );
+  const handleContentLayout = useCallback((nextContentTopY: number) => {
+    setContentTopY((current) => (current === nextContentTopY ? current : nextContentTopY));
+  }, []);
+  const handleTitleLayout = useCallback((nextTitleOffsetY: number) => {
+    setTitleOffsetY((current) => (current === nextTitleOffsetY ? current : nextTitleOffsetY));
+  }, []);
+  const handleActionRowLayout = useCallback((nextActionRowStartY: number) => {
+    setActionRowStartY((current) =>
+      current === nextActionRowStartY ? current : nextActionRowStartY
+    );
+  }, []);
+
+  useEffect(() => {
+    const shouldShowStickyActions = scrollOffsetYRef.current > stickyActionRowThreshold;
+    setShowStickyActions((current) =>
+      current === shouldShowStickyActions ? current : shouldShowStickyActions
+    );
+  }, [scrollOffsetYRef, stickyActionRowThreshold]);
 
   if (!isValid) {
     return (
@@ -86,6 +150,26 @@ export default function ItemDetailScreen() {
   if (!item) {
     return <ItemDetailNotFoundState colors={colors} />;
   }
+
+  const stickyActionBar = (
+    <ItemDetailActions
+      item={item}
+      colors={colors}
+      bookmarkActionIcon={viewState.bookmarkActionIcon}
+      bookmarkActionColor={viewState.bookmarkActionColor}
+      isBookmarkActionDisabled={viewState.isBookmarkActionDisabled}
+      secondaryActionIcon={viewState.secondaryActionIcon}
+      secondaryActionColor={viewState.secondaryActionColor}
+      isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
+      onBookmarkToggle={handleToggleBookmark}
+      onSecondaryAction={handleSecondaryAction}
+      onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
+      onShare={handleShare}
+      onOpenLink={handleOpenLink}
+      useAnimatedContainer={false}
+      style={styles.stickyActionRow}
+    />
+  );
 
   if (viewState.isXPost) {
     return (
@@ -109,6 +193,14 @@ export default function ItemDetailScreen() {
         secondaryActionColor={viewState.secondaryActionColor}
         isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
         creatorData={creatorData}
+        showCollapsedTitle={showCollapsedTitle}
+        showStickyActions={showStickyActions}
+        stickyActionsTop={stickyActionsTop}
+        stickyBackdropHeight={stickyBackdropHeight}
+        onScroll={handleScroll}
+        onContentLayout={handleContentLayout}
+        onTitleLayout={handleTitleLayout}
+        onActionRowLayout={handleActionRowLayout}
       />
     );
   }
@@ -122,6 +214,13 @@ export default function ItemDetailScreen() {
         colors={colors}
         insets={insets}
         onBack={() => router.back()}
+        onScroll={handleScroll}
+        screenTitle={item.title}
+        showCollapsedTitle={showCollapsedTitle}
+        showStickyActions={showStickyActions}
+        stickyActions={stickyActionBar}
+        stickyActionsTop={stickyActionsTop}
+        stickyBackdropHeight={stickyBackdropHeight}
         headerImage={
           <Image
             source={{ uri: item.thumbnailUrl! }}
@@ -154,13 +253,27 @@ export default function ItemDetailScreen() {
           onOpenLink={handleOpenLink}
           useAnimatedActions
           useAnimatedDescription
+          onContentLayout={handleContentLayout}
+          onTitleLayout={handleTitleLayout}
+          onActionRowLayout={handleActionRowLayout}
         />
       </ItemDetailParallaxLayout>
     );
   }
 
   return (
-    <ItemDetailScrollLayout colors={colors} insets={insets} onBack={() => router.back()}>
+    <ItemDetailScrollLayout
+      colors={colors}
+      insets={insets}
+      onBack={() => router.back()}
+      onScroll={handleScroll}
+      screenTitle={item.title}
+      showCollapsedTitle={showCollapsedTitle}
+      showStickyActions={showStickyActions}
+      stickyActions={stickyActionBar}
+      stickyActionsTop={stickyActionsTop}
+      stickyBackdropHeight={stickyBackdropHeight}
+    >
       <ItemDetailContent
         item={item}
         colors={colors}
@@ -183,6 +296,9 @@ export default function ItemDetailScreen() {
         onOpenLink={handleOpenLink}
         useAnimatedActions={false}
         useAnimatedDescription={false}
+        onContentLayout={handleContentLayout}
+        onTitleLayout={handleTitleLayout}
+        onActionRowLayout={handleActionRowLayout}
       />
     </ItemDetailScrollLayout>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
@@ -1,16 +1,21 @@
 import type { Ionicons } from '@expo/vector-icons';
+import type { StyleProp, ViewStyle } from 'react-native';
 import { Pressable, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { UserItemState } from '@/hooks/use-items-trpc';
 
-import { IconActionButton } from '../../item-detail-components';
 import { getFabConfig } from '../../item-detail-helpers';
 import { styles } from '../../item-detail-styles';
 import type { ItemDetailColors, ItemDetailItem } from '../types';
+import { IconActionButton } from './ItemDetailButtons';
+
+type ItemDetailActionItem = Pick<ItemDetailItem, 'state'> & {
+  provider: ItemDetailItem['provider'] | string;
+};
 
 type ItemDetailActionsProps = {
-  item: ItemDetailItem;
+  item: ItemDetailActionItem;
   colors: ItemDetailColors;
   bookmarkActionIcon: keyof typeof Ionicons.glyphMap;
   bookmarkActionColor: string;
@@ -24,6 +29,8 @@ type ItemDetailActionsProps = {
   onShare: () => void;
   onOpenLink: () => void;
   useAnimatedContainer: boolean;
+  onLayout?: (actionRowStartY: number) => void;
+  style?: StyleProp<ViewStyle>;
 };
 
 export function ItemDetailActions({
@@ -41,13 +48,18 @@ export function ItemDetailActions({
   onShare,
   onOpenLink,
   useAnimatedContainer,
+  onLayout,
+  style,
 }: ItemDetailActionsProps) {
   const fabConfig = getFabConfig(item.provider);
   const canManageTags = item.state === UserItemState.BOOKMARKED;
   const Container = useAnimatedContainer ? Animated.View : View;
 
   return (
-    <Container style={styles.actionRow}>
+    <Container
+      style={[styles.actionRow, style]}
+      onLayout={({ nativeEvent }) => onLayout?.(nativeEvent.layout.y)}
+    >
       <View style={styles.actionRowLeft}>
         <IconActionButton
           icon={bookmarkActionIcon}

--- a/apps/mobile/app/item/detail/components/ItemDetailButtons.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailButtons.tsx
@@ -1,0 +1,60 @@
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+
+import { IconButton } from '@/components/primitives';
+import type { Colors } from '@/constants/theme';
+
+import { styles } from '../../item-detail-styles';
+
+export function IconActionButton({
+  icon,
+  color,
+  onPress,
+  disabled = false,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+  onPress?: () => void;
+  disabled?: boolean;
+}) {
+  const handlePress = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onPress?.();
+  };
+
+  return (
+    <IconButton
+      onPress={handlePress}
+      disabled={disabled}
+      size="md"
+      variant="ghost"
+      style={styles.iconActionButton}
+      accessibilityLabel={icon}
+    >
+      <Ionicons name={icon} size={24} color={color} style={{ fontWeight: '700' }} />
+    </IconButton>
+  );
+}
+
+export function HeaderIconButton({
+  icon,
+  colors,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  colors: typeof Colors.dark;
+  onPress?: () => void;
+}) {
+  return (
+    <IconButton
+      onPress={onPress}
+      size="md"
+      variant="subtle"
+      colors={colors}
+      style={[styles.headerIconButton, { backgroundColor: colors.backgroundSecondary }]}
+      accessibilityLabel={icon}
+    >
+      <Ionicons name={icon} size={20} color={colors.text} />
+    </IconButton>
+  );
+}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -30,6 +30,9 @@ type ItemDetailContentProps = {
   onOpenLink: () => void;
   useAnimatedDescription: boolean;
   useAnimatedActions: boolean;
+  onContentLayout?: (contentTopY: number) => void;
+  onTitleLayout?: (titleOffsetY: number) => void;
+  onActionRowLayout?: (actionRowStartY: number) => void;
 };
 
 export function ItemDetailContent({
@@ -52,13 +55,19 @@ export function ItemDetailContent({
   onOpenLink,
   useAnimatedActions,
   useAnimatedDescription,
+  onContentLayout,
+  onTitleLayout,
+  onActionRowLayout,
 }: ItemDetailContentProps) {
   const DescriptionContainer = useAnimatedDescription ? Animated.View : View;
 
   return (
     <>
-      <Animated.View style={styles.contentContainer}>
-        <ItemDetailHeader item={item} colors={colors} />
+      <Animated.View
+        style={styles.contentContainer}
+        onLayout={({ nativeEvent }) => onContentLayout?.(nativeEvent.layout.y)}
+      >
+        <ItemDetailHeader item={item} colors={colors} onTitleLayout={onTitleLayout} />
         <ItemDetailCreatorRow
           item={item}
           colors={colors}
@@ -83,6 +92,7 @@ export function ItemDetailContent({
         onShare={onShare}
         onOpenLink={onOpenLink}
         useAnimatedContainer={useAnimatedActions}
+        onLayout={onActionRowLayout}
       />
 
       {item.summary && (

--- a/apps/mobile/app/item/detail/components/ItemDetailFloatingBack.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailFloatingBack.tsx
@@ -1,23 +1,86 @@
-import { View } from 'react-native';
-import Animated from 'react-native-reanimated';
+import type { ReactNode } from 'react';
+import { View, Text } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 
-import { HeaderIconButton } from '../../item-detail-components';
 import { styles } from '../../item-detail-styles';
 import type { ItemDetailColors } from '../types';
+import { HeaderIconButton } from './ItemDetailButtons';
 
 type ItemDetailFloatingBackProps = {
   colors: ItemDetailColors;
   insets: EdgeInsets;
   onBack: () => void;
+  screenTitle: string;
+  showCollapsedTitle: boolean;
+  showStickyActions?: boolean;
+  stickyActions?: ReactNode;
+  stickyActionsTop?: number;
+  stickyBackdropHeight?: number;
 };
 
-export function ItemDetailFloatingBack({ colors, insets, onBack }: ItemDetailFloatingBackProps) {
+export function ItemDetailFloatingBack({
+  colors,
+  insets,
+  onBack,
+  screenTitle,
+  showCollapsedTitle,
+  showStickyActions = false,
+  stickyActions,
+  stickyActionsTop = 0,
+  stickyBackdropHeight = 0,
+}: ItemDetailFloatingBackProps) {
+  const backdropHeight = showStickyActions
+    ? stickyBackdropHeight
+    : showCollapsedTitle
+      ? insets.top + 56
+      : 0;
+
   return (
-    <View style={[styles.floatingHeader, { top: insets.top + 8 }]} pointerEvents="box-none">
-      <Animated.View>
-        <HeaderIconButton icon="chevron-back" colors={colors} onPress={onBack} />
-      </Animated.View>
+    <View style={styles.floatingOverlay} pointerEvents="box-none">
+      {backdropHeight > 0 ? (
+        <Animated.View
+          entering={FadeIn.duration(160)}
+          exiting={FadeOut.duration(160)}
+          style={[
+            styles.floatingHeaderBackdrop,
+            {
+              backgroundColor: colors.background,
+              height: backdropHeight,
+            },
+          ]}
+          pointerEvents="none"
+        />
+      ) : null}
+
+      {showCollapsedTitle ? (
+        <Animated.View
+          entering={FadeIn.duration(160)}
+          exiting={FadeOut.duration(160)}
+          style={[styles.floatingTitleContainer, { top: insets.top + 14 }]}
+          pointerEvents="none"
+        >
+          <Text style={[styles.floatingTitle, { color: colors.text }]} numberOfLines={1}>
+            {screenTitle}
+          </Text>
+        </Animated.View>
+      ) : null}
+
+      {showStickyActions && stickyActions ? (
+        <Animated.View
+          entering={FadeIn.duration(160)}
+          exiting={FadeOut.duration(160)}
+          style={[styles.stickyActionRowContainer, { top: stickyActionsTop }]}
+        >
+          {stickyActions}
+        </Animated.View>
+      ) : null}
+
+      <View style={[styles.floatingHeader, { top: insets.top + 8 }]} pointerEvents="box-none">
+        <Animated.View>
+          <HeaderIconButton icon="chevron-back" colors={colors} onPress={onBack} />
+        </Animated.View>
+      </View>
     </View>
   );
 }

--- a/apps/mobile/app/item/detail/components/ItemDetailHeader.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailHeader.tsx
@@ -8,9 +8,10 @@ import type { ItemDetailColors, ItemDetailItem } from '../types';
 type ItemDetailHeaderProps = {
   item: ItemDetailItem;
   colors: ItemDetailColors;
+  onTitleLayout?: (titleOffsetY: number) => void;
 };
 
-export function ItemDetailHeader({ item, colors }: ItemDetailHeaderProps) {
+export function ItemDetailHeader({ item, colors, onTitleLayout }: ItemDetailHeaderProps) {
   return (
     <>
       <View style={styles.badgeRow}>
@@ -18,7 +19,12 @@ export function ItemDetailHeader({ item, colors }: ItemDetailHeaderProps) {
         <TypeBadge contentType={item.contentType} />
       </View>
 
-      <Text style={[styles.title, { color: colors.text }]}>{item.title}</Text>
+      <Text
+        style={[styles.title, { color: colors.text }]}
+        onLayout={({ nativeEvent }) => onTitleLayout?.(nativeEvent.layout.y)}
+      >
+        {item.title}
+      </Text>
     </>
   );
 }

--- a/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
@@ -1,6 +1,6 @@
 import { Stack } from 'expo-router';
 import type { ReactElement, ReactNode } from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, View, type ScrollViewProps } from 'react-native';
 import Animated from 'react-native-reanimated';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 
@@ -15,6 +15,13 @@ type ItemDetailLayoutBaseProps = {
   insets: EdgeInsets;
   onBack: () => void;
   children: ReactNode;
+  onScroll: ScrollViewProps['onScroll'];
+  screenTitle: string;
+  showCollapsedTitle: boolean;
+  showStickyActions?: boolean;
+  stickyActions?: ReactNode;
+  stickyActionsTop?: number;
+  stickyBackdropHeight?: number;
 };
 
 export function ItemDetailParallaxLayout({
@@ -22,6 +29,13 @@ export function ItemDetailParallaxLayout({
   insets,
   onBack,
   children,
+  onScroll,
+  screenTitle,
+  showCollapsedTitle,
+  showStickyActions,
+  stickyActions,
+  stickyActionsTop,
+  stickyBackdropHeight,
   headerImage,
   headerAspectRatio,
 }: ItemDetailLayoutBaseProps & {
@@ -33,12 +47,26 @@ export function ItemDetailParallaxLayout({
       <Stack.Screen options={{ title: '', headerShown: false }} />
 
       <Animated.View style={styles.animatedContainer}>
-        <ParallaxScrollView headerImage={headerImage} headerAspectRatio={headerAspectRatio}>
+        <ParallaxScrollView
+          headerImage={headerImage}
+          headerAspectRatio={headerAspectRatio}
+          onScroll={onScroll}
+        >
           {children}
         </ParallaxScrollView>
       </Animated.View>
 
-      <ItemDetailFloatingBack colors={colors} insets={insets} onBack={onBack} />
+      <ItemDetailFloatingBack
+        colors={colors}
+        insets={insets}
+        onBack={onBack}
+        screenTitle={screenTitle}
+        showCollapsedTitle={showCollapsedTitle}
+        showStickyActions={showStickyActions}
+        stickyActions={stickyActions}
+        stickyActionsTop={stickyActionsTop}
+        stickyBackdropHeight={stickyBackdropHeight}
+      />
     </View>
   );
 }
@@ -48,6 +76,13 @@ export function ItemDetailScrollLayout({
   insets,
   onBack,
   children,
+  onScroll,
+  screenTitle,
+  showCollapsedTitle,
+  showStickyActions,
+  stickyActions,
+  stickyActionsTop,
+  stickyBackdropHeight,
 }: ItemDetailLayoutBaseProps) {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -57,11 +92,23 @@ export function ItemDetailScrollLayout({
         style={styles.scrollView}
         contentContainerStyle={[styles.scrollContent, { paddingTop: insets.top + 56 }]}
         showsVerticalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={32}
       >
         {children}
       </ScrollView>
 
-      <ItemDetailFloatingBack colors={colors} insets={insets} onBack={onBack} />
+      <ItemDetailFloatingBack
+        colors={colors}
+        insets={insets}
+        onBack={onBack}
+        screenTitle={screenTitle}
+        showCollapsedTitle={showCollapsedTitle}
+        showStickyActions={showStickyActions}
+        stickyActions={stickyActions}
+        stickyActionsTop={stickyActionsTop}
+        stickyBackdropHeight={stickyBackdropHeight}
+      />
     </View>
   );
 }

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -1,21 +1,21 @@
 import { Ionicons } from '@expo/vector-icons';
-import * as Haptics from 'expo-haptics';
 import { Image } from 'expo-image';
 import { Stack } from 'expo-router';
-import { View, Text, ScrollView, Pressable, Linking } from 'react-native';
+import { View, Text, ScrollView, Pressable, Linking, type ScrollViewProps } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { SourceBadge, TypeBadge } from '@/components/badges';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
-import { IconButton } from '@/components/primitives';
 import type { Colors } from '@/constants/theme';
 import { Spacing } from '@/constants/theme';
-import type { Provider } from '@/hooks/use-items-trpc';
-import { ContentType, UserItemState } from '@/hooks/use-items-trpc';
+import type { Provider, UserItemState } from '@/hooks/use-items-trpc';
+import { ContentType } from '@/hooks/use-items-trpc';
 import { formatRelativeTime } from '@/lib/format';
 import { logger } from '@/lib/logger';
 
-import { extractXHandle, getFabConfig } from './item-detail-helpers';
+import { ItemDetailActions } from './detail/components/ItemDetailActions';
+import { ItemDetailFloatingBack } from './detail/components/ItemDetailFloatingBack';
+import { extractXHandle } from './item-detail-helpers';
 import { styles, xPostStyles } from './item-detail-styles';
 
 // ============================================================================
@@ -69,67 +69,6 @@ export function LinkedText({
 }
 
 // ============================================================================
-// Icon Action Button
-// ============================================================================
-
-export function IconActionButton({
-  icon,
-  color,
-  onPress,
-  disabled = false,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  color: string;
-  onPress?: () => void;
-  disabled?: boolean;
-}) {
-  const handlePress = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onPress?.();
-  };
-
-  return (
-    <IconButton
-      onPress={handlePress}
-      disabled={disabled}
-      size="md"
-      variant="ghost"
-      style={styles.iconActionButton}
-      accessibilityLabel={icon}
-    >
-      <Ionicons name={icon} size={24} color={color} style={{ fontWeight: '700' }} />
-    </IconButton>
-  );
-}
-
-// ============================================================================
-// Floating Header Button
-// ============================================================================
-
-export function HeaderIconButton({
-  icon,
-  colors,
-  onPress,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  colors: typeof Colors.dark;
-  onPress?: () => void;
-}) {
-  return (
-    <IconButton
-      onPress={onPress}
-      size="md"
-      variant="subtle"
-      colors={colors}
-      style={[styles.headerIconButton, { backgroundColor: colors.backgroundSecondary }]}
-      accessibilityLabel={icon}
-    >
-      <Ionicons name={icon} size={20} color={colors.text} />
-    </IconButton>
-  );
-}
-
-// ============================================================================
 // X Post Body Component
 // ============================================================================
 
@@ -162,6 +101,14 @@ export function XPostBookmarkView({
   secondaryActionColor,
   isSecondaryActionDisabled,
   creatorData,
+  showCollapsedTitle,
+  showStickyActions,
+  stickyActionsTop,
+  stickyBackdropHeight,
+  onScroll,
+  onContentLayout,
+  onTitleLayout,
+  onActionRowLayout,
 }: {
   item: {
     id: string;
@@ -192,14 +139,17 @@ export function XPostBookmarkView({
   secondaryActionColor: string;
   isSecondaryActionDisabled: boolean;
   creatorData?: { handle?: string | null } | null;
+  showCollapsedTitle: boolean;
+  showStickyActions: boolean;
+  stickyActionsTop: number;
+  stickyBackdropHeight: number;
+  onScroll: ScrollViewProps['onScroll'];
+  onContentLayout: (contentTopY: number) => void;
+  onTitleLayout: (titleOffsetY: number) => void;
+  onActionRowLayout: (actionRowStartY: number) => void;
 }) {
-  const canManageTags = item.state === UserItemState.BOOKMARKED;
-
   // Extract @handle from URL as fallback if creatorData.handle not available
   const handle = creatorData?.handle || extractXHandle(item.canonicalUrl);
-
-  // Get FAB config for X
-  const fabConfig = getFabConfig(item.provider);
 
   // Check if we have a thumbnail for parallax
   const hasThumbnail = !!item.thumbnailUrl;
@@ -276,43 +226,29 @@ export function XPostBookmarkView({
         </View>
       </Animated.View>
 
-      {/* Icon Action Row */}
-      <Animated.View style={styles.actionRow}>
-        <View style={styles.actionRowLeft}>
-          <IconActionButton
-            icon={bookmarkActionIcon}
-            color={bookmarkActionColor}
-            onPress={onBookmarkToggle}
-            disabled={isBookmarkActionDisabled}
-          />
-          <IconActionButton
-            icon={secondaryActionIcon}
-            color={secondaryActionColor}
-            onPress={onSecondaryAction}
-            disabled={isSecondaryActionDisabled}
-          />
-          <IconActionButton
-            icon="add-circle-outline"
-            color={colors.textSecondary}
-            onPress={onManageTags}
-            disabled={!canManageTags}
-          />
-          <IconActionButton icon="share-outline" color={colors.textSecondary} onPress={onShare} />
-          <IconActionButton icon="ellipsis-horizontal" color={colors.textSecondary} />
-        </View>
-        <IconButton
-          onPress={onOpenLink}
-          size="lg"
-          variant="solid"
-          style={[styles.fabButton, { backgroundColor: fabConfig.backgroundColor }]}
-          accessibilityLabel="Open original source"
-        >
-          {fabConfig.providerIcon}
-        </IconButton>
-      </Animated.View>
+      <ItemDetailActions
+        item={item}
+        colors={colors}
+        bookmarkActionIcon={bookmarkActionIcon}
+        bookmarkActionColor={bookmarkActionColor}
+        isBookmarkActionDisabled={isBookmarkActionDisabled}
+        secondaryActionIcon={secondaryActionIcon}
+        secondaryActionColor={secondaryActionColor}
+        isSecondaryActionDisabled={isSecondaryActionDisabled}
+        onBookmarkToggle={onBookmarkToggle}
+        onSecondaryAction={onSecondaryAction}
+        onManageTags={onManageTags}
+        onShare={onShare}
+        onOpenLink={onOpenLink}
+        useAnimatedContainer
+        onLayout={onActionRowLayout}
+      />
 
       {/* Tweet Content Section - Twitter-like layout */}
-      <Animated.View style={xPostStyles.tweetContentSection}>
+      <Animated.View
+        style={xPostStyles.tweetContentSection}
+        onLayout={({ nativeEvent }) => onContentLayout(nativeEvent.layout.y)}
+      >
         <View style={xPostStyles.tweetRow}>
           {/* Avatar on the left */}
           {item.creatorImageUrl ? (
@@ -359,12 +295,14 @@ export function XPostBookmarkView({
             </View>
 
             {/* Tweet text with link detection */}
-            <LinkedText
-              style={[xPostStyles.postText, { color: colors.text }]}
-              linkColor={colors.primary}
-            >
-              {item.title}
-            </LinkedText>
+            <View onLayout={({ nativeEvent }) => onTitleLayout(nativeEvent.layout.y)}>
+              <LinkedText
+                style={[xPostStyles.postText, { color: colors.text }]}
+                linkColor={colors.primary}
+              >
+                {item.title}
+              </LinkedText>
+            </View>
 
             {/* Additional content from summary if different from title */}
             {item.summary && item.summary !== item.title && (
@@ -398,17 +336,41 @@ export function XPostBookmarkView({
               />
             }
             headerAspectRatio={16 / 9}
+            onScroll={onScroll}
           >
             {renderContent()}
           </ParallaxScrollView>
         </Animated.View>
 
-        {/* Floating Back Button */}
-        <View style={[styles.floatingHeader, { top: insets.top + 8 }]} pointerEvents="box-none">
-          <Animated.View>
-            <HeaderIconButton icon="chevron-back" colors={colors} onPress={onBack} />
-          </Animated.View>
-        </View>
+        <ItemDetailFloatingBack
+          colors={colors}
+          insets={insets}
+          onBack={onBack}
+          screenTitle={item.title}
+          showCollapsedTitle={showCollapsedTitle}
+          showStickyActions={showStickyActions}
+          stickyActionsTop={stickyActionsTop}
+          stickyBackdropHeight={stickyBackdropHeight}
+          stickyActions={
+            <ItemDetailActions
+              item={item}
+              colors={colors}
+              bookmarkActionIcon={bookmarkActionIcon}
+              bookmarkActionColor={bookmarkActionColor}
+              isBookmarkActionDisabled={isBookmarkActionDisabled}
+              secondaryActionIcon={secondaryActionIcon}
+              secondaryActionColor={secondaryActionColor}
+              isSecondaryActionDisabled={isSecondaryActionDisabled}
+              onBookmarkToggle={onBookmarkToggle}
+              onSecondaryAction={onSecondaryAction}
+              onManageTags={onManageTags}
+              onShare={onShare}
+              onOpenLink={onOpenLink}
+              useAnimatedContainer={false}
+              style={styles.stickyActionRow}
+            />
+          }
+        />
       </View>
     );
   }
@@ -423,17 +385,42 @@ export function XPostBookmarkView({
           style={styles.scrollView}
           contentContainerStyle={[styles.scrollContent, { paddingTop: insets.top + 56 }]}
           showsVerticalScrollIndicator={false}
+          onScroll={onScroll}
+          scrollEventThrottle={32}
         >
           {renderContent()}
         </ScrollView>
       </Animated.View>
 
-      {/* Floating Back Button */}
-      <View style={[styles.floatingHeader, { top: insets.top + 8 }]} pointerEvents="box-none">
-        <Animated.View>
-          <HeaderIconButton icon="chevron-back" colors={colors} onPress={onBack} />
-        </Animated.View>
-      </View>
+      <ItemDetailFloatingBack
+        colors={colors}
+        insets={insets}
+        onBack={onBack}
+        screenTitle={item.title}
+        showCollapsedTitle={showCollapsedTitle}
+        showStickyActions={showStickyActions}
+        stickyActionsTop={stickyActionsTop}
+        stickyBackdropHeight={stickyBackdropHeight}
+        stickyActions={
+          <ItemDetailActions
+            item={item}
+            colors={colors}
+            bookmarkActionIcon={bookmarkActionIcon}
+            bookmarkActionColor={bookmarkActionColor}
+            isBookmarkActionDisabled={isBookmarkActionDisabled}
+            secondaryActionIcon={secondaryActionIcon}
+            secondaryActionColor={secondaryActionColor}
+            isSecondaryActionDisabled={isSecondaryActionDisabled}
+            onBookmarkToggle={onBookmarkToggle}
+            onSecondaryAction={onSecondaryAction}
+            onManageTags={onManageTags}
+            onShare={onShare}
+            onOpenLink={onOpenLink}
+            useAnimatedContainer={false}
+            style={styles.stickyActionRow}
+          />
+        }
+      />
     </View>
   );
 }

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -53,6 +53,32 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     zIndex: 100,
   },
+  floatingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 100,
+  },
+  floatingHeaderBackdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  floatingTitleContainer: {
+    position: 'absolute',
+    left: 72,
+    right: 72,
+    alignItems: 'center',
+    zIndex: 101,
+  },
+  floatingTitle: {
+    ...Typography.titleMedium,
+  },
+  stickyActionRowContainer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    zIndex: 101,
+  },
   headerIconButton: {
     width: 40,
     height: 40,
@@ -154,6 +180,9 @@ export const styles = StyleSheet.create({
     marginBottom: Spacing.md,
     paddingLeft: Spacing.xl,
     paddingRight: Spacing.xl + Spacing.sm,
+  },
+  stickyActionRow: {
+    marginBottom: 0,
   },
   actionRowLeft: {
     flexDirection: 'row',

--- a/apps/mobile/components/ParallaxScrollView.tsx
+++ b/apps/mobile/components/ParallaxScrollView.tsx
@@ -13,7 +13,7 @@
 
 import { LinearGradient } from 'expo-linear-gradient';
 import type { PropsWithChildren, ReactElement } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, useWindowDimensions, View, type ScrollViewProps } from 'react-native';
 import Animated, {
   interpolate,
   useAnimatedRef,
@@ -31,6 +31,7 @@ type Props = PropsWithChildren<{
   headerAspectRatio?: number;
   /** Fraction of screen height to use for header when aspect ratio <= 1. Defaults to 0.33. */
   headerHeightFraction?: number;
+  onScroll?: ScrollViewProps['onScroll'];
 }>;
 
 export default function ParallaxScrollView({
@@ -39,6 +40,7 @@ export default function ParallaxScrollView({
   scrollEnabled = true,
   headerAspectRatio = 1,
   headerHeightFraction = 0.33,
+  onScroll,
 }: Props) {
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollViewOffset(scrollRef);
@@ -78,6 +80,7 @@ export default function ParallaxScrollView({
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: insets.bottom + 40 }}
       scrollEnabled={scrollEnabled}
+      onScroll={onScroll}
     >
       <Animated.View
         style={[styles.headerContainer, { height: headerHeight }, headerAnimatedStyle]}

--- a/apps/mobile/lib/native-large-title-header.test.ts
+++ b/apps/mobile/lib/native-large-title-header.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import {
+  getCollapsedHeaderTitleThreshold,
+  getStickyActionRowThreshold,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+
+describe('native-large-title-header', () => {
+  it('uses the default collapsed title threshold', () => {
+    const { result } = renderHook(() => useCollapsedHeaderTitle());
+
+    act(() => {
+      result.current.handleScroll({
+        nativeEvent: {
+          contentOffset: {
+            y: 44,
+          },
+        },
+      } as never);
+    });
+
+    expect(result.current.showCollapsedTitle).toBe(false);
+
+    act(() => {
+      result.current.handleScroll({
+        nativeEvent: {
+          contentOffset: {
+            y: 45,
+          },
+        },
+      } as never);
+    });
+
+    expect(result.current.showCollapsedTitle).toBe(true);
+  });
+
+  it('supports custom collapsed title thresholds', () => {
+    const { result } = renderHook(() => useCollapsedHeaderTitle({ threshold: 160 }));
+
+    act(() => {
+      result.current.handleScroll({
+        nativeEvent: {
+          contentOffset: {
+            y: 160,
+          },
+        },
+      } as never);
+    });
+
+    expect(result.current.showCollapsedTitle).toBe(false);
+
+    act(() => {
+      result.current.handleScroll({
+        nativeEvent: {
+          contentOffset: {
+            y: 161,
+          },
+        },
+      } as never);
+    });
+
+    expect(result.current.showCollapsedTitle).toBe(true);
+  });
+
+  it('derives a bookmark collapse threshold from the title start position', () => {
+    expect(getCollapsedHeaderTitleThreshold(180)).toBe(136);
+    expect(getCollapsedHeaderTitleThreshold(32)).toBe(44);
+  });
+
+  it('derives a sticky action threshold from the row start position', () => {
+    expect(getStickyActionRowThreshold(340, 120)).toBe(220);
+    expect(getStickyActionRowThreshold(90, 120)).toBe(0);
+    expect(getStickyActionRowThreshold(Number.NaN, 120)).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -1,10 +1,29 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 import { Colors } from '@/constants/theme';
 
-const COLLAPSED_TITLE_THRESHOLD = 44;
+export const COLLAPSED_TITLE_THRESHOLD = 44;
+
+export function getCollapsedHeaderTitleThreshold(
+  titleStartY: number,
+  collapsedTitleThreshold = COLLAPSED_TITLE_THRESHOLD
+) {
+  if (!Number.isFinite(titleStartY)) {
+    return collapsedTitleThreshold;
+  }
+
+  return Math.max(collapsedTitleThreshold, titleStartY - collapsedTitleThreshold);
+}
+
+export function getStickyActionRowThreshold(actionRowStartY: number, stickyTopY: number) {
+  if (!Number.isFinite(actionRowStartY) || !Number.isFinite(stickyTopY)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.max(0, actionRowStartY - stickyTopY);
+}
 
 export const lightweightHeaderStackScreenOptions: NativeStackNavigationOptions = {
   headerBackButtonDisplayMode: 'minimal',
@@ -26,6 +45,8 @@ export function createLightweightHeaderScreenOptions({
   tintColor,
   screenTitle,
   showScreenTitle = true,
+  headerStyle,
+  headerTitleStyle,
   ...options
 }: NativeStackNavigationOptions & {
   backgroundColor: string;
@@ -34,34 +55,50 @@ export function createLightweightHeaderScreenOptions({
   showScreenTitle?: boolean;
 }): NativeStackNavigationOptions {
   return {
-    ...options,
-    title: showScreenTitle ? screenTitle : '',
     headerLargeTitle: false,
     headerTransparent: false,
     headerShadowVisible: false,
+    ...options,
+    title: showScreenTitle ? screenTitle : '',
     headerTintColor: tintColor,
     headerStyle: {
       backgroundColor,
+      ...headerStyle,
     },
     headerTitleStyle: {
       color: tintColor,
+      ...headerTitleStyle,
     },
   };
 }
 
-export function useCollapsedHeaderTitle() {
+export function useCollapsedHeaderTitle({
+  threshold = COLLAPSED_TITLE_THRESHOLD,
+}: {
+  threshold?: number;
+} = {}) {
   const scrollOffsetYRef = useRef(0);
   const [showCollapsedTitle, setShowCollapsedTitle] = useState(false);
 
-  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const offsetY = event.nativeEvent.contentOffset.y;
-    scrollOffsetYRef.current = offsetY;
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const offsetY = event.nativeEvent.contentOffset.y;
+      scrollOffsetYRef.current = offsetY;
 
-    const shouldShowCollapsedTitle = offsetY > COLLAPSED_TITLE_THRESHOLD;
+      const shouldShowCollapsedTitle = offsetY > threshold;
+      setShowCollapsedTitle((current) =>
+        current === shouldShowCollapsedTitle ? current : shouldShowCollapsedTitle
+      );
+    },
+    [threshold]
+  );
+
+  useEffect(() => {
+    const shouldShowCollapsedTitle = scrollOffsetYRef.current > threshold;
     setShowCollapsedTitle((current) =>
       current === shouldShowCollapsedTitle ? current : shouldShowCollapsedTitle
     );
-  }, []);
+  }, [threshold]);
 
   return {
     handleScroll,

--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -113,7 +113,7 @@ describe('BookmarksPage', () => {
     expect(screen.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
     expect(screen.getByTestId('bookmark-detail-skeleton')).toBeVisible();
     expect(screen.getAllByTestId('bookmark-row-skeleton')).toHaveLength(6);
-    expect(screen.queryByText('Loading bookmarks')).not.toBeInTheDocument();
+    expect(screen.getByRole('status', { hidden: true })).toHaveTextContent('Loading bookmarks');
     loadingView.unmount();
 
     hookSpies.itemsLibraryUseQuery.mockReturnValueOnce({


### PR DESCRIPTION
## Summary
- Adds bookmark detail title collapse behavior so the title fades into the header area without changing its starting layout.
- Pins the bookmark action row and FAB to the top while the content scrolls underneath.
- Leaves the existing home and inbox header behavior unchanged.
- Includes TDD coverage for the shared collapse/sticky threshold logic and a web test fix required by the repo hook.

## Notes
- Manual simulator verification was performed on the mobile flow.
- The branch includes a follow-up test adjustment in `apps/web/src/bookmarks-page.test.tsx` to satisfy pre-push checks.