### PR TITLE
mobile: restore homepage visual caps

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -52,6 +52,9 @@ function ChevronRightIcon({ size = 16, color = '#94A3B8' }: { size?: number; col
 }
 
 const INBOX_PAGE_SIZE = 20;
+const HOME_RECENT_BOOKMARKS_VISIBLE_LIMIT = 6;
+const HOME_INBOX_VISIBLE_LIMIT = 4;
+const HOME_PODCASTS_VISIBLE_LIMIT = 5;
 const HOME_TOP_THRESHOLD = 4;
 const HOME_COLLAPSED_TITLE_THRESHOLD = 44;
 
@@ -319,21 +322,23 @@ export default function HomeScreen() {
     [contentTypeFilter, jumpBackInItems]
   );
 
-  const filteredRecentlyBookmarked = useMemo(
-    () =>
+  const filteredRecentlyBookmarked = useMemo(() => {
+    const visibleItems =
       contentTypeFilter === null
         ? recentlyBookmarked
-        : recentlyBookmarked.filter((item) => item.contentType === contentTypeFilter),
-    [contentTypeFilter, recentlyBookmarked]
-  );
+        : recentlyBookmarked.filter((item) => item.contentType === contentTypeFilter);
 
-  const filteredInboxItems = useMemo(
-    () =>
+    return visibleItems.slice(0, HOME_RECENT_BOOKMARKS_VISIBLE_LIMIT);
+  }, [contentTypeFilter, recentlyBookmarked]);
+
+  const filteredInboxItems = useMemo(() => {
+    const visibleItems =
       contentTypeFilter === null
         ? inboxItems
-        : inboxItems.filter((item) => item.contentType === contentTypeFilter),
-    [contentTypeFilter, inboxItems]
-  );
+        : inboxItems.filter((item) => item.contentType === contentTypeFilter);
+
+    return visibleItems.slice(0, HOME_INBOX_VISIBLE_LIMIT);
+  }, [contentTypeFilter, inboxItems]);
 
   const showPodcastsSection = contentTypeFilter === null || contentTypeFilter === 'podcast';
   const showVideosSection = contentTypeFilter === null || contentTypeFilter === 'video';
@@ -378,7 +383,7 @@ export default function HomeScreen() {
         type: 'cover-rail',
         title: 'Podcasts',
         count: podcasts.length,
-        items: podcasts,
+        items: podcasts.slice(0, HOME_PODCASTS_VISIBLE_LIMIT),
       });
     }
 

--- a/apps/mobile/lib/home-layout.test.ts
+++ b/apps/mobile/lib/home-layout.test.ts
@@ -13,7 +13,7 @@ describe('getValidFeaturedGridItems', () => {
     expect(getValidFeaturedGridItems([1])).toEqual([1]);
   });
 
