### PR TITLE
[codex] Add unified creator and library search

### DIFF
--- a/apps/mobile/app/(tabs)/search/creator-result-row.tsx
+++ b/apps/mobile/app/(tabs)/search/creator-result-row.tsx
@@ -1,0 +1,130 @@
+import { Image } from 'expo-image';
+import { useRouter, type Href } from 'expo-router';
+import { memo, useCallback, useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { SourceBadge } from '@/components/badges';
+import { Surface, Text } from '@/components/primitives';
+import { Radius, Spacing, Typography } from '@/constants/theme';
+import { useAppTheme } from '@/hooks/use-app-theme';
+import type { CreatorSearchResult } from '@/hooks/use-search';
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function getLibraryCountText(count: number): string {
+  if (count <= 0) {
+    return 'Creator';
+  }
+
+  return `${count} library ${count === 1 ? 'item' : 'items'}`;
+}
+
+export const CreatorResultRow = memo(function CreatorResultRow({
+  creator,
+}: {
+  creator: CreatorSearchResult;
+}) {
+  const router = useRouter();
+  const { colors, motion } = useAppTheme();
+  const initials = useMemo(() => getInitials(creator.name), [creator.name]);
+
+  const handlePress = useCallback(() => {
+    router.push(`/creator/${creator.creatorId}?source=search` as Href);
+  }, [creator.creatorId, router]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${creator.name}, creator`}
+      onPress={handlePress}
+      style={({ pressed }) => [styles.pressable, pressed && { opacity: motion.opacity.pressed }]}
+    >
+      <Surface tone="transparent" style={styles.row}>
+        <View style={[styles.avatar, { backgroundColor: colors.surfaceRaised }]}>
+          {creator.imageUrl ? (
+            <Image
+              source={{ uri: creator.imageUrl }}
+              style={styles.avatarImage}
+              contentFit="cover"
+            />
+          ) : (
+            <Text variant="labelLarge" tone="secondary" transform="none">
+              {initials}
+            </Text>
+          )}
+        </View>
+
+        <View style={styles.content}>
+          <View style={styles.titleRow}>
+            <Text variant="bodyMedium" tone="primary" numberOfLines={1} style={styles.title}>
+              {creator.name}
+            </Text>
+            {creator.isSubscribed ? (
+              <Text variant="labelSmall" tone="accent" numberOfLines={1}>
+                Subscribed
+              </Text>
+            ) : null}
+          </View>
+
+          <View style={styles.metadataRow}>
+            <SourceBadge provider={creator.provider} />
+            <Text variant="bodySmall" tone="tertiary" numberOfLines={1}>
+              {creator.handle ?? getLibraryCountText(creator.libraryItemCount)}
+            </Text>
+          </View>
+        </View>
+      </Surface>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  pressable: {
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.xs,
+  },
+  row: {
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  avatar: {
+    width: 52,
+    height: 52,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  avatarImage: {
+    width: '100%',
+    height: '100%',
+  },
+  content: {
+    flex: 1,
+    minWidth: 0,
+    gap: Spacing.xs,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  title: {
+    ...Typography.bodyMedium,
+    flex: 1,
+  },
+  metadataRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+});

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Stack, useNavigation } from 'expo-router';
 import { Surface } from 'heroui-native';
 import { FlatList, type ListRenderItemInfo, StyleSheet, View } from 'react-native';
+import type { SearchBarCommands } from 'react-native-screens';
 
 import { type ItemCardData, ItemCard } from '@/components/item-card';
 import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
@@ -26,6 +27,8 @@ type SearchRow =
 export default function SearchTabScreen() {
   const navigation = useNavigation();
   const listScrollRef = useRef<FlatList<SearchRow>>(null);
+  const searchBarRef = useRef<SearchBarCommands | null>(null);
+  const focusSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
 
@@ -40,6 +43,17 @@ export default function SearchTabScreen() {
   }, [searchQuery]);
 
   const { data, isLoading, error } = useSearchResults(debouncedSearchQuery);
+
+  const focusSearchBar = useCallback(() => {
+    if (focusSearchTimeoutRef.current) {
+      clearTimeout(focusSearchTimeoutRef.current);
+    }
+
+    focusSearchTimeoutRef.current = setTimeout(() => {
+      searchBarRef.current?.focus();
+      focusSearchTimeoutRef.current = null;
+    }, 100);
+  }, []);
 
   const searchRows: SearchRow[] = useMemo(
     () =>
@@ -75,12 +89,24 @@ export default function SearchTabScreen() {
   useEffect(() => {
     const tabNavigation = navigation.getParent() ?? navigation;
 
-    return tabNavigation.addListener('tabPress', () => {
+    const removeTabPressListener = tabNavigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
 
       listScrollRef.current?.scrollToOffset({ offset: 0, animated: true });
+      focusSearchBar();
     });
-  }, [navigation]);
+
+    const removeFocusListener = navigation.addListener('focus', focusSearchBar);
+
+    return () => {
+      if (focusSearchTimeoutRef.current) {
+        clearTimeout(focusSearchTimeoutRef.current);
+        focusSearchTimeoutRef.current = null;
+      }
+      removeTabPressListener();
+      removeFocusListener();
+    };
+  }, [focusSearchBar, navigation]);
 
   const renderItem = useCallback(({ item, index }: ListRenderItemInfo<SearchRow>) => {
     if (item.type === 'creator') {
@@ -114,6 +140,8 @@ export default function SearchTabScreen() {
           tintColor: colors.text,
           screenTitle: 'Search',
           headerSearchBarOptions: {
+            ref: searchBarRef,
+            autoFocus: true,
             placement: 'automatic',
             placeholder: 'Search your library',
             hideWhenScrolling: false,

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -9,12 +9,23 @@ import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
 import { Colors, Spacing } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
-import { useLibraryItems } from '@/hooks/use-items-trpc';
+import { useSearchResults, type CreatorSearchResult } from '@/hooks/use-search';
 import { createLightweightHeaderScreenOptions } from '@/lib/native-large-title-header';
+import { CreatorResultRow } from './creator-result-row';
+
+type SearchRow =
+  | {
+      type: 'creator';
+      creator: CreatorSearchResult;
+    }
+  | {
+      type: 'item';
+      item: ItemCardData;
+    };
 
 export default function SearchTabScreen() {
   const navigation = useNavigation();
-  const listScrollRef = useRef<FlatList<ItemCardData>>(null);
+  const listScrollRef = useRef<FlatList<SearchRow>>(null);
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
 
@@ -28,27 +39,37 @@ export default function SearchTabScreen() {
     return () => clearTimeout(handle);
   }, [searchQuery]);
 
-  const { data, isLoading, error } = useLibraryItems({
-    search: debouncedSearchQuery || undefined,
-  });
+  const { data, isLoading, error } = useSearchResults(debouncedSearchQuery);
 
-  const libraryItems: ItemCardData[] = useMemo(
+  const searchRows: SearchRow[] = useMemo(
     () =>
-      (data?.items ?? []).map((item) => ({
-        id: item.id,
-        title: item.title,
-        creator: item.creator,
-        creatorImageUrl: item.creatorImageUrl ?? null,
-        thumbnailUrl: item.thumbnailUrl ?? null,
-        contentType: mapContentType(item.contentType) as ContentType,
-        provider: mapProvider(item.provider) as Provider,
-        duration: item.duration ?? null,
-        readingTimeMinutes: item.readingTimeMinutes ?? null,
-        bookmarkedAt: item.bookmarkedAt ?? null,
-        publishedAt: item.publishedAt ?? null,
-        isFinished: item.isFinished,
-      })),
-    [data?.items]
+      (data?.results ?? []).map((result) => {
+        if (result.type === 'creator') {
+          return {
+            type: 'creator',
+            creator: result,
+          };
+        }
+
+        return {
+          type: 'item',
+          item: {
+            id: result.id,
+            title: result.title,
+            creator: result.creator,
+            creatorImageUrl: result.creatorImageUrl ?? null,
+            thumbnailUrl: result.thumbnailUrl ?? null,
+            contentType: mapContentType(result.contentType) as ContentType,
+            provider: mapProvider(result.provider) as Provider,
+            duration: result.duration ?? null,
+            readingTimeMinutes: result.readingTimeMinutes ?? null,
+            bookmarkedAt: result.bookmarkedAt ?? null,
+            publishedAt: result.publishedAt ?? null,
+            isFinished: result.isFinished,
+          },
+        };
+      }),
+    [data?.results]
   );
 
   useEffect(() => {
@@ -61,14 +82,15 @@ export default function SearchTabScreen() {
     });
   }, [navigation]);
 
-  const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
-      <ItemCard item={item} shape="row" index={index} />
-    ),
-    []
-  );
+  const renderItem = useCallback(({ item, index }: ListRenderItemInfo<SearchRow>) => {
+    if (item.type === 'creator') {
+      return <CreatorResultRow creator={item.creator} />;
+    }
 
-  const isShowingState = isLoading || Boolean(error) || libraryItems.length === 0;
+    return <ItemCard item={item.item} shape="row" index={index} />;
+  }, []);
+
+  const isShowingState = isLoading || Boolean(error) || searchRows.length === 0;
   const listEmptyComponent = isLoading ? (
     <LoadingState />
   ) : error ? (
@@ -104,8 +126,10 @@ export default function SearchTabScreen() {
 
       <FlatList
         ref={listScrollRef}
-        data={isShowingState ? [] : libraryItems}
-        keyExtractor={(item) => item.id}
+        data={isShowingState ? [] : searchRows}
+        keyExtractor={(item) =>
+          item.type === 'creator' ? `creator:${item.creator.creatorId}` : `item:${item.item.id}`
+        }
         renderItem={renderItem}
         style={styles.listContainer}
         contentContainerStyle={[styles.listContent, isShowingState && styles.emptyListContent]}

--- a/apps/mobile/hooks/use-search.test.ts
+++ b/apps/mobile/hooks/use-search.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+const mockSearchUseQuery = jest.fn();
+
+jest.mock('../lib/trpc', () => ({
+  trpc: {
+    search: {
+      query: {
+        useQuery: mockSearchUseQuery,
+      },
+    },
+  },
+}));
+
+import { useSearchResults } from './use-search';
+
+describe('useSearchResults', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchUseQuery.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  });
+
+  it('trims the query before requesting unified search results', () => {
+    renderHook(() => useSearchResults('  Joe Rogan  '));
+
+    expect(mockSearchUseQuery).toHaveBeenCalledWith(
+      {
+        query: 'Joe Rogan',
+        scope: 'library',
+        creatorsLimit: 5,
+        itemsLimit: 20,
+      },
+      expect.objectContaining({
+        enabled: true,
+      })
+    );
+  });
+
+  it('disables the backend query when the search text is blank', () => {
+    renderHook(() => useSearchResults('   '));
+
+    expect(mockSearchUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: ' ',
+      }),
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+});

--- a/apps/mobile/hooks/use-search.ts
+++ b/apps/mobile/hooks/use-search.ts
@@ -1,0 +1,33 @@
+import { keepPreviousData } from '@tanstack/react-query';
+
+import { trpc } from '@/lib/trpc';
+import type { RouterOutputs } from '@/lib/trpc-types';
+
+export type SearchOutput = RouterOutputs['search']['query'];
+export type SearchResult = SearchOutput['results'][number];
+export type CreatorSearchResult = Extract<SearchResult, { type: 'creator' }>;
+export type ItemSearchResult = Extract<SearchResult, { type: 'item' }>;
+
+export function useSearchResults(
+  query: string,
+  options?: {
+    creatorsLimit?: number;
+    itemsLimit?: number;
+  }
+) {
+  const trimmedQuery = query.trim();
+  const enabled = trimmedQuery.length > 0;
+
+  return trpc.search.query.useQuery(
+    {
+      query: enabled ? trimmedQuery : ' ',
+      scope: 'library',
+      creatorsLimit: options?.creatorsLimit ?? 5,
+      itemsLimit: options?.itemsLimit ?? 20,
+    },
+    {
+      enabled,
+      placeholderData: keepPreviousData,
+    }
+  );
+}

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -9,6 +9,7 @@ import { bookmarksRouter } from './routers/bookmarks';
 import { creatorsRouter } from './routers/creators';
 import { adminRouter } from './routers/admin';
 import { insightsRouter } from './routers/insights';
+import { searchRouter } from './routers/search';
 
 /**
  * Root tRPC router
@@ -63,6 +64,7 @@ export const appRouter = router({
   admin: adminRouter,
   // Creator view operations
   creators: creatorsRouter,
+  search: searchRouter,
   insights: insightsRouter,
 });
 

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -306,7 +306,7 @@ async function getTagsForUserItems(
   return map;
 }
 
-async function toItemViewsWithTags(
+export async function toItemViewsWithTags(
   ctx: { db: Database; userId: string },
   rows: Array<{
     user_items: typeof userItems.$inferSelect;

--- a/apps/worker/src/trpc/routers/search.test.ts
+++ b/apps/worker/src/trpc/routers/search.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for unified search response ranking and shaping.
+ *
+ * @vitest-environment miniflare
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ContentType, Provider, UserItemState } from '@zine/shared';
+
+import { buildSearchResponse, type CreatorSearchRow, type SearchItemView } from './search';
+
+const baseCreator: CreatorSearchRow = {
+  id: 'creator_joe',
+  name: 'Joe Rogan',
+  normalizedName: 'joe rogan',
+  handle: '@joerogan',
+  imageUrl: 'https://example.com/joe.jpg',
+  provider: Provider.SPOTIFY,
+  description: 'Podcast host',
+  externalUrl: 'https://open.spotify.com/show/joe',
+  isSubscribed: true,
+  subscriptionId: 'sub_joe',
+  libraryItemCount: 12,
+  latestPublishedAt: '2026-04-01T00:00:00Z',
+};
+
+const baseItem: SearchItemView = {
+  id: 'user_item_1',
+  itemId: 'item_1',
+  title: 'Joe Rogan Experience #123',
+  thumbnailUrl: null,
+  canonicalUrl: 'https://example.com/episode',
+  contentType: ContentType.PODCAST,
+  provider: Provider.SPOTIFY,
+  creator: 'Joe Rogan',
+  creatorImageUrl: 'https://example.com/joe.jpg',
+  creatorId: 'creator_joe',
+  publisher: null,
+  summary: null,
+  duration: 3600,
+  publishedAt: '2026-03-01T00:00:00Z',
+  wordCount: null,
+  readingTimeMinutes: null,
+  state: UserItemState.BOOKMARKED,
+  ingestedAt: '2026-03-02T00:00:00Z',
+  bookmarkedAt: '2026-03-03T00:00:00Z',
+  lastOpenedAt: null,
+  progress: null,
+  isFinished: false,
+  finishedAt: null,
+  tags: [],
+};
+
+describe('buildSearchResponse', () => {
+  it('returns exact creator matches before matching library items', () => {
+    const response = buildSearchResponse({
+      query: 'Joe Rogan',
+      creatorRows: [baseCreator],
+      items: [baseItem],
+      nextCursor: null,
+    });
+
+    expect(response.results.map((result) => result.type)).toEqual(['creator', 'item']);
+    expect(response.results[0]).toMatchObject({
+      type: 'creator',
+      creatorId: 'creator_joe',
+      name: 'Joe Rogan',
+      isSubscribed: true,
+      libraryItemCount: 12,
+    });
+    expect(response.sections.creators).toHaveLength(1);
+    expect(response.sections.items).toHaveLength(1);
+  });
+
+  it('deduplicates creator rows while preserving subscription and library metadata', () => {
+    const response = buildSearchResponse({
+      query: 'joe',
+      creatorRows: [
+        {
+          ...baseCreator,
+          isSubscribed: false,
+          subscriptionId: null,
+          libraryItemCount: 3,
+          latestPublishedAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          ...baseCreator,
+          isSubscribed: true,
+          subscriptionId: 'sub_joe',
+          libraryItemCount: 0,
+          latestPublishedAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+      items: [],
+      nextCursor: null,
+    });
+
+    expect(response.sections.creators).toHaveLength(1);
+    expect(response.sections.creators[0]).toMatchObject({
+      creatorId: 'creator_joe',
+      isSubscribed: true,
+      subscriptionId: 'sub_joe',
+      libraryItemCount: 3,
+      latestPublishedAt: '2026-04-01T00:00:00Z',
+    });
+  });
+});

--- a/apps/worker/src/trpc/routers/search.ts
+++ b/apps/worker/src/trpc/routers/search.ts
@@ -1,0 +1,410 @@
+import { and, desc, eq, lt, ne, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { z } from 'zod';
+import type { Provider } from '@zine/shared';
+import { UserItemState } from '@zine/shared';
+
+import { router, protectedProcedure } from '../trpc';
+import { creators, items, subscriptions, userItems } from '../../db/schema';
+import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import { toItemViewsWithTags, type ItemView } from './items';
+
+const DEFAULT_CREATORS_LIMIT = 5;
+
+const SearchInputSchema = z.object({
+  query: z.string().trim().min(1).max(100),
+  scope: z.enum(['library']).default('library'),
+  creatorsLimit: z.number().int().min(0).max(10).default(DEFAULT_CREATORS_LIMIT),
+  itemsLimit: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+  cursor: z.string().optional(),
+});
+
+export type SearchScope = z.infer<typeof SearchInputSchema>['scope'];
+
+export type CreatorSearchRow = {
+  id: string;
+  name: string;
+  normalizedName: string;
+  handle: string | null;
+  imageUrl: string | null;
+  provider: Provider;
+  description: string | null;
+  externalUrl: string | null;
+  isSubscribed: boolean;
+  subscriptionId: string | null;
+  libraryItemCount: number;
+  latestPublishedAt: string | null;
+};
+
+export type CreatorSearchResult = {
+  type: 'creator';
+  id: string;
+  creatorId: string;
+  name: string;
+  handle: string | null;
+  imageUrl: string | null;
+  provider: Provider;
+  description: string | null;
+  externalUrl: string | null;
+  isSubscribed: boolean;
+  subscriptionId: string | null;
+  libraryItemCount: number;
+  latestPublishedAt: string | null;
+  score: number;
+};
+
+export type SearchItemView = ItemView;
+
+export type ItemSearchResult = SearchItemView & {
+  type: 'item';
+  score: number;
+};
+
+export type SearchResult = CreatorSearchResult | ItemSearchResult;
+
+export type SearchResponse = {
+  results: SearchResult[];
+  sections: {
+    creators: CreatorSearchResult[];
+    items: ItemSearchResult[];
+  };
+  nextCursor: string | null;
+};
+
+function toCompactSearchTerm(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function stripVowels(value: string): string {
+  return value.replace(/[aeiou]/g, '');
+}
+
+function toCompactSql(value: SQLWrapper): SQL {
+  return sql`replace(replace(replace(replace(replace(replace(lower(coalesce(${value}, '')), ' ', ''), '-', ''), '_', ''), '.', ''), '/', ''), '&', '')`;
+}
+
+function toConsonantSql(value: SQLWrapper): SQL {
+  const compact = toCompactSql(value);
+  return sql`replace(replace(replace(replace(replace(${compact}, 'a', ''), 'e', ''), 'i', ''), 'o', ''), 'u', '')`;
+}
+
+function buildSearchConditions(search: string, fields: SQLWrapper[]): SQL[] {
+  const loweredSearch = search.toLowerCase();
+  const compactSearch = toCompactSearchTerm(search);
+  const consonantSearch = stripVowels(compactSearch);
+  const conditions: SQL[] = [];
+
+  for (const field of fields) {
+    conditions.push(sql`lower(coalesce(${field}, '')) LIKE ${`%${loweredSearch}%`}`);
+  }
+
+  if (compactSearch.length > 0) {
+    for (const field of fields) {
+      conditions.push(sql`${toCompactSql(field)} LIKE ${`%${compactSearch}%`}`);
+    }
+  }
+
+  if (consonantSearch.length >= 3) {
+    for (const field of fields) {
+      conditions.push(sql`${toConsonantSql(field)} LIKE ${`%${consonantSearch}%`}`);
+    }
+  }
+
+  return conditions;
+}
+
+function normalizeForRanking(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+function compactForRanking(value: string | null | undefined): string {
+  return toCompactSearchTerm(value ?? '');
+}
+
+function scoreTextMatch(query: string, value: string | null | undefined): number {
+  const normalizedQuery = normalizeForRanking(query);
+  const normalizedValue = normalizeForRanking(value);
+  const compactQuery = compactForRanking(query);
+  const compactValue = compactForRanking(value);
+
+  if (!normalizedValue || !normalizedQuery) {
+    return 0;
+  }
+
+  if (normalizedValue === normalizedQuery || compactValue === compactQuery) {
+    return 100;
+  }
+
+  if (normalizedValue.startsWith(normalizedQuery) || compactValue.startsWith(compactQuery)) {
+    return 70;
+  }
+
+  if (normalizedValue.includes(normalizedQuery) || compactValue.includes(compactQuery)) {
+    return 50;
+  }
+
+  const consonantQuery = stripVowels(compactQuery);
+  if (consonantQuery.length >= 3 && stripVowels(compactValue).includes(consonantQuery)) {
+    return 35;
+  }
+
+  return 0;
+}
+
+function scoreCreator(query: string, creator: CreatorSearchRow): number {
+  const nameScore = scoreTextMatch(query, creator.name);
+  const handleScore = scoreTextMatch(query, creator.handle);
+  const subscriptionBoost = creator.isSubscribed ? 20 : 0;
+  const libraryBoost = creator.libraryItemCount > 0 ? Math.min(10, creator.libraryItemCount) : 0;
+
+  return Math.max(nameScore, handleScore) + subscriptionBoost + libraryBoost;
+}
+
+function scoreItem(query: string, item: SearchItemView): number {
+  const titleScore = scoreTextMatch(query, item.title);
+  const creatorScore = Math.max(0, scoreTextMatch(query, item.creator) - 10);
+
+  return Math.max(titleScore, creatorScore);
+}
+
+function mergeCreatorRows(query: string, rows: CreatorSearchRow[]): CreatorSearchResult[] {
+  const merged = new Map<string, CreatorSearchRow>();
+
+  for (const row of rows) {
+    const existing = merged.get(row.id);
+    if (!existing) {
+      merged.set(row.id, row);
+      continue;
+    }
+
+    merged.set(row.id, {
+      ...existing,
+      isSubscribed: existing.isSubscribed || row.isSubscribed,
+      subscriptionId: existing.subscriptionId ?? row.subscriptionId,
+      libraryItemCount: Math.max(existing.libraryItemCount, row.libraryItemCount),
+      latestPublishedAt:
+        !existing.latestPublishedAt ||
+        (row.latestPublishedAt && row.latestPublishedAt > existing.latestPublishedAt)
+          ? row.latestPublishedAt
+          : existing.latestPublishedAt,
+    });
+  }
+
+  return Array.from(merged.values())
+    .map((row) => ({
+      type: 'creator' as const,
+      id: row.id,
+      creatorId: row.id,
+      name: row.name,
+      handle: row.handle,
+      imageUrl: row.imageUrl,
+      provider: row.provider,
+      description: row.description,
+      externalUrl: row.externalUrl,
+      isSubscribed: row.isSubscribed,
+      subscriptionId: row.subscriptionId,
+      libraryItemCount: row.libraryItemCount,
+      latestPublishedAt: row.latestPublishedAt,
+      score: scoreCreator(query, row),
+    }))
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+}
+
+export function buildSearchResponse(input: {
+  query: string;
+  creatorRows: CreatorSearchRow[];
+  items: SearchItemView[];
+  nextCursor: string | null;
+  creatorsLimit?: number;
+}): SearchResponse {
+  const creatorsSection = mergeCreatorRows(input.query, input.creatorRows).slice(
+    0,
+    input.creatorsLimit ?? DEFAULT_CREATORS_LIMIT
+  );
+  const itemsSection = input.items.map((item) => ({
+    ...item,
+    type: 'item' as const,
+    score: scoreItem(input.query, item),
+  }));
+
+  return {
+    results: [...creatorsSection, ...itemsSection],
+    sections: {
+      creators: creatorsSection,
+      items: itemsSection,
+    },
+    nextCursor: input.nextCursor,
+  };
+}
+
+function normalizeCreatorRow(row: {
+  id: string;
+  name: string;
+  normalizedName: string;
+  handle: string | null;
+  imageUrl: string | null;
+  provider: string;
+  description: string | null;
+  externalUrl: string | null;
+  isSubscribed: boolean | number | null;
+  subscriptionId: string | null;
+  libraryItemCount: number | string | null;
+  latestPublishedAt: string | number | null;
+}): CreatorSearchRow {
+  const latestPublishedAt =
+    typeof row.latestPublishedAt === 'number'
+      ? new Date(row.latestPublishedAt).toISOString()
+      : row.latestPublishedAt;
+
+  return {
+    id: row.id,
+    name: row.name,
+    normalizedName: row.normalizedName,
+    handle: row.handle,
+    imageUrl: row.imageUrl,
+    provider: row.provider as Provider,
+    description: row.description,
+    externalUrl: row.externalUrl,
+    isSubscribed: Boolean(row.isSubscribed),
+    subscriptionId: row.subscriptionId,
+    libraryItemCount: Number(row.libraryItemCount ?? 0),
+    latestPublishedAt,
+  };
+}
+
+export const searchRouter = router({
+  query: protectedProcedure.input(SearchInputSchema).query(async ({ ctx, input }) => {
+    const search = input.query.trim();
+    const itemLimit = input.itemsLimit;
+    const cursor = input.cursor ? decodeCursor(input.cursor) : null;
+    const searchConditions = buildSearchConditions(search, [items.title, creators.name]);
+    const creatorSearchConditions = buildSearchConditions(search, [creators.name, creators.handle]);
+    const creatorRows: CreatorSearchRow[] = [];
+
+    if (!cursor && input.creatorsLimit > 0) {
+      const subscribedCreatorRows = await ctx.db
+        .select({
+          id: creators.id,
+          name: creators.name,
+          normalizedName: creators.normalizedName,
+          handle: creators.handle,
+          imageUrl: creators.imageUrl,
+          provider: creators.provider,
+          description: creators.description,
+          externalUrl: creators.externalUrl,
+          isSubscribed: sql<boolean>`${subscriptions.status} = 'ACTIVE'`,
+          subscriptionId: subscriptions.id,
+          libraryItemCount: sql<number>`0`,
+          latestPublishedAt: subscriptions.lastPublishedAt,
+        })
+        .from(subscriptions)
+        .innerJoin(creators, eq(subscriptions.creatorId, creators.id))
+        .where(
+          and(
+            eq(subscriptions.userId, ctx.userId),
+            ne(subscriptions.status, 'UNSUBSCRIBED'),
+            or(...creatorSearchConditions)!
+          )
+        )
+        .limit(input.creatorsLimit * 3);
+
+      const libraryCreatorRows = await ctx.db
+        .select({
+          id: creators.id,
+          name: creators.name,
+          normalizedName: creators.normalizedName,
+          handle: creators.handle,
+          imageUrl: creators.imageUrl,
+          provider: creators.provider,
+          description: creators.description,
+          externalUrl: creators.externalUrl,
+          isSubscribed: sql<boolean>`max(case when ${subscriptions.status} = 'ACTIVE' then 1 else 0 end)`,
+          subscriptionId: sql<string | null>`max(${subscriptions.id})`,
+          libraryItemCount: sql<number>`count(${userItems.id})`,
+          latestPublishedAt: sql<string | null>`max(${items.publishedAt})`,
+        })
+        .from(userItems)
+        .innerJoin(items, eq(userItems.itemId, items.id))
+        .innerJoin(creators, eq(items.creatorId, creators.id))
+        .leftJoin(
+          subscriptions,
+          and(
+            eq(subscriptions.userId, ctx.userId),
+            eq(subscriptions.creatorId, creators.id),
+            ne(subscriptions.status, 'UNSUBSCRIBED')
+          )
+        )
+        .where(
+          and(
+            eq(userItems.userId, ctx.userId),
+            eq(userItems.state, UserItemState.BOOKMARKED),
+            or(...creatorSearchConditions)!
+          )
+        )
+        .groupBy(
+          creators.id,
+          creators.name,
+          creators.normalizedName,
+          creators.handle,
+          creators.imageUrl,
+          creators.provider,
+          creators.description,
+          creators.externalUrl
+        )
+        .limit(input.creatorsLimit * 3);
+
+      creatorRows.push(
+        ...subscribedCreatorRows.map(normalizeCreatorRow),
+        ...libraryCreatorRows.map(normalizeCreatorRow)
+      );
+    }
+
+    const itemConditions = [
+      eq(userItems.userId, ctx.userId),
+      eq(userItems.state, UserItemState.BOOKMARKED),
+      eq(userItems.isFinished, false),
+      or(...searchConditions)!,
+    ];
+
+    const sortField = sql`COALESCE(${userItems.bookmarkedAt}, ${userItems.ingestedAt})`;
+    if (cursor) {
+      itemConditions.push(
+        or(
+          sql`${sortField} < ${cursor.sortValue}`,
+          and(sql`${sortField} = ${cursor.sortValue}`, lt(userItems.id, cursor.id))
+        )!
+      );
+    }
+
+    const itemRows = await ctx.db
+      .select()
+      .from(userItems)
+      .innerJoin(items, eq(userItems.itemId, items.id))
+      .leftJoin(creators, eq(items.creatorId, creators.id))
+      .where(and(...itemConditions))
+      .orderBy(desc(sql`${sortField}`), desc(userItems.id))
+      .limit(itemLimit + 1);
+
+    const hasMore = itemRows.length > itemLimit;
+    const pageRows = hasMore ? itemRows.slice(0, itemLimit) : itemRows;
+    const itemViews = await toItemViewsWithTags(ctx, pageRows);
+
+    const nextCursor =
+      hasMore && pageRows.length > 0
+        ? encodeCursor({
+            sortValue:
+              pageRows[pageRows.length - 1].user_items.bookmarkedAt ??
+              pageRows[pageRows.length - 1].user_items.ingestedAt,
+            id: pageRows[pageRows.length - 1].user_items.id,
+          })
+        : null;
+
+    return buildSearchResponse({
+      query: search,
+      creatorRows,
+      items: itemViews,
+      nextCursor,
+      creatorsLimit: input.creatorsLimit,
+    });
+  }),
+});


### PR DESCRIPTION
## Summary

Adds a unified search API that returns creator results above matching library items, then updates the mobile Search tab to render mixed creator/item rows.

## Changes

- Added search.query tRPC endpoint with local DB creator and library item search.
- Ranks exact/prefix creator matches above item matches and deduplicates subscription/library creator rows.
- Added mobile useSearchResults hook and a creator result row that links to Creator View with source=search.
- Updated the Search tab to use mixed search results instead of calling items.library directly.

## Validation

- Red/green tests added for worker search response shaping and mobile search hook behavior.
- Manual local worker verification: Action Bronson returned a creator result first and the matching saved item underneath; subscribed creator-only queries like Lex Fridman and Waveform returned creator rows.
- bun run format:check
- bun run lint (passes with existing unrelated mobile warnings)
- bun run typecheck
- bun run build
- bun run test