### PR TITLE
fix(web): fill completed bookmark icon green

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -367,6 +367,51 @@ describe('BookmarksPage', () => {
     expect(invalidateSpies.itemsHomeInvalidate).toHaveBeenCalled();
   });
 
+  test('uses the mobile-complete green fill for finished bookmark icons in detail view', () => {
+    const finishedVideoItem = createLibraryItem({
+      ...videoItem,
+      isFinished: true,
+    });
+
+    hookSpies.itemsLibraryUseQuery.mockImplementation((input) => ({
+      data: {
+        items: input.filter.contentType
+          ? [
+              finishedVideoItem,
+              ...libraryItems.filter((item) => item.id !== finishedVideoItem.id),
+            ].filter((item) => item.contentType === input.filter.contentType)
+          : [finishedVideoItem, ...libraryItems.filter((item) => item.id !== finishedVideoItem.id)],
+      },
+      isLoading: false,
+      error: null,
+    }));
+    hookSpies.itemsGetUseQuery.mockImplementation((input) => {
+      if (!input.id) {
+        return { data: undefined, isLoading: false, error: null };
+      }
+
+      if (input.id === finishedVideoItem.id) {
+        return { data: finishedVideoItem, isLoading: false, error: null };
+      }
+
+      const item = libraryItems.find((candidate) => candidate.id === input.id);
+      return item
+        ? { data: item, isLoading: false, error: null }
+        : { data: undefined, isLoading: false, error: new Error('Missing bookmark') };
+    });
+
+    renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${finishedVideoItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    expect(
+      screen
+        .getByRole('button', { name: `Remove bookmark for ${finishedVideoItem.title}` })
+        .querySelector('.new-page-bookmark-view__bookmark-icon')
+    ).toHaveClass('new-page-bookmark-view__bookmark-icon--finished');
+  });
+
   test('opens tag management from the action row and saves normalized tags', async () => {
     const user = userEvent.setup();
     const taggedVideoItem = createLibraryItem({

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -1128,7 +1128,11 @@ export function BookmarksPage() {
                             }}
                           >
                             <Bookmark
-                              className="new-page-bookmark-view__bookmark-icon"
+                              className={cn(
+                                'new-page-bookmark-view__bookmark-icon',
+                                selectedBookmarkIsFinished &&
+                                  'new-page-bookmark-view__bookmark-icon--finished'
+                              )}
                               size={BOOKMARK_ACTION_ICON_SIZE}
                               strokeWidth={1.85}
                               fill="currentColor"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1254,6 +1254,10 @@ img {
   color: #ffffff;
 }
 
+.new-page-bookmark-view__bookmark-icon--finished {
+  color: var(--success);
+}
+
 .new-page-bookmark-view__icon-action:hover:not(:disabled),
 .new-page-bookmark-view__icon-action:focus-visible:not(:disabled) {
   --bookmark-action-bg: var(--bookmark-action-hover-bg);


### PR DESCRIPTION
## What
- Fill the bookmark icon green in the web bookmark detail view when the bookmark is marked finished.
- Keep the styling aligned with the mobile finished/completed state by using the shared success color token.
- Add a regression test that locks the finished-state icon class in the bookmark detail view.

## Why
- The web detail page previously kept the bookmark icon monochrome even after completion, which diverged from the mobile treatment.
- This makes the finished state easier to scan and keeps the two surfaces visually consistent.

## Verification
- `bun run --cwd apps/web test --run src/bookmarks-page.test.tsx`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web build`

## Notes
- No related issue number was provided.
- One unrelated auto-generated mobile Storybook file was left out of the commit.