### PR TITLE
refactor: tighten typing and remove legacy fallback code

### DIFF
--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -68,10 +68,6 @@ export function LinkedText({
   );
 }
 
-// ============================================================================
-// Icon Action Button
-// ============================================================================
-
 export function IconActionButton({
   icon,
   color,
@@ -101,10 +97,6 @@ export function IconActionButton({
     </IconButton>
   );
 }
-
-// ============================================================================
-// Floating Header Button
-// ============================================================================
 
 export function HeaderIconButton({
   icon,

--- a/apps/mobile/components/creator/CreatorBookmarks.test.ts
+++ b/apps/mobile/components/creator/CreatorBookmarks.test.ts
@@ -7,8 +7,6 @@
  * - Empty state
  * - Success state with items
  * - Infinite scroll pagination
- *
- * @see Task zine-k472 for requirements
  */
 
 // ============================================================================

--- a/apps/mobile/components/creator/CreatorLatestContent.test.ts
+++ b/apps/mobile/components/creator/CreatorLatestContent.test.ts
@@ -9,8 +9,6 @@
  * - Error state
  * - Empty state
  * - Success state with content carousel
- *
- * @see Task zine-1yfa for requirements
  */
 
 import React from 'react';

--- a/apps/mobile/components/creator/LatestContentCard.test.ts
+++ b/apps/mobile/components/creator/LatestContentCard.test.ts
@@ -8,8 +8,6 @@
  * - Showing published date
  * - Showing "Saved" badge when bookmarked
  * - Handling press to open URL
- *
- * @see Task zine-1yfa for requirements
  */
 
 import { type LatestContentItem } from './LatestContentCard';

--- a/apps/mobile/hooks/use-bookmarks.test.ts
+++ b/apps/mobile/hooks/use-bookmarks.test.ts
@@ -5,8 +5,6 @@
  * - isValidUrl() validation function
  * - usePreview hook behavior
  * - useSaveBookmark hook behavior
- *
- * @see Task zine-e40.7 for requirements
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';

--- a/apps/mobile/hooks/use-creator.test.ts
+++ b/apps/mobile/hooks/use-creator.test.ts
@@ -7,8 +7,6 @@
  * - useCreatorPublications hook behavior with pagination
  * - useCreatorLatestContent hook behavior
  * - useCreatorSubscription hook behavior with optimistic updates
- *
- * @see Task zine-8791 for requirements
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';

--- a/apps/mobile/hooks/use-offline-mutation.ts
+++ b/apps/mobile/hooks/use-offline-mutation.ts
@@ -25,7 +25,7 @@ import { createMobileActionTraceContext, runWithMobileActionTrace } from '../lib
  *
  * @template TPayload - The type of payload the mutation accepts
  */
-export interface UseOfflineMutationOptions<TPayload> {
+export interface UseOfflineMutationOptions<TPayload extends object> {
   /**
    * The action type for offline queue identification.
    * Maps to tRPC mutation endpoints when queue is processed.
@@ -69,7 +69,7 @@ export interface UseOfflineMutationOptions<TPayload> {
 /**
  * Return type of useOfflineMutation hook.
  */
-export interface UseOfflineMutationResult<TPayload> {
+export interface UseOfflineMutationResult<TPayload extends object> {
   /**
    * Execute the mutation. Will either run immediately (if online)
    * or queue for later execution (if offline).
@@ -103,8 +103,7 @@ export interface UseOfflineMutationResult<TPayload> {
  *
  * In both cases, onOptimisticUpdate is called first to provide immediate UI feedback.
  *
- * @template TPayload - The mutation payload type (must extend Record<string, unknown>
- *                      for serialization to offline queue)
+ * @template TPayload - The mutation payload type
  *
  * @example
  * ```tsx
@@ -140,7 +139,7 @@ export interface UseOfflineMutationResult<TPayload> {
  * </Button>
  * ```
  */
-export function useOfflineMutation<TPayload extends Record<string, unknown>>({
+export function useOfflineMutation<TPayload extends object>({
   actionType,
   mutationFn,
   onOptimisticUpdate,

--- a/apps/mobile/hooks/use-subscriptions.ts
+++ b/apps/mobile/hooks/use-subscriptions.ts
@@ -29,42 +29,12 @@ import { mapSubscriptionsResponse } from './use-subscriptions-query';
 
 // Re-export types for convenience
 export type { Subscription, SubscriptionsResponse, SubscriptionProvider };
+export type SubscribePayload = AddSubscriptionInput;
+export type UnsubscribePayload = RemoveSubscriptionInput;
 
 // ============================================================================
 // Types
 // ============================================================================
-
-/**
- * Payload for subscribing to a channel/show.
- *
- * The index signature allows this interface to satisfy Record<string, unknown>
- * constraint required by useOfflineMutation for serialization to the offline queue.
- */
-export interface SubscribePayload {
-  /** The content provider */
-  provider: AddSubscriptionInput['provider'];
-  /** Provider-specific channel/show ID */
-  providerChannelId: string;
-  /** Display name of the channel/show */
-  name: string;
-  /** Optional thumbnail URL */
-  imageUrl?: string;
-  /** Index signature for Record<string, unknown> compatibility */
-  [key: string]: unknown;
-}
-
-/**
- * Payload for unsubscribing from a channel/show.
- *
- * The index signature allows this interface to satisfy Record<string, unknown>
- * constraint required by useOfflineMutation for serialization to the offline queue.
- */
-export interface UnsubscribePayload {
-  /** The subscription ID to remove */
-  subscriptionId: RemoveSubscriptionInput['subscriptionId'];
-  /** Index signature for Record<string, unknown> compatibility */
-  [key: string]: unknown;
-}
 
 /**
  * Return type for the useSubscriptions hook.
@@ -82,7 +52,7 @@ export interface UseSubscriptionsReturn {
 
   // Subscribe mutation
   /** Subscribe to a channel/show */
-  subscribe: (payload: SubscribePayload) => void;
+  subscribe: (payload: AddSubscriptionInput) => void;
   /** Whether a subscribe mutation is in progress */
   isSubscribing: boolean;
   /** Whether a subscribe action was queued for offline execution */
@@ -90,7 +60,7 @@ export interface UseSubscriptionsReturn {
 
   // Unsubscribe mutation
   /** Unsubscribe from a channel/show */
-  unsubscribe: (payload: UnsubscribePayload) => void;
+  unsubscribe: (payload: RemoveSubscriptionInput) => void;
   /** Whether an unsubscribe mutation is in progress */
   isUnsubscribing: boolean;
   /** Whether an unsubscribe action was queued for offline execution */
@@ -204,17 +174,12 @@ export function useSubscriptions(): UseSubscriptionsReturn {
     mutate: subscribe,
     isPending: isSubscribing,
     isQueued: subscribeQueued,
-  } = useOfflineMutation<SubscribePayload>({
+  } = useOfflineMutation<AddSubscriptionInput>({
     actionType: 'SUBSCRIBE',
 
     // Execute the actual mutation when online
     mutationFn: async (payload) => {
-      await utils.client.subscriptions.add.mutate({
-        provider: payload.provider,
-        providerChannelId: payload.providerChannelId,
-        name: payload.name,
-        imageUrl: payload.imageUrl,
-      });
+      await utils.client.subscriptions.add.mutate(payload);
     },
 
     // Apply optimistic update to cache immediately
@@ -275,14 +240,12 @@ export function useSubscriptions(): UseSubscriptionsReturn {
     mutate: unsubscribe,
     isPending: isUnsubscribing,
     isQueued: unsubscribeQueued,
-  } = useOfflineMutation<UnsubscribePayload>({
+  } = useOfflineMutation<RemoveSubscriptionInput>({
     actionType: 'UNSUBSCRIBE',
 
     // Execute the actual mutation when online
     mutationFn: async (payload) => {
-      await utils.client.subscriptions.remove.mutate({
-        subscriptionId: payload.subscriptionId,
-      });
+      await utils.client.subscriptions.remove.mutate(payload);
     },
 
     // Apply optimistic update to cache immediately
@@ -350,7 +313,7 @@ export function useSubscriptions(): UseSubscriptionsReturn {
  * All nullable fields are set to null, and status is ACTIVE.
  */
 function createTempSubscriptionRow(
-  payload: SubscribePayload
+  payload: AddSubscriptionInput
 ): SubscriptionsListOutput['items'][number] {
   return {
     id: `temp-${Date.now()}`,
@@ -358,7 +321,7 @@ function createTempSubscriptionRow(
     provider: payload.provider,
     providerChannelId: payload.providerChannelId,
     creatorId: null,
-    name: payload.name,
+    name: payload.name ?? 'Unknown',
     imageUrl: payload.imageUrl ?? null,
     description: null,
     externalUrl: null,

--- a/apps/mobile/lib/analytics.ts
+++ b/apps/mobile/lib/analytics.ts
@@ -174,8 +174,6 @@ class Analytics {
         properties: formatProperties(properties as Record<string, unknown>),
       });
     }
-
-    // Production analytics intentionally no-op until a provider is selected (zine-x5ut.4.3).
   }
 
   /**
@@ -191,8 +189,6 @@ class Analytics {
     if (isDev()) {
       analyticsLogger.info('Identify user', { userId, traits });
     }
-
-    // Production analytics intentionally no-op until a provider is selected (zine-x5ut.4.3).
   }
 
   /**
@@ -202,8 +198,6 @@ class Analytics {
     if (isDev()) {
       analyticsLogger.info('Analytics reset');
     }
-
-    // Production analytics intentionally no-op until a provider is selected (zine-x5ut.4.3).
   }
 }
 

--- a/apps/mobile/lib/offline-queue.test.ts
+++ b/apps/mobile/lib/offline-queue.test.ts
@@ -12,6 +12,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import NetInfo from '@react-native-community/netinfo';
+import { Provider } from '@zine/shared';
 
 // ============================================================================
 // Module-level Mocks
@@ -52,14 +53,11 @@ process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY = 'test-clerk-key';
 const QUEUE_KEY = 'zine:offline_action_queue';
 
 // Import after mocks are set up
-import {
-  offlineQueue,
-  type OfflineAction,
-  type OfflineActionType,
-  type ErrorClassification,
-} from './offline-queue';
+import { offlineQueue, type OfflineAction, type OfflineActionType } from './offline-queue';
 import { createOfflineTRPCClient, notifyQueueProcessed } from './trpc-offline-client';
 import { getClerkInstance } from '@clerk/clerk-expo';
+import type { ErrorClassification } from './error-utils';
+import type { AddSubscriptionInput, RemoveSubscriptionInput } from './trpc-types';
 
 // Helper to reset queue state between tests
 async function resetQueue(): Promise<void> {
@@ -83,17 +81,50 @@ function getSavedQueue(): OfflineAction[] {
 }
 
 // Create a test action
-function createTestAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+function createSubscribePayload(
+  overrides: Partial<AddSubscriptionInput> = {}
+): AddSubscriptionInput {
   return {
+    provider: Provider.YOUTUBE,
+    providerChannelId: 'UC_TEST_CHANNEL',
+    name: 'Test Channel',
+    ...overrides,
+  };
+}
+
+function createUnsubscribePayload(
+  overrides: Partial<RemoveSubscriptionInput> = {}
+): RemoveSubscriptionInput {
+  return {
+    subscriptionId: 'sub-123',
+    ...overrides,
+  };
+}
+
+function createTestAction(overrides: Partial<OfflineAction> = {}): OfflineAction {
+  const base = {
     id: 'test-action-id',
-    type: 'SUBSCRIBE',
-    payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
     traceId: 'trc_test_action',
     createdAt: Date.now(),
     retryCount: 0,
     authRetryCount: 0,
-    ...overrides,
   };
+
+  if (overrides.type === 'UNSUBSCRIBE') {
+    return {
+      ...base,
+      type: 'UNSUBSCRIBE',
+      payload: createUnsubscribePayload(),
+      ...overrides,
+    } as OfflineAction;
+  }
+
+  return {
+    ...base,
+    type: 'SUBSCRIBE',
+    payload: createSubscribePayload(),
+    ...overrides,
+  } as OfflineAction;
 }
 
 // ============================================================================
@@ -134,7 +165,7 @@ describe('OfflineActionQueue', () => {
     it('adds action to queue with ULID', async () => {
       const id = await offlineQueue.enqueue({
         type: 'SUBSCRIBE',
-        payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
+        payload: createSubscribePayload(),
       });
 
       expect(id).toBeDefined();
@@ -145,7 +176,7 @@ describe('OfflineActionQueue', () => {
     it('persists action to AsyncStorage', async () => {
       await offlineQueue.enqueue({
         type: 'SUBSCRIBE',
-        payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
+        payload: createSubscribePayload(),
       });
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(
@@ -157,7 +188,7 @@ describe('OfflineActionQueue', () => {
     it('initializes retry counts to zero', async () => {
       await offlineQueue.enqueue({
         type: 'SUBSCRIBE',
-        payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
+        payload: createSubscribePayload(),
       });
 
       const savedQueue = getSavedQueue();
@@ -169,7 +200,7 @@ describe('OfflineActionQueue', () => {
     it('stores a trace ID for later replay correlation', async () => {
       await offlineQueue.enqueue({
         type: 'SUBSCRIBE',
-        payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
+        payload: createSubscribePayload(),
       });
 
       const savedQueue = getSavedQueue();
@@ -180,7 +211,7 @@ describe('OfflineActionQueue', () => {
       const beforeEnqueue = Date.now();
       await offlineQueue.enqueue({
         type: 'SUBSCRIBE',
-        payload: {},
+        payload: createSubscribePayload(),
       });
       const afterEnqueue = Date.now();
 
@@ -209,7 +240,10 @@ describe('OfflineActionQueue', () => {
 
       for (const type of actionTypes) {
         await resetQueue();
-        await offlineQueue.enqueue({ type, payload: {} });
+        await offlineQueue.enqueue({
+          type,
+          payload: type === 'SUBSCRIBE' ? createSubscribePayload() : createUnsubscribePayload(),
+        });
         const savedQueue = getSavedQueue();
         expect(savedQueue[0].type).toBe(type);
       }
@@ -285,7 +319,7 @@ describe('OfflineActionQueue', () => {
       const listener = jest.fn();
       const unsubscribe = offlineQueue.subscribe(listener);
 
-      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: {} });
+      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: createSubscribePayload() });
 
       expect(listener).toHaveBeenCalled();
 
@@ -301,7 +335,7 @@ describe('OfflineActionQueue', () => {
       // Clear previous calls
       listener.mockClear();
 
-      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: {} });
+      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: createSubscribePayload() });
 
       // Listener should not be called after unsubscribe
       expect(listener).not.toHaveBeenCalled();
@@ -314,7 +348,7 @@ describe('OfflineActionQueue', () => {
       const unsub1 = offlineQueue.subscribe(listener1);
       const unsub2 = offlineQueue.subscribe(listener2);
 
-      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: {} });
+      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: createSubscribePayload() });
 
       expect(listener1).toHaveBeenCalled();
       expect(listener2).toHaveBeenCalled();
@@ -333,7 +367,7 @@ describe('OfflineActionQueue', () => {
       const unsub2 = offlineQueue.subscribe(goodListener);
 
       // Should not throw
-      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: {} });
+      await offlineQueue.enqueue({ type: 'SUBSCRIBE', payload: createSubscribePayload() });
 
       // Both listeners should be called despite the error
       expect(errorListener).toHaveBeenCalled();
@@ -370,7 +404,7 @@ describe('OfflineActionQueue', () => {
 
 describe('Queue Processing', () => {
   let mockTrpcClient: {
-    sources: {
+    subscriptions: {
       add: { mutate: jest.Mock };
       remove: { mutate: jest.Mock };
     };
@@ -381,7 +415,7 @@ describe('Queue Processing', () => {
 
     // Set up mock tRPC client
     mockTrpcClient = {
-      sources: {
+      subscriptions: {
         add: { mutate: jest.fn().mockResolvedValue({}) },
         remove: { mutate: jest.fn().mockResolvedValue({}) },
       },
@@ -407,7 +441,7 @@ describe('Queue Processing', () => {
 
       await offlineQueue.processQueue();
 
-      expect(mockTrpcClient.sources.add.mutate).not.toHaveBeenCalled();
+      expect(mockTrpcClient.subscriptions.add.mutate).not.toHaveBeenCalled();
     });
 
     it('replays queued actions with the persisted trace ID', async () => {
@@ -433,7 +467,7 @@ describe('Queue Processing', () => {
 
       await offlineQueue.processQueue();
 
-      expect(mockTrpcClient.sources.add.mutate).not.toHaveBeenCalled();
+      expect(mockTrpcClient.subscriptions.add.mutate).not.toHaveBeenCalled();
     });
 
     it('processes when online and reachable', async () => {
@@ -442,7 +476,7 @@ describe('Queue Processing', () => {
 
       await offlineQueue.processQueue();
 
-      expect(mockTrpcClient.sources.add.mutate).toHaveBeenCalled();
+      expect(mockTrpcClient.subscriptions.add.mutate).toHaveBeenCalled();
     });
   });
 
@@ -450,25 +484,25 @@ describe('Queue Processing', () => {
     it('executes SUBSCRIBE action', async () => {
       const action = createTestAction({
         type: 'SUBSCRIBE',
-        payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@test' },
+        payload: createSubscribePayload(),
       });
       mockQueueContents([action]);
 
       await offlineQueue.processQueue();
 
-      expect(mockTrpcClient.sources.add.mutate).toHaveBeenCalledWith(action.payload);
+      expect(mockTrpcClient.subscriptions.add.mutate).toHaveBeenCalledWith(action.payload);
     });
 
     it('executes UNSUBSCRIBE action', async () => {
       const action = createTestAction({
         type: 'UNSUBSCRIBE',
-        payload: { id: 'sub-123' },
+        payload: { subscriptionId: 'sub-123' },
       });
       mockQueueContents([action]);
 
       await offlineQueue.processQueue();
 
-      expect(mockTrpcClient.sources.remove.mutate).toHaveBeenCalledWith(action.payload);
+      expect(mockTrpcClient.subscriptions.remove.mutate).toHaveBeenCalledWith(action.payload);
     });
 
     it('removes successful action from queue', async () => {
@@ -492,19 +526,31 @@ describe('Queue Processing', () => {
 
     it('processes multiple actions in order', async () => {
       const actions = [
-        createTestAction({ id: 'action-1', type: 'SUBSCRIBE', payload: { order: 1 } }),
-        createTestAction({ id: 'action-2', type: 'SUBSCRIBE', payload: { order: 2 } }),
-        createTestAction({ id: 'action-3', type: 'SUBSCRIBE', payload: { order: 3 } }),
+        createTestAction({
+          id: 'action-1',
+          type: 'SUBSCRIBE',
+          payload: createSubscribePayload({ providerChannelId: 'channel-1', name: 'Channel 1' }),
+        }),
+        createTestAction({
+          id: 'action-2',
+          type: 'SUBSCRIBE',
+          payload: createSubscribePayload({ providerChannelId: 'channel-2', name: 'Channel 2' }),
+        }),
+        createTestAction({
+          id: 'action-3',
+          type: 'SUBSCRIBE',
+          payload: createSubscribePayload({ providerChannelId: 'channel-3', name: 'Channel 3' }),
+        }),
       ];
       mockQueueContents(actions);
 
       await offlineQueue.processQueue();
 
-      const calls = mockTrpcClient.sources.add.mutate.mock.calls;
+      const calls = mockTrpcClient.subscriptions.add.mutate.mock.calls;
       expect(calls).toHaveLength(3);
-      expect(calls[0][0].order).toBe(1);
-      expect(calls[1][0].order).toBe(2);
-      expect(calls[2][0].order).toBe(3);
+      expect(calls[0][0].providerChannelId).toBe('channel-1');
+      expect(calls[1][0].providerChannelId).toBe('channel-2');
+      expect(calls[2][0].providerChannelId).toBe('channel-3');
     });
   });
 
@@ -515,7 +561,7 @@ describe('Queue Processing', () => {
         mockQueueContents([action]);
 
         // Simulate 409 Conflict error
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 409, code: 'CONFLICT' },
           message: 'Already subscribed',
         });
@@ -533,7 +579,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 400 },
           message: 'Invalid payload',
         });
@@ -548,7 +594,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 400 },
           message: 'Invalid payload',
         });
@@ -564,7 +610,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue(
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(
           new TypeError('Network request failed')
         );
 
@@ -580,7 +626,7 @@ describe('Queue Processing', () => {
         const action = createTestAction({ retryCount: 3 }); // Already at MAX_RETRIES
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue(
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(
           new TypeError('Network request failed')
         );
 
@@ -595,7 +641,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue(new Error('Connection timeout'));
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(new Error('Connection timeout'));
 
         await offlineQueue.processQueue();
 
@@ -609,7 +655,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 500 },
           message: 'Internal server error',
         });
@@ -635,7 +681,7 @@ describe('Queue Processing', () => {
         });
 
         // First call fails with 401, second succeeds after refresh
-        mockTrpcClient.sources.add.mutate
+        mockTrpcClient.subscriptions.add.mutate
           .mockRejectedValueOnce({
             data: { httpStatus: 401, code: 'UNAUTHORIZED' },
             message: 'Token expired',
@@ -661,7 +707,7 @@ describe('Queue Processing', () => {
           },
         });
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 401, code: 'UNAUTHORIZED' },
           message: 'Token expired',
         });
@@ -678,7 +724,7 @@ describe('Queue Processing', () => {
         const action = createTestAction({ authRetryCount: 1 }); // Already at limit
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: 401, code: 'UNAUTHORIZED' },
           message: 'Token expired',
         });
@@ -696,7 +742,7 @@ describe('Queue Processing', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           someUnknownProperty: 'value',
         });
 
@@ -728,20 +774,26 @@ describe('Queue Processing', () => {
       await offlineQueue.processQueue();
 
       // Both calls should complete successfully
-      expect(mockTrpcClient.sources.add.mutate).toHaveBeenCalledTimes(2);
+      expect(mockTrpcClient.subscriptions.add.mutate).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('partial success handling', () => {
     it('processes remaining actions after one fails', async () => {
       const actions = [
-        createTestAction({ id: 'fail-action', payload: { fail: true } }),
-        createTestAction({ id: 'success-action', payload: { fail: false } }),
+        createTestAction({
+          id: 'fail-action',
+          payload: createSubscribePayload({ providerChannelId: 'UC_FAIL' }),
+        }),
+        createTestAction({
+          id: 'success-action',
+          payload: createSubscribePayload({ providerChannelId: 'UC_SUCCESS' }),
+        }),
       ];
       mockQueueContents(actions);
 
       // First action fails, second succeeds
-      mockTrpcClient.sources.add.mutate
+      mockTrpcClient.subscriptions.add.mutate
         .mockRejectedValueOnce(new TypeError('Network request failed'))
         .mockResolvedValueOnce({});
 
@@ -765,7 +817,7 @@ describe('Queue Processing', () => {
 
 describe('Error Classification Integration', () => {
   let mockTrpcClient: {
-    sources: {
+    subscriptions: {
       add: { mutate: jest.Mock };
       remove: { mutate: jest.Mock };
     };
@@ -775,7 +827,7 @@ describe('Error Classification Integration', () => {
     await resetQueue();
 
     mockTrpcClient = {
-      sources: {
+      subscriptions: {
         add: { mutate: jest.fn() },
         remove: { mutate: jest.fn() },
       },
@@ -793,7 +845,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue(new TypeError('Failed to fetch'));
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(new TypeError('Failed to fetch'));
 
       await offlineQueue.processQueue();
 
@@ -805,7 +857,9 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue(new Error('Request timeout exceeded'));
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(
+        new Error('Request timeout exceeded')
+      );
 
       await offlineQueue.processQueue();
 
@@ -817,7 +871,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue(new Error('Connection refused'));
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(new Error('Connection refused'));
 
       await offlineQueue.processQueue();
 
@@ -829,7 +883,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue(new Error('Request aborted'));
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue(new Error('Request aborted'));
 
       await offlineQueue.processQueue();
 
@@ -862,7 +916,7 @@ describe('Error Classification Integration', () => {
         const action = createTestAction();
         mockQueueContents([action]);
 
-        mockTrpcClient.sources.add.mutate.mockRejectedValue({
+        mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
           data: { httpStatus: status, code },
           message: `HTTP ${status} error`,
         });
@@ -892,7 +946,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue({
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
         data: { httpStatus: 500, code: 'INTERNAL_SERVER_ERROR' },
       });
 
@@ -906,7 +960,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue({
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
         data: { code: 'UNAUTHORIZED' },
       });
 
@@ -921,7 +975,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue({
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
         status: 503,
         message: 'Service unavailable',
       });
@@ -936,7 +990,7 @@ describe('Error Classification Integration', () => {
       const action = createTestAction();
       mockQueueContents([action]);
 
-      mockTrpcClient.sources.add.mutate.mockRejectedValue({
+      mockTrpcClient.subscriptions.add.mutate.mockRejectedValue({
         statusCode: 404,
         message: 'Not found',
       });

--- a/apps/mobile/lib/offline-queue.ts
+++ b/apps/mobile/lib/offline-queue.ts
@@ -25,14 +25,10 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import NetInfo from '@react-native-community/netinfo';
 import { createTraceId } from '@zine/shared';
 import { ulid } from 'ulid';
-import type { createOfflineTRPCClient } from './trpc-offline-client';
 import { offlineLogger } from './logger';
 import { classifyErrorLegacy, type ErrorClassification } from './error-utils';
 import { CLERK_PUBLISHABLE_KEY, tokenCache } from './auth';
 import type { AddSubscriptionInput, RemoveSubscriptionInput } from './trpc-types';
-
-// Re-export for backward compatibility
-export type { ErrorClassification } from './error-utils';
 
 // ============================================================================
 // Constants
@@ -52,16 +48,22 @@ const AUTH_RETRY_LIMIT = 1; // Only retry auth errors once after token refresh
  */
 export type OfflineActionType = 'SUBSCRIBE' | 'UNSUBSCRIBE';
 
+type SubscribeOfflineAction = {
+  type: 'SUBSCRIBE';
+  payload: AddSubscriptionInput;
+};
+
+type UnsubscribeOfflineAction = {
+  type: 'UNSUBSCRIBE';
+  payload: RemoveSubscriptionInput;
+};
+
 /**
  * A queued offline action with metadata for retry handling.
  */
-export interface OfflineAction {
+export type OfflineAction = (SubscribeOfflineAction | UnsubscribeOfflineAction) & {
   /** ULID for ordering (lexicographically sortable by creation time) */
   id: string;
-  /** The type of mutation to perform */
-  type: OfflineActionType;
-  /** Mutation payload (specific to action type) */
-  payload: Record<string, unknown>;
   /** Logical trace ID for the originating user action */
   traceId?: string;
   /** Timestamp when the action was created */
@@ -74,21 +76,12 @@ export interface OfflineAction {
   lastError?: string;
   /** Last error classification for UI display */
   lastErrorType?: ErrorClassification;
-}
+};
 
 /**
  * Callback type for queue change listeners.
  */
 type QueueListener = () => void;
-
-type LegacySourcesMutations = {
-  sources?: {
-    add?: { mutate: (input: AddSubscriptionInput) => Promise<unknown> };
-    remove?: { mutate: (input: RemoveSubscriptionInput) => Promise<unknown> };
-  };
-};
-
-type OfflineQueueTRPCClient = ReturnType<typeof createOfflineTRPCClient> & LegacySourcesMutations;
 
 /**
  * Result of processing a single action.
@@ -178,20 +171,30 @@ class OfflineActionQueue {
    */
   async enqueue(action: {
     type: OfflineActionType;
-    payload: Record<string, unknown>;
+    payload: object;
     traceId?: string;
   }): Promise<string> {
     const queue = await this.getQueue();
 
-    const queuedAction: OfflineAction = {
+    const metadata = {
       id: ulid(),
-      type: action.type,
-      payload: action.payload,
       traceId: action.traceId ?? createTraceId(),
       createdAt: Date.now(),
       retryCount: 0,
       authRetryCount: 0,
     };
+    const queuedAction: OfflineAction =
+      action.type === 'SUBSCRIBE'
+        ? {
+            ...metadata,
+            type: action.type,
+            payload: action.payload as AddSubscriptionInput,
+          }
+        : {
+            ...metadata,
+            type: action.type,
+            payload: action.payload as RemoveSubscriptionInput,
+          };
 
     queue.push(queuedAction);
     await this.saveQueue(queue);
@@ -515,32 +518,16 @@ class OfflineActionQueue {
     const client = createOfflineTRPCClient({
       traceId: action.traceId ?? `trc_offline_${action.id}`,
       clientRequestId: action.id,
-    }) as OfflineQueueTRPCClient;
+    });
 
-    // Map action types to tRPC mutations. Legacy `sources` route is kept as
-    // a fallback for older test/mocked clients.
     switch (action.type) {
       case 'SUBSCRIBE': {
-        const payload = action.payload as AddSubscriptionInput;
-        if (client.sources?.add?.mutate) {
-          // Legacy router path
-          await client.sources.add.mutate(payload);
-        } else {
-          // Current router path
-          await client.subscriptions.add.mutate(payload);
-        }
+        await client.subscriptions.add.mutate(action.payload);
         break;
       }
 
       case 'UNSUBSCRIBE': {
-        const payload = action.payload as RemoveSubscriptionInput;
-        if (client.sources?.remove?.mutate) {
-          // Legacy router path
-          await client.sources.remove.mutate(payload);
-        } else {
-          // Current router path
-          await client.subscriptions.remove.mutate(payload);
-        }
+        await client.subscriptions.remove.mutate(action.payload);
         break;
       }
     }
@@ -560,7 +547,7 @@ class OfflineActionQueue {
  *
  * await offlineQueue.enqueue({
  *   type: 'SUBSCRIBE',
- *   payload: { provider: 'YOUTUBE', feedUrl: 'https://youtube.com/@channel' }
+ *   payload: { provider: 'YOUTUBE', providerChannelId: 'UC...' }
  * });
  * ```
  */

--- a/apps/worker/src/admin/repair-subscriptions.ts
+++ b/apps/worker/src/admin/repair-subscriptions.ts
@@ -23,7 +23,7 @@
  */
 
 import { eq, sql, and } from 'drizzle-orm';
-import type { DrizzleD1Database } from 'drizzle-orm/d1';
+import type { Database } from '../db';
 import { subscriptions, subscriptionItems, items } from '../db/schema';
 import { logger } from '../lib/logger';
 
@@ -121,7 +121,7 @@ const repairLogger = logger.child('admin:repair');
  * @returns List of corrupted subscriptions with diagnosis info
  */
 export async function findCorruptedSubscriptions(
-  db: DrizzleD1Database,
+  db: Database,
   options?: {
     /** Filter by provider (default: 'SPOTIFY') */
     provider?: string;
@@ -277,7 +277,7 @@ export function generateRepairReport(result: FindCorruptedResult): string {
  * @returns Repair operation result
  */
 export async function repairCorruptedSubscriptions(
-  db: DrizzleD1Database,
+  db: Database,
   options?: {
     /** If true, only report what would be done without making changes */
     dryRun?: boolean;
@@ -409,7 +409,7 @@ export async function repairCorruptedSubscriptions(
  * @returns Verification result
  */
 export async function verifyRepairs(
-  db: DrizzleD1Database,
+  db: Database,
   options?: {
     provider?: string;
     userId?: string;

--- a/apps/worker/src/polling/adaptive.ts
+++ b/apps/worker/src/polling/adaptive.ts
@@ -15,8 +15,7 @@
  */
 
 import { desc, eq } from 'drizzle-orm';
-import type { DrizzleD1Database } from 'drizzle-orm/d1';
-import type * as schema from '../db/schema';
+import type { Database } from '../db';
 import { subscriptions, subscriptionItems } from '../db/schema';
 import { pollLogger } from '../lib/logger';
 
@@ -25,7 +24,7 @@ const adaptiveLogger = pollLogger.child('adaptive');
 /**
  * Database type with full schema inference
  */
-type DrizzleDB = DrizzleD1Database<typeof schema>;
+type DrizzleDB = Database;
 
 // ============================================================================
 // Types

--- a/apps/worker/src/polling/types.ts
+++ b/apps/worker/src/polling/types.ts
@@ -7,8 +7,7 @@
  * @see /features/subscriptions/backend-spec.md Section 3: Polling Architecture
  */
 
-import type { DrizzleD1Database } from 'drizzle-orm/d1';
-import type * as schema from '../db/schema';
+import type { Database } from '../db';
 import type { subscriptions, creators } from '../db/schema';
 import type { Bindings } from '../types';
 import { YOUTUBE_SHORTS_MAX_DURATION_SECONDS } from '@zine/shared';
@@ -20,7 +19,7 @@ import { YOUTUBE_SHORTS_MAX_DURATION_SECONDS } from '@zine/shared';
 /**
  * Database type with full schema inference
  */
-export type DrizzleDB = DrizzleD1Database<typeof schema>;
+export type DrizzleDB = Database;
 
 /**
  * Subscription row from database (normalized - no name/imageUrl fields)

--- a/apps/worker/src/providers/youtube.test.ts
+++ b/apps/worker/src/providers/youtube.test.ts
@@ -21,7 +21,6 @@ import {
   createYouTubeClient,
   getChannelDetails,
   getUploadsPlaylistId,
-  getChannelUploadsPlaylistId,
   getYouTubeClientForConnection,
   fetchRecentVideos,
   fetchVideoDetails,
@@ -30,7 +29,6 @@ import {
   getAllUserSubscriptions,
   searchChannels,
   extractVideoInfo,
-  parseISO8601Duration,
 } from './youtube';
 import { mockLogger } from '../test/mock-logger';
 
@@ -417,29 +415,6 @@ describe('getUploadsPlaylistId', () => {
   it('should throw for empty string', () => {
     expect(() => getUploadsPlaylistId('')).toThrow(
       'Invalid YouTube channel ID: . Expected UC prefix.'
-    );
-  });
-});
-
-// ============================================================================
-// getChannelUploadsPlaylistId Tests (Deprecated API-based function)
-// ============================================================================
-
-describe('getChannelUploadsPlaylistId (deprecated)', () => {
-  it('should return uploads playlist ID via deterministic mapping', async () => {
-    const client = createMockYouTubeClient();
-
-    const result = await getChannelUploadsPlaylistId(client, 'UCxxxxxx');
-
-    expect(result).toBe('UUxxxxxx');
-    expect(mockChannelsList).not.toHaveBeenCalled();
-  });
-
-  it('should throw for invalid channel ID', async () => {
-    const client = createMockYouTubeClient();
-
-    await expect(getChannelUploadsPlaylistId(client, 'invalid123')).rejects.toThrow(
-      'Invalid YouTube channel ID: invalid123. Expected UC prefix.'
     );
   });
 });
@@ -1414,29 +1389,6 @@ describe('extractVideoInfo', () => {
     const result = extractVideoInfo(item);
 
     expect(result.videoId).toBeNull();
-  });
-});
-
-// ============================================================================
-// parseISO8601Duration Tests (re-exported from duration module)
-// ============================================================================
-
-describe('parseISO8601Duration (re-export)', () => {
-  it('should parse minutes and seconds', () => {
-    expect(parseISO8601Duration('PT1M30S')).toBe(90);
-  });
-
-  it('should parse hours', () => {
-    expect(parseISO8601Duration('PT1H')).toBe(3600);
-  });
-
-  it('should parse full format', () => {
-    expect(parseISO8601Duration('PT1H30M45S')).toBe(5445);
-  });
-
-  it('should handle edge cases gracefully', () => {
-    expect(parseISO8601Duration('')).toBe(0);
-    expect(parseISO8601Duration('invalid')).toBe(0);
   });
 });
 

--- a/apps/worker/src/providers/youtube.ts
+++ b/apps/worker/src/providers/youtube.ts
@@ -17,9 +17,6 @@ import { decrypt } from '../lib/crypto';
 import { parseISO8601Duration } from '../lib/duration';
 import { logger } from '../lib/logger';
 
-// Re-export for external consumers
-export { parseISO8601Duration } from '../lib/duration';
-
 const youtubeLogger = logger.child('provider:youtube');
 
 // The OAuth2Client type comes from google.auth.OAuth2 instance
@@ -166,24 +163,6 @@ export function getUploadsPlaylistId(channelId: string): string {
     throw new Error(`Invalid YouTube channel ID: ${channelId}. Expected UC prefix.`);
   }
   return 'UU' + channelId.slice(2);
-}
-
-/**
- * Get the uploads playlist ID for a YouTube channel via legacy API signature.
- *
- * @deprecated Use getUploadsPlaylistId() instead - it's deterministic and requires no API call.
- * This wrapper now avoids the deprecated API call and uses the deterministic mapping.
- *
- * @param _client - Unused (kept for backward compatibility)
- * @param channelId - YouTube channel ID (starts with UC)
- * @returns Uploads playlist ID (starts with UU)
- * @throws Error if channelId doesn't start with UC
- */
-export async function getChannelUploadsPlaylistId(
-  _client: YouTubeClient,
-  channelId: string
-): Promise<string> {
-  return getUploadsPlaylistId(channelId);
 }
 
 /**
@@ -397,9 +376,6 @@ export function extractVideoInfo(item: youtube_v3.Schema$PlaylistItem): {
       null,
   };
 }
-
-// Note: parseISO8601Duration has been moved to ../lib/duration.ts
-// and is re-exported from this file for backward compatibility
 
 /**
  * Video details returned from fetchVideoDetails.

--- a/apps/worker/src/sync/consumer.ts
+++ b/apps/worker/src/sync/consumer.ts
@@ -29,7 +29,7 @@ import {
 } from '../polling/spotify-poller';
 import type { ProviderConnection } from '../lib/token-refresh';
 import type { Bindings } from '../types';
-import type { Subscription as PollingSubscription, DrizzleDB } from '../polling/types';
+import type { Subscription as PollingSubscription } from '../polling/types';
 import { SyncQueueMessageSchema, type SyncQueueMessage } from './types';
 import { updateJobProgress } from './service';
 
@@ -264,7 +264,7 @@ async function processProviderMessages(
           client,
           userId,
           env,
-          db as unknown as DrizzleDB
+          db
         );
 
         // Update progress for each subscription
@@ -301,7 +301,7 @@ async function processProviderMessages(
             client,
             userId,
             env,
-            db as unknown as DrizzleDB
+            db
           );
 
           await updateJobProgress(jobId, sub.id, true, result.newItems, null, env.OAUTH_STATE_KV);
@@ -328,7 +328,7 @@ async function processProviderMessages(
           client,
           userId,
           env,
-          db as unknown as DrizzleDB
+          db
         );
 
         // Update progress for each subscription
@@ -365,7 +365,7 @@ async function processProviderMessages(
             client,
             userId,
             env,
-            db as unknown as DrizzleDB
+            db
           );
 
           await updateJobProgress(jobId, sub.id, true, result.newItems, null, env.OAUTH_STATE_KV);

--- a/apps/worker/src/sync/service.ts
+++ b/apps/worker/src/sync/service.ts
@@ -36,7 +36,7 @@ import {
 // Note: Provider and polling imports are done dynamically in processSyncFallback
 // to avoid loading googleapis at module init time (breaks workerd test environment)
 import type { ProviderConnection } from '../lib/token-refresh';
-import type { Subscription as PollingSubscription, DrizzleDB } from '../polling/types';
+import type { Subscription as PollingSubscription } from '../polling/types';
 
 // ============================================================================
 // Constants
@@ -521,7 +521,7 @@ async function processSyncFallback(
           client,
           userId,
           env,
-          db as unknown as DrizzleDB
+          db
         );
 
         totalSucceeded += result.processed - (result.errors?.length ?? 0);
@@ -579,7 +579,7 @@ async function processSyncFallback(
           client,
           userId,
           env,
-          db as unknown as DrizzleDB
+          db
         );
 
         totalSucceeded += result.processed - (result.errors?.length ?? 0);

--- a/apps/worker/src/trpc/routers/admin.ts
+++ b/apps/worker/src/trpc/routers/admin.ts
@@ -17,7 +17,6 @@ import {
   generateRepairReport,
 } from '../../admin/repair-subscriptions';
 import { logger } from '../../lib/logger';
-import type { DrizzleD1Database } from 'drizzle-orm/d1';
 
 const adminLogger = logger.child('admin');
 
@@ -75,7 +74,7 @@ export const adminRouter = router({
         provider: input?.provider,
       });
 
-      const result = await findCorruptedSubscriptions(ctx.db as unknown as DrizzleD1Database, {
+      const result = await findCorruptedSubscriptions(ctx.db, {
         provider: input?.provider,
         userId: ctx.userId,
       });
@@ -108,7 +107,7 @@ export const adminRouter = router({
         provider: input?.provider,
       });
 
-      const result = await findCorruptedSubscriptions(ctx.db as unknown as DrizzleD1Database, {
+      const result = await findCorruptedSubscriptions(ctx.db, {
         provider: input?.provider,
         userId: ctx.userId,
       });
@@ -135,7 +134,7 @@ export const adminRouter = router({
       subscriptionIds: input.subscriptionIds?.length,
     });
 
-    const result = await repairCorruptedSubscriptions(ctx.db as unknown as DrizzleD1Database, {
+    const result = await repairCorruptedSubscriptions(ctx.db, {
       provider: input.provider,
       userId: ctx.userId,
       dryRun: input.dryRun,
@@ -167,7 +166,7 @@ export const adminRouter = router({
         provider: input?.provider,
       });
 
-      const result = await verifyRepairs(ctx.db as unknown as DrizzleD1Database, {
+      const result = await verifyRepairs(ctx.db, {
         provider: input?.provider,
         userId: ctx.userId,
       });

--- a/apps/worker/src/trpc/routers/subscriptions.ts
+++ b/apps/worker/src/trpc/routers/subscriptions.ts
@@ -45,7 +45,7 @@ import { triggerInitialFetch, type InitialFetchEnv } from '../../subscriptions/i
 import { pollSingleYouTubeSubscription } from '../../polling/youtube-poller';
 import { pollSingleSpotifySubscription } from '../../polling/spotify-poller';
 import type { Bindings } from '../../types';
-import type { Subscription as PollingSubscription, DrizzleDB } from '../../polling/types';
+import type { Subscription as PollingSubscription } from '../../polling/types';
 import {
   initiateSyncJob,
   getSyncStatus,
@@ -603,7 +603,7 @@ export const subscriptionsRouter = router({
           client,
           ctx.userId,
           ctx.env as Bindings,
-          ctx.db as unknown as DrizzleDB
+          ctx.db
         );
       } else if (sub.provider === 'SPOTIFY') {
         const client = await getSpotifyClientForConnection(
@@ -615,7 +615,7 @@ export const subscriptionsRouter = router({
           client,
           ctx.userId,
           ctx.env as Bindings,
-          ctx.db as unknown as DrizzleDB
+          ctx.db
         );
       } else {
         throw new TRPCError({


### PR DESCRIPTION
## Summary
- consolidate worker database typing and remove unsafe cast chains across polling, sync, and admin paths
- tighten mobile subscription and offline queue payload typing around router-derived inputs and remove the legacy `sources.*` fallback path
- remove deprecated YouTube helper exports and trim low-value legacy/task comments in touched mobile files

## Why
This cleanup reduces type noise, removes dead compatibility paths, and keeps the mobile and worker surfaces closer to the current router contracts.

## Notes
- no circular dependencies were found during the dependency audit
- the only remaining lint output is the pre-existing warning in `apps/mobile/app/(tabs)/library/index.tsx`

## Validation
- `bun run lint && bun run test && bun run build`
- `bun run format:check && bun run design-system:check && bun run typecheck && bun run test:web && bun run test:worker:ci`