### PR TITLE
refactor(mobile): remove sticky snap-to action row from item detail

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -15,22 +15,20 @@
 
 import { Image } from 'expo-image';
 import { useRouter, type Href } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Colors, Spacing } from '@/constants/theme';
+import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { upgradeSpotifyImageUrl, upgradeYouTubeImageUrl } from '@/lib/content-utils';
 import {
   COLLAPSED_TITLE_THRESHOLD,
   getCollapsedHeaderTitleThreshold,
-  getStickyActionRowThreshold,
   useCollapsedHeaderTitle,
 } from '@/lib/native-large-title-header';
 
 import { XPostBookmarkView } from './item-detail-components';
 import { styles } from './item-detail-styles';
-import { ItemDetailActions } from './detail/components/ItemDetailActions';
 import { ItemDetailContent } from './detail/components/ItemDetailContent';
 import {
   ItemDetailParallaxLayout,
@@ -54,8 +52,6 @@ export default function ItemDetailScreen() {
   const insets = useSafeAreaInsets();
   const [contentTopY, setContentTopY] = useState<number | null>(null);
   const [titleOffsetY, setTitleOffsetY] = useState<number | null>(null);
-  const [actionRowStartY, setActionRowStartY] = useState<number | null>(null);
-  const [showStickyActions, setShowStickyActions] = useState(false);
 
   const { id, isValid, message } = useItemDetailParams();
   const { item, isLoading, error, refetch, creatorData } = useItemDetailData({ id, isValid });
@@ -85,32 +81,14 @@ export default function ItemDetailScreen() {
 
     return getCollapsedHeaderTitleThreshold(contentTopY + titleOffsetY);
   }, [contentTopY, titleOffsetY]);
-  const stickyActionsTop = insets.top + 56 + Spacing.sm;
-  const stickyBackdropHeight = stickyActionsTop + 56 + Spacing.sm;
-  const stickyActionRowThreshold = useMemo(() => {
-    if (actionRowStartY === null) {
-      return Number.POSITIVE_INFINITY;
-    }
-
-    return getStickyActionRowThreshold(actionRowStartY, stickyActionsTop);
-  }, [actionRowStartY, stickyActionsTop]);
-  const {
-    handleScroll: handleTitleScroll,
-    showCollapsedTitle,
-    scrollOffsetYRef,
-  } = useCollapsedHeaderTitle({
+  const { handleScroll: handleTitleScroll, showCollapsedTitle } = useCollapsedHeaderTitle({
     threshold: collapsedTitleThreshold,
   });
   const handleScroll = useCallback(
     (event: Parameters<typeof handleTitleScroll>[0]) => {
       handleTitleScroll(event);
-
-      const shouldShowStickyActions = event.nativeEvent.contentOffset.y > stickyActionRowThreshold;
-      setShowStickyActions((current) =>
-        current === shouldShowStickyActions ? current : shouldShowStickyActions
-      );
     },
-    [handleTitleScroll, stickyActionRowThreshold]
+    [handleTitleScroll]
   );
   const handleContentLayout = useCallback((nextContentTopY: number) => {
     setContentTopY((current) => (current === nextContentTopY ? current : nextContentTopY));
@@ -118,18 +96,6 @@ export default function ItemDetailScreen() {
   const handleTitleLayout = useCallback((nextTitleOffsetY: number) => {
     setTitleOffsetY((current) => (current === nextTitleOffsetY ? current : nextTitleOffsetY));
   }, []);
-  const handleActionRowLayout = useCallback((nextActionRowStartY: number) => {
-    setActionRowStartY((current) =>
-      current === nextActionRowStartY ? current : nextActionRowStartY
-    );
-  }, []);
-
-  useEffect(() => {
-    const shouldShowStickyActions = scrollOffsetYRef.current > stickyActionRowThreshold;
-    setShowStickyActions((current) =>
-      current === shouldShowStickyActions ? current : shouldShowStickyActions
-    );
-  }, [scrollOffsetYRef, stickyActionRowThreshold]);
 
   if (!isValid) {
     return (
@@ -150,26 +116,6 @@ export default function ItemDetailScreen() {
   if (!item) {
     return <ItemDetailNotFoundState colors={colors} />;
   }
-
-  const stickyActionBar = (
-    <ItemDetailActions
-      item={item}
-      colors={colors}
-      bookmarkActionIcon={viewState.bookmarkActionIcon}
-      bookmarkActionColor={viewState.bookmarkActionColor}
-      isBookmarkActionDisabled={viewState.isBookmarkActionDisabled}
-      secondaryActionIcon={viewState.secondaryActionIcon}
-      secondaryActionColor={viewState.secondaryActionColor}
-      isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
-      onBookmarkToggle={handleToggleBookmark}
-      onSecondaryAction={handleSecondaryAction}
-      onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
-      onShare={handleShare}
-      onOpenLink={handleOpenLink}
-      useAnimatedContainer={false}
-      style={styles.stickyActionRow}
-    />
-  );
 
   if (viewState.isXPost) {
     return (
@@ -194,13 +140,9 @@ export default function ItemDetailScreen() {
         isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
         creatorData={creatorData}
         showCollapsedTitle={showCollapsedTitle}
-        showStickyActions={showStickyActions}
-        stickyActionsTop={stickyActionsTop}
-        stickyBackdropHeight={stickyBackdropHeight}
         onScroll={handleScroll}
         onContentLayout={handleContentLayout}
         onTitleLayout={handleTitleLayout}
-        onActionRowLayout={handleActionRowLayout}
       />
     );
   }
@@ -217,10 +159,6 @@ export default function ItemDetailScreen() {
         onScroll={handleScroll}
         screenTitle={item.title}
         showCollapsedTitle={showCollapsedTitle}
-        showStickyActions={showStickyActions}
-        stickyActions={stickyActionBar}
-        stickyActionsTop={stickyActionsTop}
-        stickyBackdropHeight={stickyBackdropHeight}
         headerImage={
           <Image
             source={{ uri: item.thumbnailUrl! }}
@@ -255,7 +193,6 @@ export default function ItemDetailScreen() {
           useAnimatedDescription
           onContentLayout={handleContentLayout}
           onTitleLayout={handleTitleLayout}
-          onActionRowLayout={handleActionRowLayout}
         />
       </ItemDetailParallaxLayout>
     );
@@ -269,10 +206,6 @@ export default function ItemDetailScreen() {
       onScroll={handleScroll}
       screenTitle={item.title}
       showCollapsedTitle={showCollapsedTitle}
-      showStickyActions={showStickyActions}
-      stickyActions={stickyActionBar}
-      stickyActionsTop={stickyActionsTop}
-      stickyBackdropHeight={stickyBackdropHeight}
     >
       <ItemDetailContent
         item={item}
@@ -298,7 +231,6 @@ export default function ItemDetailScreen() {
         useAnimatedDescription={false}
         onContentLayout={handleContentLayout}
         onTitleLayout={handleTitleLayout}
-        onActionRowLayout={handleActionRowLayout}
       />
     </ItemDetailScrollLayout>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
@@ -29,7 +29,6 @@ type ItemDetailActionsProps = {
   onShare: () => void;
   onOpenLink: () => void;
   useAnimatedContainer: boolean;
-  onLayout?: (actionRowStartY: number) => void;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -48,7 +47,6 @@ export function ItemDetailActions({
   onShare,
   onOpenLink,
   useAnimatedContainer,
-  onLayout,
   style,
 }: ItemDetailActionsProps) {
   const fabConfig = getFabConfig(item.provider);
@@ -56,10 +54,7 @@ export function ItemDetailActions({
   const Container = useAnimatedContainer ? Animated.View : View;
 
   return (
-    <Container
-      style={[styles.actionRow, style]}
-      onLayout={({ nativeEvent }) => onLayout?.(nativeEvent.layout.y)}
-    >
+    <Container style={[styles.actionRow, style]}>
       <View style={styles.actionRowLeft}>
         <IconActionButton
           icon={bookmarkActionIcon}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -34,7 +34,6 @@ type ItemDetailContentProps = {
   useAnimatedActions: boolean;
   onContentLayout?: (contentTopY: number) => void;
   onTitleLayout?: (titleOffsetY: number) => void;
-  onActionRowLayout?: (actionRowStartY: number) => void;
 };
 
 export function ItemDetailContent({
@@ -59,7 +58,6 @@ export function ItemDetailContent({
   useAnimatedDescription,
   onContentLayout,
   onTitleLayout,
-  onActionRowLayout,
 }: ItemDetailContentProps) {
   const DescriptionContainer = useAnimatedDescription ? Animated.View : View;
 
@@ -94,7 +92,6 @@ export function ItemDetailContent({
         onShare={onShare}
         onOpenLink={onOpenLink}
         useAnimatedContainer={useAnimatedActions}
-        onLayout={onActionRowLayout}
       />
 
       {item.summary && (

--- a/apps/mobile/app/item/detail/components/ItemDetailFloatingBack.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailFloatingBack.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import { View, Text } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import type { EdgeInsets } from 'react-native-safe-area-context';
@@ -13,10 +12,6 @@ type ItemDetailFloatingBackProps = {
   onBack: () => void;
   screenTitle: string;
   showCollapsedTitle: boolean;
-  showStickyActions?: boolean;
-  stickyActions?: ReactNode;
-  stickyActionsTop?: number;
-  stickyBackdropHeight?: number;
 };
 
 export function ItemDetailFloatingBack({
@@ -25,16 +20,8 @@ export function ItemDetailFloatingBack({
   onBack,
   screenTitle,
   showCollapsedTitle,
-  showStickyActions = false,
-  stickyActions,
-  stickyActionsTop = 0,
-  stickyBackdropHeight = 0,
 }: ItemDetailFloatingBackProps) {
-  const backdropHeight = showStickyActions
-    ? stickyBackdropHeight
-    : showCollapsedTitle
-      ? insets.top + 56
-      : 0;
+  const backdropHeight = showCollapsedTitle ? insets.top + 56 : 0;
 
   return (
     <View style={styles.floatingOverlay} pointerEvents="box-none">
@@ -63,16 +50,6 @@ export function ItemDetailFloatingBack({
           <Text style={[styles.floatingTitle, { color: colors.text }]} numberOfLines={1}>
             {screenTitle}
           </Text>
-        </Animated.View>
-      ) : null}
-
-      {showStickyActions && stickyActions ? (
-        <Animated.View
-          entering={FadeIn.duration(160)}
-          exiting={FadeOut.duration(160)}
-          style={[styles.stickyActionRowContainer, { top: stickyActionsTop }]}
-        >
-          {stickyActions}
         </Animated.View>
       ) : null}
 

--- a/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
@@ -18,10 +18,6 @@ type ItemDetailLayoutBaseProps = {
   onScroll: ScrollViewProps['onScroll'];
   screenTitle: string;
   showCollapsedTitle: boolean;
-  showStickyActions?: boolean;
-  stickyActions?: ReactNode;
-  stickyActionsTop?: number;
-  stickyBackdropHeight?: number;
 };
 
 export function ItemDetailParallaxLayout({
@@ -32,10 +28,6 @@ export function ItemDetailParallaxLayout({
   onScroll,
   screenTitle,
   showCollapsedTitle,
-  showStickyActions,
-  stickyActions,
-  stickyActionsTop,
-  stickyBackdropHeight,
   headerImage,
   headerAspectRatio,
 }: ItemDetailLayoutBaseProps & {
@@ -62,10 +54,6 @@ export function ItemDetailParallaxLayout({
         onBack={onBack}
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
-        showStickyActions={showStickyActions}
-        stickyActions={stickyActions}
-        stickyActionsTop={stickyActionsTop}
-        stickyBackdropHeight={stickyBackdropHeight}
       />
     </View>
   );
@@ -79,10 +67,6 @@ export function ItemDetailScrollLayout({
   onScroll,
   screenTitle,
   showCollapsedTitle,
-  showStickyActions,
-  stickyActions,
-  stickyActionsTop,
-  stickyBackdropHeight,
 }: ItemDetailLayoutBaseProps) {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -104,10 +88,6 @@ export function ItemDetailScrollLayout({
         onBack={onBack}
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
-        showStickyActions={showStickyActions}
-        stickyActions={stickyActions}
-        stickyActionsTop={stickyActionsTop}
-        stickyBackdropHeight={stickyBackdropHeight}
       />
     </View>
   );

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -98,13 +98,9 @@ export function XPostBookmarkView({
   isSecondaryActionDisabled,
   creatorData,
   showCollapsedTitle,
-  showStickyActions,
-  stickyActionsTop,
-  stickyBackdropHeight,
   onScroll,
   onContentLayout,
   onTitleLayout,
-  onActionRowLayout,
 }: {
   item: {
     id: string;
@@ -136,13 +132,9 @@ export function XPostBookmarkView({
   isSecondaryActionDisabled: boolean;
   creatorData?: { handle?: string | null } | null;
   showCollapsedTitle: boolean;
-  showStickyActions: boolean;
-  stickyActionsTop: number;
-  stickyBackdropHeight: number;
   onScroll: ScrollViewProps['onScroll'];
   onContentLayout: (contentTopY: number) => void;
   onTitleLayout: (titleOffsetY: number) => void;
-  onActionRowLayout: (actionRowStartY: number) => void;
 }) {
   // Extract @handle from URL as fallback if creatorData.handle not available
   const handle = creatorData?.handle || extractXHandle(item.canonicalUrl);
@@ -237,7 +229,6 @@ export function XPostBookmarkView({
         onShare={onShare}
         onOpenLink={onOpenLink}
         useAnimatedContainer
-        onLayout={onActionRowLayout}
       />
 
       {/* Tweet Content Section - Twitter-like layout */}
@@ -344,28 +335,6 @@ export function XPostBookmarkView({
           onBack={onBack}
           screenTitle={item.title}
           showCollapsedTitle={showCollapsedTitle}
-          showStickyActions={showStickyActions}
-          stickyActionsTop={stickyActionsTop}
-          stickyBackdropHeight={stickyBackdropHeight}
-          stickyActions={
-            <ItemDetailActions
-              item={item}
-              colors={colors}
-              bookmarkActionIcon={bookmarkActionIcon}
-              bookmarkActionColor={bookmarkActionColor}
-              isBookmarkActionDisabled={isBookmarkActionDisabled}
-              secondaryActionIcon={secondaryActionIcon}
-              secondaryActionColor={secondaryActionColor}
-              isSecondaryActionDisabled={isSecondaryActionDisabled}
-              onBookmarkToggle={onBookmarkToggle}
-              onSecondaryAction={onSecondaryAction}
-              onManageTags={onManageTags}
-              onShare={onShare}
-              onOpenLink={onOpenLink}
-              useAnimatedContainer={false}
-              style={styles.stickyActionRow}
-            />
-          }
         />
       </View>
     );
@@ -394,28 +363,6 @@ export function XPostBookmarkView({
         onBack={onBack}
         screenTitle={item.title}
         showCollapsedTitle={showCollapsedTitle}
-        showStickyActions={showStickyActions}
-        stickyActionsTop={stickyActionsTop}
-        stickyBackdropHeight={stickyBackdropHeight}
-        stickyActions={
-          <ItemDetailActions
-            item={item}
-            colors={colors}
-            bookmarkActionIcon={bookmarkActionIcon}
-            bookmarkActionColor={bookmarkActionColor}
-            isBookmarkActionDisabled={isBookmarkActionDisabled}
-            secondaryActionIcon={secondaryActionIcon}
-            secondaryActionColor={secondaryActionColor}
-            isSecondaryActionDisabled={isSecondaryActionDisabled}
-            onBookmarkToggle={onBookmarkToggle}
-            onSecondaryAction={onSecondaryAction}
-            onManageTags={onManageTags}
-            onShare={onShare}
-            onOpenLink={onOpenLink}
-            useAnimatedContainer={false}
-            style={styles.stickyActionRow}
-          />
-        }
       />
     </View>
   );

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -69,12 +69,6 @@ export const styles = StyleSheet.create({
   floatingTitle: {
     ...Typography.titleMedium,
   },
-  stickyActionRowContainer: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    zIndex: 101,
-  },
   headerIconButton: {
     width: 40,
     height: 40,
@@ -176,9 +170,6 @@ export const styles = StyleSheet.create({
     marginBottom: Spacing.md,
     paddingLeft: Spacing.xl,
     paddingRight: Spacing.xl + Spacing.sm,
-  },
-  stickyActionRow: {
-    marginBottom: 0,
   },
   actionRowLeft: {
     flexDirection: 'row',

--- a/apps/mobile/lib/native-large-title-header.test.ts
+++ b/apps/mobile/lib/native-large-title-header.test.ts
@@ -2,7 +2,6 @@ import { act, renderHook } from '@testing-library/react-hooks';
 
 import {
   getCollapsedHeaderTitleThreshold,
-  getStickyActionRowThreshold,
   useCollapsedHeaderTitle,
 } from '@/lib/native-large-title-header';
 
@@ -66,11 +65,5 @@ describe('native-large-title-header', () => {
   it('derives a bookmark collapse threshold from the title start position', () => {
     expect(getCollapsedHeaderTitleThreshold(180)).toBe(136);
     expect(getCollapsedHeaderTitleThreshold(32)).toBe(44);
-  });
-
-  it('derives a sticky action threshold from the row start position', () => {
-    expect(getStickyActionRowThreshold(340, 120)).toBe(220);
-    expect(getStickyActionRowThreshold(90, 120)).toBe(0);
-    expect(getStickyActionRowThreshold(Number.NaN, 120)).toBe(Number.POSITIVE_INFINITY);
   });
 });

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -17,14 +17,6 @@ export function getCollapsedHeaderTitleThreshold(
   return Math.max(collapsedTitleThreshold, titleStartY - collapsedTitleThreshold);
 }
 
-export function getStickyActionRowThreshold(actionRowStartY: number, stickyTopY: number) {
-  if (!Number.isFinite(actionRowStartY) || !Number.isFinite(stickyTopY)) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  return Math.max(0, actionRowStartY - stickyTopY);
-}
-
 export const lightweightHeaderStackScreenOptions: NativeStackNavigationOptions = {
   headerBackButtonDisplayMode: 'minimal',
   headerShadowVisible: false,


### PR DESCRIPTION
## Summary

Removes the sticky/snapping action row feature from the mobile item detail screen. The action row (icon buttons + provider FAB) now stays as part of the normal scrollable content body instead of snapping into a floating overlay when the user scrolls past it.

## Changes

- `[id].tsx` — removed `showStickyActions` state, `actionRowStartY` tracking, `stickyActionsTop`/`stickyBackdropHeight` calculations, sticky action bar JSX, and `getStickyActionRowThreshold` import
- `ItemDetailLayouts.tsx` — removed `showStickyActions`, `stickyActions`, `stickyActionsTop`, `stickyBackdropHeight` props from both layout components
- `ItemDetailFloatingBack.tsx` — removed all sticky-actions overlay rendering; backdrop now only responds to the collapsed title state
- `ItemDetailContent.tsx` — removed `onActionRowLayout` prop
- `ItemDetailActions.tsx` — removed `onLayout` prop and `nativeEvent` handler
- `item-detail-components.tsx` (XPost) — removed sticky action bar wiring and the three sticky props from `XPostBookmarkView`
- `item-detail-styles.ts` — removed `stickyActionRow` and `stickyActionRowContainer` style rules
- `native-large-title-header.ts` — removed `getStickyActionRowThreshold` helper
- `native-large-title-header.test.ts` — removed corresponding test case