### PR TITLE
web: add onboarding mocks and local OAuth fallbacks

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -25,3 +25,18 @@ VITE_CLERK_PUBLISHABLE_KEY=pk_test
 VITE_SPOTIFY_CLIENT_ID=your_spotify_client_id
 # Google uses the same OAuth client ID for both YouTube and Gmail on web.
 VITE_YOUTUBE_CLIENT_ID=your_google_client_id
+
+# =============================================================================
+# Development-only onboarding mocks
+# =============================================================================
+# Enable a mock onboarding scenario without touching live provider auth.
+# Useful options:
+# - youtube-connect
+# - youtube-empty
+# - youtube-populated
+# - spotify-populated
+# - gmail-scan
+# - gmail-populated
+# - rss-populated
+# - intro-connected
+# VITE_ONBOARDING_MOCK_MODE=youtube-populated

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -4,3 +4,5 @@ export const API_URL = import.meta.env.VITE_API_URL?.trim() || fallbackApiUrl;
 export const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY?.trim() || '';
 export const YOUTUBE_CLIENT_ID = import.meta.env.VITE_YOUTUBE_CLIENT_ID?.trim() || '';
 export const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID?.trim() || '';
+export const ONBOARDING_MOCK_MODE =
+  import.meta.env.VITE_ONBOARDING_MOCK_MODE?.trim().toLowerCase() || '';

--- a/apps/web/src/lib/oauth.test.ts
+++ b/apps/web/src/lib/oauth.test.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@zine/shared';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 const createTRPCClientMock = vi.fn();
 const httpBatchLinkMock = vi.fn((options: unknown) => options);
