### PR TITLE
fix(web): unify bookmark hero sizing

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -534,6 +534,32 @@ describe('BookmarksPage', () => {
     expect(screen.getByRole('button', { name: 'Back to bookmarks list' })).toBeVisible();
   });
 
+  test('uses the same bookmark hero treatment for non-video content on phone widths', () => {
+    setViewportWidth(390);
+
+    const { container } = renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${articleItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    const hero = container.querySelector('.new-page-bookmark-view__hero');
+    expect(hero).toBeTruthy();
+    expect(hero?.className).toBe('new-page-bookmark-view__hero');
+  });
+
+  test('uses the same bookmark hero treatment for non-video content on desktop widths', () => {
+    setViewportWidth(1280);
+
+    const { container } = renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${articleItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    const hero = container.querySelector('.new-page-bookmark-view__hero');
+    expect(hero).toBeTruthy();
+    expect(hero?.className).toBe('new-page-bookmark-view__hero');
+  });
+
   test('hides the mobile tab bar on desktop widths', () => {
     setViewportWidth(1280);
 

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -1022,15 +1022,7 @@ export function BookmarksPage() {
                     ) : null}
 
                     {showBookmarkHero ? (
-                      <div
-                        ref={bookmarkHeroRef}
-                        className={cn(
-                          'new-page-bookmark-view__hero',
-                          displayBookmark.contentType === ContentType.VIDEO
-                            ? 'new-page-bookmark-view__hero--video'
-                            : 'new-page-bookmark-view__hero--square'
-                        )}
-                      >
+                      <div ref={bookmarkHeroRef} className="new-page-bookmark-view__hero">
                         {bookmarkHeroImageUrl ? (
                           <img src={bookmarkHeroImageUrl} alt="" />
                         ) : (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1003,6 +1003,7 @@ img {
   --bookmark-hero-translate-y: 0px;
   --bookmark-hero-scale: 1;
   --bookmark-hero-opacity: 1;
+  --bookmark-hero-height: clamp(8rem, 33vh, 20rem);
   --bookmark-header-overlap: clamp(2.75rem, 7vw, 4.5rem);
   position: relative;
   width: 100%;
@@ -1027,9 +1028,7 @@ img {
 
 .new-page-bookmark-view__hero {
   position: relative;
-  height: 40%;
-  min-height: 10rem;
-  max-height: 50%;
+  height: var(--bookmark-hero-height);
   flex-shrink: 0;
   background: #0d0d0d;
   overflow: hidden;
@@ -3922,20 +3921,8 @@ input:focus {
     display: inline;
   }
 
-  .new-page-bookmark-view__hero,
-  .new-page-bookmark-view__hero--video,
-  .new-page-bookmark-view__hero--square {
-    height: auto;
-    min-height: 0;
-    max-height: none;
-  }
-
-  .new-page-bookmark-view__hero--video {
-    aspect-ratio: 16 / 9;
-  }
-
-  .new-page-bookmark-view__hero--square {
-    aspect-ratio: 1;
+  .new-page-bookmark-view {
+    --bookmark-hero-height: clamp(8rem, 33svh, 16rem);
   }
 
   .new-page-bookmark-view__hero::after {


### PR DESCRIPTION
## Summary
- use one shared bookmark detail hero treatment for all content types
- constrain the hero to a responsive height of about one-third of the page instead of letting it grow with the pane width
- add coverage that non-video bookmark detail pages use the same hero treatment on phone and desktop widths

## Why
The bookmark detail cover was inconsistent across content types, and the first pass at unifying it made the hero visually too large on wide layouts. This keeps the cover behavior consistent while preserving the intended editorial balance of the page.

## Validation
- `bun run format:check`
- `bun run test:web`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`

## Notes
- Left an unrelated generated change in `apps/mobile/.rnstorybook/storybook.requires.ts` out of this PR.