### PR TITLE
fix(mobile): add bookmark detail summary surface

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -2,6 +2,8 @@ import type { Ionicons } from '@expo/vector-icons';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
+import { Surface } from '@/components/primitives/surface';
+
 import { styles } from '../../item-detail-styles';
 import type { ItemDetailColors, ItemDetailCreator, ItemDetailItem } from '../types';
 import { ItemDetailActions } from './ItemDetailActions';
@@ -97,7 +99,19 @@ export function ItemDetailContent({
 
       {item.summary && (
         <DescriptionContainer style={styles.descriptionContainer}>
-          <ItemDetailDescription summary={item.summary} label={descriptionLabel} colors={colors} />
+          <Surface
+            tone="subtle"
+            radius="lg"
+            padding="lg"
+            colors={colors}
+            style={styles.descriptionSurface}
+          >
+            <ItemDetailDescription
+              summary={item.summary}
+              label={descriptionLabel}
+              colors={colors}
+            />
+          </Surface>
         </DescriptionContainer>
       )}
     </>

--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -1,4 +1,4 @@
-import { Text } from 'react-native';
+import { Text } from '@/components/primitives/text';
 
 import { LinkedText } from '../../item-detail-components';
 import { styles } from '../../item-detail-styles';
@@ -13,7 +13,9 @@ type ItemDetailDescriptionProps = {
 export function ItemDetailDescription({ summary, label, colors }: ItemDetailDescriptionProps) {
   return (
     <>
-      <Text style={[styles.descriptionLabel, { color: colors.text }]}>{label}</Text>
+      <Text variant="labelSmall" tone="tertiary" colors={colors}>
+        {label}
+      </Text>
       <LinkedText
         style={[styles.description, { color: colors.textSubheader }]}
         linkColor={colors.primary}

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -208,9 +208,8 @@ export const styles = StyleSheet.create({
     marginTop: Spacing.md,
     paddingHorizontal: Spacing.xl,
   },
-  descriptionLabel: {
-    ...Typography.titleLarge,
-    marginBottom: Spacing.sm,
+  descriptionSurface: {
+    gap: Spacing.md,
   },
   description: {
     ...Typography.bodyMedium,


### PR DESCRIPTION
## Summary
- move the mobile bookmark detail summary into a subtle rounded surface
- switch the summary label to a quieter eyebrow-style treatment to match the web bookmark view
- slightly reduce the card corner radius after the initial UI update

## Why
The web bookmark detail view presents the summary/description on a quiet gray surface, which gives the copy clearer separation from the rest of the page. This brings the mobile bookmark/content view in line with that treatment for a more consistent detail experience.

## Validation
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:mobile`