### PR TITLE
feat(web): redesign guided integration modal

### DIFF
--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -1,0 +1,10 @@
+---
+name: pr
+description: when creating PRs
+---
+
+commit and push all changes
+
+create a PR. use semantic commit messages as the title with a detailed description of the changes made. include any relevant issue numbers or links to related discussions. ensure that the PR follows the repository's contribution guidelines and includes any necessary tests or documentation updates.
+
+watch the PR to make sure everything passes. if something fails, fix it and push the changes to the same branch. if there are any merge conflicts, resolve them and push the changes. keep watching the PR and repeat this loop until it is ready to be merged.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2968,7 +2968,9 @@ input:focus {
 }
 
 .onboarding-dialog__content--compact {
-  width: min(29rem, calc(100vw - 2rem));
+  width: min(27rem, calc(100vw - 2rem));
+  border-radius: 1.25rem;
+  overflow: hidden;
 }
 
 .onboarding-dialog {
@@ -2979,8 +2981,9 @@ input:focus {
 }
 
 .onboarding-dialog--compact {
+  position: relative;
   grid-template-rows: auto minmax(0, 1fr);
-  min-height: min(44rem, calc(100vh - 2rem));
+  min-height: 0;
   max-height: min(44rem, calc(100vh - 2rem));
 }
 
@@ -2991,11 +2994,6 @@ input:focus {
   gap: 1rem;
   padding: 1.5rem 1.5rem 1rem;
   border-bottom: 1px solid var(--border);
-}
-
-.onboarding-dialog__header-copy {
-  display: grid;
-  gap: 0.55rem;
 }
 
 .onboarding-dialog__title {
@@ -3013,19 +3011,53 @@ input:focus {
 }
 
 .onboarding-dialog__close {
-  flex-shrink: 0;
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+  z-index: 1;
+}
+
+.onboarding-dialog__close:hover {
+  background: var(--surface-subtle);
+  color: var(--text);
+}
+
+.onboarding-dialog__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .onboarding-dialog--compact .onboarding-dialog__header {
-  padding: 1.25rem 1.25rem 0.9rem;
+  display: grid;
+  gap: 0.45rem;
+  padding: 1.75rem 1.5rem 0.5rem;
+  border-bottom: none;
 }
 
 .onboarding-dialog--compact .onboarding-dialog__title {
-  font-size: clamp(1.45rem, 4vw, 1.95rem);
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
 }
 
 .onboarding-dialog--compact .onboarding-dialog__description {
   max-width: none;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--text-dim);
 }
 
 .onboarding-stepper {
@@ -3101,32 +3133,18 @@ input:focus {
   padding: 1.25rem 1.5rem 1.5rem;
 }
 
-.onboarding-dialog__body--compact {
+.onboarding-dialog__body--intro {
+  padding: 0.75rem 1rem 1.25rem;
+}
+
+.onboarding-dialog__body--step {
   padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .onboarding-dialog__workspace {
   min-width: 0;
-}
-
-.onboarding-dialog__panel {
-  height: 100%;
-}
-
-.wizard-panel {
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-}
-
-.wizard-intro {
-  padding: 0.85rem;
-}
-
-.wizard-intro__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
 }
 
 .wizard-intro__list {
@@ -3134,7 +3152,7 @@ input:focus {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.35rem;
 }
 
 .wizard-intro__item {
@@ -3143,25 +3161,29 @@ input:focus {
 
 .wizard-intro__button {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.85rem;
   width: 100%;
-  padding: 0.85rem 0.95rem;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  background: var(--surface-subtle);
+  padding: 0.75rem 0.75rem 0.75rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0.85rem;
+  background: transparent;
   color: inherit;
   text-align: left;
+  cursor: pointer;
   transition:
-    border-color 180ms ease,
-    background 180ms ease,
-    transform 180ms ease;
+    border-color 160ms ease,
+    background 160ms ease;
 }
 
 .wizard-intro__button:hover {
-  border-color: var(--line-strong);
-  background: var(--surface-raised);
-  transform: translateY(-1px);
+  background: var(--surface-subtle);
+  border-color: var(--border);
+}
+
+.wizard-intro__button:hover .wizard-intro__chevron {
+  color: var(--text);
+  transform: translateX(2px);
 }
 
 .wizard-intro__button:focus-visible {
@@ -3175,71 +3197,104 @@ input:focus {
   justify-content: center;
   width: 2.25rem;
   height: 2.25rem;
-  border-radius: 0.75rem;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text);
-  flex-shrink: 0;
-}
-
-.wizard-intro__icon--brand {
+  border-radius: 0.65rem;
   color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 .wizard-intro__copy {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.1rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .wizard-intro__copy h3 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.97rem;
+  font-weight: 600;
   color: var(--text);
+  letter-spacing: -0.005em;
 }
 
 .wizard-intro__copy p {
   margin: 0;
   color: var(--text-dim);
-  font-size: 0.88rem;
+  font-size: 0.84rem;
   line-height: 1.35;
+}
+
+.wizard-intro__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.5rem 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--success, #22c55e) 16%, transparent);
+  color: var(--success, #22c55e);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  flex-shrink: 0;
+}
+
+.wizard-intro__chevron {
+  color: var(--text-dim);
+  flex-shrink: 0;
+  transition:
+    color 160ms ease,
+    transform 160ms ease;
 }
 
 .wizard-step {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
   height: 100%;
 }
 
 .wizard-step__header {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .wizard-step__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.85rem;
-  background: var(--surface-subtle);
-  color: var(--text);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.6rem;
+  color: #fff;
   flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.wizard-step__icon > * {
+  transform: scale(0.85);
+}
+
+.wizard-step__heading {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
 }
 
 .wizard-step__title {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.05rem;
   font-weight: 650;
   color: var(--text);
+  letter-spacing: -0.01em;
 }
 
 .wizard-step__summary {
-  margin: 0.15rem 0 0;
+  margin: 0;
   color: var(--text-dim);
-  font-size: 0.95rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
 }
 
 .wizard-step__body {
@@ -3366,8 +3421,7 @@ input:focus {
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--border);
+  padding-top: 0.75rem;
   margin-top: auto;
 }
 
@@ -3386,33 +3440,62 @@ input:focus {
 .wizard-connect {
   display: flex;
   flex-direction: column;
+  gap: 1.25rem;
+  flex: 1;
+  min-height: 0;
+  padding-top: 0.5rem;
+}
+
+.wizard-connect__hero {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  padding: 2rem 1rem;
+  gap: 0.75rem;
+  padding: 1.75rem 1rem 1.25rem;
   text-align: center;
   flex: 1;
 }
 
-.wizard-connect__icon {
+.wizard-connect__brand {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 1rem;
-  background: var(--surface-subtle);
+  color: #fff;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 10px 32px -18px rgba(0, 0, 0, 0.65);
+}
+
+.wizard-connect__brand > * {
+  transform: scale(1.4);
+  transform-origin: center;
+}
+
+.wizard-connect__title {
+  margin: 0.25rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 650;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 
-.wizard-connect__copy {
-  max-width: 28rem;
+.wizard-connect__description {
+  margin: 0;
+  max-width: 22rem;
   color: var(--text-dim);
+  font-size: 0.88rem;
+  line-height: 1.55;
 }
 
 .wizard-connect__error {
+  margin: 0;
+  text-align: center;
   color: var(--danger, #ef4444);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
 .wizard-rss__form {
@@ -3743,29 +3826,25 @@ input:focus {
   }
 
   .onboarding-dialog__body,
-  .onboarding-dialog__body--compact {
+  .onboarding-dialog__body--intro,
+  .onboarding-dialog__body--step {
     padding: 0.75rem;
   }
 
-  .wizard-intro {
-    padding: 0.5rem;
-  }
-
   .wizard-intro__button {
-    padding: 1rem;
+    padding: 0.85rem 0.85rem 0.85rem 0.75rem;
     gap: 1rem;
     border-radius: 0.85rem;
   }
 
-  .wizard-intro__icon,
-  .wizard-intro__icon--brand {
-    width: 2.75rem;
-    height: 2.75rem;
-    border-radius: 0.85rem;
+  .wizard-intro__icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
   }
 
   .wizard-intro__copy h3 {
-    font-size: 1.05rem;
+    font-size: 1.02rem;
   }
 
   .wizard-intro__copy p {

--- a/apps/web/src/welcome-page.tsx
+++ b/apps/web/src/welcome-page.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Mail, Podcast, Rss, Video, X, type LucideIcon } from 'lucide-react';
+import { Check, ChevronRight, Loader2, Mail, Rss, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { FaSpotify } from 'react-icons/fa';
 import { IoLogoYoutube, IoNewspaperOutline } from 'react-icons/io5';
@@ -6,7 +6,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { Provider } from '@zine/shared';
 
-import { Button, EmptyState, Surface, cn } from './components';
+import { Button, EmptyState, cn } from './components';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from './components/ui/dialog';
 import {
   clearOnboardingOAuthContext,
@@ -20,13 +20,6 @@ import { connectProvider } from './lib/oauth';
 import { trpc, useAppSession } from './lib/trpc';
 
 type IntegrationStep = Exclude<WizardStep, 'DONE'>;
-
-const STEP_ICONS: Record<IntegrationStep, LucideIcon> = {
-  SPOTIFY: Podcast,
-  YOUTUBE: Video,
-  GMAIL: Mail,
-  RSS: Rss,
-};
 
 const INTRO_STEPS: IntegrationStep[] = ['YOUTUBE', 'SPOTIFY', 'GMAIL', 'RSS'];
 
@@ -241,22 +234,29 @@ type ConnectGateProps = {
 };
 
 function ConnectGate({ provider, title, description, onConnect, onBack, error }: ConnectGateProps) {
-  const Icon = STEP_ICONS[provider];
+  const brand = INTRO_BRAND[provider];
+  const config = sourceConfigs[provider];
   return (
     <div className="wizard-connect">
-      <div className="wizard-connect__icon" aria-hidden="true">
-        <Icon size={28} />
-      </div>
-      <div className="wizard-connect__copy">
-        <h3>{title}</h3>
-        <p>{description}</p>
+      <div className="wizard-connect__hero">
+        <span
+          className="wizard-connect__brand"
+          aria-hidden="true"
+          style={{ backgroundColor: brand.bg }}
+        >
+          {brand.icon}
+        </span>
+        <h2 className="wizard-connect__title">{config.title}</h2>
+        <p className="wizard-connect__description">
+          {title}. {description}
+        </p>
       </div>
       {error ? <p className="wizard-connect__error">{error}</p> : null}
       <div className="wizard-footer">
         <Button tone="ghost" onClick={onBack}>
-          Back to integrations
+          Back
         </Button>
-        <Button onClick={onConnect}>Connect {sourceConfigs[provider].title}</Button>
+        <Button onClick={onConnect}>Connect {config.title}</Button>
       </div>
     </div>
   );
@@ -496,95 +496,93 @@ export function WelcomePage() {
         aria-labelledby="welcome-dialog-title"
       >
         <div className="onboarding-dialog onboarding-dialog--compact">
+          <button
+            type="button"
+            className="onboarding-dialog__close"
+            aria-label="Close guided setup"
+            onClick={handleClose}
+          >
+            <X size={16} strokeWidth={2.2} />
+          </button>
+
           <header className="onboarding-dialog__header">
-            <div className="onboarding-dialog__header-copy">
-              <p className="eyebrow">Guided setup</p>
-              <DialogTitle id="welcome-dialog-title" className="onboarding-dialog__title">
-                {dialogTitle}
-              </DialogTitle>
-              <DialogDescription
-                id="welcome-dialog-description"
-                className="onboarding-dialog__description"
-              >
-                {dialogDescription}
-              </DialogDescription>
-            </div>
-            <button
-              type="button"
-              className="button button--ghost onboarding-dialog__close"
-              aria-label="Close guided setup"
-              onClick={handleClose}
+            <DialogTitle id="welcome-dialog-title" className="onboarding-dialog__title">
+              {dialogTitle}
+            </DialogTitle>
+            <DialogDescription
+              id="welcome-dialog-description"
+              className="onboarding-dialog__description"
             >
-              <X size={16} strokeWidth={2.2} />
-            </button>
+              {dialogDescription}
+            </DialogDescription>
           </header>
 
-          <div className="onboarding-dialog__body onboarding-dialog__body--compact">
-            <Surface
-              className={cn(
-                'onboarding-dialog__panel',
-                !activeStep ? 'wizard-intro' : 'wizard-panel'
-              )}
-            >
-              {!activeStep ? <IntroStep onSelect={handleSelectStep} /> : null}
+          <div
+            className={cn(
+              'onboarding-dialog__body',
+              !activeStep ? 'onboarding-dialog__body--intro' : 'onboarding-dialog__body--step'
+            )}
+          >
+            {!activeStep ? (
+              <IntroStep onSelect={handleSelectStep} connections={connections} />
+            ) : null}
 
-              {activeStep === 'SPOTIFY' ? (
-                <SpotifyStep
-                  connections={connections}
-                  available={spotifyAvailable.data?.items ?? []}
-                  isLoading={spotifyAvailable.isLoading}
-                  isImporting={isImporting}
-                  onConnect={() => void handleConnect('SPOTIFY')}
-                  onBack={handleBackToIntegrations}
-                  onImport={importSpotify}
-                  error={stepError.SPOTIFY ?? null}
-                />
-              ) : null}
+            {activeStep === 'SPOTIFY' ? (
+              <SpotifyStep
+                connections={connections}
+                available={spotifyAvailable.data?.items ?? []}
+                isLoading={spotifyAvailable.isLoading}
+                isImporting={isImporting}
+                onConnect={() => void handleConnect('SPOTIFY')}
+                onBack={handleBackToIntegrations}
+                onImport={importSpotify}
+                error={stepError.SPOTIFY ?? null}
+              />
+            ) : null}
 
-              {activeStep === 'YOUTUBE' ? (
-                <YoutubeStep
-                  connections={connections}
-                  available={youtubeAvailable.data?.items ?? []}
-                  isLoading={youtubeAvailable.isLoading}
-                  isImporting={isImporting}
-                  onConnect={() => void handleConnect('YOUTUBE')}
-                  onBack={handleBackToIntegrations}
-                  onImport={importYoutube}
-                  error={stepError.YOUTUBE ?? null}
-                />
-              ) : null}
+            {activeStep === 'YOUTUBE' ? (
+              <YoutubeStep
+                connections={connections}
+                available={youtubeAvailable.data?.items ?? []}
+                isLoading={youtubeAvailable.isLoading}
+                isImporting={isImporting}
+                onConnect={() => void handleConnect('YOUTUBE')}
+                onBack={handleBackToIntegrations}
+                onImport={importYoutube}
+                error={stepError.YOUTUBE ?? null}
+              />
+            ) : null}
 
-              {activeStep === 'GMAIL' ? (
-                <GmailStep
-                  connections={connections}
-                  newsletters={newslettersListQuery.data?.items ?? []}
-                  isLoading={newslettersListQuery.isLoading}
-                  isSyncing={syncNewsletters.isPending}
-                  isImporting={isImporting}
-                  onConnect={() => void handleConnect('GMAIL')}
-                  onScan={() => void handleScanNewsletters()}
-                  onBack={handleBackToIntegrations}
-                  onImport={importNewsletters}
-                  error={stepError.GMAIL ?? null}
-                />
-              ) : null}
+            {activeStep === 'GMAIL' ? (
+              <GmailStep
+                connections={connections}
+                newsletters={newslettersListQuery.data?.items ?? []}
+                isLoading={newslettersListQuery.isLoading}
+                isSyncing={syncNewsletters.isPending}
+                isImporting={isImporting}
+                onConnect={() => void handleConnect('GMAIL')}
+                onScan={() => void handleScanNewsletters()}
+                onBack={handleBackToIntegrations}
+                onImport={importNewsletters}
+                error={stepError.GMAIL ?? null}
+              />
+            ) : null}
 
-              {activeStep === 'RSS' ? (
-                <RssStep
-                  url={rssUrl}
-                  onUrlChange={setRssUrl}
-                  onDiscover={() => {
-                    if (rssUrl.trim()) setRssDiscoveryUrl(rssUrl.trim());
-                  }}
-                  candidates={rssCandidates}
-                  isDiscovering={rssDiscoverQuery.isLoading && Boolean(rssDiscoveryUrl)}
-                  isImporting={isImporting}
-                  onBack={handleBackToIntegrations}
-                  onImport={importRss}
-                  error={stepError.RSS ?? null}
-                />
-              ) : null}
-            </Surface>
+            {activeStep === 'RSS' ? (
+              <RssStep
+                url={rssUrl}
+                onUrlChange={setRssUrl}
+                onDiscover={() => {
+                  if (rssUrl.trim()) setRssDiscoveryUrl(rssUrl.trim());
+                }}
+                candidates={rssCandidates}
+                isDiscovering={rssDiscoverQuery.isLoading && Boolean(rssDiscoveryUrl)}
+                isImporting={isImporting}
+                onBack={handleBackToIntegrations}
+                onImport={importRss}
+                error={stepError.RSS ?? null}
+              />
+            ) : null}
           </div>
         </div>
       </DialogContent>
@@ -592,38 +590,58 @@ export function WelcomePage() {
   );
 }
 
-function IntroStep({ onSelect }: { onSelect: (step: IntegrationStep) => void }) {
+function IntroStep({
+  onSelect,
+  connections,
+}: {
+  onSelect: (step: IntegrationStep) => void;
+  connections: ConnectionsData;
+}) {
   return (
-    <div className="wizard-intro__content">
-      <ul className="wizard-intro__list" aria-label="Available integrations">
-        {INTRO_STEPS.map((step) => {
-          const config = sourceConfigs[step];
-          const brand = INTRO_BRAND[step];
-          return (
-            <li key={step} className="wizard-intro__item">
-              <button
-                type="button"
-                className="wizard-intro__button"
-                onClick={() => onSelect(step)}
-                aria-label={`Open ${config.title} integration`}
+    <ul className="wizard-intro__list" aria-label="Available integrations">
+      {INTRO_STEPS.map((step) => {
+        const config = sourceConfigs[step];
+        const brand = INTRO_BRAND[step];
+        const connected =
+          step !== 'RSS'
+            ? isConnected(connections, step as 'YOUTUBE' | 'SPOTIFY' | 'GMAIL')
+            : false;
+        return (
+          <li key={step} className="wizard-intro__item">
+            <button
+              type="button"
+              className="wizard-intro__button"
+              onClick={() => onSelect(step)}
+              aria-label={`Open ${config.title} integration`}
+            >
+              <span
+                className="wizard-intro__icon"
+                aria-hidden="true"
+                style={{ backgroundColor: brand.bg }}
               >
-                <span
-                  className="wizard-intro__icon wizard-intro__icon--brand"
-                  aria-hidden="true"
-                  style={{ backgroundColor: brand.bg }}
-                >
-                  {brand.icon}
+                {brand.icon}
+              </span>
+              <div className="wizard-intro__copy">
+                <h3>{config.title}</h3>
+                <p>{INTRO_STEP_SUMMARIES[step]}</p>
+              </div>
+              {connected ? (
+                <span className="wizard-intro__status" aria-label="Connected">
+                  <Check size={12} strokeWidth={2.5} />
+                  Connected
                 </span>
-                <div className="wizard-intro__copy">
-                  <h3>{config.title}</h3>
-                  <p>{INTRO_STEP_SUMMARIES[step]}</p>
-                </div>
-              </button>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+              ) : null}
+              <ChevronRight
+                size={16}
+                strokeWidth={2}
+                className="wizard-intro__chevron"
+                aria-hidden="true"
+              />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 
@@ -653,16 +671,14 @@ function SpotifyStep({
 
   if (!connected) {
     return (
-      <StepShell title={config.title} summary={config.summary} stepIcon="SPOTIFY">
-        <ConnectGate
-          provider="SPOTIFY"
-          title="Connect Spotify"
-          description="Log in with Spotify to see the podcasts you follow."
-          onConnect={onConnect}
-          onBack={onBack}
-          error={error}
-        />
-      </StepShell>
+      <ConnectGate
+        provider="SPOTIFY"
+        title="Log in with Spotify"
+        description="See the podcasts you follow and pick which ones to bring into Zine."
+        onConnect={onConnect}
+        onBack={onBack}
+        error={error}
+      />
     );
   }
 
@@ -700,16 +716,14 @@ function YoutubeStep({
 
   if (!connected) {
     return (
-      <StepShell title={config.title} summary={config.summary} stepIcon="YOUTUBE">
-        <ConnectGate
-          provider="YOUTUBE"
-          title="Connect YouTube"
-          description="Log in with Google to see the channels you subscribe to."
-          onConnect={onConnect}
-          onBack={onBack}
-          error={error}
-        />
-      </StepShell>
+      <ConnectGate
+        provider="YOUTUBE"
+        title="Log in with Google"
+        description="See the channels you subscribe to and pick which ones to bring into Zine."
+        onConnect={onConnect}
+        onBack={onBack}
+        error={error}
+      />
     );
   }
 
@@ -771,47 +785,43 @@ function GmailStep({
 
   if (!connected) {
     return (
-      <StepShell title={config.title} summary={config.summary} stepIcon="GMAIL">
-        <ConnectGate
-          provider="GMAIL"
-          title="Connect Gmail"
-          description="Log in with Google so Zine can scan for newsletters in your inbox."
-          onConnect={onConnect}
-          onBack={onBack}
-          error={error}
-        />
-      </StepShell>
+      <ConnectGate
+        provider="GMAIL"
+        title="Log in with Google"
+        description="Zine will scan your inbox for newsletter senders you can keep or skip."
+        onConnect={onConnect}
+        onBack={onBack}
+        error={error}
+      />
     );
   }
 
   if (newsletters.length === 0) {
     return (
-      <StepShell
-        title={config.title}
-        summary="Scan your inbox to find newsletter senders."
-        stepIcon="GMAIL"
-      >
-        {error ? <p className="wizard-connect__error">{error}</p> : null}
-        <div className="wizard-connect">
-          <div className="wizard-connect__icon" aria-hidden="true">
-            <Mail size={28} />
-          </div>
-          <div className="wizard-connect__copy">
-            <h3>Scan for newsletters</h3>
-            <p>
-              Gmail is connected. Run a quick scan to pull in newsletter senders you can pick from.
-            </p>
-          </div>
-          <div className="wizard-footer">
-            <Button tone="ghost" onClick={onBack}>
-              Back to integrations
-            </Button>
-            <Button onClick={onScan} disabled={isSyncing || isLoading}>
-              {isSyncing ? 'Scanning…' : 'Scan newsletters'}
-            </Button>
-          </div>
+      <div className="wizard-connect">
+        <div className="wizard-connect__hero">
+          <span
+            className="wizard-connect__brand"
+            aria-hidden="true"
+            style={{ backgroundColor: INTRO_BRAND.GMAIL.bg }}
+          >
+            <Mail size={22} color="#fff" />
+          </span>
+          <h2 className="wizard-connect__title">Scan for newsletters</h2>
+          <p className="wizard-connect__description">
+            Gmail is connected. Run a quick scan to pull in newsletter senders you can pick from.
+          </p>
         </div>
-      </StepShell>
+        {error ? <p className="wizard-connect__error">{error}</p> : null}
+        <div className="wizard-footer">
+          <Button tone="ghost" onClick={onBack}>
+            Back
+          </Button>
+          <Button onClick={onScan} disabled={isSyncing || isLoading}>
+            {isSyncing ? 'Scanning…' : 'Scan newsletters'}
+          </Button>
+        </div>
+      </div>
     );
   }
 
@@ -918,14 +928,18 @@ type StepShellProps = {
 };
 
 function StepShell({ title, summary, stepIcon, children }: StepShellProps) {
-  const Icon = STEP_ICONS[stepIcon];
+  const brand = INTRO_BRAND[stepIcon];
   return (
     <div className="wizard-step">
       <header className="wizard-step__header">
-        <span className="wizard-step__icon" aria-hidden="true">
-          <Icon size={20} />
+        <span
+          className="wizard-step__icon"
+          aria-hidden="true"
+          style={{ backgroundColor: brand.bg }}
+        >
+          {brand.icon}
         </span>
-        <div>
+        <div className="wizard-step__heading">
           <h2 className="wizard-step__title">{title}</h2>
           <p className="wizard-step__summary">{summary}</p>
         </div>


### PR DESCRIPTION
## Summary
Redesign the guided integration connection modal into a simpler, more elegant experience.

## What changed
- Reworked the intro state into a cleaner integration list with tighter spacing, hover states, connected indicators, and branded icons.
- Simplified provider connection states so disconnected steps use a centered hero layout instead of a duplicated nested card.
- Refined the dialog chrome, close button, step headers, and mobile behavior for a more polished modal.
- Included the repository PR prompt artifact present in the worktree.

## Validation
- `bunx tsc --noEmit`
- `bun run lint`
- `bunx vitest run welcome-page`

## Notes
No linked issue or discussion was provided.