### PR TITLE
fix(web): align bookmark detail row actions with mobile

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -338,6 +338,17 @@ describe('BookmarksPage', () => {
 
     expect(screen.getByRole('heading', { name: videoItem.title })).toBeVisible();
     expect(screen.getByLabelText('Bookmark metadata')).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: `Manage tags for ${videoItem.title}` })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: `More actions for ${videoItem.title}` })
+    ).toBeVisible();
+    expect(
+      screen
+        .getByRole('button', { name: `Remove bookmark for ${videoItem.title}` })
+        .querySelector('svg')
+    ).toHaveAttribute('fill', 'currentColor');
     expect(screen.getByRole('link', { name: 'Open in YouTube' })).toHaveAttribute(
       'href',
       videoItem.canonicalUrl
@@ -353,6 +364,90 @@ describe('BookmarksPage', () => {
 
     expect(invalidateSpies.itemsGetInvalidate).toHaveBeenCalledWith({ id: videoItem.id });
     expect(invalidateSpies.itemsLibraryInvalidate).toHaveBeenCalled();
+    expect(invalidateSpies.itemsHomeInvalidate).toHaveBeenCalled();
+  });
+
+  test('opens tag management from the action row and saves normalized tags', async () => {
+    const user = userEvent.setup();
+    const taggedVideoItem = createLibraryItem({
+      ...videoItem,
+      tags: [{ id: 'tag-design-systems', name: 'Design systems' }],
+    });
+
+    hookSpies.itemsLibraryUseQuery.mockImplementation((input) => ({
+      data: {
+        items: input.filter.contentType
+          ? [
+              taggedVideoItem,
+              ...libraryItems.filter((item) => item.id !== taggedVideoItem.id),
+            ].filter((item) => item.contentType === input.filter.contentType)
+          : [taggedVideoItem, ...libraryItems.filter((item) => item.id !== taggedVideoItem.id)],
+      },
+      isLoading: false,
+      error: null,
+    }));
+    hookSpies.itemsGetUseQuery.mockImplementation((input) => {
+      if (!input.id) {
+        return { data: undefined, isLoading: false, error: null };
+      }
+
+      if (input.id === taggedVideoItem.id) {
+        return { data: taggedVideoItem, isLoading: false, error: null };
+      }
+
+      const item = libraryItems.find((candidate) => candidate.id === input.id);
+      return item
+        ? { data: item, isLoading: false, error: null }
+        : { data: undefined, isLoading: false, error: new Error('Missing bookmark') };
+    });
+    hookSpies.itemsListTagsUseQuery.mockReturnValue({
+      data: {
+        tags: [
+          { id: 'tag-design-systems', name: 'Design systems' },
+          { id: 'tag-research', name: 'Research' },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${taggedVideoItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: `Manage tags for ${taggedVideoItem.title}` })
+    );
+
+    expect(screen.getByRole('heading', { name: 'Tags' })).toBeVisible();
+
+    await user.type(screen.getByLabelText('Add or search tags'), '  Research   Notes  ');
+    await user.click(screen.getByRole('button', { name: 'Add tag Research Notes' }));
+    await user.click(screen.getByRole('button', { name: 'Save tags' }));
+
+    expect(mutationSpies.setTags).toHaveBeenCalledWith({
+      id: taggedVideoItem.id,
+      tags: ['Design systems', 'Research Notes'],
+    });
+    expect(invalidateSpies.itemsGetInvalidate).toHaveBeenCalledWith({ id: taggedVideoItem.id });
+    expect(invalidateSpies.itemsLibraryInvalidate).toHaveBeenCalled();
+    expect(invalidateSpies.itemsHomeInvalidate).toHaveBeenCalled();
+    expect(invalidateSpies.itemsListTagsInvalidate).toHaveBeenCalled();
+  });
+
+  test('marks a bookmark as opened when the provider FAB is used', async () => {
+    const user = userEvent.setup();
+
+    renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${videoItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    await user.click(screen.getByRole('link', { name: 'Open in YouTube' }));
+
+    expect(mutationSpies.markOpened).toHaveBeenCalledWith({ id: videoItem.id });
+    expect(invalidateSpies.itemsGetInvalidate).toHaveBeenCalledWith({ id: videoItem.id });
     expect(invalidateSpies.itemsHomeInvalidate).toHaveBeenCalled();
   });
 

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -1,12 +1,14 @@
 import {
+  Bookmark,
   BookmarkCheck,
-  Check,
+  CircleCheck,
+  CirclePlus,
   ChevronLeft,
   ChevronRight,
   Ellipsis,
   Plus,
   Settings,
-  Share2,
+  Share,
 } from 'lucide-react';
 import { FaSpotify } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
@@ -26,6 +28,7 @@ import { Colors, getButtonMetrics } from '@zine/design-system';
 import { ContentType, Provider } from '@zine/shared';
 
 import { Badge, Button, EmptyState, cn } from './components';
+import { BookmarkTagsDialog } from './components/bookmark-tags-dialog';
 import { ManualBookmarkDialog } from './components/manual-bookmark-dialog';
 import { MobileTabBar } from './components/mobile-tab-bar';
 import { FilterChip } from './components/ui/filter-chip';
@@ -508,6 +511,7 @@ export function BookmarksPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [manualBookmarkOpen, setManualBookmarkOpen] = useState(false);
   const [manualBookmarkNotice, setManualBookmarkNotice] = useState<string | null>(null);
+  const [bookmarkTagsOpen, setBookmarkTagsOpen] = useState(false);
   const isPhoneLayout = useMediaQuery('(max-width: 700px)');
   const bookmarkFilter = parseBookmarkFilter(searchParams.get(CONTENT_FILTER_SEARCH_PARAM));
   const bookmarkSearch = searchParams.toString();
@@ -642,6 +646,18 @@ export function BookmarksPage() {
   });
   const unbookmarkMutation = trpc.items.unbookmark.useMutation({
     onSuccess: invalidateSelectedBookmark,
+  });
+  const markOpenedMutation = trpc.items.markOpened.useMutation({
+    onSuccess: () => {
+      if (!selectedBookmarkId) {
+        return;
+      }
+
+      void Promise.all([
+        utils.items.get.invalidate({ id: selectedBookmarkId }),
+        utils.items.home.invalidate(),
+      ]);
+    },
   });
 
   useEffect(() => {
@@ -1044,7 +1060,11 @@ export function BookmarksPage() {
                               unbookmarkMutation.mutate({ id: selectedBookmarkId });
                             }}
                           >
-                            <BookmarkCheck size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
+                            <Bookmark
+                              size={BOOKMARK_ACTION_ICON_SIZE}
+                              strokeWidth={1.85}
+                              fill="currentColor"
+                            />
                           </Button>
 
                           <Button
@@ -1067,7 +1087,20 @@ export function BookmarksPage() {
                               toggleFinishedMutation.mutate({ id: selectedBookmarkId });
                             }}
                           >
-                            <Check size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
+                            <CircleCheck size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
+                          </Button>
+
+                          <Button
+                            tone="ghost"
+                            size="icon"
+                            className="new-page-bookmark-view__icon-action"
+                            style={detailActionButtonStyle}
+                            aria-label={`Manage tags for ${displayBookmark.title}`}
+                            title="Manage tags"
+                            disabled={!selectedBookmarkId}
+                            onClick={() => setBookmarkTagsOpen(true)}
+                          >
+                            <CirclePlus size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
                           </Button>
 
                           <Button
@@ -1106,7 +1139,7 @@ export function BookmarksPage() {
                               }
                             }}
                           >
-                            <Share2 size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
+                            <Share size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
                           </Button>
 
                           <Button
@@ -1132,6 +1165,13 @@ export function BookmarksPage() {
                             rel="noreferrer"
                             aria-label={bookmarkFabConfig.label}
                             title={bookmarkFabConfig.label}
+                            onClick={() => {
+                              if (!selectedBookmarkId) {
+                                return;
+                              }
+
+                              markOpenedMutation.mutate({ id: selectedBookmarkId });
+                            }}
                           >
                             {bookmarkFabConfig.icon}
                           </a>
@@ -1234,6 +1274,13 @@ export function BookmarksPage() {
         onOpenChange={setManualBookmarkOpen}
         onSaved={handleManualBookmarkSaved}
       />
+      {displayBookmark ? (
+        <BookmarkTagsDialog
+          bookmark={displayBookmark}
+          open={bookmarkTagsOpen}
+          onOpenChange={setBookmarkTagsOpen}
+        />
+      ) : null}
     </main>
   );
 }

--- a/apps/web/src/components/bookmark-tags-dialog.tsx
+++ b/apps/web/src/components/bookmark-tags-dialog.tsx
@@ -1,0 +1,293 @@
+import { LoaderCircle, Plus, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { LibraryItem } from '../lib/router-types';
+import { trpc } from '../lib/trpc';
+import { Button } from '../components';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './ui/dialog';
+
+function normalizeTagName(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeTagKey(value: string): string {
+  return normalizeTagName(value).toLowerCase();
+}
+
+function sanitizeTags(tags: string[]): string[] {
+  const deduped = new Map<string, string>();
+
+  for (const tag of tags) {
+    const normalizedName = normalizeTagName(tag);
+    if (!normalizedName) {
+      continue;
+    }
+
+    const normalizedKey = normalizeTagKey(normalizedName);
+    if (!deduped.has(normalizedKey)) {
+      deduped.set(normalizedKey, normalizedName);
+    }
+  }
+
+  return Array.from(deduped.values()).slice(0, 20);
+}
+
+type BookmarkTagsDialogProps = {
+  bookmark: Pick<LibraryItem, 'id' | 'title' | 'tags'>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function BookmarkTagsDialog({ bookmark, open, onOpenChange }: BookmarkTagsDialogProps) {
+  const utils = trpc.useUtils();
+  const [query, setQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [saveErrorMessage, setSaveErrorMessage] = useState<string | null>(null);
+
+  const tagsQuery = trpc.items.listTags.useQuery();
+  const initialTagNames = useMemo(
+    () => sanitizeTags((bookmark.tags ?? []).map((tag) => tag.name)),
+    [bookmark.tags]
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setSaveErrorMessage(null);
+      return;
+    }
+
+    setQuery('');
+    setSaveErrorMessage(null);
+    setSelectedTags(initialTagNames);
+  }, [initialTagNames, open]);
+
+  const setTagsMutation = trpc.items.setTags.useMutation({
+    onSuccess: () => {
+      void Promise.all([
+        utils.items.get.invalidate({ id: bookmark.id }),
+        utils.items.library.invalidate(),
+        utils.items.home.invalidate(),
+        utils.items.listTags.invalidate(),
+      ]);
+      onOpenChange(false);
+    },
+  });
+
+  const normalizedQuery = normalizeTagName(query);
+  const normalizedQueryKey = normalizeTagKey(query);
+  const allTags = tagsQuery.data?.tags ?? [];
+  const selectedTagKeys = useMemo(
+    () => new Set(selectedTags.map((tag) => normalizeTagKey(tag))),
+    [selectedTags]
+  );
+  const initialTagKeys = useMemo(
+    () => new Set(initialTagNames.map((tag) => normalizeTagKey(tag))),
+    [initialTagNames]
+  );
+  const filteredTags = useMemo(() => {
+    if (!normalizedQuery) {
+      return allTags;
+    }
+
+    return allTags.filter((tag) => normalizeTagKey(tag.name).includes(normalizedQueryKey));
+  }, [allTags, normalizedQuery, normalizedQueryKey]);
+  const canCreateTag =
+    normalizedQuery.length > 0 &&
+    normalizedQuery.length <= 32 &&
+    !selectedTagKeys.has(normalizedQueryKey) &&
+    !allTags.some((tag) => normalizeTagKey(tag.name) === normalizedQueryKey);
+  const hasChanges =
+    initialTagKeys.size !== selectedTagKeys.size ||
+    Array.from(selectedTagKeys).some((tagKey) => !initialTagKeys.has(tagKey));
+
+  const toggleTag = (name: string) => {
+    const normalizedName = normalizeTagName(name);
+    const normalizedKey = normalizeTagKey(normalizedName);
+
+    if (!normalizedName || normalizedName.length > 32) {
+      return;
+    }
+
+    setSelectedTags((previous) => {
+      const next = previous.some((tag) => normalizeTagKey(tag) === normalizedKey)
+        ? previous.filter((tag) => normalizeTagKey(tag) !== normalizedKey)
+        : [...previous, normalizedName];
+
+      return sanitizeTags(next);
+    });
+  };
+
+  const handleSave = async () => {
+    if (!hasChanges || setTagsMutation.isPending) {
+      return;
+    }
+
+    setSaveErrorMessage(null);
+
+    try {
+      await setTagsMutation.mutateAsync({
+        id: bookmark.id,
+        tags: sanitizeTags(selectedTags),
+      });
+    } catch (error) {
+      setSaveErrorMessage(error instanceof Error ? error.message : 'Failed to update tags.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <DialogContent
+          className="bookmark-tags-dialog__content"
+          aria-describedby="bookmark-tags-dialog-description"
+          aria-labelledby="bookmark-tags-dialog-title"
+        >
+          <div className="bookmark-tags-dialog">
+            <div className="bookmark-tags-dialog__header">
+              <div className="bookmark-tags-dialog__header-copy">
+                <DialogTitle
+                  id="bookmark-tags-dialog-title"
+                  className="bookmark-tags-dialog__title"
+                >
+                  Tags
+                </DialogTitle>
+                <DialogDescription
+                  id="bookmark-tags-dialog-description"
+                  className="bookmark-tags-dialog__description"
+                >
+                  Organize this bookmark the same way the mobile flow does.
+                </DialogDescription>
+                <p className="bookmark-tags-dialog__bookmark-title">{bookmark.title}</p>
+              </div>
+
+              <button
+                type="button"
+                className="button button--ghost bookmark-tags-dialog__close"
+                aria-label="Close tags dialog"
+                onClick={() => onOpenChange(false)}
+              >
+                <X size={16} strokeWidth={2.2} />
+              </button>
+            </div>
+
+            <div className="bookmark-tags-dialog__body">
+              <label className="field bookmark-tags-dialog__field">
+                <span className="field__label">Add or search tags</span>
+                <span className="field__hint">Tags are trimmed, deduped, and capped at 20.</span>
+                <div className="manual-bookmark-dialog__input-row">
+                  <input
+                    autoFocus
+                    type="text"
+                    value={query}
+                    placeholder="Design systems"
+                    aria-label="Add or search tags"
+                    onChange={(event) => setQuery(event.currentTarget.value)}
+                  />
+
+                  {canCreateTag ? (
+                    <Button
+                      type="button"
+                      tone="ghost"
+                      onClick={() => {
+                        toggleTag(normalizedQuery);
+                        setQuery('');
+                      }}
+                      aria-label={`Add tag ${normalizedQuery}`}
+                    >
+                      <Plus size={16} strokeWidth={2.1} />
+                      Add tag
+                    </Button>
+                  ) : null}
+                </div>
+              </label>
+
+              <section className="bookmark-tags-dialog__section" aria-label="Selected tags">
+                <div className="bookmark-tags-dialog__section-header">
+                  <strong>Selected</strong>
+                  <span>{selectedTags.length}/20</span>
+                </div>
+
+                {selectedTags.length > 0 ? (
+                  <div className="chip-row">
+                    {selectedTags.map((tag) => (
+                      <button
+                        key={normalizeTagKey(tag)}
+                        type="button"
+                        className="chip chip--active bookmark-tags-dialog__chip"
+                        onClick={() => toggleTag(tag)}
+                      >
+                        {tag}
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="bookmark-tags-dialog__empty">No tags selected yet.</p>
+                )}
+              </section>
+
+              <section className="bookmark-tags-dialog__section" aria-label="Available tags">
+                <div className="bookmark-tags-dialog__section-header">
+                  <strong>Available</strong>
+                  <span>{tagsQuery.isLoading ? 'Loading…' : `${filteredTags.length} tags`}</span>
+                </div>
+
+                {tagsQuery.isLoading ? (
+                  <p className="bookmark-tags-dialog__empty">Loading tags…</p>
+                ) : filteredTags.length > 0 ? (
+                  <div className="chip-row">
+                    {filteredTags.map((tag) => {
+                      const isSelected = selectedTagKeys.has(normalizeTagKey(tag.name));
+
+                      return (
+                        <button
+                          key={tag.id}
+                          type="button"
+                          className={isSelected ? 'chip chip--active' : 'chip'}
+                          aria-pressed={isSelected}
+                          onClick={() => toggleTag(tag.name)}
+                        >
+                          {tag.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="bookmark-tags-dialog__empty">No matching tags yet.</p>
+                )}
+              </section>
+            </div>
+
+            <div className="bookmark-tags-dialog__footer">
+              {saveErrorMessage ? (
+                <p className="bookmark-tags-dialog__footer-note bookmark-tags-dialog__footer-note--error">
+                  {saveErrorMessage}
+                </p>
+              ) : null}
+
+              <Button
+                type="button"
+                className="bookmark-tags-dialog__save"
+                disabled={!hasChanges || setTagsMutation.isPending}
+                onClick={() => void handleSave()}
+              >
+                {setTagsMutation.isPending ? (
+                  <>
+                    <LoaderCircle
+                      className="manual-bookmark-dialog__spinner"
+                      size={16}
+                      strokeWidth={2}
+                    />
+                    Saving tags...
+                  </>
+                ) : (
+                  'Save tags'
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -23,8 +23,7 @@ body {
   color: var(--foreground);
   background:
     radial-gradient(circle at top, rgba(255, 255, 255, 0.06), transparent 24%),
-    radial-gradient(circle at 85% 8%, rgba(255, 255, 255, 0.03), transparent 18%),
-    #000000;
+    radial-gradient(circle at 85% 8%, rgba(255, 255, 255, 0.03), transparent 18%), #000000;
   font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -276,7 +275,7 @@ img {
   width: 100%;
   padding: 1.5rem;
   background: #ffffff;
-  border: 1px solid #E5E7EB;
+  border: 1px solid #e5e7eb;
   border-radius: 1.45rem;
   box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
 }
@@ -330,31 +329,31 @@ img {
 .auth-panel__surface .cl-dividerText,
 .auth-panel__surface .cl-footerActionText,
 .auth-panel__surface .cl-formFieldHintText {
-  color: #6B7280 !important;
+  color: #6b7280 !important;
 }
 
 .auth-panel__surface .cl-formFieldErrorText {
-  color: #DC2626 !important;
+  color: #dc2626 !important;
 }
 
 .auth-panel__surface .cl-socialButtonsBlockButton {
   background: #ffffff !important;
-  border: 1px solid #E5E7EB !important;
+  border: 1px solid #e5e7eb !important;
   color: #111111 !important;
 }
 
 .auth-panel__surface .cl-socialButtonsBlockButton:hover {
-  background: #F9FAFB !important;
+  background: #f9fafb !important;
 }
 
 .auth-panel__surface .cl-dividerLine {
-  background: #E5E7EB !important;
+  background: #e5e7eb !important;
 }
 
 .auth-panel__surface .cl-formFieldInput {
-  background: #F9FAFB !important;
+  background: #f9fafb !important;
   color: #111111 !important;
-  border-color: #E5E7EB !important;
+  border-color: #e5e7eb !important;
 }
 
 .auth-panel__surface .cl-formButtonPrimary {
@@ -852,7 +851,9 @@ img {
   font-weight: 500;
   cursor: pointer;
   text-align: left;
-  transition: background 120ms ease, color 120ms ease;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
 }
 
 .settings-page__nav-item:hover {
@@ -1075,7 +1076,12 @@ img {
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(180deg, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.24) 40%, rgba(18, 18, 18, 0.98) 100%),
+    linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.08) 0%,
+      rgba(0, 0, 0, 0.24) 40%,
+      rgba(18, 18, 18, 0.98) 100%
+    ),
     linear-gradient(90deg, rgba(18, 18, 18, 0.08), rgba(18, 18, 18, 0.22));
 }
 
@@ -1451,10 +1457,22 @@ img {
   padding: 0;
 }
 
+.bookmark-tags-dialog__content {
+  width: min(38rem, calc(100vw - 2rem));
+  padding: 0;
+}
+
 .manual-bookmark-dialog {
   display: flex;
   flex-direction: column;
   min-height: min(42rem, calc(100vh - 2rem));
+  max-height: calc(100vh - 2rem);
+}
+
+.bookmark-tags-dialog {
+  display: flex;
+  flex-direction: column;
+  min-height: min(34rem, calc(100vh - 2rem));
   max-height: calc(100vh - 2rem);
 }
 
@@ -1463,7 +1481,21 @@ img {
   flex-shrink: 0;
 }
 
+.bookmark-tags-dialog__header,
+.bookmark-tags-dialog__footer {
+  flex-shrink: 0;
+}
+
 .manual-bookmark-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.25rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.bookmark-tags-dialog__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -1477,10 +1509,23 @@ img {
   gap: 0.45rem;
 }
 
+.bookmark-tags-dialog__header-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
 .manual-bookmark-dialog__title {
   margin: 0;
   font-size: clamp(1.55rem, 2.4vw, 2.1rem);
   line-height: 0.98;
+  letter-spacing: -0.05em;
+  color: var(--text);
+}
+
+.bookmark-tags-dialog__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.2vw, 1.85rem);
+  line-height: 1;
   letter-spacing: -0.05em;
   color: var(--text);
 }
@@ -1492,7 +1537,22 @@ img {
   line-height: 1.55;
 }
 
+.bookmark-tags-dialog__description,
+.bookmark-tags-dialog__bookmark-title {
+  margin: 0;
+  color: var(--text-subheader);
+}
+
+.bookmark-tags-dialog__bookmark-title {
+  font-size: 0.92rem;
+}
+
 .manual-bookmark-dialog__icon-button {
+  width: 2.9rem;
+  padding-inline: 0;
+}
+
+.bookmark-tags-dialog__close {
   width: 2.9rem;
   padding-inline: 0;
 }
@@ -1505,6 +1565,45 @@ img {
   gap: 0.85rem;
   padding: 1.25rem;
   overflow: auto;
+}
+
+.bookmark-tags-dialog__body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  overflow: auto;
+}
+
+.bookmark-tags-dialog__field {
+  gap: 0.45rem;
+}
+
+.bookmark-tags-dialog__section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bookmark-tags-dialog__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--text-subheader);
+  font-size: 0.85rem;
+}
+
+.bookmark-tags-dialog__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bookmark-tags-dialog__empty {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: 0.9rem;
 }
 
 .manual-bookmark-dialog__input-row {
@@ -1710,7 +1809,22 @@ img {
   border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
+.bookmark-tags-dialog__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
 .manual-bookmark-dialog__footer-note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-subheader);
+}
+
+.bookmark-tags-dialog__footer-note {
   margin: 0;
   font-size: 0.82rem;
   color: var(--text-subheader);
@@ -1720,7 +1834,15 @@ img {
   color: var(--danger);
 }
 
+.bookmark-tags-dialog__footer-note--error {
+  color: var(--danger);
+}
+
 .manual-bookmark-dialog__save {
+  margin-left: auto;
+}
+
+.bookmark-tags-dialog__save {
   margin-left: auto;
 }
 
@@ -3042,7 +3164,18 @@ input:focus {
     padding: 0.85rem 1rem 1rem;
   }
 
+  .bookmark-tags-dialog__footer {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0.85rem 1rem 1rem;
+  }
+
   .manual-bookmark-dialog__save {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .bookmark-tags-dialog__save {
     width: 100%;
     margin-left: 0;
   }

--- a/apps/web/src/test/mocks/trpc.tsx
+++ b/apps/web/src/test/mocks/trpc.tsx
@@ -11,7 +11,7 @@ type QueryResult<T> = {
 };
 
 type MutationOptions = {
-  onSuccess?: () => void;
+  onSuccess?: (data: unknown, input: unknown) => void;
 };
 
 type ItemsLibraryInput = {
@@ -27,6 +27,11 @@ type ItemsGetInput = {
 
 type CreatorGetInput = {
   creatorId: string;
+};
+
+type ItemTag = {
+  id: string;
+  name: string;
 };
 
 type BookmarkPreviewInput = {
@@ -58,11 +63,14 @@ export const invalidateSpies = {
   itemsGetInvalidate: vi.fn(async () => undefined),
   itemsLibraryInvalidate: vi.fn(async () => undefined),
   itemsHomeInvalidate: vi.fn(async () => undefined),
+  itemsListTagsInvalidate: vi.fn(async () => undefined),
 };
 
 export const mutationSpies = {
   toggleFinished: vi.fn<(input: unknown) => void>(),
   unbookmark: vi.fn<(input: unknown) => void>(),
+  setTags: vi.fn<(input: unknown) => void>(),
+  markOpened: vi.fn<(input: unknown) => void>(),
   bookmarkSave: vi.fn<(input: unknown) => void>(),
 };
 
@@ -76,6 +84,9 @@ export const hookSpies = {
   creatorsGetUseQuery: vi.fn<(input: CreatorGetInput, options?: unknown) => QueryResult<unknown>>(
     (_input) => createQueryResult({})
   ),
+  itemsListTagsUseQuery: vi.fn<() => QueryResult<{ tags: ItemTag[] }>>(() =>
+    createQueryResult({ data: { tags: [] } })
+  ),
   bookmarksPreviewUseQuery: vi.fn<
     (input: BookmarkPreviewInput, options?: unknown) => QueryResult<unknown>
   >((_input) => createQueryResult({})),
@@ -87,6 +98,12 @@ export const hookSpies = {
   ),
   unbookmarkUseMutation: vi.fn((options?: MutationOptions) =>
     createMutationResult(mutationSpies.unbookmark, options)
+  ),
+  setTagsUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.setTags, options)
+  ),
+  markOpenedUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.markOpened, options)
   ),
 };
 
@@ -104,8 +121,14 @@ function createMutationResult(spy: MutationSpy, options?: MutationOptions) {
     isPending: false,
     mutate: (input: unknown) => {
       spy(input);
-      options?.onSuccess?.();
+      options?.onSuccess?.(undefined, input);
     },
+    mutateAsync: async (input: unknown) => {
+      spy(input);
+      options?.onSuccess?.(undefined, input);
+      return undefined;
+    },
+    reset: vi.fn(),
   };
 }
 
@@ -136,6 +159,11 @@ export function resetTrpcMocks() {
   hookSpies.creatorsGetUseQuery.mockReset();
   hookSpies.creatorsGetUseQuery.mockImplementation((_input) => createQueryResult());
 
+  hookSpies.itemsListTagsUseQuery.mockReset();
+  hookSpies.itemsListTagsUseQuery.mockImplementation(() =>
+    createQueryResult({ data: { tags: [] } })
+  );
+
   hookSpies.bookmarksPreviewUseQuery.mockReset();
   hookSpies.bookmarksPreviewUseQuery.mockImplementation((_input) => createQueryResult());
 
@@ -153,6 +181,16 @@ export function resetTrpcMocks() {
   hookSpies.unbookmarkUseMutation.mockImplementation((options?: MutationOptions) =>
     createMutationResult(mutationSpies.unbookmark, options)
   );
+
+  hookSpies.setTagsUseMutation.mockReset();
+  hookSpies.setTagsUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.setTags, options)
+  );
+
+  hookSpies.markOpenedUseMutation.mockReset();
+  hookSpies.markOpenedUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.markOpened, options)
+  );
 }
 
 export function setAuthAvailability(nextState: Partial<typeof authAvailability>) {
@@ -169,6 +207,7 @@ export const trpc = {
       get: { invalidate: invalidateSpies.itemsGetInvalidate },
       library: { invalidate: invalidateSpies.itemsLibraryInvalidate },
       home: { invalidate: invalidateSpies.itemsHomeInvalidate },
+      listTags: { invalidate: invalidateSpies.itemsListTagsInvalidate },
     },
   }),
   items: {
@@ -179,11 +218,20 @@ export const trpc = {
       useQuery: (input: ItemsGetInput, options?: unknown) =>
         hookSpies.itemsGetUseQuery(input, options),
     },
+    listTags: {
+      useQuery: () => hookSpies.itemsListTagsUseQuery(),
+    },
     toggleFinished: {
       useMutation: (options?: MutationOptions) => hookSpies.toggleFinishedUseMutation(options),
     },
     unbookmark: {
       useMutation: (options?: MutationOptions) => hookSpies.unbookmarkUseMutation(options),
+    },
+    setTags: {
+      useMutation: (options?: MutationOptions) => hookSpies.setTagsUseMutation(options),
+    },
+    markOpened: {
+      useMutation: (options?: MutationOptions) => hookSpies.markOpenedUseMutation(options),
     },
   },
   creators: {


### PR DESCRIPTION
## Summary
- align the web bookmark detail action row with the mobile five-action control set and icon treatment
- add a web tag-management dialog backed by `items.listTags` and `items.setTags`
- record bookmark opens from the provider FAB and extend tests/mocks around the detail action row

## Why
The bookmark/content detail page on web had drifted from the mobile interaction model. The row actions looked different, one action slot was effectively repurposed, and the open-source action was not recording opens like mobile. This brings the web page back into parity so the row looks and behaves like the mobile source of truth.

## Notes for reviewers
- scoped to the web bookmark detail surface and test mocks
- leaves an unrelated existing change in `apps/mobile/.rnstorybook/storybook.requires.ts` out of this PR
- manual browser verification covered the restored action order, tag flow, and open-state recording