-  it('keeps counts up to twenty', () => {
+  it('keeps counts up to six', () => {
     expect(getValidFeaturedGridItems([1, 2])).toEqual([1, 2]);
     expect(getValidFeaturedGridItems([1, 2, 3, 4])).toEqual([1, 2, 3, 4]);
     expect(getValidFeaturedGridItems([1, 2, 3, 4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6]);
@@ -24,9 +24,9 @@ describe('getValidFeaturedGridItems', () => {
     expect(getValidFeaturedGridItems([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]);
   });
 
-  it('caps results at twenty items', () => {
-    expect(getValidFeaturedGridItems(Array.from({ length: 22 }, (_, index) => index + 1))).toEqual(
-      Array.from({ length: 20 }, (_, index) => index + 1)
+  it('caps results at six items', () => {
+    expect(getValidFeaturedGridItems(Array.from({ length: 8 }, (_, index) => index + 1))).toEqual(
+      Array.from({ length: 6 }, (_, index) => index + 1)
     );
   });
 });
@@ -50,7 +50,7 @@ describe('getVisibleFeaturedGridItems', () => {
     ]);
   });
 
-  it('preserves later filtered matches up to the larger cap', () => {
+  it('preserves later filtered matches up to the visual cap', () => {
     expect(getVisibleFeaturedGridItems(items, 'article')).toEqual([
       { id: 'article-1', contentType: 'article' },
       { id: 'article-2', contentType: 'article' },

--- a/apps/mobile/lib/home-layout.ts
+++ b/apps/mobile/lib/home-layout.ts
@@ -1,4 +1,4 @@
-const MAX_FEATURED_GRID_ITEMS = 20;
+const MAX_FEATURED_GRID_ITEMS = 6;
 const FEATURED_GRID_COLUMNS = 2;
 
 interface FeaturedGridItem {

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -10,9 +10,32 @@ const mockScrollTo = jest.fn();
 const mockRemoveListener = jest.fn();
 let mockConnections: Array<{ provider: string; status: string }> = [];
 let mockSubscriptionsData: { items: Array<{ provider: string; status: string }> } = { items: [] };
+type MockFeedItem = {
+  id: string;
+  title: string;
+  creator: string;
+  publisher?: string;
+  creatorImageUrl: string | null;
+  thumbnailUrl: string | null;
+  contentType?: string;
+  provider: string;
+  duration: number | null;
+  readingTimeMinutes: number | null;
+};
+
+type MockHomeData = {
+  jumpBackIn: MockFeedItem[];
+  recentBookmarks: MockFeedItem[];
+  byContentType: {
+    podcasts: MockFeedItem[];
+    videos: MockFeedItem[];
+    articles: MockFeedItem[];
+  };
+};
+
 const mockUseInfiniteInboxItems = jest.fn((_options?: unknown) => ({
   data: {
-    pages: [{ items: [], nextCursor: null }],
+    pages: [{ items: [] as MockFeedItem[], nextCursor: null }],
   },
   isLoading: false,
 }));
@@ -25,7 +48,7 @@ const mockUseHomeData = jest.fn((_options?: unknown) => ({
       videos: [],
       articles: [],
     },
-  },
+  } as MockHomeData,
   isLoading: false,
 }));
 
@@ -179,7 +202,7 @@ jest.mock('react-native', () => ({
 
       return React.createElement(
         'flat-list',
-        props,
+        { data, renderItem, ...props },
         renderListBoundary(ListHeaderComponent),
         renderedItems,
         renderListBoundary(ListFooterComponent)
@@ -269,8 +292,8 @@ jest.mock('@/hooks/use-subscriptions-query', () => ({
 }));
 
 jest.mock('@/lib/home-layout', () => ({
+  ...jest.requireActual('@/lib/home-layout'),
   getFeaturedGridItemWidth: () => 160,
-  getVisibleFeaturedGridItems: (items: unknown[]) => items,
 }));
 
 jest.mock('@/hooks/use-items-trpc', () => ({
@@ -433,5 +456,90 @@ describe('HomeScreen', () => {
       filter: { contentType: 'ARTICLE' },
       limit: 20,
     });
+  });
+
+  it('restores the home section visual caps without changing the expanded fetch size', () => {
+    mockUseHomeData.mockReturnValue({
+      data: {
+        jumpBackIn: Array.from({ length: 8 }, (_, index) => ({
+          id: `jump-${index + 1}`,
+          title: `Jump ${index + 1}`,
+          creator: 'Creator',
+          publisher: 'Publisher',
+          creatorImageUrl: null,
+          thumbnailUrl: null,
+          contentType: 'ARTICLE',
+          provider: 'RSS',
+          duration: null,
+          readingTimeMinutes: null,
+        })),
+        recentBookmarks: Array.from({ length: 8 }, (_, index) => ({
+          id: `bookmark-${index + 1}`,
+          title: `Bookmark ${index + 1}`,
+          creator: 'Creator',
+          publisher: 'Publisher',
+          creatorImageUrl: null,
+          thumbnailUrl: null,
+          contentType: 'ARTICLE',
+          provider: 'RSS',
+          duration: null,
+          readingTimeMinutes: null,
+        })),
+        byContentType: {
+          podcasts: Array.from({ length: 6 }, (_, index) => ({
+            id: `podcast-${index + 1}`,
+            title: `Podcast ${index + 1}`,
+            creator: 'Creator',
+            publisher: 'Publisher',
+            creatorImageUrl: null,
+            thumbnailUrl: null,
+            provider: 'SPOTIFY',
+            duration: null,
+            readingTimeMinutes: null,
+          })),
+          videos: [],
+          articles: [],
+        },
+      },
+      isLoading: false,
+    });
+    mockUseInfiniteInboxItems.mockReturnValue({
+      data: {
+        pages: [
+          {
+            items: Array.from({ length: 8 }, (_, index) => ({
+              id: `inbox-${index + 1}`,
+              title: `Inbox ${index + 1}`,
+              creator: 'Creator',
+              creatorImageUrl: null,
+              thumbnailUrl: null,
+              contentType: 'ARTICLE',
+              provider: 'RSS',
+              duration: null,
+              readingTimeMinutes: null,
+            })),
+            nextCursor: null,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    const sections = findHomeList(renderer!).props.data as Array<{
+      key: string;
+      items: unknown[];
+    }>;
+
+    expect(sections.find((section) => section.key === 'jump-back-in')?.items).toHaveLength(6);
+    expect(sections.find((section) => section.key === 'recently-bookmarked')?.items).toHaveLength(
+      6
+    );
+    expect(sections.find((section) => section.key === 'inbox')?.items).toHaveLength(4);
+    expect(sections.find((section) => section.key === 'podcasts')?.items).toHaveLength(5);
   });
 });


### PR DESCRIPTION
## Summary
- restore the mobile home screen's visual caps for Jump Back In, Inbox, and podcast rails
- keep the recent home filtering change so filtered views still fetch enough items before slicing for presentation
- add regression coverage for the capped home sections and featured grid helper

## Why
The previous home feed update correctly expanded filtering to the latest 20 items, but it also removed the UI-level limits that kept the homepage sections visually constrained.