### PR TITLE
fix(web): align bookmark detail view with mobile

### DIFF
--- a/apps/web/e2e/app.smoke.spec.ts
+++ b/apps/web/e2e/app.smoke.spec.ts
@@ -120,10 +120,12 @@ test('uses a phone drill-in flow and keeps mobile chrome usable', async ({ page 
       return {
         backgroundColor: styles.backgroundColor,
         paddingLeft: styles.paddingLeft,
+        borderRadius: styles.borderRadius,
       };
     });
-  expect(descriptionSection.backgroundColor).toBe('rgba(0, 0, 0, 0)');
-  expect(parseFloat(descriptionSection.paddingLeft)).toBeGreaterThanOrEqual(0);
+  expect(descriptionSection.backgroundColor).toBe('rgb(26, 26, 26)');
+  expect(parseFloat(descriptionSection.paddingLeft)).toBeGreaterThanOrEqual(16);
+  expect(parseFloat(descriptionSection.borderRadius)).toBeGreaterThanOrEqual(16);
 
   await page.getByRole('button', { name: 'Back to bookmarks list' }).click();
 

--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -522,6 +522,18 @@ describe('BookmarksPage', () => {
     expect(document.body).not.toHaveClass('mobile-bookmarks-scroll-lock');
   });
 
+  test('hides the mobile tab bar on phone detail routes', () => {
+    setViewportWidth(390);
+
+    renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${videoItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    expect(screen.queryByRole('navigation', { name: 'Tab bar' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back to bookmarks list' })).toBeVisible();
+  });
+
   test('hides the mobile tab bar on desktop widths', () => {
     setViewportWidth(1280);
 

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -24,10 +24,10 @@ import {
 } from 'react';
 import { Link, NavLink, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
-import { Colors, getButtonMetrics } from '@zine/design-system';
+import { Colors, ContentColors, ProviderColors, getButtonMetrics } from '@zine/design-system';
 import { ContentType, Provider } from '@zine/shared';
 
-import { Badge, Button, EmptyState, cn } from './components';
+import { Button, EmptyState, cn } from './components';
 import { BookmarkTagsDialog } from './components/bookmark-tags-dialog';
 import { ManualBookmarkDialog } from './components/manual-bookmark-dialog';
 import { MobileTabBar } from './components/mobile-tab-bar';
@@ -82,6 +82,51 @@ const mobileBookmarkActionButtonStyle = {
   width: 44,
   borderRadius: 999,
 } as const;
+
+function getBookmarkProviderBadgeColor(provider: Provider | string) {
+  switch (provider) {
+    case Provider.SPOTIFY:
+      return ProviderColors.spotify;
+    case Provider.YOUTUBE:
+      return ProviderColors.youtube;
+    case Provider.GMAIL:
+      return ProviderColors.gmail;
+    case Provider.SUBSTACK:
+      return ProviderColors.substack;
+    case Provider.X:
+      return ProviderColors.x;
+    default:
+      return ProviderColors.web;
+  }
+}
+
+function getBookmarkContentBadgeColor(contentType: ContentType) {
+  switch (contentType) {
+    case ContentType.PODCAST:
+      return ContentColors.podcast;
+    case ContentType.VIDEO:
+      return ContentColors.video;
+    case ContentType.POST:
+      return ContentColors.post;
+    case ContentType.ARTICLE:
+    default:
+      return ContentColors.article;
+  }
+}
+
+function BookmarkDetailBadge({
+  label,
+  backgroundColor,
+}: {
+  label: string;
+  backgroundColor: string;
+}) {
+  return (
+    <span className="new-page-bookmark-view__badge" style={{ backgroundColor }}>
+      {label}
+    </span>
+  );
+}
 
 function getLibrarySummary(item: LibraryItem) {
   return (
@@ -583,6 +628,7 @@ export function BookmarksPage() {
       : null;
   const selectedBookmarkIsFinished = Boolean(displayBookmark?.isFinished);
   const isPhonePostView = isPhoneLayout && displayBookmark?.contentType === ContentType.POST;
+  const isPhoneDetailView = isPhoneLayout && Boolean(selectedBookmarkId);
   const bookmarkPlainSummary = displayBookmark ? formatPlainText(displayBookmark.summary) : null;
   const bookmarkPostHandle =
     displayBookmark?.provider === Provider.X
@@ -620,6 +666,7 @@ export function BookmarksPage() {
     Boolean(selectedBookmarkId && !displayBookmark && selectedBookmarkDetailQuery.isLoading);
   const showBookmarkListPane = !isPhoneLayout || !selectedBookmarkId;
   const showBookmarkDetailPane = !isPhoneLayout || Boolean(selectedBookmarkId);
+  const showMobileTabBar = isPhoneLayout && !selectedBookmarkId;
   const refreshNotice = bookmarksQuery.error
     ? (bookmarksQuery.error.message ?? 'Could not refresh bookmarks.')
     : bookmarksAreRefreshing
@@ -716,7 +763,7 @@ export function BookmarksPage() {
           title="Could not load bookmarks"
           message={bookmarksQuery.error.message ?? 'Please refresh and try again.'}
         />
-        <MobileTabBar />
+        {showMobileTabBar ? <MobileTabBar /> : null}
       </main>
     );
   }
@@ -775,7 +822,7 @@ export function BookmarksPage() {
         </div>
       ) : null}
 
-      <MobileTabBar />
+      {showMobileTabBar ? <MobileTabBar /> : null}
 
       <div className="new-page-inset">
         {showInsetHeader ? (
@@ -956,6 +1003,7 @@ export function BookmarksPage() {
                     className={cn(
                       'new-page-bookmark-view new-page-bookmark-view--pane',
                       isPhoneLayout && 'new-page-bookmark-view--phone',
+                      isPhoneDetailView && 'new-page-bookmark-view--phone-detail',
                       !showBookmarkHero && 'new-page-bookmark-view--no-hero',
                       displayBookmark.contentType === ContentType.POST &&
                         'new-page-bookmark-view--post'
@@ -991,8 +1039,18 @@ export function BookmarksPage() {
 
                         {showHeroBadges ? (
                           <div className="new-page-bookmark-view__hero-badges">
-                            <Badge>{mapProvider(displayBookmark.provider)}</Badge>
-                            <Badge>{mapContentType(displayBookmark.contentType)}</Badge>
+                            <BookmarkDetailBadge
+                              label={mapProvider(displayBookmark.provider)}
+                              backgroundColor={getBookmarkProviderBadgeColor(
+                                displayBookmark.provider
+                              )}
+                            />
+                            <BookmarkDetailBadge
+                              label={mapContentType(displayBookmark.contentType)}
+                              backgroundColor={getBookmarkContentBadgeColor(
+                                displayBookmark.contentType
+                              )}
+                            />
                           </div>
                         ) : null}
                       </div>
@@ -1002,8 +1060,18 @@ export function BookmarksPage() {
                       <div className="new-page-bookmark-view__header">
                         {showHeaderBadges ? (
                           <div className="new-page-bookmark-view__badges">
-                            <Badge>{mapProvider(displayBookmark.provider)}</Badge>
-                            <Badge>{mapContentType(displayBookmark.contentType)}</Badge>
+                            <BookmarkDetailBadge
+                              label={mapProvider(displayBookmark.provider)}
+                              backgroundColor={getBookmarkProviderBadgeColor(
+                                displayBookmark.provider
+                              )}
+                            />
+                            <BookmarkDetailBadge
+                              label={mapContentType(displayBookmark.contentType)}
+                              backgroundColor={getBookmarkContentBadgeColor(
+                                displayBookmark.contentType
+                              )}
+                            />
                           </div>
                         ) : null}
 
@@ -1028,6 +1096,13 @@ export function BookmarksPage() {
                           <div className="new-page-bookmark-view__creator-copy">
                             <strong>{getLibraryCreatorLabel(displayBookmark)}</strong>
                           </div>
+
+                          <ChevronRight
+                            className="new-page-bookmark-view__creator-chevron"
+                            size={14}
+                            strokeWidth={2.2}
+                            aria-hidden="true"
+                          />
                         </div>
                       </div>
 
@@ -1061,6 +1136,7 @@ export function BookmarksPage() {
                             }}
                           >
                             <Bookmark
+                              className="new-page-bookmark-view__bookmark-icon"
                               size={BOOKMARK_ACTION_ICON_SIZE}
                               strokeWidth={1.85}
                               fill="currentColor"
@@ -1228,15 +1304,9 @@ export function BookmarksPage() {
                         </section>
                       ) : (
                         <section className="new-page-bookmark-view__section">
-                          {isPhoneLayout ? (
-                            <h3 className="new-page-bookmark-view__section-title">
-                              {getBookmarkAboutLabel(displayBookmark.contentType)}
-                            </h3>
-                          ) : (
-                            <p className="eyebrow">
-                              {getBookmarkAboutLabel(displayBookmark.contentType)}
-                            </p>
-                          )}
+                          <p className="eyebrow new-page-bookmark-view__section-label">
+                            {getBookmarkAboutLabel(displayBookmark.contentType)}
+                          </p>
                           <p className="new-page-bookmark-view__summary">
                             {getLibrarySummary(displayBookmark)}
                           </p>

--- a/apps/web/src/pwa-support.tsx
+++ b/apps/web/src/pwa-support.tsx
@@ -17,7 +17,7 @@ export function PwaSupport() {
   } = usePwaState();
 
   const hidesInstallPrompt = pathname.startsWith('/sign-in') || pathname.startsWith('/sign-up');
-  const usesBottomTabBar = pathname.startsWith('/bookmarks') || pathname.startsWith('/settings');
+  const usesBottomTabBar = pathname === '/bookmarks' || pathname === '/settings';
   const hasInlineInstallSurface = pathname.startsWith('/settings');
   const showInstallBanner =
     isPhoneLayout &&

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1057,6 +1057,19 @@ img {
   gap: 0.5rem;
 }
 
+.new-page-bookmark-view__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.5rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 999px;
+  color: var(--text);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
 .new-page-bookmark-view__hero img {
   object-fit: cover;
 }
@@ -1155,6 +1168,11 @@ img {
   gap: 0.625rem;
 }
 
+.new-page-bookmark-view__creator-chevron {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+
 .new-page-bookmark-view__creator-avatar {
   width: 1.75rem;
   height: 1.75rem;
@@ -1233,6 +1251,10 @@ img {
     opacity 120ms ease;
 }
 
+.new-page-bookmark-view__bookmark-icon {
+  color: #ffffff;
+}
+
 .new-page-bookmark-view__icon-action:hover:not(:disabled),
 .new-page-bookmark-view__icon-action:focus-visible:not(:disabled) {
   --bookmark-action-bg: var(--bookmark-action-hover-bg);
@@ -1294,6 +1316,10 @@ img {
   font-weight: 700;
   line-height: 1.1;
   letter-spacing: -0.03em;
+}
+
+.new-page-bookmark-view__section-label {
+  margin: 0;
 }
 
 .new-page-bookmark-view__section .eyebrow {
@@ -3234,10 +3260,27 @@ input:focus {
   .new-page-bookmark-view__hero,
   .new-page-bookmark-view__hero--video,
   .new-page-bookmark-view__hero--square {
-    height: clamp(15.5rem, 34vh, 18.5rem);
-    min-height: clamp(15.5rem, 34vh, 18.5rem);
-    max-height: clamp(15.5rem, 34vh, 18.5rem);
-    aspect-ratio: auto;
+    height: auto;
+    min-height: 0;
+    max-height: none;
+  }
+
+  .new-page-bookmark-view__hero--video {
+    aspect-ratio: 16 / 9;
+  }
+
+  .new-page-bookmark-view__hero--square {
+    aspect-ratio: 1;
+  }
+
+  .new-page-bookmark-view__hero::after {
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 12%,
+      rgba(0, 0, 0, 0.08) 38%,
+      rgba(0, 0, 0, 0.22) 62%,
+      var(--surface-canvas) 100%
+    );
   }
 
   .new-page-bookmark-view__body {
@@ -3246,19 +3289,28 @@ input:focus {
     padding-bottom: calc(6rem + env(safe-area-inset-bottom, 0));
   }
 
+  .new-page-bookmark-view--phone-detail .new-page-bookmark-view__body {
+    padding-bottom: calc(1.75rem + env(safe-area-inset-bottom, 0));
+  }
+
   .new-page-bookmark-view--phone.new-page-bookmark-view--no-hero .new-page-bookmark-view__body {
     padding-top: calc(4.25rem + env(safe-area-inset-top, 0));
   }
 
   .new-page-bookmark-view__header {
     gap: 0.65rem;
+    margin-top: calc(-1 * clamp(1.75rem, 7vw, 2.5rem));
+  }
+
+  .new-page-bookmark-view--phone.new-page-bookmark-view--no-hero .new-page-bookmark-view__header {
     margin-top: 0;
   }
 
   .new-page-bookmark-view__title {
     max-width: none;
-    font-size: clamp(1.9rem, 7.4vw, 2.5rem);
-    line-height: 0.98;
+    font-size: clamp(1.18rem, 4.8vw, 1.42rem);
+    line-height: 1.22;
+    letter-spacing: -0.03em;
   }
 
   .new-page-bookmark-view--post .new-page-bookmark-view__title {
@@ -3277,13 +3329,19 @@ input:focus {
   }
 
   .new-page-bookmark-view__creator-copy strong {
-    font-size: 1rem;
+    font-size: 0.92rem;
+    font-weight: 500;
   }
 
   .new-page-bookmark-view__meta {
-    gap: 0.35rem;
-    font-size: 0.95rem;
+    gap: 0.25rem;
+    font-size: 0.72rem;
+    line-height: 1.2;
     color: var(--text-tertiary);
+  }
+
+  .new-page-bookmark-view__meta span {
+    gap: 0.25rem;
   }
 
   .new-page-bookmark-view__creator-block,
@@ -3355,15 +3413,17 @@ input:focus {
   }
 
   .new-page-bookmark-view__section {
-    gap: 0.5rem;
-    padding: 0;
-    border-radius: 0;
-    background: transparent;
+    gap: 0.7rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    background: var(--surface-subtle);
+    border: 1px solid var(--border-subtle);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
   }
 
   .new-page-bookmark-view__summary {
-    font-size: 1rem;
-    line-height: 1.7;
+    font-size: 0.875rem;
+    line-height: 1.43;
   }
 
   .new-page-bookmark-view__post {


### PR DESCRIPTION
## Summary
- align the web bookmark detail action row and hero/detail presentation more closely with the mobile experience
- add mobile-style provider/content badges, tighter mobile title/meta treatment, updated hero/body spacing, and a white filled bookmark icon
- hide the mobile tab bar on phone bookmark detail routes and add coverage for that route behavior

## Why
The web bookmark detail route had drifted from the mobile detail experience. This PR brings the detail view back toward mobile parity so the bookmark page feels more consistent across platforms, especially on phone layouts.

## Validation
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- pre-push checks: `bun run format:check`, `bun run design-system:check`, `bun run typecheck`, `bun run test:web`, and worker CI test subset

## Notes
- this branch also includes the prior action-row parity commit as part of the same bookmark detail polish
- no additional related issue/ticket was provided