### PR TITLE
[codex] Add related unfinished bookmarks to item detail

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -54,7 +54,8 @@ export default function ItemDetailScreen() {
   const [titleOffsetY, setTitleOffsetY] = useState<number | null>(null);
 
   const { id, isValid, message } = useItemDetailParams();
-  const { item, isLoading, error, refetch, creatorData } = useItemDetailData({ id, isValid });
+  const { item, otherUnfinishedBookmarks, isLoading, error, refetch, creatorData } =
+    useItemDetailData({ id, isValid });
   const {
     handleOpenLink,
     handleShare,
@@ -143,6 +144,8 @@ export default function ItemDetailScreen() {
         onScroll={handleScroll}
         onContentLayout={handleContentLayout}
         onTitleLayout={handleTitleLayout}
+        otherUnfinishedBookmarks={otherUnfinishedBookmarks}
+        onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
       />
     );
   }
@@ -189,6 +192,8 @@ export default function ItemDetailScreen() {
           onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
           onShare={handleShare}
           onOpenLink={handleOpenLink}
+          otherUnfinishedBookmarks={otherUnfinishedBookmarks}
+          onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
           useAnimatedActions
           useAnimatedDescription
           onContentLayout={handleContentLayout}
@@ -227,6 +232,8 @@ export default function ItemDetailScreen() {
         onManageTags={() => router.push(`/item-tags/${item.id}` as Href)}
         onShare={handleShare}
         onOpenLink={handleOpenLink}
+        otherUnfinishedBookmarks={otherUnfinishedBookmarks}
+        onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
         useAnimatedActions={false}
         useAnimatedDescription={false}
         onContentLayout={handleContentLayout}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -121,7 +121,6 @@ export function ItemDetailContent({
         <ItemDetailOtherBookmarks
           bookmarks={otherUnfinishedBookmarks}
           colors={colors}
-          creatorName={item.creator}
           onBookmarkPress={onOtherBookmarkPress}
         />
       )}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -11,6 +11,7 @@ import { ItemDetailCreatorRow } from './ItemDetailCreatorRow';
 import { ItemDetailDescription } from './ItemDetailDescription';
 import { ItemDetailHeader } from './ItemDetailHeader';
 import { ItemDetailMetaRow } from './ItemDetailMetaRow';
+import { ItemDetailOtherBookmarks } from './ItemDetailOtherBookmarks';
 
 type ItemDetailContentProps = {
   item: ItemDetailItem;
@@ -30,6 +31,8 @@ type ItemDetailContentProps = {
   onManageTags: () => void;
   onShare: () => void;
   onOpenLink: () => void;
+  otherUnfinishedBookmarks?: ItemDetailItem[];
+  onOtherBookmarkPress?: (id: string) => void;
   useAnimatedDescription: boolean;
   useAnimatedActions: boolean;
   onContentLayout?: (contentTopY: number) => void;
@@ -54,6 +57,8 @@ export function ItemDetailContent({
   onManageTags,
   onShare,
   onOpenLink,
+  otherUnfinishedBookmarks = [],
+  onOtherBookmarkPress,
   useAnimatedActions,
   useAnimatedDescription,
   onContentLayout,
@@ -110,6 +115,15 @@ export function ItemDetailContent({
             />
           </Surface>
         </DescriptionContainer>
+      )}
+
+      {onOtherBookmarkPress && (
+        <ItemDetailOtherBookmarks
+          bookmarks={otherUnfinishedBookmarks}
+          colors={colors}
+          creatorName={item.creator}
+          onBookmarkPress={onOtherBookmarkPress}
+        />
       )}
     </>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -1,0 +1,75 @@
+import { Pressable, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { Text } from '@/components/primitives/text';
+import { Surface } from '@/components/primitives/surface';
+import { IconSizes } from '@/constants/theme';
+
+import { styles } from '../../item-detail-styles';
+import type { ItemDetailColors, ItemDetailItem } from '../types';
+
+type ItemDetailOtherBookmarksProps = {
+  bookmarks: ItemDetailItem[];
+  colors: ItemDetailColors;
+  creatorName: string;
+  onBookmarkPress: (id: string) => void;
+};
+
+export function ItemDetailOtherBookmarks({
+  bookmarks,
+  colors,
+  creatorName,
+  onBookmarkPress,
+}: ItemDetailOtherBookmarksProps) {
+  if (bookmarks.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.otherBookmarksContainer}>
+      <Surface
+        tone="subtle"
+        radius="lg"
+        padding="lg"
+        colors={colors}
+        style={styles.otherBookmarksSurface}
+        accessibilityLabel="Other bookmarks from creator"
+      >
+        <View style={styles.otherBookmarksHeader}>
+          <Text variant="titleSmall" colors={colors}>
+            More from {creatorName}
+          </Text>
+          <Text variant="bodySmall" tone="subheader" colors={colors}>
+            Unfinished bookmarks
+          </Text>
+        </View>
+
+        <View style={styles.otherBookmarksList}>
+          {bookmarks.map((bookmark) => (
+            <Pressable
+              key={bookmark.id}
+              accessibilityRole="button"
+              accessibilityLabel={`Open bookmark ${bookmark.title}`}
+              onPress={() => onBookmarkPress(bookmark.id)}
+              style={({ pressed }) => [
+                styles.otherBookmarkRow,
+                { borderColor: colors.borderSubtle },
+                pressed && { opacity: 0.72 },
+              ]}
+            >
+              <View style={styles.otherBookmarkTextGroup}>
+                <Text variant="bodyMedium" colors={colors} numberOfLines={2}>
+                  {bookmark.title}
+                </Text>
+                <Text variant="bodySmall" tone="subheader" colors={colors} numberOfLines={1}>
+                  {bookmark.publisher ?? bookmark.creator}
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={IconSizes.sm} color={colors.textTertiary} />
+            </Pressable>
+          ))}
+        </View>
+      </Surface>
+    </View>
+  );
+}

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -48,10 +48,10 @@ export function ItemDetailOtherBookmarks({
         accessibilityLabel="Other bookmarks from creator"
       >
         <View style={styles.otherBookmarksHeader}>
-          <Text style={styles.otherBookmarksTitle} tone="primary" colors={colors}>
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
             Your Bookmarks
           </Text>
-          <Text style={styles.otherBookmarksCount} tone="subheader" colors={colors}>
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
             {items.length} item{items.length === 1 ? '' : 's'}
           </Text>
         </View>

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -1,8 +1,11 @@
-import { View } from 'react-native';
+import { useState } from 'react';
+import { Pressable, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { Surface } from '@/components/primitives/surface';
 import { Text } from '@/components/primitives/text';
+import { IconSizes } from '@/constants/theme';
 import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
 
 import { styles } from '../../item-detail-styles';
@@ -19,6 +22,8 @@ export function ItemDetailOtherBookmarks({
   colors,
   onBookmarkPress,
 }: ItemDetailOtherBookmarksProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   if (bookmarks.length === 0) {
     return null;
   }
@@ -47,24 +52,38 @@ export function ItemDetailOtherBookmarks({
         style={styles.otherBookmarksSurface}
         accessibilityLabel="Other bookmarks from creator"
       >
-        <View style={styles.otherBookmarksHeader}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Toggle other bookmarks from creator"
+          accessibilityState={{ expanded: isExpanded }}
+          onPress={() => setIsExpanded((current) => !current)}
+          style={({ pressed }) => [
+            styles.otherBookmarksHeader,
+            isExpanded ? styles.otherBookmarksHeaderExpanded : null,
+            pressed ? { opacity: 0.72 } : null,
+          ]}
+        >
           <Text variant="labelSmall" tone="tertiary" colors={colors}>
             Your Bookmarks
           </Text>
-          <Text variant="labelSmall" tone="tertiary" colors={colors}>
-            {items.length} item{items.length === 1 ? '' : 's'}
-          </Text>
-        </View>
-
-        {items.map((item, index) => (
-          <ItemCard
-            key={item.id}
-            item={item}
-            shape="row"
-            index={index}
-            onPress={() => onBookmarkPress(item.id)}
+          <Ionicons
+            name={isExpanded ? 'chevron-up' : 'chevron-down'}
+            size={IconSizes.sm}
+            color={colors.textTertiary}
           />
-        ))}
+        </Pressable>
+
+        {isExpanded
+          ? items.map((item, index) => (
+              <ItemCard
+                key={item.id}
+                item={item}
+                shape="row"
+                index={index}
+                onPress={() => onBookmarkPress(item.id)}
+              />
+            ))
+          : null}
       </Surface>
     </View>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -1,6 +1,7 @@
 import { View } from 'react-native';
 
 import { ItemCard, type ItemCardData } from '@/components/item-card';
+import { Surface } from '@/components/primitives/surface';
 import { Text } from '@/components/primitives/text';
 import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
 
@@ -39,24 +40,32 @@ export function ItemDetailOtherBookmarks({
 
   return (
     <View style={styles.otherBookmarksContainer}>
-      <View style={styles.otherBookmarksHeader} accessibilityLabel="Other bookmarks from creator">
-        <Text style={styles.otherBookmarksTitle} tone="primary" colors={colors}>
-          Your Bookmarks
-        </Text>
-        <Text style={styles.otherBookmarksCount} tone="subheader" colors={colors}>
-          {items.length} item{items.length === 1 ? '' : 's'}
-        </Text>
-      </View>
+      <Surface
+        tone="subtle"
+        radius="lg"
+        colors={colors}
+        style={styles.otherBookmarksSurface}
+        accessibilityLabel="Other bookmarks from creator"
+      >
+        <View style={styles.otherBookmarksHeader}>
+          <Text style={styles.otherBookmarksTitle} tone="primary" colors={colors}>
+            Your Bookmarks
+          </Text>
+          <Text style={styles.otherBookmarksCount} tone="subheader" colors={colors}>
+            {items.length} item{items.length === 1 ? '' : 's'}
+          </Text>
+        </View>
 
-      {items.map((item, index) => (
-        <ItemCard
-          key={item.id}
-          item={item}
-          shape="row"
-          index={index}
-          onPress={() => onBookmarkPress(item.id)}
-        />
-      ))}
+        {items.map((item, index) => (
+          <ItemCard
+            key={item.id}
+            item={item}
+            shape="row"
+            index={index}
+            onPress={() => onBookmarkPress(item.id)}
+          />
+        ))}
+      </Surface>
     </View>
   );
 }

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -1,9 +1,8 @@
-import { Pressable, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { View } from 'react-native';
 
+import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { Text } from '@/components/primitives/text';
-import { Surface } from '@/components/primitives/surface';
-import { IconSizes } from '@/constants/theme';
+import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
 
 import { styles } from '../../item-detail-styles';
 import type { ItemDetailColors, ItemDetailItem } from '../types';
@@ -11,65 +10,53 @@ import type { ItemDetailColors, ItemDetailItem } from '../types';
 type ItemDetailOtherBookmarksProps = {
   bookmarks: ItemDetailItem[];
   colors: ItemDetailColors;
-  creatorName: string;
   onBookmarkPress: (id: string) => void;
 };
 
 export function ItemDetailOtherBookmarks({
   bookmarks,
   colors,
-  creatorName,
   onBookmarkPress,
 }: ItemDetailOtherBookmarksProps) {
   if (bookmarks.length === 0) {
     return null;
   }
 
+  const items: ItemCardData[] = bookmarks.map((bookmark) => ({
+    id: bookmark.id,
+    title: bookmark.title,
+    creator: bookmark.creator,
+    creatorImageUrl: bookmark.creatorImageUrl ?? null,
+    thumbnailUrl: bookmark.thumbnailUrl ?? null,
+    contentType: mapContentType(bookmark.contentType) as ContentType,
+    provider: mapProvider(bookmark.provider) as Provider,
+    duration: bookmark.duration ?? null,
+    readingTimeMinutes: bookmark.readingTimeMinutes ?? null,
+    bookmarkedAt: bookmark.bookmarkedAt ?? null,
+    publishedAt: bookmark.publishedAt ?? null,
+    isFinished: bookmark.isFinished,
+  }));
+
   return (
     <View style={styles.otherBookmarksContainer}>
-      <Surface
-        tone="subtle"
-        radius="lg"
-        padding="lg"
-        colors={colors}
-        style={styles.otherBookmarksSurface}
-        accessibilityLabel="Other bookmarks from creator"
-      >
-        <View style={styles.otherBookmarksHeader}>
-          <Text variant="titleSmall" colors={colors}>
-            More from {creatorName}
-          </Text>
-          <Text variant="bodySmall" tone="subheader" colors={colors}>
-            Unfinished bookmarks
-          </Text>
-        </View>
+      <View style={styles.otherBookmarksHeader} accessibilityLabel="Other bookmarks from creator">
+        <Text style={styles.otherBookmarksTitle} tone="primary" colors={colors}>
+          Your Bookmarks
+        </Text>
+        <Text style={styles.otherBookmarksCount} tone="subheader" colors={colors}>
+          {items.length} item{items.length === 1 ? '' : 's'}
+        </Text>
+      </View>
 
-        <View style={styles.otherBookmarksList}>
-          {bookmarks.map((bookmark) => (
-            <Pressable
-              key={bookmark.id}
-              accessibilityRole="button"
-              accessibilityLabel={`Open bookmark ${bookmark.title}`}
-              onPress={() => onBookmarkPress(bookmark.id)}
-              style={({ pressed }) => [
-                styles.otherBookmarkRow,
-                { borderColor: colors.borderSubtle },
-                pressed && { opacity: 0.72 },
-              ]}
-            >
-              <View style={styles.otherBookmarkTextGroup}>
-                <Text variant="bodyMedium" colors={colors} numberOfLines={2}>
-                  {bookmark.title}
-                </Text>
-                <Text variant="bodySmall" tone="subheader" colors={colors} numberOfLines={1}>
-                  {bookmark.publisher ?? bookmark.creator}
-                </Text>
-              </View>
-              <Ionicons name="chevron-forward" size={IconSizes.sm} color={colors.textTertiary} />
-            </Pressable>
-          ))}
-        </View>
-      </Surface>
+      {items.map((item, index) => (
+        <ItemCard
+          key={item.id}
+          item={item}
+          shape="row"
+          index={index}
+          onPress={() => onBookmarkPress(item.id)}
+        />
+      ))}
     </View>
   );
 }

--- a/apps/mobile/app/item/detail/hooks/useItemDetailData.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailData.ts
@@ -1,5 +1,5 @@
 import { useCreator } from '@/hooks/use-creator';
-import { useItem } from '@/hooks/use-items-trpc';
+import { useItem, useOtherUnfinishedBookmarksByCreator } from '@/hooks/use-items-trpc';
 
 type ItemDetailDataInput = {
   id: string;
@@ -8,11 +8,13 @@ type ItemDetailDataInput = {
 
 export function useItemDetailData({ id, isValid }: ItemDetailDataInput) {
   const { data: item, isLoading, error, refetch } = useItem(isValid ? id : '');
+  const { data: otherBookmarksData } = useOtherUnfinishedBookmarksByCreator(isValid ? id : '');
 
   const { creator: creatorData } = useCreator(item?.creatorId ?? '');
 
   return {
     item,
+    otherUnfinishedBookmarks: otherBookmarksData?.items ?? [],
     isLoading,
     error,
     refetch,

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -314,7 +314,6 @@ export function XPostBookmarkView({
         <ItemDetailOtherBookmarks
           bookmarks={otherUnfinishedBookmarks}
           colors={colors}
-          creatorName={item.creator}
           onBookmarkPress={onOtherBookmarkPress}
         />
       )}

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -15,6 +15,8 @@ import { logger } from '@/lib/logger';
 
 import { ItemDetailActions } from './detail/components/ItemDetailActions';
 import { ItemDetailFloatingBack } from './detail/components/ItemDetailFloatingBack';
+import { ItemDetailOtherBookmarks } from './detail/components/ItemDetailOtherBookmarks';
+import type { ItemDetailItem } from './detail/types';
 import { extractXHandle } from './item-detail-helpers';
 import { styles, xPostStyles } from './item-detail-styles';
 
@@ -101,6 +103,8 @@ export function XPostBookmarkView({
   onScroll,
   onContentLayout,
   onTitleLayout,
+  otherUnfinishedBookmarks = [],
+  onOtherBookmarkPress,
 }: {
   item: {
     id: string;
@@ -116,7 +120,7 @@ export function XPostBookmarkView({
     state: UserItemState;
   };
   colors: typeof Colors.dark;
-  insets: { top: number; bottom: number };
+  insets: { top: number; bottom: number; left: number; right: number };
   onBack: () => void;
   onOpenLink: () => void;
   onShare: () => void;
@@ -135,6 +139,8 @@ export function XPostBookmarkView({
   onScroll: ScrollViewProps['onScroll'];
   onContentLayout: (contentTopY: number) => void;
   onTitleLayout: (titleOffsetY: number) => void;
+  otherUnfinishedBookmarks?: ItemDetailItem[];
+  onOtherBookmarkPress?: (id: string) => void;
 }) {
   // Extract @handle from URL as fallback if creatorData.handle not available
   const handle = creatorData?.handle || extractXHandle(item.canonicalUrl);
@@ -303,6 +309,15 @@ export function XPostBookmarkView({
           </View>
         </View>
       </Animated.View>
+
+      {onOtherBookmarkPress && (
+        <ItemDetailOtherBookmarks
+          bookmarks={otherUnfinishedBookmarks}
+          colors={colors}
+          creatorName={item.creator}
+          onBookmarkPress={onOtherBookmarkPress}
+        />
+      )}
     </>
   );
 

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -205,30 +205,21 @@ export const styles = StyleSheet.create({
 
   // Other bookmarks
   otherBookmarksContainer: {
-    marginTop: Spacing.md,
-    paddingHorizontal: Spacing.xl,
-  },
-  otherBookmarksSurface: {
-    gap: Spacing.md,
+    paddingTop: Spacing.lg,
   },
   otherBookmarksHeader: {
-    gap: Spacing.xs,
-  },
-  otherBookmarksList: {
-    gap: Spacing.sm,
-  },
-  otherBookmarkRow: {
-    minHeight: 56,
     flexDirection: 'row',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    gap: Spacing.md,
-    paddingTop: Spacing.sm,
-    paddingBottom: Spacing.sm,
-    borderTopWidth: 1,
+    paddingHorizontal: Spacing.lg,
+    marginBottom: Spacing.md,
   },
-  otherBookmarkTextGroup: {
-    flex: 1,
-    gap: Spacing.xs,
+  otherBookmarksTitle: {
+    ...Typography.titleMedium,
+    fontWeight: '600',
+  },
+  otherBookmarksCount: {
+    ...Typography.bodySmall,
   },
 });
 

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -219,13 +219,6 @@ export const styles = StyleSheet.create({
     paddingHorizontal: Spacing.lg,
     marginBottom: Spacing.md,
   },
-  otherBookmarksTitle: {
-    ...Typography.titleMedium,
-    fontWeight: '600',
-  },
-  otherBookmarksCount: {
-    ...Typography.bodySmall,
-  },
 });
 
 // X Post Styles

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -217,6 +217,8 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     paddingHorizontal: Spacing.lg,
+  },
+  otherBookmarksHeaderExpanded: {
     marginBottom: Spacing.md,
   },
 });

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -205,7 +205,12 @@ export const styles = StyleSheet.create({
 
   // Other bookmarks
   otherBookmarksContainer: {
-    paddingTop: Spacing.lg,
+    marginTop: Spacing.md,
+    paddingHorizontal: Spacing.xl,
+  },
+  otherBookmarksSurface: {
+    paddingVertical: Spacing.lg,
+    overflow: 'hidden',
   },
   otherBookmarksHeader: {
     flexDirection: 'row',

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -202,6 +202,34 @@ export const styles = StyleSheet.create({
     ...Typography.bodyMedium,
     lineHeight: 24,
   },
+
+  // Other bookmarks
+  otherBookmarksContainer: {
+    marginTop: Spacing.md,
+    paddingHorizontal: Spacing.xl,
+  },
+  otherBookmarksSurface: {
+    gap: Spacing.md,
+  },
+  otherBookmarksHeader: {
+    gap: Spacing.xs,
+  },
+  otherBookmarksList: {
+    gap: Spacing.sm,
+  },
+  otherBookmarkRow: {
+    minHeight: 56,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.sm,
+    borderTopWidth: 1,
+  },
+  otherBookmarkTextGroup: {
+    flex: 1,
+    gap: Spacing.xs,
+  },
 });
 
 // X Post Styles

--- a/apps/mobile/hooks/use-item-detail-data.test.ts
+++ b/apps/mobile/hooks/use-item-detail-data.test.ts
@@ -9,11 +9,14 @@ import { useItemDetailData } from '@/app/item/detail/hooks/useItemDetailData';
 // Module-level Mocks
 
 const mockUseItem = jest.fn();
+const mockUseOtherUnfinishedBookmarksByCreator = jest.fn();
 const mockUseCreator = jest.fn();
 const mockRefetch = jest.fn();
 
 jest.mock('@/hooks/use-items-trpc', () => ({
   useItem: (id: string) => mockUseItem(id),
+  useOtherUnfinishedBookmarksByCreator: (id: string) =>
+    mockUseOtherUnfinishedBookmarksByCreator(id),
 }));
 
 jest.mock('@/hooks/use-creator', () => ({
@@ -37,14 +40,21 @@ describe('useItemDetailData', () => {
       error: null,
       refetch: jest.fn(),
     });
+    mockUseOtherUnfinishedBookmarksByCreator.mockReturnValue({
+      data: { items: [] },
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('uses an empty id when params are invalid', () => {
     const { result } = renderHook(() => useItemDetailData({ id: 'bad-id', isValid: false }));
 
     expect(mockUseItem).toHaveBeenCalledWith('');
+    expect(mockUseOtherUnfinishedBookmarksByCreator).toHaveBeenCalledWith('');
     expect(mockUseCreator).toHaveBeenCalledWith('');
     expect(result.current.item).toBeNull();
+    expect(result.current.otherUnfinishedBookmarks).toEqual([]);
   });
 
   it('requests creator data for the item creator', () => {
@@ -67,6 +77,7 @@ describe('useItemDetailData', () => {
     const { result } = renderHook(() => useItemDetailData({ id: 'item-1', isValid: true }));
 
     expect(mockUseItem).toHaveBeenCalledWith('item-1');
+    expect(mockUseOtherUnfinishedBookmarksByCreator).toHaveBeenCalledWith('item-1');
     expect(mockUseCreator).toHaveBeenCalledWith('creator-1');
     expect(result.current.creatorData).toBe(creator);
     expect(result.current.item).toBe(item);

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -15,6 +15,7 @@ const mockInboxUseInfiniteQuery = jest.fn();
 const mockLibraryUseQuery = jest.fn();
 const mockLibraryUseInfiniteQuery = jest.fn();
 const mockHomeUseQuery = jest.fn();
+const mockOtherUnfinishedBookmarksByCreatorUseQuery = jest.fn();
 const mockBookmarkUseMutation = jest.fn();
 const mockArchiveUseMutation = jest.fn();
 const mockToggleFinishedUseMutation = jest.fn();
@@ -33,6 +34,9 @@ jest.mock('../lib/trpc', () => ({
       },
       home: {
         useQuery: mockHomeUseQuery,
+      },
+      otherUnfinishedBookmarksByCreator: {
+        useQuery: mockOtherUnfinishedBookmarksByCreatorUseQuery,
       },
       bookmark: {
         useMutation: (...args: unknown[]) => mockBookmarkUseMutation(...args),
@@ -231,6 +235,7 @@ function createToggleUtils(initial?: {
   const mockInboxInvalidate = jest.fn();
   const mockHomeInvalidate = jest.fn();
   const mockGetInvalidate = jest.fn();
+  const mockOtherUnfinishedBookmarksByCreatorInvalidate = jest.fn();
   const mockWeeklyRecapInvalidate = jest.fn();
   const mockWeeklyRecapTeaserInvalidate = jest.fn();
 
@@ -330,6 +335,9 @@ function createToggleUtils(initial?: {
           return next;
         }),
       },
+      otherUnfinishedBookmarksByCreator: {
+        invalidate: mockOtherUnfinishedBookmarksByCreatorInvalidate,
+      },
     },
     insights: {
       weeklyRecap: {
@@ -354,6 +362,7 @@ function createToggleUtils(initial?: {
       mockInboxInvalidate,
       mockHomeInvalidate,
       mockGetInvalidate,
+      mockOtherUnfinishedBookmarksByCreatorInvalidate,
       mockWeeklyRecapInvalidate,
       mockWeeklyRecapTeaserInvalidate,
     },
@@ -391,6 +400,11 @@ beforeEach(() => {
   });
   mockHomeUseQuery.mockReturnValue({
     data: null,
+    isLoading: false,
+    error: null,
+  });
+  mockOtherUnfinishedBookmarksByCreatorUseQuery.mockReturnValue({
+    data: { items: [] },
     isLoading: false,
     error: null,
   });

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -197,6 +197,7 @@ function createOptimisticConfig<TInput extends { id: string }>(
     utils.items.inbox.invalidate();
     utils.items.library.invalidate();
     utils.items.home.invalidate();
+    utils.items.otherUnfinishedBookmarksByCreator.invalidate();
     if (options.updateSingleItem) {
       utils.items.get.invalidate({ id: input.id });
     }
@@ -457,6 +458,16 @@ export function useHomeData(options?: HomeItemsOptions) {
  */
 export function useItem(id: string) {
   return trpc.items.get.useQuery({ id }, { enabled: !!id });
+}
+
+export function useOtherUnfinishedBookmarksByCreator(id: string) {
+  return trpc.items.otherUnfinishedBookmarksByCreator.useQuery(
+    { id },
+    {
+      enabled: !!id,
+      placeholderData: keepPreviousData,
+    }
+  );
 }
 
 /**
@@ -832,6 +843,7 @@ export function useToggleFinished() {
         utils.items.library.invalidate();
         utils.items.inbox.invalidate();
         utils.items.home.invalidate();
+        utils.items.otherUnfinishedBookmarksByCreator.invalidate();
         utils.items.get.invalidate({ id });
       });
 
@@ -846,6 +858,7 @@ export function useToggleFinished() {
           utils.items.library.invalidate();
           utils.items.inbox.invalidate();
           utils.items.home.invalidate();
+          utils.items.otherUnfinishedBookmarksByCreator.invalidate();
           utils.items.get.invalidate({ id });
         }
       }
@@ -859,6 +872,7 @@ export function useToggleFinished() {
       utils.items.library.invalidate();
       utils.items.inbox.invalidate();
       utils.items.home.invalidate();
+      utils.items.otherUnfinishedBookmarksByCreator.invalidate();
       utils.items.get.invalidate({ id });
       invalidateRecapQueries(utils);
     },

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -86,6 +86,28 @@ jest.mock('@/hooks/use-app-theme', () => ({
 
 jest.mock('@/lib/content-utils', () => ({
   getContentIcon: () => null,
+  mapContentType: (contentType: string) => contentType,
+  mapProvider: (provider: string) => provider,
+}));
+
+jest.mock('@/components/item-card', () => ({
+  ItemCard: ({
+    item,
+    onPress,
+  }: {
+    item: { title: string; creator: string; duration?: number | null };
+    onPress?: () => void;
+  }) =>
+    React.createElement(
+      'button',
+      {
+        accessibilityLabel: `Open bookmark ${item.title}`,
+        onPress,
+      },
+      React.createElement('span', null, item.title),
+      React.createElement('span', null, item.creator),
+      item.duration ? React.createElement('span', null, `${item.duration}`) : null
+    ),
 }));
 
 function createItem(overrides: Partial<ItemDetailItem> = {}): ItemDetailItem {
@@ -187,8 +209,9 @@ describe('ItemDetailContent other creator bookmarks', () => {
 
     const labels = renderer.root.findAllByType('span').map(textContent).join(' ');
     expect(labels.indexOf('Current bookmark summary')).toBeLessThan(
-      labels.indexOf('More from Example Creator')
+      labels.indexOf('Your Bookmarks')
     );
+    expect(labels).toContain('1 item');
     expect(labels).toContain('Next bookmark');
 
     const bookmarkButton = renderer.root.findByProps({

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -195,7 +195,7 @@ describe('ItemDetailContent other creator bookmarks', () => {
     ).toThrow();
   });
 
-  it('shows other unfinished bookmarks below the description and navigates to the selected bookmark', () => {
+  it('shows a collapsed other bookmarks card below the description and expands to navigate to a bookmark', () => {
     const renderer = renderContent({
       otherUnfinishedBookmarks: [
         createItem({
@@ -211,8 +211,21 @@ describe('ItemDetailContent other creator bookmarks', () => {
     expect(labels.indexOf('Current bookmark summary')).toBeLessThan(
       labels.indexOf('Your Bookmarks')
     );
-    expect(labels).toContain('1 item');
-    expect(labels).toContain('Next bookmark');
+    expect(labels).not.toContain('1 item');
+    expect(labels).not.toContain('Next bookmark');
+
+    const toggleButton = renderer.root.findByProps({
+      accessibilityLabel: 'Toggle other bookmarks from creator',
+    });
+    expect(toggleButton.props.accessibilityState).toEqual({ expanded: false });
+
+    act(() => {
+      toggleButton.props.onPress();
+    });
+
+    expect(toggleButton.props.accessibilityState).toEqual({ expanded: true });
+    const expandedLabels = renderer.root.findAllByType('span').map(textContent).join(' ');
+    expect(expandedLabels).toContain('Next bookmark');
 
     const bookmarkButton = renderer.root.findByProps({
       accessibilityLabel: 'Open bookmark Next bookmark',

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { UserItemState, ContentType, Provider } from '@zine/shared';
+
+import { Colors } from '@/constants/theme';
+import { ItemDetailContent } from '@/app/item/detail/components/ItemDetailContent';
+import type { ItemDetailItem } from '@/app/item/detail/types';
+
+const mockPush = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  Stack: {
+    Screen: () => null,
+  },
+}));
+
+jest.mock('react-native', () => ({
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('span', props, children),
+  ScrollView: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('scroll-view', props, children),
+  Pressable: ({
+    children,
+    onPress,
+    ...props
+  }: {
+    children: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
+    onPress?: () => void;
+  }) =>
+    React.createElement(
+      'button',
+      { onClick: onPress, onPress, ...props },
+      typeof children === 'function' ? children({ pressed: false }) : children
+    ),
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    flatten: (style: unknown) => style,
+    absoluteFillObject: {},
+  },
+  Platform: {
+    OS: 'ios',
+    select: (options: Record<string, unknown>) => options.ios ?? options.default,
+  },
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
+}));
+
+jest.mock('@/components/ParallaxScrollView', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    View: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement('div', props, children),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock('expo-image', () => ({
+  Image: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('img', props, children),
+}));
+
+jest.mock('@/hooks/use-app-theme', () => ({
+  useAppTheme: () => ({
+    colorScheme: 'dark',
+    colors: Colors.dark,
+    motion: { duration: { normal: 0 } },
+  }),
+}));
+
+jest.mock('@/lib/content-utils', () => ({
+  getContentIcon: () => null,
+}));
+
+function createItem(overrides: Partial<ItemDetailItem> = {}): ItemDetailItem {
+  return {
+    id: 'ui-current',
+    itemId: 'item-current',
+    title: 'Current bookmark',
+    thumbnailUrl: null,
+    canonicalUrl: 'https://example.com/current',
+    contentType: ContentType.ARTICLE,
+    provider: Provider.WEB,
+    creator: 'Example Creator',
+    creatorImageUrl: null,
+    creatorId: 'creator-1',
+    publisher: null,
+    summary: 'Current bookmark summary',
+    duration: null,
+    publishedAt: '2026-01-01T00:00:00.000Z',
+    wordCount: 1200,
+    readingTimeMinutes: 6,
+    state: UserItemState.BOOKMARKED,
+    ingestedAt: '2026-01-01T00:00:00.000Z',
+    bookmarkedAt: '2026-01-01T00:00:00.000Z',
+    lastOpenedAt: null,
+    progress: null,
+    isFinished: false,
+    finishedAt: null,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function renderContent(props: Partial<React.ComponentProps<typeof ItemDetailContent>> = {}) {
+  let renderer: ReturnType<typeof TestRenderer.create> | null = null;
+
+  act(() => {
+    renderer = TestRenderer.create(
+      <ItemDetailContent
+        item={createItem()}
+        colors={Colors.dark}
+        descriptionLabel="Description"
+        bookmarkActionIcon="bookmark"
+        bookmarkActionColor={Colors.dark.textPrimary}
+        isBookmarkActionDisabled={false}
+        secondaryActionIcon="checkmark-circle"
+        secondaryActionColor={Colors.dark.textPrimary}
+        isSecondaryActionDisabled={false}
+        onBookmarkToggle={jest.fn()}
+        onSecondaryAction={jest.fn()}
+        onManageTags={jest.fn()}
+        onShare={jest.fn()}
+        onOpenLink={jest.fn()}
+        useAnimatedDescription={false}
+        useAnimatedActions={false}
+        otherUnfinishedBookmarks={[]}
+        onOtherBookmarkPress={(bookmarkId) => mockPush(`/item/${bookmarkId}`)}
+        {...props}
+      />
+    );
+  });
+
+  return renderer!;
+}
+
+function textContent(node: { children: Array<string | { children: unknown[] }> }): string {
+  return node.children
+    .map((child) =>
+      typeof child === 'string'
+        ? child
+        : textContent(child as { children: Array<string | { children: unknown[] }> })
+    )
+    .join('');
+}
+
+describe('ItemDetailContent other creator bookmarks', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('hides the other bookmarks card when there are no other unfinished bookmarks', () => {
+    const renderer = renderContent();
+
+    expect(() =>
+      renderer.root.findByProps({ accessibilityLabel: 'Other bookmarks from creator' })
+    ).toThrow();
+  });
+
+  it('shows other unfinished bookmarks below the description and navigates to the selected bookmark', () => {
+    const renderer = renderContent({
+      otherUnfinishedBookmarks: [
+        createItem({
+          id: 'ui-next',
+          itemId: 'item-next',
+          title: 'Next bookmark',
+          summary: 'Another thing to read',
+        }),
+      ],
+    });
+
+    const labels = renderer.root.findAllByType('span').map(textContent).join(' ');
+    expect(labels.indexOf('Current bookmark summary')).toBeLessThan(
+      labels.indexOf('More from Example Creator')
+    );
+    expect(labels).toContain('Next bookmark');
+
+    const bookmarkButton = renderer.root.findByProps({
+      accessibilityLabel: 'Open bookmark Next bookmark',
+    });
+
+    act(() => {
+      bookmarkButton.props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/item/ui-next');
+  });
+});

--- a/apps/worker/src/trpc/routers/items.test.ts
+++ b/apps/worker/src/trpc/routers/items.test.ts
@@ -220,6 +220,35 @@ function createMockItemsCaller(options: {
       return item;
     },
 
+    otherUnfinishedBookmarksByCreator: async (input: { id: string; limit?: number }) => {
+      if (!userId) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+      const item = allItems.get(input.id);
+      if (!item) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Item ${input.id} not found`,
+        });
+      }
+      if (!item.creatorId) {
+        return { items: [] };
+      }
+
+      const limit = input.limit ?? 5;
+      return {
+        items: libraryItems
+          .filter(
+            (candidate) =>
+              candidate.id !== item.id &&
+              candidate.creatorId === item.creatorId &&
+              candidate.state === UserItemState.BOOKMARKED &&
+              candidate.isFinished === false
+          )
+          .slice(0, limit),
+      };
+    },
+
     bookmark: async (input: { id: string }) => {
       if (!userId) {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
@@ -340,6 +369,11 @@ describe('Items Router', () => {
     it('should reject unauthenticated requests to get', async () => {
       const caller = createMockItemsCaller({ userId: null });
       await expectUnauthorized(() => caller.get({ id: 'ui-001' }));
+    });
+
+    it('should reject unauthenticated requests to other unfinished bookmarks by creator', async () => {
+      const caller = createMockItemsCaller({ userId: null });
+      await expectUnauthorized(() => caller.otherUnfinishedBookmarksByCreator({ id: 'ui-001' }));
     });
 
     it('should reject unauthenticated requests to bookmark', async () => {
@@ -924,6 +958,76 @@ describe('Items Router', () => {
         expect(result.items[0].isFinished).toBe(true);
         expect(result.items[0].contentType).toBe(ContentType.VIDEO);
         expect(result.items[0].provider).toBe(Provider.YOUTUBE);
+      });
+    });
+  });
+
+  // items.otherUnfinishedBookmarksByCreator Tests
+
+  describe('items.otherUnfinishedBookmarksByCreator', () => {
+    it('returns other unfinished bookmarked items by the same creator', async () => {
+      const current = createMockItemView({
+        id: 'ui-current',
+        creatorId: 'creator-1',
+        creator: 'Creator One',
+        state: UserItemState.BOOKMARKED,
+        isFinished: false,
+      });
+      const sameCreatorUnfinished = createMockItemView({
+        id: 'ui-same-unfinished',
+        creatorId: 'creator-1',
+        creator: 'Creator One',
+        title: 'Next from creator',
+        state: UserItemState.BOOKMARKED,
+        isFinished: false,
+      });
+      const sameCreatorFinished = createMockItemView({
+        id: 'ui-same-finished',
+        creatorId: 'creator-1',
+        creator: 'Creator One',
+        state: UserItemState.BOOKMARKED,
+        isFinished: true,
+      });
+      const otherCreatorUnfinished = createMockItemView({
+        id: 'ui-other-creator',
+        creatorId: 'creator-2',
+        creator: 'Creator Two',
+        state: UserItemState.BOOKMARKED,
+        isFinished: false,
+      });
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        allItems: new Map([[current.id, current]]),
+        libraryItems: [current, sameCreatorUnfinished, sameCreatorFinished, otherCreatorUnfinished],
+      });
+
+      const result = await caller.otherUnfinishedBookmarksByCreator({ id: current.id });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        id: 'ui-same-unfinished',
+        title: 'Next from creator',
+        creatorId: 'creator-1',
+        isFinished: false,
+      });
+    });
+
+    it('returns an empty list when the current item has no creator', async () => {
+      const current = createMockItemView({
+        id: 'ui-current',
+        creatorId: null,
+        state: UserItemState.BOOKMARKED,
+      });
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        allItems: new Map([[current.id, current]]),
+        libraryItems: [current],
+      });
+
+      await expect(caller.otherUnfinishedBookmarksByCreator({ id: current.id })).resolves.toEqual({
+        items: [],
       });
     });
   });

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -6,6 +6,7 @@ import {
   eq,
   and,
   desc,
+  ne,
   or,
   lt,
   isNotNull,
@@ -680,6 +681,60 @@ export const itemsRouter = router({
       },
     };
   }),
+
+  /**
+   * Get other unfinished bookmarked items from the same creator as a detail item.
+   */
+  otherUnfinishedBookmarksByCreator: protectedProcedure
+    .input(
+      z.object({
+        id: z.string().min(1),
+        limit: z.number().min(1).max(10).default(5),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const current = await ctx.db
+        .select({
+          creatorId: items.creatorId,
+        })
+        .from(userItems)
+        .innerJoin(items, eq(userItems.itemId, items.id))
+        .where(and(eq(userItems.id, input.id), eq(userItems.userId, ctx.userId)))
+        .limit(1);
+
+      if (current.length === 0) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Item ${input.id} not found`,
+        });
+      }
+
+      const creatorId = current[0].creatorId;
+      if (!creatorId) {
+        return { items: [] };
+      }
+
+      const results = await ctx.db
+        .select()
+        .from(userItems)
+        .innerJoin(items, eq(userItems.itemId, items.id))
+        .leftJoin(creators, eq(items.creatorId, creators.id))
+        .where(
+          and(
+            eq(userItems.userId, ctx.userId),
+            eq(userItems.state, UserItemState.BOOKMARKED),
+            eq(userItems.isFinished, false),
+            eq(items.creatorId, creatorId),
+            ne(userItems.id, input.id)
+          )
+        )
+        .orderBy(desc(userItems.bookmarkedAt), desc(userItems.ingestedAt), desc(userItems.id))
+        .limit(input.limit);
+
+      const itemViews = await toItemViewsWithTags(ctx, results);
+
+      return { items: itemViews };
+    }),
 
   /**
    * Get a single item by UserItem ID.


### PR DESCRIPTION
## Summary

Adds a related-bookmarks card to the mobile bookmark detail page. The card appears below the item description when the same creator has other unfinished bookmarked items for the current user, and each row navigates to that bookmark detail page.

## Changes

- Added a worker tRPC endpoint for other unfinished bookmarks by creator.
- Added a mobile tRPC hook and item-detail data plumbing.
- Added the detail-page card UI for standard and X-post detail layouts.
- Added red/green coverage for the new UI path and worker/query behavior.

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run test:worker:ci`
- Manual simulator verification with local worker/Expo: confirmed the detail page fetched `items.otherUnfinishedBookmarksByCreator` and exposed the related bookmark row below the description for a seeded item with another unfinished bookmark from the same creator.
