### PR TITLE
mobile: expand filtered home feed to 20 items

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -15,6 +15,7 @@ import {
   type NativeSyntheticEvent,
 } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
+import type { ContentType as ApiContentType } from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
 import { ArticleIcon, HeadphonesIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
@@ -179,13 +180,20 @@ export default function HomeScreen() {
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
   const [showCollapsedTitle, setShowCollapsedTitle] = useState(false);
   const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
+  const apiContentTypeFilter = useMemo(
+    () => (contentTypeFilter ? (contentTypeFilter.toUpperCase() as ApiContentType) : undefined),
+    [contentTypeFilter]
+  );
 
   useTabPrefetch('home');
 
   const { data: inboxPages, isLoading: isInboxLoading } = useInfiniteInboxItems({
+    ...(apiContentTypeFilter ? { filter: { contentType: apiContentTypeFilter } } : {}),
     limit: INBOX_PAGE_SIZE,
   });
-  const { data: homeData, isLoading: isHomeLoading } = useHomeData();
+  const { data: homeData, isLoading: isHomeLoading } = useHomeData(
+    apiContentTypeFilter ? { filter: { contentType: apiContentTypeFilter } } : undefined
+  );
   const { data: libraryData } = useLibraryItems();
   const { data: connections } = useConnections();
   const { data: subscriptionsData } = useSubscriptions();
@@ -209,7 +217,7 @@ export default function HomeScreen() {
   }, [homeData?.jumpBackIn]);
 
   const recentlyBookmarked = useMemo((): ItemCardData[] => {
-    return (homeData?.recentBookmarks ?? []).slice(0, 6).map((item) => ({
+    return (homeData?.recentBookmarks ?? []).map((item) => ({
       id: item.id,
       title: item.title,
       creator: item.publisher ?? item.creator,
@@ -225,7 +233,7 @@ export default function HomeScreen() {
   const inboxItems = useMemo((): ItemCardData[] => {
     const allInboxItems = inboxPages?.pages.flatMap((page) => page.items) ?? [];
 
-    return allInboxItems.slice(0, 4).map((item) => ({
+    return allInboxItems.map((item) => ({
       id: item.id,
       title: item.title,
       creator: item.creator,
@@ -370,7 +378,7 @@ export default function HomeScreen() {
         type: 'cover-rail',
         title: 'Podcasts',
         count: podcasts.length,
-        items: podcasts.slice(0, 5),
+        items: podcasts,
       });
     }
 

--- a/apps/mobile/hooks/use-bookmarks.ts
+++ b/apps/mobile/hooks/use-bookmarks.ts
@@ -11,6 +11,12 @@
 import { trpc } from '../lib/trpc';
 import { ContentType, Provider, UserItemState, isValidUrl as isValidSharedUrl } from '@zine/shared';
 import * as Crypto from 'expo-crypto';
+import {
+  getHomeQueryInputsForContentType,
+  type HomeQueryInput,
+  HOME_SECTION_LIMIT,
+  matchesHomeQueryContentType,
+} from '@/lib/home-query';
 
 /**
  * Preview data returned from bookmarks.preview
@@ -92,11 +98,12 @@ type InboxItem = NonNullable<InboxData>['items'][number];
 type OptimisticSaveContext = {
   previousLibrary?: LibraryData;
   previousContentTypeLibrary?: LibraryData;
-  previousHome?: HomeData;
+  previousHomes?: Array<{
+    input: HomeQueryInput | undefined;
+    data: HomeData;
+  }>;
   previousInbox?: InboxData;
 };
-
-const HOME_SECTION_LIMIT = 5;
 
 // Validation
 
@@ -284,11 +291,12 @@ export function useSaveBookmark() {
   const mutation = trpc.bookmarks.save.useMutation({
     onMutate: async (input: SaveBookmarkInput): Promise<OptimisticSaveContext> => {
       const optimisticItem = createOptimisticItem(input);
+      const homeInputs = getHomeQueryInputsForContentType(input.contentType);
 
       const cancellations: Promise<void>[] = [
         utils.items.library.cancel(),
-        utils.items.home.cancel(),
         utils.items.inbox.cancel(),
+        ...homeInputs.map((homeInput) => utils.items.home.cancel(homeInput)),
       ];
       if (input.contentType) {
         cancellations.push(
@@ -301,7 +309,10 @@ export function useSaveBookmark() {
       const previousContentTypeLibrary = input.contentType
         ? utils.items.library.getData({ filter: { contentType: input.contentType } })
         : undefined;
-      const previousHome = utils.items.home.getData();
+      const previousHomes = homeInputs.map((homeInput) => ({
+        input: homeInput,
+        data: utils.items.home.getData(homeInput),
+      }));
       const previousInbox = utils.items.inbox.getData();
 
       utils.items.library.setData(undefined, (old) => {
@@ -328,35 +339,43 @@ export function useSaveBookmark() {
         });
       }
 
-      utils.items.home.setData(undefined, (old) => {
-        if (!old) return old;
+      for (const homeInput of homeInputs) {
+        utils.items.home.setData(homeInput, (old) => {
+          if (
+            !old ||
+            !input.contentType ||
+            !matchesHomeQueryContentType(homeInput, input.contentType)
+          ) {
+            return old;
+          }
 
-        const recentBookmarks = [optimisticItem, ...old.recentBookmarks].slice(
-          0,
-          HOME_SECTION_LIMIT
-        );
-        const byContentType = {
-          ...old.byContentType,
-          videos:
-            input.contentType === ContentType.VIDEO
-              ? [optimisticItem, ...old.byContentType.videos].slice(0, HOME_SECTION_LIMIT)
-              : old.byContentType.videos,
-          podcasts:
-            input.contentType === ContentType.PODCAST
-              ? [optimisticItem, ...old.byContentType.podcasts].slice(0, HOME_SECTION_LIMIT)
-              : old.byContentType.podcasts,
-          articles:
-            input.contentType === ContentType.ARTICLE
-              ? [optimisticItem, ...old.byContentType.articles].slice(0, HOME_SECTION_LIMIT)
-              : old.byContentType.articles,
-        };
+          const recentBookmarks = [optimisticItem, ...old.recentBookmarks].slice(
+            0,
+            HOME_SECTION_LIMIT
+          );
+          const byContentType = {
+            ...old.byContentType,
+            videos:
+              input.contentType === ContentType.VIDEO
+                ? [optimisticItem, ...old.byContentType.videos].slice(0, HOME_SECTION_LIMIT)
+                : old.byContentType.videos,
+            podcasts:
+              input.contentType === ContentType.PODCAST
+                ? [optimisticItem, ...old.byContentType.podcasts].slice(0, HOME_SECTION_LIMIT)
+                : old.byContentType.podcasts,
+            articles:
+              input.contentType === ContentType.ARTICLE
+                ? [optimisticItem, ...old.byContentType.articles].slice(0, HOME_SECTION_LIMIT)
+                : old.byContentType.articles,
+          };
 
-        return {
-          ...old,
-          recentBookmarks,
-          byContentType,
-        };
-      });
+          return {
+            ...old,
+            recentBookmarks,
+            byContentType,
+          };
+        });
+      }
 
       const shouldRemoveInboxItem = (item: InboxItem) =>
         item.itemId === input.providerId || item.id === input.providerId;
@@ -374,7 +393,7 @@ export function useSaveBookmark() {
       return {
         previousLibrary,
         previousContentTypeLibrary,
-        previousHome,
+        previousHomes,
         previousInbox,
       };
     },
@@ -388,7 +407,9 @@ export function useSaveBookmark() {
           context.previousContentTypeLibrary
         );
       }
-      utils.items.home.setData(undefined, context.previousHome);
+      context.previousHomes?.forEach(({ input: homeInput, data }) => {
+        utils.items.home.setData(homeInput, data);
+      });
       utils.items.inbox.setData(undefined, context.previousInbox);
     },
     onSuccess: () => {

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -147,12 +147,29 @@ function serializeLibraryInput(
   });
 }
 
+function serializeHomeInput(
+  input?:
+    | {
+        filter?: {
+          contentType?: ContentType;
+        };
+      }
+    | undefined
+): string {
+  if (!input?.filter?.contentType) return 'default';
+
+  return JSON.stringify({
+    contentType: input.filter.contentType,
+  });
+}
+
 function createToggleUtils(initial?: {
   defaultLibrary?: MockListData;
   unfinishedLibrary?: MockListData;
   finishedLibrary?: MockListData;
   inbox?: MockListData;
   home?: MockHomeData;
+  filteredHome?: Partial<Record<ContentType, MockHomeData>>;
   itemsById?: Record<string, ReturnType<typeof createMockItem> | undefined>;
 }) {
   const libraryDataByKey = new Map<string, MockListData | undefined>();
@@ -196,9 +213,14 @@ function createToggleUtils(initial?: {
   const itemsById = new Map<string, ReturnType<typeof createMockItem> | undefined>(
     Object.entries(initial?.itemsById ?? {})
   );
-  const homeRef: { current: MockHomeData | undefined } = {
-    current: initial?.home,
-  };
+  const homeDataByKey = new Map<string, MockHomeData | undefined>();
+  homeDataByKey.set('default', initial?.home);
+  for (const [contentType, data] of Object.entries(initial?.filteredHome ?? {})) {
+    homeDataByKey.set(
+      serializeHomeInput({ filter: { contentType: contentType as ContentType } }),
+      data
+    );
+  }
 
   const mockLibraryCancel = jest.fn().mockResolvedValue(undefined);
   const mockInboxCancel = jest.fn().mockResolvedValue(undefined);
@@ -276,14 +298,17 @@ function createToggleUtils(initial?: {
       home: {
         cancel: mockHomeCancel,
         invalidate: mockHomeInvalidate,
-        getData: jest.fn(() => homeRef.current),
-        setData: jest.fn((_: undefined, updater: unknown) => {
-          const previous = homeRef.current;
+        getData: jest.fn((input?: Parameters<typeof serializeHomeInput>[0]) =>
+          homeDataByKey.get(serializeHomeInput(input))
+        ),
+        setData: jest.fn((input: Parameters<typeof serializeHomeInput>[0], updater: unknown) => {
+          const key = serializeHomeInput(input);
+          const previous = homeDataByKey.get(key);
           const next =
             typeof updater === 'function'
               ? (updater as (value: MockHomeData | undefined) => MockHomeData | undefined)(previous)
               : (updater as MockHomeData | undefined);
-          homeRef.current = next;
+          homeDataByKey.set(key, next);
           return next;
         }),
       },
@@ -321,7 +346,8 @@ function createToggleUtils(initial?: {
     readLibrary: (input?: Parameters<typeof serializeLibraryInput>[0]) =>
       libraryDataByKey.get(serializeLibraryInput(input)),
     readInbox: () => inboxRef.current,
-    readHome: () => homeRef.current,
+    readHome: (input?: Parameters<typeof serializeHomeInput>[0]) =>
+      homeDataByKey.get(serializeHomeInput(input)),
     readItem: (id: string) => itemsById.get(id),
     spies: {
       mockLibraryInvalidate,
@@ -431,6 +457,15 @@ describe('useItems list queries', () => {
 
     expect(mockHomeUseQuery).toHaveBeenCalledWith(
       undefined,
+      expect.objectContaining({ placeholderData: expect.any(Function) })
+    );
+  });
+
+  it('passes content type filters through to home data queries', () => {
+    renderHook(() => useHomeData({ filter: { contentType: ContentType.ARTICLE } }));
+
+    expect(mockHomeUseQuery).toHaveBeenCalledWith(
+      { filter: { contentType: ContentType.ARTICLE } },
       expect.objectContaining({ placeholderData: expect.any(Function) })
     );
   });
@@ -569,6 +604,9 @@ describe('useArchiveItem', () => {
         nextCursor: null,
       },
       home: createMockHomeData([item]),
+      filteredHome: {
+        [ContentType.ARTICLE]: createMockHomeData([item]),
+      },
       itemsById: {
         [item.id]: item,
       },
@@ -583,6 +621,9 @@ describe('useArchiveItem', () => {
     });
 
     expect(harness.readHome()?.recentBookmarks).toHaveLength(0);
+    expect(
+      harness.readHome({ filter: { contentType: ContentType.ARTICLE } })?.recentBookmarks
+    ).toHaveLength(0);
     expect(harness.readHome()?.byContentType.articles).toHaveLength(0);
   });
 });
@@ -826,6 +867,9 @@ describe('useToggleFinished', () => {
         nextCursor: null,
       },
       home: createMockHomeData([item]),
+      filteredHome: {
+        [ContentType.ARTICLE]: createMockHomeData([item]),
+      },
       itemsById: {
         [item.id]: item,
       },
@@ -841,6 +885,9 @@ describe('useToggleFinished', () => {
 
     expect(harness.readHome()?.recentBookmarks).toHaveLength(0);
     expect(harness.readHome()?.jumpBackIn).toHaveLength(0);
+    expect(
+      harness.readHome({ filter: { contentType: ContentType.ARTICLE } })?.recentBookmarks
+    ).toHaveLength(0);
     expect(harness.readHome()?.byContentType.articles).toHaveLength(0);
   });
 });

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -8,6 +8,15 @@ import { keepPreviousData } from '@tanstack/react-query';
 import { useRef } from 'react';
 import { trpc } from '@/lib/trpc';
 import { ContentType, Provider, UserItemState } from '@zine/shared';
+import {
+  buildHomeItemsInput,
+  getAllHomeQueryInputs,
+  type HomeItemsOptions,
+  type HomeQueryInput,
+  HOME_JUMP_BACK_IN_LIMIT,
+  HOME_SECTION_LIMIT,
+  matchesHomeQueryContentType,
+} from '@/lib/home-query';
 
 /** Type alias for tRPC utils */
 type TrpcUtils = ReturnType<typeof trpc.useUtils>;
@@ -16,6 +25,10 @@ type TrpcUtils = ReturnType<typeof trpc.useUtils>;
 type ListQueryData = ReturnType<TrpcUtils['items']['inbox']['getData']>;
 type InfiniteListQueryData = ReturnType<TrpcUtils['items']['inbox']['getInfiniteData']>;
 type HomeQueryData = ReturnType<TrpcUtils['items']['home']['getData']>;
+type HomeQuerySnapshot = {
+  input: HomeQueryInput | undefined;
+  data: HomeQueryData;
+};
 
 /** Single item query data type */
 type ItemQueryData = ReturnType<TrpcUtils['items']['get']['getData']>;
@@ -29,12 +42,9 @@ type OptimisticContext = {
   previousLibrary?: ListQueryData;
   previousInfiniteInbox?: InfiniteListQueryData;
   previousInfiniteLibrary?: InfiniteListQueryData;
-  previousHome?: HomeQueryData;
+  previousHomes?: HomeQuerySnapshot[];
   previousItem?: ItemQueryData;
 };
-
-const HOME_SECTION_LIMIT = 5;
-const HOME_JUMP_BACK_IN_LIMIT = 10;
 
 function removeItemFromHomeData(
   old: NonNullable<HomeQueryData>,
@@ -55,6 +65,42 @@ function removeItemFromHomeData(
 function invalidateRecapQueries(utils: TrpcUtils) {
   utils.insights.weeklyRecap.invalidate();
   utils.insights.weeklyRecapTeaser.invalidate();
+}
+
+function cancelHomeQueries(utils: TrpcUtils, inputs = getAllHomeQueryInputs()): Promise<void>[] {
+  return inputs.map((input) => utils.items.home.cancel(input));
+}
+
+function getHomeQuerySnapshots(
+  utils: TrpcUtils,
+  inputs = getAllHomeQueryInputs()
+): HomeQuerySnapshot[] {
+  return inputs.map((input) => ({
+    input,
+    data: utils.items.home.getData(input),
+  }));
+}
+
+function restoreHomeQuerySnapshots(utils: TrpcUtils, snapshots: HomeQuerySnapshot[]) {
+  for (const { input, data } of snapshots) {
+    utils.items.home.setData(input, data);
+  }
+}
+
+function updateHomeQueries(
+  utils: TrpcUtils,
+  updater: (
+    home: NonNullable<HomeQueryData>,
+    input: HomeQueryInput | undefined
+  ) => NonNullable<HomeQueryData>,
+  inputs = getAllHomeQueryInputs()
+) {
+  for (const input of inputs) {
+    utils.items.home.setData(input, (old) => {
+      if (!old) return old;
+      return updater(old, input);
+    });
+  }
 }
 
 type InboxItemsOptions = {
@@ -109,7 +155,11 @@ function createOptimisticConfig<TInput extends { id: string }>(
     /** Transform library items (return filtered/mapped items) */
     updateLibrary?: (items: ListItem[], input: TInput) => ListItem[];
     /** Transform home query data */
-    updateHome?: (home: NonNullable<HomeQueryData>, input: TInput) => NonNullable<HomeQueryData>;
+    updateHome?: (
+      home: NonNullable<HomeQueryData>,
+      input: TInput,
+      homeInput: HomeQueryInput | undefined
+    ) => NonNullable<HomeQueryData>;
     /** Transform single item cache */
     updateSingleItem?: (
       item: NonNullable<ItemQueryData>,
@@ -156,7 +206,7 @@ function createOptimisticConfig<TInput extends { id: string }>(
     onMutate: async (input: TInput): Promise<OptimisticContext> => {
       // Apply optimistic state immediately so swipe/tap actions do not wait on query cancellation.
       // Cancellation still runs in the background to reduce stale overwrite races.
-      const cancellations: Promise<void>[] = [utils.items.home.cancel()];
+      const cancellations: Promise<void>[] = [...cancelHomeQueries(utils)];
       if (options.updateInbox) cancellations.push(utils.items.inbox.cancel());
       if (options.updateLibrary) cancellations.push(utils.items.library.cancel());
       if (options.updateSingleItem) cancellations.push(utils.items.get.cancel({ id: input.id }));
@@ -190,11 +240,8 @@ function createOptimisticConfig<TInput extends { id: string }>(
       }
 
       if (options.updateHome) {
-        context.previousHome = utils.items.home.getData();
-        utils.items.home.setData(undefined, (old) => {
-          if (!old) return old;
-          return options.updateHome!(old, input);
-        });
+        context.previousHomes = getHomeQuerySnapshots(utils);
+        updateHomeQueries(utils, (old, homeInput) => options.updateHome!(old, input, homeInput));
       }
 
       if (options.updateSingleItem) {
@@ -221,8 +268,8 @@ function createOptimisticConfig<TInput extends { id: string }>(
       if (context?.previousInfiniteLibrary) {
         utils.items.library.setInfiniteData(undefined, context.previousInfiniteLibrary);
       }
-      if (context?.previousHome) {
-        utils.items.home.setData(undefined, context.previousHome);
+      if (context?.previousHomes) {
+        restoreHomeQuerySnapshots(utils, context.previousHomes);
       }
       if (context?.previousItem) {
         utils.items.get.setData({ id: vars.id }, context.previousItem);
@@ -386,8 +433,8 @@ export function useInfiniteLibraryItems(options?: LibraryItemsOptions) {
  *   );
  * }
  */
-export function useHomeData() {
-  return trpc.items.home.useQuery(undefined, {
+export function useHomeData(options?: HomeItemsOptions) {
+  return trpc.items.home.useQuery(buildHomeItemsInput(options), {
     placeholderData: keepPreviousData,
   });
 }
@@ -704,10 +751,12 @@ export function useToggleFinished() {
       return updatedItem as NonNullable<ItemQueryData>;
     });
 
-    utils.items.home.setData(undefined, (old) => {
-      if (!old) return old;
-
+    updateHomeQueries(utils, (old, homeInput) => {
       if (nowFinished || updatedItem.state !== UserItemState.BOOKMARKED) {
+        return removeItemFromHomeData(old, id);
+      }
+
+      if (!matchesHomeQueryContentType(homeInput, updatedItem.contentType)) {
         return removeItemFromHomeData(old, id);
       }
 
@@ -777,7 +826,7 @@ export function useToggleFinished() {
       void Promise.all([
         utils.items.library.cancel(),
         utils.items.inbox.cancel(),
-        utils.items.home.cancel(),
+        ...cancelHomeQueries(utils),
         utils.items.get.cancel({ id }),
       ]).catch(() => {
         utils.items.library.invalidate();

--- a/apps/mobile/lib/home-layout.test.ts
+++ b/apps/mobile/lib/home-layout.test.ts
@@ -9,23 +9,25 @@ describe('getValidFeaturedGridItems', () => {
     expect(getValidFeaturedGridItems([])).toEqual([]);
   });
 
-  it('returns an empty array when there is only one item', () => {
-    expect(getValidFeaturedGridItems([1])).toEqual([]);
+  it('keeps a single item when there is only one item', () => {
+    expect(getValidFeaturedGridItems([1])).toEqual([1]);
   });
 
-  it('keeps even counts up to six', () => {
+  it('keeps counts up to twenty', () => {
     expect(getValidFeaturedGridItems([1, 2])).toEqual([1, 2]);
     expect(getValidFeaturedGridItems([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
     expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
-  it('rounds odd counts down to the nearest even count', () => {
-    expect(getValidFeaturedGridItems([1, 2, 3])).toEqual([1, 2]);
-    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4]);
+  it('preserves odd counts', () => {
+    expect(getValidFeaturedGridItems([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]);
   });
 
-  it('caps results at six items', () => {
-    expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6, 7, 8])).toEqual([1, 2, 3, 4, 5, 6]);
+  it('caps results at twenty items', () => {
+    expect(getValidFeaturedGridItems(Array.from({ length: 22 }, (_, index) => index + 1))).toEqual(
+      Array.from({ length: 20 }, (_, index) => index + 1)
+    );
   });
 });
 
@@ -48,7 +50,7 @@ describe('getVisibleFeaturedGridItems', () => {
     ]);
   });
 
-  it('preserves the even-count cap after filtering', () => {
+  it('preserves later filtered matches up to the larger cap', () => {
     expect(getVisibleFeaturedGridItems(items, 'article')).toEqual([
       { id: 'article-1', contentType: 'article' },
       { id: 'article-2', contentType: 'article' },

--- a/apps/mobile/lib/home-layout.ts
+++ b/apps/mobile/lib/home-layout.ts
@@ -1,4 +1,4 @@
-const MAX_FEATURED_GRID_ITEMS = 6;
+const MAX_FEATURED_GRID_ITEMS = 20;
 const FEATURED_GRID_COLUMNS = 2;
 
 interface FeaturedGridItem {
@@ -6,10 +6,7 @@ interface FeaturedGridItem {
 }
 
 export function getValidFeaturedGridItems<T>(items: readonly T[]): T[] {
-  const cappedItems = items.slice(0, MAX_FEATURED_GRID_ITEMS);
-  const evenCount = cappedItems.length - (cappedItems.length % 2);
-
-  return cappedItems.slice(0, evenCount);
+  return items.slice(0, MAX_FEATURED_GRID_ITEMS);
 }
 
 export function getFeaturedGridItemWidth(containerWidth: number, gap: number): number {

--- a/apps/mobile/lib/home-query.ts
+++ b/apps/mobile/lib/home-query.ts
@@ -1,0 +1,52 @@
+import { ContentType } from '@zine/shared';
+
+export const HOME_SECTION_LIMIT = 20;
+export const HOME_JUMP_BACK_IN_LIMIT = 20;
+
+export type HomeItemsOptions = {
+  filter?: {
+    contentType?: ContentType;
+  };
+};
+
+export type HomeQueryInput = {
+  filter?: {
+    contentType?: ContentType;
+  };
+};
+
+const HOME_FILTER_CONTENT_TYPES = Object.values(ContentType);
+
+export function buildHomeItemsInput(options?: HomeItemsOptions): HomeQueryInput | undefined {
+  const filter = options?.filter?.contentType
+    ? { contentType: options.filter.contentType }
+    : undefined;
+
+  return filter ? { filter } : undefined;
+}
+
+export function matchesHomeQueryContentType(
+  input: HomeQueryInput | undefined,
+  contentType: ContentType
+): boolean {
+  return !input?.filter?.contentType || input.filter.contentType === contentType;
+}
+
+export function getAllHomeQueryInputs(): Array<HomeQueryInput | undefined> {
+  return [
+    undefined,
+    ...HOME_FILTER_CONTENT_TYPES.map((contentType) => ({
+      filter: { contentType },
+    })),
+  ];
+}
+
+export function getHomeQueryInputsForContentType(
+  contentType?: ContentType
+): Array<HomeQueryInput | undefined> {
+  if (!contentType) {
+    return [undefined];
+  }
+
+  return [undefined, { filter: { contentType } }];
+}

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -10,6 +10,24 @@ const mockScrollTo = jest.fn();
 const mockRemoveListener = jest.fn();
 let mockConnections: Array<{ provider: string; status: string }> = [];
 let mockSubscriptionsData: { items: Array<{ provider: string; status: string }> } = { items: [] };
+const mockUseInfiniteInboxItems = jest.fn((_options?: unknown) => ({
+  data: {
+    pages: [{ items: [], nextCursor: null }],
+  },
+  isLoading: false,
+}));
+const mockUseHomeData = jest.fn((_options?: unknown) => ({
+  data: {
+    jumpBackIn: [],
+    recentBookmarks: [],
+    byContentType: {
+      podcasts: [],
+      videos: [],
+      articles: [],
+    },
+  },
+  isLoading: false,
+}));
 
 const mockNavigation: {
   addListener: typeof mockAddListener;
@@ -257,24 +275,8 @@ jest.mock('@/lib/home-layout', () => ({
 
 jest.mock('@/hooks/use-items-trpc', () => ({
   useInboxItems: () => ({ data: { items: [] }, isLoading: false }),
-  useInfiniteInboxItems: () => ({
-    data: {
-      pages: [{ items: [], nextCursor: null }],
-    },
-    isLoading: false,
-  }),
-  useHomeData: () => ({
-    data: {
-      jumpBackIn: [],
-      recentBookmarks: [],
-      byContentType: {
-        podcasts: [],
-        videos: [],
-        articles: [],
-      },
-    },
-    isLoading: false,
-  }),
+  useInfiniteInboxItems: (options?: unknown) => mockUseInfiniteInboxItems(options),
+  useHomeData: (options?: unknown) => mockUseHomeData(options),
   useLibraryItems: () => ({ data: { items: [] } }),
   mapContentType: (value: string) => value.toLowerCase(),
   mapProvider: (value: string) => value,
@@ -287,6 +289,8 @@ describe('HomeScreen', () => {
     mockConnections = [];
     mockSubscriptionsData = { items: [] };
     mockIsFocused.mockReturnValue(true);
+    mockUseInfiniteInboxItems.mockClear();
+    mockUseHomeData.mockClear();
     mockAddListener.mockImplementation((event: 'tabPress', listener: () => void) => {
       if (event === 'tabPress') {
         tabPressListener = listener;
@@ -410,5 +414,24 @@ describe('HomeScreen', () => {
 
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
     expect(mockScrollTo).not.toHaveBeenCalled();
+  });
+
+  it('requests filtered home and inbox data after selecting a content type', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    expect(mockUseHomeData).toHaveBeenLastCalledWith({
+      filter: { contentType: 'ARTICLE' },
+    });
+    expect(mockUseInfiniteInboxItems).toHaveBeenLastCalledWith({
+      filter: { contentType: 'ARTICLE' },
+      limit: 20,
+    });
   });
 });

--- a/apps/worker/src/trpc/routers/items.test.ts
+++ b/apps/worker/src/trpc/routers/items.test.ts
@@ -175,27 +175,33 @@ function createMockItemsCaller(options: {
       };
     },
 
-    home: async () => {
+    home: async (input?: { filter?: { contentType?: string } }) => {
       if (!userId) {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
       }
-      const bookmarked = libraryItems.filter((item) => item.state === UserItemState.BOOKMARKED);
+      const bookmarked = libraryItems
+        .filter(
+          (item) =>
+            item.state === UserItemState.BOOKMARKED &&
+            (!input?.filter?.contentType || item.contentType === input.filter.contentType)
+        )
+        .sort((a, b) => (b.bookmarkedAt ?? '').localeCompare(a.bookmarkedAt ?? ''));
       const jumpBackIn = bookmarked
         .filter((item) => item.lastOpenedAt !== null)
         .sort((a, b) => (b.lastOpenedAt ?? '').localeCompare(a.lastOpenedAt ?? ''))
-        .slice(0, 10);
+        .slice(0, 20);
 
       return {
-        recentBookmarks: bookmarked.slice(0, 5),
+        recentBookmarks: bookmarked.slice(0, 20),
         jumpBackIn,
         byContentType: {
-          videos: bookmarked.filter((item) => item.contentType === ContentType.VIDEO).slice(0, 5),
+          videos: bookmarked.filter((item) => item.contentType === ContentType.VIDEO).slice(0, 20),
           podcasts: bookmarked
             .filter((item) => item.contentType === ContentType.PODCAST)
-            .slice(0, 5),
+            .slice(0, 20),
           articles: bookmarked
             .filter((item) => item.contentType === ContentType.ARTICLE)
-            .slice(0, 5),
+            .slice(0, 20),
         },
       };
     },
@@ -995,6 +1001,66 @@ describe('Items Router', () => {
       expect(result.byContentType.videos).toHaveLength(1);
       expect(result.byContentType.podcasts).toHaveLength(1);
       expect(result.byContentType.articles).toHaveLength(1);
+    });
+
+    it('should return up to 20 items per home section', async () => {
+      const libraryItems = Array.from({ length: 24 }, (_, index) =>
+        createMockItemView({
+          id: `ui-article-${index + 1}`,
+          itemId: `item-article-${index + 1}`,
+          state: UserItemState.BOOKMARKED,
+          contentType: ContentType.ARTICLE,
+          bookmarkedAt: new Date(Date.UTC(2026, 0, 24 - index)).toISOString(),
+        })
+      );
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        libraryItems,
+      });
+      const result = await caller.home();
+
+      expect(result.recentBookmarks).toHaveLength(20);
+      expect(result.byContentType.articles).toHaveLength(20);
+    });
+
+    it('should refill filtered home sections with up to 20 matching items', async () => {
+      const libraryItems = [
+        ...Array.from({ length: 12 }, (_, index) =>
+          createMockItemView({
+            id: `ui-video-${index + 1}`,
+            itemId: `item-video-${index + 1}`,
+            state: UserItemState.BOOKMARKED,
+            contentType: ContentType.VIDEO,
+            bookmarkedAt: new Date(Date.UTC(2026, 0, 30 - index * 2)).toISOString(),
+          })
+        ),
+        ...Array.from({ length: 12 }, (_, index) =>
+          createMockItemView({
+            id: `ui-article-${index + 1}`,
+            itemId: `item-article-${index + 1}`,
+            state: UserItemState.BOOKMARKED,
+            contentType: ContentType.ARTICLE,
+            bookmarkedAt: new Date(Date.UTC(2026, 0, 29 - index * 2)).toISOString(),
+          })
+        ),
+      ];
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        libraryItems,
+      });
+      const result = await caller.home({
+        filter: { contentType: ContentType.ARTICLE },
+      });
+
+      expect(result.recentBookmarks).toHaveLength(12);
+      expect(result.recentBookmarks.every((item) => item.contentType === ContentType.ARTICLE)).toBe(
+        true
+      );
+      expect(result.byContentType.articles).toHaveLength(12);
+      expect(result.byContentType.videos).toEqual([]);
+      expect(result.byContentType.podcasts).toEqual([]);
     });
   });
 

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -395,6 +395,16 @@ const PaginationSchema = z.object({
   limit: z.number().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
 });
 
+const HomeInputSchema = z
+  .object({
+    filter: z
+      .object({
+        contentType: ContentTypeSchema.nullish(),
+      })
+      .optional(),
+  })
+  .optional();
+
 // Router
 
 export const itemsRouter = router({
@@ -580,9 +590,10 @@ export const itemsRouter = router({
    * Get curated home sections.
    * Returns recent bookmarks, recently opened bookmarks ("Jump Back In"), and items by content type.
    */
-  home: protectedProcedure.query(async ({ ctx }) => {
-    const SECTION_LIMIT = 5;
-    const RECENTLY_OPENED_LIMIT = 10;
+  home: protectedProcedure.input(HomeInputSchema).query(async ({ input, ctx }) => {
+    const SECTION_LIMIT = 20;
+    const RECENTLY_OPENED_LIMIT = 20;
+    const contentTypeFilter = input?.filter?.contentType;
 
     // Base query for bookmarked items
     const baseConditions = [
@@ -590,6 +601,9 @@ export const itemsRouter = router({
       eq(userItems.state, UserItemState.BOOKMARKED),
       eq(userItems.isFinished, false),
     ];
+    const filteredConditions = contentTypeFilter
+      ? [...baseConditions, eq(items.contentType, contentTypeFilter)]
+      : baseConditions;
 
     // Fetch recent bookmarks
     const recentBookmarksQuery = ctx.db
@@ -597,7 +611,7 @@ export const itemsRouter = router({
       .from(userItems)
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
-      .where(and(...baseConditions))
+      .where(and(...filteredConditions))
       .orderBy(desc(userItems.bookmarkedAt))
       .limit(SECTION_LIMIT);
 
@@ -607,7 +621,7 @@ export const itemsRouter = router({
       .from(userItems)
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
-      .where(and(...baseConditions, isNotNull(userItems.lastOpenedAt)))
+      .where(and(...filteredConditions, isNotNull(userItems.lastOpenedAt)))
       .orderBy(desc(userItems.lastOpenedAt))
       .limit(RECENTLY_OPENED_LIMIT);
 
@@ -617,7 +631,7 @@ export const itemsRouter = router({
       .from(userItems)
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
-      .where(and(...baseConditions, eq(items.contentType, ContentType.VIDEO)))
+      .where(and(...filteredConditions, eq(items.contentType, ContentType.VIDEO)))
       .orderBy(desc(userItems.bookmarkedAt))
       .limit(SECTION_LIMIT);
 
@@ -627,7 +641,7 @@ export const itemsRouter = router({
       .from(userItems)
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
-      .where(and(...baseConditions, eq(items.contentType, ContentType.PODCAST)))
+      .where(and(...filteredConditions, eq(items.contentType, ContentType.PODCAST)))
       .orderBy(desc(userItems.bookmarkedAt))
       .limit(SECTION_LIMIT);
 
@@ -637,7 +651,7 @@ export const itemsRouter = router({
       .from(userItems)
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
-      .where(and(...baseConditions, eq(items.contentType, ContentType.ARTICLE)))
+      .where(and(...filteredConditions, eq(items.contentType, ContentType.ARTICLE)))
       .orderBy(desc(userItems.bookmarkedAt))
       .limit(SECTION_LIMIT);
 


### PR DESCRIPTION
## Summary
- raise home section caps to 20 items and share the home query limits in mobile
- make home content-type filters fetch the latest matching home and inbox items instead of only filtering the unfiltered payload
- keep optimistic home cache updates aligned with both default and filtered home query variants

## Testing
- `bun run --cwd apps/worker test:run src/trpc/routers/items.test.ts`
- `bun run --cwd apps/mobile test -- --runInBand hooks/use-items-trpc.test.ts hooks/use-bookmarks.test.ts lib/home-screen.test.tsx lib/home-layout.test.ts`
- `bun run typecheck`