@@ -55,6 +55,10 @@ describe('oauth helpers', () => {
     sessionStorage.clear();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test('connectProvider rejects when the provider client id is missing', async () => {
     const { connectProvider } = await loadOAuthModule({ SPOTIFY_CLIENT_ID: '' });
 
@@ -89,6 +93,30 @@ describe('oauth helpers', () => {
     expect(redirectUrl.searchParams.get('code_challenge_method')).toBe('S256');
     expect(redirectUrl.searchParams.get('access_type')).toBe('offline');
     expect(redirectUrl.searchParams.get('prompt')).toBe('consent');
+  });
+
+  test('connectProvider falls back when secure-context crypto helpers are unavailable', async () => {
+    const originalCrypto = globalThis.crypto;
+
+    vi.stubGlobal('crypto', {
+      getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+    });
+
+    const { connectProvider } = await loadOAuthModule();
+    const redirectMock = vi.fn();
+
+    await connectProvider('YOUTUBE', async () => 'token-123', redirectMock);
+
+    expect(registerStateMutate).toHaveBeenCalledTimes(1);
+
+    const [registration] = registerStateMutate.mock.calls[0]!;
+    expect(registration.state).toMatch(
+      /^YOUTUBE:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+
+    const redirectUrl = new URL(redirectMock.mock.calls[0][0] as string);
+    expect(redirectUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(redirectUrl.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/);
   });
 
   test('completeOAuthFlow exchanges the callback code and clears stored oauth state', async () => {

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -11,6 +11,21 @@ export type { OAuthProvider } from '@zine/shared/types';
 type TokenGetter = () => Promise<string | null>;
 type RedirectHandler = (url: string) => void;
 
+const SHA256_INITIAL_HASH = new Uint32Array([
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]);
+
+const SHA256_K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
 const OAUTH_CONFIG = {
   YOUTUBE: {
     clientId: YOUTUBE_CLIENT_ID,
@@ -82,11 +97,132 @@ function base64URLEncode(buffer: Uint8Array): string {
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 
+function getCryptoApi() {
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error('Web Crypto random values are unavailable in this browser.');
+  }
+
+  return globalThis.crypto;
+}
+
+function getRandomBytes(length: number) {
+  const bytes = new Uint8Array(length);
+  getCryptoApi().getRandomValues(bytes);
+  return bytes;
+}
+
+function rightRotate(value: number, shift: number) {
+  return (value >>> shift) | (value << (32 - shift));
+}
+
+function sha256Fallback(input: Uint8Array) {
+  const paddedLength = Math.ceil((input.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(input);
+  padded[input.length] = 0x80;
+
+  const bitLength = input.length * 8;
+  const paddedView = new DataView(padded.buffer);
+  paddedView.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false);
+  paddedView.setUint32(paddedLength - 4, bitLength >>> 0, false);
+
+  const hash = new Uint32Array(SHA256_INITIAL_HASH);
+  const schedule = new Uint32Array(64);
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i += 1) {
+      schedule[i] = paddedView.getUint32(offset + i * 4, false);
+    }
+
+    for (let i = 16; i < 64; i += 1) {
+      const s0 =
+        rightRotate(schedule[i - 15]!, 7) ^
+        rightRotate(schedule[i - 15]!, 18) ^
+        (schedule[i - 15]! >>> 3);
+      const s1 =
+        rightRotate(schedule[i - 2]!, 17) ^
+        rightRotate(schedule[i - 2]!, 19) ^
+        (schedule[i - 2]! >>> 10);
+      schedule[i] = (schedule[i - 16]! + s0 + schedule[i - 7]! + s1) >>> 0;
+    }
+
+    let a = hash[0]!;
+    let b = hash[1]!;
+    let c = hash[2]!;
+    let d = hash[3]!;
+    let e = hash[4]!;
+    let f = hash[5]!;
+    let g = hash[6]!;
+    let h = hash[7]!;
+
+    for (let i = 0; i < 64; i += 1) {
+      const sigma1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+      const choose = (e & f) ^ (~e & g);
+      const temp1 = (h + sigma1 + choose + SHA256_K[i]! + schedule[i]!) >>> 0;
+      const sigma0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (sigma0 + majority) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    hash[0] = (hash[0]! + a) >>> 0;
+    hash[1] = (hash[1]! + b) >>> 0;
+    hash[2] = (hash[2]! + c) >>> 0;
+    hash[3] = (hash[3]! + d) >>> 0;
+    hash[4] = (hash[4]! + e) >>> 0;
+    hash[5] = (hash[5]! + f) >>> 0;
+    hash[6] = (hash[6]! + g) >>> 0;
+    hash[7] = (hash[7]! + h) >>> 0;
+  }
+
+  const output = new Uint8Array(32);
+  const outputView = new DataView(output.buffer);
+
+  for (let i = 0; i < hash.length; i += 1) {
+    outputView.setUint32(i * 4, hash[i]!, false);
+  }
+
+  return output;
+}
+
+async function sha256(input: Uint8Array) {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle) {
+    const subtleInput = new ArrayBuffer(input.byteLength);
+    new Uint8Array(subtleInput).set(input);
+    const digestBuffer = await subtle.digest('SHA-256', subtleInput);
+    return new Uint8Array(digestBuffer);
+  }
+
+  return sha256Fallback(input);
+}
+
+function createStateId() {
+  const cryptoApi = getCryptoApi();
+  if (typeof cryptoApi.randomUUID === 'function') {
+    return cryptoApi.randomUUID();
+  }
+
+  const bytes = getRandomBytes(16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 async function generatePKCE() {
-  const randomBytes = crypto.getRandomValues(new Uint8Array(32));
+  const randomBytes = getRandomBytes(32);
   const verifier = base64URLEncode(randomBytes);
-  const digestBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
-  const challenge = base64URLEncode(new Uint8Array(digestBuffer));
+  const challenge = base64URLEncode(await sha256(new TextEncoder().encode(verifier)));
   return { verifier, challenge };
 }
 
@@ -123,7 +259,7 @@ export async function connectProvider(
 
   const client = createClient(getToken);
   const { verifier, challenge } = await generatePKCE();
-  const state = `${provider}:${crypto.randomUUID()}`;
+  const state = `${provider}:${createStateId()}`;
 
   sessionStorage.setItem(getStorageKey(provider, 'verifier'), verifier);
   sessionStorage.setItem(getStorageKey(provider, 'state'), state);

--- a/apps/web/src/lib/onboarding-mocks.ts
+++ b/apps/web/src/lib/onboarding-mocks.ts
@@ -260,6 +260,31 @@ export function createMockOnboardingState(scenario: MockOnboardingScenario): Moc
   return JSON.parse(JSON.stringify(MOCK_SCENARIO_STATE[scenario])) as MockOnboardingState;
 }
 
+export function disconnectMockProvider(
+  state: MockOnboardingState,
+  provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'
+): MockOnboardingState {
+  const connections = { ...state.connections, [provider]: null };
+
+  if (provider === 'YOUTUBE') {
+    return {
+      ...state,
+      connections,
+      available: { ...state.available, YOUTUBE: [] },
+    };
+  }
+
+  if (provider === 'SPOTIFY') {
+    return {
+      ...state,
+      connections,
+      available: { ...state.available, SPOTIFY: [] },
+    };
+  }
+
+  return { ...state, connections, newsletters: [] };
+}
+
 export function connectMockProvider(
   state: MockOnboardingState,
   provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'

--- a/apps/web/src/lib/onboarding-mocks.ts
+++ b/apps/web/src/lib/onboarding-mocks.ts
@@ -1,0 +1,335 @@
+import { ONBOARDING_MOCK_MODE } from './env';
+
+export type MockOnboardingScenario =
+  | 'youtube-connect'
+  | 'youtube-empty'
+  | 'youtube-populated'
+  | 'spotify-populated'
+  | 'gmail-scan'
+  | 'gmail-populated'
+  | 'rss-populated'
+  | 'intro-connected';
+
+export type MockConnectionsData = {
+  YOUTUBE: { provider: 'YOUTUBE'; status: 'ACTIVE'; connectedAt: number } | null;
+  SPOTIFY: { provider: 'SPOTIFY'; status: 'ACTIVE'; connectedAt: number } | null;
+  GMAIL: { provider: 'GMAIL'; status: 'ACTIVE'; connectedAt: number } | null;
+};
+
+export type MockDiscoverItem = {
+  id: string;
+  name: string;
+};
+
+export type MockNewsletterItem = {
+  id: string;
+  displayName: string;
+  fromAddress: string | null;
+  status?: string;
+};
+
+export type MockRssCandidate = {
+  feedUrl: string;
+  title: string;
+  description?: string;
+};
+
+export type MockOnboardingState = {
+  scenario: MockOnboardingScenario;
+  connections: MockConnectionsData;
+  available: {
+    YOUTUBE: MockDiscoverItem[];
+    SPOTIFY: MockDiscoverItem[];
+  };
+  newsletters: MockNewsletterItem[];
+  rssCandidates: MockRssCandidate[];
+  activeStep: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL' | 'RSS' | null;
+};
+
+const MOCK_SCENARIOS = [
+  'youtube-connect',
+  'youtube-empty',
+  'youtube-populated',
+  'spotify-populated',
+  'gmail-scan',
+  'gmail-populated',
+  'rss-populated',
+  'intro-connected',
+] as const satisfies readonly MockOnboardingScenario[];
+
+const MOCK_CONNECTED_AT = Date.UTC(2026, 3, 22, 0, 0, 0);
+
+const DEFAULT_YOUTUBE_CHANNELS: MockDiscoverItem[] = [
+  { id: 'youtube-1', name: 'Wendover Productions' },
+  { id: 'youtube-2', name: 'Veritasium' },
+  { id: 'youtube-3', name: 'MKBHD' },
+  { id: 'youtube-4', name: 'ColdFusion' },
+];
+
+const DEFAULT_SPOTIFY_SHOWS: MockDiscoverItem[] = [
+  { id: 'spotify-1', name: 'Sharp Tech' },
+  { id: 'spotify-2', name: 'Studio Notes' },
+  { id: 'spotify-3', name: 'The Vergecast' },
+];
+
+const DEFAULT_NEWSLETTERS: MockNewsletterItem[] = [
+  {
+    id: 'gmail-1',
+    displayName: 'Stratechery',
+    fromAddress: 'ben@stratechery.com',
+    status: 'ACTIVE',
+  },
+  {
+    id: 'gmail-2',
+    displayName: 'Morning Brew',
+    fromAddress: 'crew@morningbrew.com',
+    status: 'ACTIVE',
+  },
+  {
+    id: 'gmail-3',
+    displayName: 'Dense Discovery',
+    fromAddress: 'hello@densediscovery.com',
+    status: 'ACTIVE',
+  },
+];
+
+function createActiveConnection<TProvider extends 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'>(
+  provider: TProvider
+) {
+  return {
+    provider,
+    status: 'ACTIVE' as const,
+    connectedAt: MOCK_CONNECTED_AT,
+  };
+}
+
+const MOCK_SCENARIO_STATE: Record<MockOnboardingScenario, MockOnboardingState> = {
+  'youtube-connect': {
+    scenario: 'youtube-connect',
+    connections: {
+      YOUTUBE: null,
+      SPOTIFY: null,
+      GMAIL: null,
+    },
+    available: {
+      YOUTUBE: DEFAULT_YOUTUBE_CHANNELS,
+      SPOTIFY: [],
+    },
+    newsletters: [],
+    rssCandidates: [],
+    activeStep: 'YOUTUBE',
+  },
+  'youtube-empty': {
+    scenario: 'youtube-empty',
+    connections: {
+      YOUTUBE: createActiveConnection('YOUTUBE'),
+      SPOTIFY: null,
+      GMAIL: null,
+    },
+    available: {
+      YOUTUBE: [],
+      SPOTIFY: [],
+    },
+    newsletters: [],
+    rssCandidates: [],
+    activeStep: 'YOUTUBE',
+  },
+  'youtube-populated': {
+    scenario: 'youtube-populated',
+    connections: {
+      YOUTUBE: createActiveConnection('YOUTUBE'),
+      SPOTIFY: null,
+      GMAIL: null,
+    },
+    available: {
+      YOUTUBE: DEFAULT_YOUTUBE_CHANNELS,
+      SPOTIFY: [],
+    },
+    newsletters: [],
+    rssCandidates: [],
+    activeStep: 'YOUTUBE',
+  },
+  'spotify-populated': {
+    scenario: 'spotify-populated',
+    connections: {
+      YOUTUBE: null,
+      SPOTIFY: createActiveConnection('SPOTIFY'),
+      GMAIL: null,
+    },
+    available: {
+      YOUTUBE: [],
+      SPOTIFY: DEFAULT_SPOTIFY_SHOWS,
+    },
+    newsletters: [],
+    rssCandidates: [],
+    activeStep: 'SPOTIFY',
+  },
+  'gmail-scan': {
+    scenario: 'gmail-scan',
+    connections: {
+      YOUTUBE: null,
+      SPOTIFY: null,
+      GMAIL: createActiveConnection('GMAIL'),
+    },
+    available: {
+      YOUTUBE: [],
+      SPOTIFY: [],
+    },
+    newsletters: [],
+    rssCandidates: [],
+    activeStep: 'GMAIL',
+  },
+  'gmail-populated': {
+    scenario: 'gmail-populated',
+    connections: {
+      YOUTUBE: null,
+      SPOTIFY: null,
+      GMAIL: createActiveConnection('GMAIL'),
+    },
+    available: {
+      YOUTUBE: [],
+      SPOTIFY: [],
+    },
+    newsletters: DEFAULT_NEWSLETTERS,
+    rssCandidates: [],
+    activeStep: 'GMAIL',
+  },
+  'rss-populated': {
+    scenario: 'rss-populated',
+    connections: {
+      YOUTUBE: null,
+      SPOTIFY: null,
+      GMAIL: null,
+    },
+    available: {
+      YOUTUBE: [],
+      SPOTIFY: [],
+    },
+    newsletters: [],
+    rssCandidates: [
+      {
+        feedUrl: 'https://feeds.example/rss.xml',
+        title: 'Feeds Weekly',
+        description: 'Editorial picks and product notes.',
+      },
+      {
+        feedUrl: 'https://feeds.example/design.xml',
+        title: 'Design Dispatch',
+        description: 'Visual systems and interface writing.',
+      },
+    ],
+    activeStep: 'RSS',
+  },
+  'intro-connected': {
+    scenario: 'intro-connected',
+    connections: {
+      YOUTUBE: createActiveConnection('YOUTUBE'),
+      SPOTIFY: createActiveConnection('SPOTIFY'),
+      GMAIL: createActiveConnection('GMAIL'),
+    },
+    available: {
+      YOUTUBE: DEFAULT_YOUTUBE_CHANNELS,
+      SPOTIFY: DEFAULT_SPOTIFY_SHOWS,
+    },
+    newsletters: DEFAULT_NEWSLETTERS,
+    rssCandidates: [],
+    activeStep: null,
+  },
+};
+
+function isMockOnboardingScenario(value: string): value is MockOnboardingScenario {
+  return (MOCK_SCENARIOS as readonly string[]).includes(value);
+}
+
+export function resolveMockOnboardingScenario(searchParams: URLSearchParams) {
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
+  const requestedScenario =
+    searchParams.get('mockOnboarding')?.trim().toLowerCase() || ONBOARDING_MOCK_MODE;
+
+  if (!requestedScenario || !isMockOnboardingScenario(requestedScenario)) {
+    return null;
+  }
+
+  return requestedScenario;
+}
+
+export function createMockOnboardingState(scenario: MockOnboardingScenario): MockOnboardingState {
+  return JSON.parse(JSON.stringify(MOCK_SCENARIO_STATE[scenario])) as MockOnboardingState;
+}
+
+export function connectMockProvider(
+  state: MockOnboardingState,
+  provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'
+) {
+  const connections = {
+    ...state.connections,
+    [provider]: createActiveConnection(provider),
+  };
+
+  if (provider === 'YOUTUBE') {
+    return {
+      ...state,
+      connections,
+      available: {
+        ...state.available,
+        YOUTUBE:
+          state.available.YOUTUBE.length > 0 ? state.available.YOUTUBE : DEFAULT_YOUTUBE_CHANNELS,
+      },
+    };
+  }
+
+  if (provider === 'SPOTIFY') {
+    return {
+      ...state,
+      connections,
+      available: {
+        ...state.available,
+        SPOTIFY:
+          state.available.SPOTIFY.length > 0 ? state.available.SPOTIFY : DEFAULT_SPOTIFY_SHOWS,
+      },
+    };
+  }
+
+  return {
+    ...state,
+    connections,
+  };
+}
+
+export function scanMockNewsletters(state: MockOnboardingState) {
+  return {
+    ...state,
+    newsletters: DEFAULT_NEWSLETTERS,
+  };
+}
+
+export function discoverMockFeeds(state: MockOnboardingState, inputUrl: string) {
+  let host = 'feeds.example';
+
+  try {
+    host = new URL(inputUrl).hostname || host;
+  } catch {
+    // Keep the fallback host for partial or invalid draft input.
+  }
+
+  const titlePrefix = host.replace(/^www\./, '');
+
+  return {
+    ...state,
+    rssCandidates: [
+      {
+        feedUrl: `https://${host}/rss.xml`,
+        title: `${titlePrefix} Updates`,
+        description: 'Latest posts from the primary site feed.',
+      },
+      {
+        feedUrl: `https://${host}/podcast.xml`,
+        title: `${titlePrefix} Podcast`,
+        description: 'Audio episodes and show notes.',
+      },
+    ],
+  };
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3508,6 +3508,108 @@ input:focus {
   gap: 0.5rem;
 }
 
+.wizard-account-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: var(--surface-subtle, var(--surface));
+}
+
+.wizard-account-bar__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.6rem;
+  color: #fff;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.wizard-account-bar__copy {
+  display: grid;
+  gap: 0.1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.wizard-account-bar__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--success, #22c55e);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.wizard-account-bar__hint {
+  color: var(--text-dim);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.wizard-account-bar__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.wizard-account-bar__disconnect {
+  flex-shrink: 0;
+}
+
+.wizard-picker__item--rich {
+  padding: 0.7rem 0.85rem;
+  gap: 0.75rem;
+}
+
+.wizard-picker__media {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.wizard-picker__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 650;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.wizard-picker__item--rich > label {
+  display: grid;
+  gap: 0.1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.wizard-picker__item--rich > label strong {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+
+.wizard-picker__item--rich > label span {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+
 .wizard-done {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3508,75 +3508,174 @@ input:focus {
   gap: 0.5rem;
 }
 
-.wizard-account-bar {
+.wizard-provider-step {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 0.85rem;
-  padding: 0.7rem 0.85rem;
-  border: 1px solid var(--border);
-  border-radius: 0.85rem;
-  background: var(--surface-subtle, var(--surface));
+  flex: 1;
+  min-height: 0;
 }
 
-.wizard-account-bar__icon {
+.wizard-account-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.35rem 0.55rem 0.35rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  width: fit-content;
+  max-width: 100%;
+}
+
+.wizard-account-chip__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.6rem;
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 50%;
   color: #fff;
   flex-shrink: 0;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
-.wizard-account-bar__copy {
-  display: grid;
-  gap: 0.1rem;
-  flex: 1;
-  min-width: 0;
+.wizard-account-chip__icon > * {
+  transform: scale(0.82);
 }
 
-.wizard-account-bar__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  color: var(--success, #22c55e);
-  font-size: 0.82rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.wizard-account-bar__hint {
-  color: var(--text-dim);
-  font-size: 0.76rem;
-  line-height: 1.35;
-}
-
-.wizard-account-bar__actions {
+.wizard-account-chip__label {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wizard-account-chip__status {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--success, #22c55e);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--success, #22c55e) 25%, transparent);
   flex-shrink: 0;
 }
 
-.wizard-account-bar__disconnect {
-  flex-shrink: 0;
+.wizard-account-chip__link {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0.15rem 0.5rem;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 999px;
+  transition:
+    background 140ms ease,
+    color 140ms ease;
 }
 
-.wizard-picker__item--rich {
-  padding: 0.7rem 0.85rem;
+.wizard-account-chip__link:hover {
+  background: var(--surface-subtle);
+  color: var(--text);
+}
+
+.wizard-account-chip__link:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.wizard-account-chip__link--danger {
+  color: var(--danger, #ef4444);
+}
+
+.wizard-account-chip__link--danger:hover {
+  background: color-mix(in srgb, var(--danger, #ef4444) 12%, transparent);
+  color: var(--danger, #ef4444);
+}
+
+.wizard-account-chip__actions {
+  display: inline-flex;
+  gap: 0.15rem;
+  margin-left: auto;
+}
+
+.wizard-picker--rich .wizard-picker__list {
+  border: none;
+  background: transparent;
+  overflow: visible;
+}
+
+.wizard-picker--rich .wizard-picker__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.15rem;
+  max-height: 22rem;
+}
+
+.picker-row {
+  position: relative;
+  list-style: none;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: var(--surface);
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.picker-row:hover {
+  border-color: color-mix(in srgb, var(--text) 20%, var(--border));
+  background: var(--surface-subtle, var(--surface));
+}
+
+.picker-row--selected {
+  border-color: color-mix(in srgb, var(--accent, #3b82f6) 55%, transparent);
+  background: color-mix(in srgb, var(--accent, #3b82f6) 10%, var(--surface));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent, #3b82f6) 40%, transparent);
+}
+
+.picker-row__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+}
+
+.picker-row__input:focus-visible + .picker-row__label {
+  outline: 2px solid var(--accent, #3b82f6);
+  outline-offset: 2px;
+}
+
+.picker-row__label {
+  display: flex;
+  align-items: center;
   gap: 0.75rem;
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  cursor: pointer;
+  border-radius: inherit;
 }
 
-.wizard-picker__media {
+.picker-row__media {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
 }
 
-.wizard-picker__avatar {
+.picker-row__avatar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3584,30 +3683,63 @@ input:focus {
   height: 2.25rem;
   border-radius: 50%;
   color: #fff;
-  font-weight: 650;
+  font-weight: 700;
   font-size: 0.95rem;
   letter-spacing: 0.01em;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
-.wizard-picker__item--rich > label {
+.picker-row__text {
   display: grid;
   gap: 0.1rem;
   flex: 1;
   min-width: 0;
 }
 
-.wizard-picker__item--rich > label strong {
-  font-size: 0.95rem;
+.picker-row__text strong {
+  font-size: 0.93rem;
   font-weight: 600;
   color: var(--text);
   letter-spacing: -0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.wizard-picker__item--rich > label span {
+.picker-row__text span {
   color: var(--text-dim);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.picker-row__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: transparent;
+  flex-shrink: 0;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease;
+}
+
+.picker-row:hover .picker-row__check {
+  border-color: color-mix(in srgb, var(--text) 35%, var(--border));
+}
+
+.picker-row__check--on {
+  background: var(--accent, #3b82f6);
+  border-color: var(--accent, #3b82f6);
+  color: #fff;
 }
 
 .wizard-done {

--- a/apps/web/src/test/mocks/trpc.tsx
+++ b/apps/web/src/test/mocks/trpc.tsx
@@ -102,6 +102,7 @@ export const mutationSpies = {
   newslettersSyncNow: vi.fn(async (_input: unknown) => ({ success: true })),
   newslettersUpdateStatus: vi.fn(async (_input: unknown) => ({ success: true })),
   rssAdd: vi.fn(async (_input: unknown) => ({ success: true })),
+  connectionsDisconnect: vi.fn(async (_input: unknown) => ({ success: true })),
 };
 
 export const hookSpies = {
@@ -212,6 +213,9 @@ export const hookSpies = {
   rssAddUseMutation: vi.fn((options?: MutationOptions) =>
     createMutationResult(mutationSpies.rssAdd, options)
   ),
+  connectionsDisconnectUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.connectionsDisconnect, options)
+  ),
 };
 
 function createQueryResult<T>(data?: T, overrides: Partial<QueryResult<T>> = {}): QueryResult<T> {
@@ -277,6 +281,7 @@ export function resetTrpcMocks() {
   mutationSpies.newslettersSyncNow.mockResolvedValue({ success: true });
   mutationSpies.newslettersUpdateStatus.mockResolvedValue({ success: true });
   mutationSpies.rssAdd.mockResolvedValue({ success: true });
+  mutationSpies.connectionsDisconnect.mockResolvedValue({ success: true });
 
   hookSpies.itemsLibraryUseQuery.mockReset();
   hookSpies.itemsLibraryUseQuery.mockImplementation((_input) => createQueryResult());
@@ -410,6 +415,11 @@ export function resetTrpcMocks() {
   hookSpies.rssAddUseMutation.mockImplementation((options?: MutationOptions) =>
     createMutationResult(mutationSpies.rssAdd, options)
   );
+
+  hookSpies.connectionsDisconnectUseMutation.mockReset();
+  hookSpies.connectionsDisconnectUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.connectionsDisconnect, options)
+  );
 }
 
 export function setAuthAvailability(nextState: Partial<typeof authAvailability>) {
@@ -489,6 +499,10 @@ export const trpc = {
     connections: {
       list: {
         useQuery: () => hookSpies.connectionsListUseQuery(),
+      },
+      disconnect: {
+        useMutation: (options?: MutationOptions) =>
+          hookSpies.connectionsDisconnectUseMutation(options),
       },
     },
     list: {

--- a/apps/web/src/welcome-page.test.tsx
+++ b/apps/web/src/welcome-page.test.tsx
@@ -186,6 +186,24 @@ describe('WelcomePage — integration launcher', () => {
     expect(screen.queryByRole('button', { name: 'Connect YouTube' })).toBeNull();
   });
 
+  test('dev mock mode can simulate the YouTube connect-to-picker transition without OAuth', async () => {
+    const user = userEvent.setup();
+
+    renderRoute(<WelcomePage />, {
+      route: '/welcome?mockOnboarding=youtube-connect',
+      path: '/welcome',
+    });
+
+    expect(screen.getByText(/Mock mode: youtube connect/i)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Connect YouTube' })).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Connect YouTube' }));
+
+    expect(connectProvider).not.toHaveBeenCalled();
+    expect(screen.getByRole('searchbox', { name: /Search YouTube/i })).toBeVisible();
+    expect(screen.getByRole('checkbox', { name: 'Wendover Productions' })).toBeVisible();
+  });
+
   test('Newsletters opens the disconnected connect state when Gmail is not connected', async () => {
     const user = userEvent.setup();
 
@@ -195,6 +213,22 @@ describe('WelcomePage — integration launcher', () => {
 
     expect(screen.getByRole('heading', { name: 'Newsletters', level: 2 })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Connect Newsletters' })).toBeVisible();
+  });
+
+  test('dev mock mode can simulate a Gmail scan and show newsletter choices', async () => {
+    const user = userEvent.setup();
+
+    renderRoute(<WelcomePage />, {
+      route: '/welcome?mockOnboarding=gmail-scan',
+      path: '/welcome',
+    });
+
+    expect(screen.getByRole('button', { name: 'Scan newsletters' })).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Scan newsletters' }));
+
+    expect(screen.getByRole('checkbox', { name: 'Stratechery' })).toBeVisible();
+    expect(screen.getByRole('checkbox', { name: 'Morning Brew' })).toBeVisible();
   });
 
   test('connected Newsletters starts on the sender list and updates statuses', async () => {

--- a/apps/web/src/welcome-page.test.tsx
+++ b/apps/web/src/welcome-page.test.tsx
@@ -181,7 +181,7 @@ describe('WelcomePage — integration launcher', () => {
 
     await openIntegration(user, 'YouTube');
 
-    expect(screen.getByRole('heading', { name: 'YouTube', level: 2 })).toBeVisible();
+    expect(screen.getByRole('dialog', { name: 'Import from YouTube' })).toBeVisible();
     expect(screen.getByRole('checkbox', { name: 'Wendover Productions' })).toBeVisible();
     expect(screen.queryByRole('button', { name: 'Connect YouTube' })).toBeNull();
   });

--- a/apps/web/src/welcome-page.test.tsx
+++ b/apps/web/src/welcome-page.test.tsx
@@ -186,6 +186,26 @@ describe('WelcomePage — integration launcher', () => {
     expect(screen.queryByRole('button', { name: 'Connect YouTube' })).toBeNull();
   });
 
+  test('YouTube step exposes an account bar and disconnect confirm flow', async () => {
+    const user = userEvent.setup();
+
+    mockConnected({ YOUTUBE: true });
+    mockDiscoverItems({ YOUTUBE: [{ id: 'channel-1', name: 'Wendover Productions' }] });
+
+    renderRoute(<WelcomePage />, { route: '/welcome', path: '/welcome' });
+
+    await openIntegration(user, 'YouTube');
+
+    expect(screen.getByText('Connected to YouTube')).toBeVisible();
+    const disconnectButton = screen.getByRole('button', { name: 'Disconnect' });
+    await user.click(disconnectButton);
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await user.click(screen.getByRole('button', { name: 'Confirm disconnect' }));
+
+    expect(mutationSpies.connectionsDisconnect).toHaveBeenCalledWith({ provider: 'YOUTUBE' });
+  });
+
   test('dev mock mode can simulate the YouTube connect-to-picker transition without OAuth', async () => {
     const user = userEvent.setup();
 

--- a/apps/web/src/welcome-page.tsx
+++ b/apps/web/src/welcome-page.tsx
@@ -158,7 +158,10 @@ function SubscriptionPicker({
       : `Import ${selectedItems.length} ${selectedItems.length === 1 ? itemNounSingular : itemNounPlural}`;
 
   return (
-    <div className="wizard-picker" data-testid={testId}>
+    <div
+      className={cn('wizard-picker', renderItemMedia && 'wizard-picker--rich')}
+      data-testid={testId}
+    >
       {headerSlot}
       <div className="wizard-picker__controls">
         <label className="wizard-picker__search">
@@ -208,26 +211,52 @@ function SubscriptionPicker({
                 : undefined;
               const description = item.description ?? fallbackDescription;
               const rich = Boolean(renderItemMedia);
+
+              if (!rich) {
+                return (
+                  <li key={item.id} className="wizard-picker__item">
+                    <input
+                      id={inputId}
+                      type="checkbox"
+                      aria-label={item.label}
+                      checked={isSelected}
+                      onChange={() => toggleItem(item.id)}
+                    />
+                    <label htmlFor={inputId}>
+                      <strong>{item.label}</strong>
+                      {description ? <span>{description}</span> : null}
+                    </label>
+                  </li>
+                );
+              }
+
               return (
                 <li
                   key={item.id}
-                  className={cn('wizard-picker__item', rich && 'wizard-picker__item--rich')}
+                  className={cn('picker-row', isSelected && 'picker-row--selected')}
                 >
                   <input
                     id={inputId}
                     type="checkbox"
                     aria-label={item.label}
+                    className="picker-row__input"
                     checked={isSelected}
                     onChange={() => toggleItem(item.id)}
                   />
-                  {renderItemMedia ? (
-                    <span className="wizard-picker__media" aria-hidden="true">
-                      {renderItemMedia(item, isSelected)}
+                  <label htmlFor={inputId} className="picker-row__label">
+                    <span className="picker-row__media" aria-hidden="true">
+                      {renderItemMedia?.(item, isSelected)}
                     </span>
-                  ) : null}
-                  <label htmlFor={inputId}>
-                    <strong>{item.label}</strong>
-                    {description ? <span>{description}</span> : null}
+                    <span className="picker-row__text">
+                      <strong>{item.label}</strong>
+                      {description ? <span>{description}</span> : null}
+                    </span>
+                    <span
+                      className={cn('picker-row__check', isSelected && 'picker-row__check--on')}
+                      aria-hidden="true"
+                    >
+                      {isSelected ? <Check size={13} strokeWidth={3} /> : null}
+                    </span>
                   </label>
                 </li>
               );
@@ -924,11 +953,7 @@ function YoutubeStep({
   const brand = INTRO_BRAND.YOUTUBE;
 
   return (
-    <StepShell
-      title={config.title}
-      summary="Pick the channels you want in your Zine feed."
-      stepIcon="YOUTUBE"
-    >
+    <div className="wizard-provider-step">
       {error ? <p className="wizard-connect__error">{error}</p> : null}
       <SubscriptionPicker
         testId="youtube-picker"
@@ -944,7 +969,7 @@ function YoutubeStep({
         itemDescriptionFallback={() => 'YouTube channel'}
         renderItemMedia={(item) => (
           <span
-            className="wizard-picker__avatar"
+            className="picker-row__avatar"
             style={{ backgroundColor: brand.bg }}
             aria-hidden="true"
           >
@@ -960,7 +985,7 @@ function YoutubeStep({
           />
         }
       />
-    </StepShell>
+    </div>
   );
 }
 
@@ -981,28 +1006,31 @@ function ProviderAccountBar({
   const brand = INTRO_BRAND[provider];
 
   return (
-    <div className="wizard-account-bar" role="group" aria-label={`${provider} account`}>
+    <div className="wizard-account-chip" role="group" aria-label={`${provider} account`}>
       <span
-        className="wizard-account-bar__icon"
+        className="wizard-account-chip__icon"
         style={{ backgroundColor: brand.bg }}
         aria-hidden="true"
       >
         {brand.icon}
       </span>
-      <div className="wizard-account-bar__copy">
-        <span className="wizard-account-bar__status">
-          <Check size={12} strokeWidth={2.5} aria-hidden="true" />
-          {accountLabel}
-        </span>
-        <span className="wizard-account-bar__hint">Disconnecting stops future imports.</span>
-      </div>
+      <span className="wizard-account-chip__label">
+        <span className="wizard-account-chip__status" aria-hidden="true" />
+        {accountLabel}
+      </span>
       {confirming ? (
-        <div className="wizard-account-bar__actions">
-          <Button tone="ghost" onClick={() => setConfirming(false)} disabled={isDisconnecting}>
+        <span className="wizard-account-chip__actions">
+          <button
+            type="button"
+            className="wizard-account-chip__link"
+            onClick={() => setConfirming(false)}
+            disabled={isDisconnecting}
+          >
             Cancel
-          </Button>
-          <Button
-            tone="danger"
+          </button>
+          <button
+            type="button"
+            className="wizard-account-chip__link wizard-account-chip__link--danger"
             onClick={() => {
               onDisconnect();
               setConfirming(false);
@@ -1010,17 +1038,17 @@ function ProviderAccountBar({
             disabled={isDisconnecting}
           >
             {isDisconnecting ? 'Disconnecting…' : 'Confirm disconnect'}
-          </Button>
-        </div>
+          </button>
+        </span>
       ) : (
-        <Button
-          tone="ghost"
-          className="wizard-account-bar__disconnect"
+        <button
+          type="button"
+          className="wizard-account-chip__link"
           onClick={() => setConfirming(true)}
           disabled={isDisconnecting}
         >
           Disconnect
-        </Button>
+        </button>
       )}
     </div>
   );

--- a/apps/web/src/welcome-page.tsx
+++ b/apps/web/src/welcome-page.tsx
@@ -16,6 +16,13 @@ import {
   sourceConfigs,
   type WizardStep,
 } from './lib/onboarding';
+import {
+  connectMockProvider,
+  createMockOnboardingState,
+  discoverMockFeeds,
+  resolveMockOnboardingScenario,
+  scanMockNewsletters,
+} from './lib/onboarding-mocks';
 import { connectProvider } from './lib/oauth';
 import { trpc, useAppSession } from './lib/trpc';
 
@@ -266,6 +273,11 @@ export function WelcomePage() {
   const { getToken } = useAppSession();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const mockScenario = resolveMockOnboardingScenario(searchParams);
+  const mockScenarioState = useMemo(
+    () => (mockScenario ? createMockOnboardingState(mockScenario) : null),
+    [mockScenario]
+  );
 
   const origin = searchParams.get('origin') === 'settings' ? 'settings' : 'welcome';
   const closePath = origin === 'settings' ? '/settings' : '/bookmarks';
@@ -275,21 +287,32 @@ export function WelcomePage() {
   const [rssUrl, setRssUrl] = useState('');
   const [rssDiscoveryUrl, setRssDiscoveryUrl] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+  const [mockState, setMockState] = useState(mockScenarioState);
   const processedOauthContextRef = useRef<string | null>(null);
 
-  const connectionsQuery = trpc.subscriptions.connections.list.useQuery();
-  const connections = connectionsQuery.data;
+  const connectionsQuery = trpc.subscriptions.connections.list.useQuery(undefined, {
+    enabled: !mockState,
+  });
 
-  const spotifyAvailable = trpc.subscriptions.discover.available.useQuery({
-    provider: Provider.SPOTIFY,
-  });
-  const youtubeAvailable = trpc.subscriptions.discover.available.useQuery({
-    provider: Provider.YOUTUBE,
-  });
-  const newslettersListQuery = trpc.subscriptions.newsletters.list.useQuery({ limit: 100 });
+  const spotifyAvailable = trpc.subscriptions.discover.available.useQuery(
+    {
+      provider: Provider.SPOTIFY,
+    },
+    { enabled: !mockState }
+  );
+  const youtubeAvailable = trpc.subscriptions.discover.available.useQuery(
+    {
+      provider: Provider.YOUTUBE,
+    },
+    { enabled: !mockState }
+  );
+  const newslettersListQuery = trpc.subscriptions.newsletters.list.useQuery(
+    { limit: 100 },
+    { enabled: !mockState }
+  );
   const rssDiscoverQuery = trpc.subscriptions.rss.discover.useQuery(
     { url: rssDiscoveryUrl ?? 'https://example.com' },
-    { enabled: Boolean(rssDiscoveryUrl) }
+    { enabled: Boolean(rssDiscoveryUrl) && !mockState }
   );
 
   const addSubscription = trpc.subscriptions.add.useMutation();
@@ -312,9 +335,29 @@ export function WelcomePage() {
     setRssDiscoveryUrl(null);
   }, []);
 
+  useEffect(() => {
+    setMockState(mockScenarioState);
+    setActiveStep(mockScenarioState?.activeStep ?? null);
+    setStepError({});
+    setRssUrl('');
+    setRssDiscoveryUrl(null);
+    setIsImporting(false);
+    processedOauthContextRef.current = null;
+  }, [mockScenarioState]);
+
+  const connections = mockState?.connections ?? connectionsQuery.data;
+  const spotifyItems = mockState?.available.SPOTIFY ?? spotifyAvailable.data?.items ?? [];
+  const youtubeItems = mockState?.available.YOUTUBE ?? youtubeAvailable.data?.items ?? [];
+  const newsletters = mockState?.newsletters ?? newslettersListQuery.data?.items ?? [];
+
   const handleConnect = useCallback(
     async (provider: 'SPOTIFY' | 'YOUTUBE' | 'GMAIL') => {
       setStepError((current) => ({ ...current, [provider]: undefined }));
+      if (mockState) {
+        setMockState((current) => (current ? connectMockProvider(current, provider) : current));
+        return;
+      }
+
       setOnboardingOAuthContext({ origin, provider });
       try {
         await connectProvider(provider, getToken);
@@ -326,11 +369,13 @@ export function WelcomePage() {
         }));
       }
     },
-    [getToken, origin]
+    [getToken, mockState, origin]
   );
 
   // Resume on the provider step after returning from OAuth.
   useEffect(() => {
+    if (mockState) return;
+
     const context = getOnboardingOAuthContext();
     if (!context) return;
     const key = `${context.origin}:${context.provider}`;
@@ -340,10 +385,28 @@ export function WelcomePage() {
     processedOauthContextRef.current = key;
     clearOnboardingOAuthContext();
     setActiveStep(providerToWizardStep(context.provider));
-  }, [connections]);
+  }, [connections, mockState]);
 
   const importSpotify = useCallback(
     async (selected: PickerItem[]) => {
+      if (mockState) {
+        setMockState((current) =>
+          current
+            ? {
+                ...current,
+                available: {
+                  ...current.available,
+                  SPOTIFY: current.available.SPOTIFY.filter(
+                    (item) => !selected.some((selectedItem) => selectedItem.id === item.id)
+                  ),
+                },
+              }
+            : current
+        );
+        handleBackToIntegrations();
+        return;
+      }
+
       setIsImporting(true);
       try {
         for (const item of selected) {
@@ -363,11 +426,29 @@ export function WelcomePage() {
         setIsImporting(false);
       }
     },
-    [addSubscription, handleBackToIntegrations]
+    [addSubscription, handleBackToIntegrations, mockState]
   );
 
   const importYoutube = useCallback(
     async (selected: PickerItem[]) => {
+      if (mockState) {
+        setMockState((current) =>
+          current
+            ? {
+                ...current,
+                available: {
+                  ...current.available,
+                  YOUTUBE: current.available.YOUTUBE.filter(
+                    (item) => !selected.some((selectedItem) => selectedItem.id === item.id)
+                  ),
+                },
+              }
+            : current
+        );
+        handleBackToIntegrations();
+        return;
+      }
+
       setIsImporting(true);
       try {
         for (const item of selected) {
@@ -387,11 +468,27 @@ export function WelcomePage() {
         setIsImporting(false);
       }
     },
-    [addSubscription, handleBackToIntegrations]
+    [addSubscription, handleBackToIntegrations, mockState]
   );
 
   const importNewsletters = useCallback(
     async (selected: PickerItem[], deselected: PickerItem[]) => {
+      if (mockState) {
+        setMockState((current) =>
+          current
+            ? {
+                ...current,
+                newsletters: current.newsletters.map((newsletter) => ({
+                  ...newsletter,
+                  status: selected.some((item) => item.id === newsletter.id) ? 'ACTIVE' : 'HIDDEN',
+                })),
+              }
+            : current
+        );
+        handleBackToIntegrations();
+        return;
+      }
+
       setIsImporting(true);
       try {
         for (const item of selected) {
@@ -410,11 +507,26 @@ export function WelcomePage() {
         setIsImporting(false);
       }
     },
-    [handleBackToIntegrations, updateNewsletterStatus]
+    [handleBackToIntegrations, mockState, updateNewsletterStatus]
   );
 
   const importRss = useCallback(
     async (selected: PickerItem[]) => {
+      if (mockState) {
+        setMockState((current) =>
+          current
+            ? {
+                ...current,
+                rssCandidates: current.rssCandidates.filter(
+                  (candidate) => !selected.some((item) => item.id === candidate.feedUrl)
+                ),
+              }
+            : current
+        );
+        handleBackToIntegrations();
+        return;
+      }
+
       setIsImporting(true);
       try {
         for (const item of selected) {
@@ -430,11 +542,16 @@ export function WelcomePage() {
         setIsImporting(false);
       }
     },
-    [addRss, handleBackToIntegrations]
+    [addRss, handleBackToIntegrations, mockState]
   );
 
   const handleScanNewsletters = useCallback(async () => {
     setStepError((current) => ({ ...current, GMAIL: undefined }));
+    if (mockState) {
+      setMockState((current) => (current ? scanMockNewsletters(current) : current));
+      return;
+    }
+
     try {
       await syncNewsletters.mutateAsync(undefined);
     } catch (error) {
@@ -443,16 +560,24 @@ export function WelcomePage() {
         GMAIL: error instanceof Error ? error.message : 'Could not scan newsletters.',
       }));
     }
-  }, [syncNewsletters]);
+  }, [mockState, syncNewsletters]);
 
   const rssCandidates = useMemo<PickerItem[]>(() => {
+    if (mockState) {
+      return mockState.rssCandidates.map((candidate) => ({
+        id: candidate.feedUrl,
+        label: candidate.title,
+        description: candidate.description,
+      }));
+    }
+
     const candidates = rssDiscoverQuery.data?.candidates ?? [];
     return candidates.map((candidate) => ({
       id: candidate.feedUrl,
       label: candidate.title ?? candidate.feedUrl,
       description: candidate.feedUrl,
     }));
-  }, [rssDiscoverQuery.data?.candidates]);
+  }, [mockState, rssDiscoverQuery.data?.candidates]);
 
   const dialogTitle = useMemo(() => {
     if (!activeStep) {
@@ -472,21 +597,23 @@ export function WelcomePage() {
   }, [activeStep]);
 
   const dialogDescription = useMemo(() => {
+    const mockLabel = mockState ? ` Mock mode: ${mockState.scenario.replace(/-/g, ' ')}.` : '';
+
     if (!activeStep) {
-      return 'Pick an integration to connect or review. Connected providers jump straight to the subscriptions list.';
+      return `Pick an integration to connect or review. Connected providers jump straight to the subscriptions list.${mockLabel}`;
     }
 
     switch (activeStep) {
       case 'SPOTIFY':
-        return 'Connect Spotify and pick which podcasts to bring into Zine.';
+        return `Connect Spotify and pick which podcasts to bring into Zine.${mockLabel}`;
       case 'YOUTUBE':
-        return 'Connect YouTube and pick which channels to bring into Zine.';
+        return `Connect YouTube and pick which channels to bring into Zine.${mockLabel}`;
       case 'GMAIL':
-        return 'Connect Gmail and pick which newsletters to keep active in Zine.';
+        return `Connect Gmail and pick which newsletters to keep active in Zine.${mockLabel}`;
       case 'RSS':
-        return 'Paste a URL and pick which feeds to follow.';
+        return `Paste a URL and pick which feeds to follow.${mockLabel}`;
     }
-  }, [activeStep]);
+  }, [activeStep, mockState]);
 
   return (
     <Dialog open onOpenChange={(open) => (!open ? handleClose() : undefined)}>
@@ -530,8 +657,8 @@ export function WelcomePage() {
             {activeStep === 'SPOTIFY' ? (
               <SpotifyStep
                 connections={connections}
-                available={spotifyAvailable.data?.items ?? []}
-                isLoading={spotifyAvailable.isLoading}
+                available={spotifyItems}
+                isLoading={!mockState && spotifyAvailable.isLoading}
                 isImporting={isImporting}
                 onConnect={() => void handleConnect('SPOTIFY')}
                 onBack={handleBackToIntegrations}
@@ -543,8 +670,8 @@ export function WelcomePage() {
             {activeStep === 'YOUTUBE' ? (
               <YoutubeStep
                 connections={connections}
-                available={youtubeAvailable.data?.items ?? []}
-                isLoading={youtubeAvailable.isLoading}
+                available={youtubeItems}
+                isLoading={!mockState && youtubeAvailable.isLoading}
                 isImporting={isImporting}
                 onConnect={() => void handleConnect('YOUTUBE')}
                 onBack={handleBackToIntegrations}
@@ -556,9 +683,9 @@ export function WelcomePage() {
             {activeStep === 'GMAIL' ? (
               <GmailStep
                 connections={connections}
-                newsletters={newslettersListQuery.data?.items ?? []}
-                isLoading={newslettersListQuery.isLoading}
-                isSyncing={syncNewsletters.isPending}
+                newsletters={newsletters}
+                isLoading={!mockState && newslettersListQuery.isLoading}
+                isSyncing={!mockState && syncNewsletters.isPending}
                 isImporting={isImporting}
                 onConnect={() => void handleConnect('GMAIL')}
                 onScan={() => void handleScanNewsletters()}
@@ -573,10 +700,17 @@ export function WelcomePage() {
                 url={rssUrl}
                 onUrlChange={setRssUrl}
                 onDiscover={() => {
-                  if (rssUrl.trim()) setRssDiscoveryUrl(rssUrl.trim());
+                  if (!rssUrl.trim()) return;
+                  if (mockState) {
+                    setMockState((current) =>
+                      current ? discoverMockFeeds(current, rssUrl.trim()) : current
+                    );
+                    return;
+                  }
+                  setRssDiscoveryUrl(rssUrl.trim());
                 }}
                 candidates={rssCandidates}
-                isDiscovering={rssDiscoverQuery.isLoading && Boolean(rssDiscoveryUrl)}
+                isDiscovering={!mockState && rssDiscoverQuery.isLoading && Boolean(rssDiscoveryUrl)}
                 isImporting={isImporting}
                 onBack={handleBackToIntegrations}
                 onImport={importRss}

--- a/apps/web/src/welcome-page.tsx
+++ b/apps/web/src/welcome-page.tsx
@@ -20,6 +20,7 @@ import {
   connectMockProvider,
   createMockOnboardingState,
   discoverMockFeeds,
+  disconnectMockProvider,
   resolveMockOnboardingScenario,
   scanMockNewsletters,
 } from './lib/onboarding-mocks';
@@ -86,6 +87,9 @@ type SubscriptionPickerProps = {
   onBack: () => void;
   backLabel?: string;
   isImporting: boolean;
+  headerSlot?: ReactNode;
+  renderItemMedia?: (item: PickerItem, selected: boolean) => ReactNode;
+  itemDescriptionFallback?: (item: PickerItem) => string | undefined;
 };
 
 function SubscriptionPicker({
@@ -100,6 +104,9 @@ function SubscriptionPicker({
   onBack,
   backLabel = 'Back to integrations',
   isImporting,
+  headerSlot,
+  renderItemMedia,
+  itemDescriptionFallback,
 }: SubscriptionPickerProps) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -152,6 +159,7 @@ function SubscriptionPicker({
 
   return (
     <div className="wizard-picker" data-testid={testId}>
+      {headerSlot}
       <div className="wizard-picker__controls">
         <label className="wizard-picker__search">
           <span className="visually-hidden">{searchLabel}</span>
@@ -194,18 +202,32 @@ function SubscriptionPicker({
           <ul className="wizard-picker__items">
             {filtered.map((item) => {
               const inputId = `picker-${testId}-${item.id}`;
+              const isSelected = selected.has(item.id);
+              const fallbackDescription = itemDescriptionFallback
+                ? itemDescriptionFallback(item)
+                : undefined;
+              const description = item.description ?? fallbackDescription;
+              const rich = Boolean(renderItemMedia);
               return (
-                <li key={item.id} className="wizard-picker__item">
+                <li
+                  key={item.id}
+                  className={cn('wizard-picker__item', rich && 'wizard-picker__item--rich')}
+                >
                   <input
                     id={inputId}
                     type="checkbox"
                     aria-label={item.label}
-                    checked={selected.has(item.id)}
+                    checked={isSelected}
                     onChange={() => toggleItem(item.id)}
                   />
+                  {renderItemMedia ? (
+                    <span className="wizard-picker__media" aria-hidden="true">
+                      {renderItemMedia(item, isSelected)}
+                    </span>
+                  ) : null}
                   <label htmlFor={inputId}>
                     <strong>{item.label}</strong>
-                    {item.description ? <span>{item.description}</span> : null}
+                    {description ? <span>{description}</span> : null}
                   </label>
                 </li>
               );
@@ -319,6 +341,11 @@ export function WelcomePage() {
   const syncNewsletters = trpc.subscriptions.newsletters.syncNow.useMutation();
   const updateNewsletterStatus = trpc.subscriptions.newsletters.updateStatus.useMutation();
   const addRss = trpc.subscriptions.rss.add.useMutation();
+  const disconnectProviderMutation = trpc.subscriptions.connections.disconnect.useMutation();
+
+  const [disconnectingProvider, setDisconnectingProvider] = useState<
+    'YOUTUBE' | 'SPOTIFY' | 'GMAIL' | null
+  >(null);
 
   const handleClose = useCallback(() => {
     navigate(closePath, { replace: true });
@@ -328,6 +355,32 @@ export function WelcomePage() {
     setStepError((current) => ({ ...current, [step]: undefined }));
     setActiveStep(step);
   }, []);
+
+  const handleDisconnect = useCallback(
+    async (provider: 'YOUTUBE' | 'SPOTIFY' | 'GMAIL') => {
+      setStepError((current) => ({ ...current, [provider]: undefined }));
+      setDisconnectingProvider(provider);
+      try {
+        if (mockState) {
+          setMockState((current) =>
+            current ? disconnectMockProvider(current, provider) : current
+          );
+        } else {
+          await disconnectProviderMutation.mutateAsync({ provider: Provider[provider] });
+          await connectionsQuery.refetch();
+        }
+      } catch (error) {
+        setStepError((current) => ({
+          ...current,
+          [provider]:
+            error instanceof Error ? error.message : 'Could not disconnect this provider.',
+        }));
+      } finally {
+        setDisconnectingProvider(null);
+      }
+    },
+    [connectionsQuery, disconnectProviderMutation, mockState]
+  );
 
   const handleBackToIntegrations = useCallback(() => {
     setActiveStep(null);
@@ -676,6 +729,8 @@ export function WelcomePage() {
                 onConnect={() => void handleConnect('YOUTUBE')}
                 onBack={handleBackToIntegrations}
                 onImport={importYoutube}
+                onDisconnect={() => void handleDisconnect('YOUTUBE')}
+                isDisconnecting={disconnectingProvider === 'YOUTUBE'}
                 error={stepError.YOUTUBE ?? null}
               />
             ) : null}
@@ -843,8 +898,13 @@ function YoutubeStep({
   onConnect,
   onBack,
   onImport,
+  onDisconnect,
+  isDisconnecting,
   error,
-}: ProviderStepProps) {
+}: ProviderStepProps & {
+  onDisconnect: () => void;
+  isDisconnecting: boolean;
+}) {
   const connected = isConnected(connections, 'YOUTUBE');
   const config = sourceConfigs.YOUTUBE;
 
@@ -861,10 +921,12 @@ function YoutubeStep({
     );
   }
 
+  const brand = INTRO_BRAND.YOUTUBE;
+
   return (
     <StepShell
       title={config.title}
-      summary="Pick the YouTube channels to import."
+      summary="Pick the channels you want in your Zine feed."
       stepIcon="YOUTUBE"
     >
       {error ? <p className="wizard-connect__error">{error}</p> : null}
@@ -879,8 +941,88 @@ function YoutubeStep({
         onImport={onImport}
         onBack={onBack}
         isImporting={isImporting}
+        itemDescriptionFallback={() => 'YouTube channel'}
+        renderItemMedia={(item) => (
+          <span
+            className="wizard-picker__avatar"
+            style={{ backgroundColor: brand.bg }}
+            aria-hidden="true"
+          >
+            {item.label.trim().charAt(0).toUpperCase() || 'Y'}
+          </span>
+        )}
+        headerSlot={
+          <ProviderAccountBar
+            provider="YOUTUBE"
+            accountLabel="Connected to YouTube"
+            onDisconnect={onDisconnect}
+            isDisconnecting={isDisconnecting}
+          />
+        }
       />
     </StepShell>
+  );
+}
+
+type ProviderAccountBarProps = {
+  provider: IntegrationStep;
+  accountLabel: string;
+  onDisconnect: () => void;
+  isDisconnecting: boolean;
+};
+
+function ProviderAccountBar({
+  provider,
+  accountLabel,
+  onDisconnect,
+  isDisconnecting,
+}: ProviderAccountBarProps) {
+  const [confirming, setConfirming] = useState(false);
+  const brand = INTRO_BRAND[provider];
+
+  return (
+    <div className="wizard-account-bar" role="group" aria-label={`${provider} account`}>
+      <span
+        className="wizard-account-bar__icon"
+        style={{ backgroundColor: brand.bg }}
+        aria-hidden="true"
+      >
+        {brand.icon}
+      </span>
+      <div className="wizard-account-bar__copy">
+        <span className="wizard-account-bar__status">
+          <Check size={12} strokeWidth={2.5} aria-hidden="true" />
+          {accountLabel}
+        </span>
+        <span className="wizard-account-bar__hint">Disconnecting stops future imports.</span>
+      </div>
+      {confirming ? (
+        <div className="wizard-account-bar__actions">
+          <Button tone="ghost" onClick={() => setConfirming(false)} disabled={isDisconnecting}>
+            Cancel
+          </Button>
+          <Button
+            tone="danger"
+            onClick={() => {
+              onDisconnect();
+              setConfirming(false);
+            }}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting ? 'Disconnecting…' : 'Confirm disconnect'}
+          </Button>
+        </div>
+      ) : (
+        <Button
+          tone="ghost"
+          className="wizard-account-bar__disconnect"
+          onClick={() => setConfirming(true)}
+          disabled={isDisconnecting}
+        >
+          Disconnect
+        </Button>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a dev-only onboarding mock mode for the guided setup modal, with scenario presets for YouTube, Spotify, Gmail, and RSS
- let the welcome flow simulate connect, scan, discover, and import transitions locally so onboarding UI work is not blocked on live provider auth
- add PKCE fallbacks for local HTTP/Tailscale origins so the web OAuth flow no longer crashes when `crypto.subtle` or `crypto.randomUUID` are unavailable

## Why
Local onboarding iteration was blocked by Google OAuth restrictions on private HTTP origins and by secure-context-only browser crypto APIs. This PR makes the onboarding experience reviewable in-place while keeping the real provider flow intact for production.

## Testing
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun run --cwd apps/web build`