### PR TITLE
[codex] Add settings back button

### DIFF
--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -10,8 +10,9 @@
  */
 
 import { useMemo } from 'react';
+import { Ionicons } from '@expo/vector-icons';
 import { View, Text, ScrollView, Pressable, StyleSheet, Linking, Share } from 'react-native';
-import { Stack, useRouter } from 'expo-router';
+import { Stack, useNavigation, useRouter } from 'expo-router';
 import { useClerk } from '@clerk/clerk-expo';
 import Constants from 'expo-constants';
 
@@ -119,12 +120,26 @@ function SettingsScreenContent({
   authEnabled: boolean;
   signOut?: () => Promise<void>;
 }) {
+  const navigation = useNavigation();
   const router = useRouter();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
   const isStorybookEnabled = process.env.EXPO_PUBLIC_STORYBOOK_ENABLED === 'true';
   const isDeveloperDiagnosticsEnabled = __DEV__ || isStorybookEnabled;
+  const canGoBack = navigation.canGoBack();
+  const headerLeft = canGoBack
+    ? () => (
+        <Pressable
+          accessibilityLabel="Go back"
+          onPress={() => router.back()}
+          hitSlop={8}
+          style={styles.headerBack}
+        >
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </Pressable>
+      )
+    : undefined;
 
   // Data hooks
   const { data: connections } = useConnections();
@@ -193,6 +208,7 @@ function SettingsScreenContent({
           tintColor: colors.text,
           screenTitle: 'Settings',
           showScreenTitle: showCollapsedTitle,
+          headerLeft,
         })}
       />
       <ScrollView
@@ -301,6 +317,9 @@ const styles = StyleSheet.create({
   },
   screenTitle: {
     ...Typography.displayMedium,
+  },
+  headerBack: {
+    marginLeft: -Spacing.xs,
   },
   sectionTitle: {
     fontSize: 12,

--- a/apps/mobile/lib/settings-screen.test.tsx
+++ b/apps/mobile/lib/settings-screen.test.tsx
@@ -4,6 +4,9 @@ import TestRenderer, { act } from 'react-test-renderer';
 import SettingsScreen from '@/app/settings/index';
 
 const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockCanGoBack = jest.fn();
+const mockStackScreen = jest.fn();
 
 type Renderer = ReturnType<typeof TestRenderer.create>;
 type TestNode = Renderer['root'];
@@ -21,12 +24,23 @@ function getTextContent(node: TestNode): string {
 
 jest.mock('expo-router', () => ({
   Stack: {
-    Screen: (props: Record<string, unknown>) => React.createElement('stack-screen', props),
+    Screen: (props: Record<string, unknown>) => {
+      mockStackScreen(props);
+      return React.createElement('stack-screen', props);
+    },
   },
+  useNavigation: () => ({
+    canGoBack: mockCanGoBack,
+  }),
   useRouter: () => ({
     push: mockPush,
+    back: mockBack,
     replace: jest.fn(),
   }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: Record<string, unknown>) => React.createElement('ionicons', props),
 }));
 
 jest.mock('react-native', () => ({
@@ -142,6 +156,7 @@ jest.mock('@/providers/auth-provider', () => ({
 describe('SettingsScreen subscriptions entrypoint', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(false);
   });
 
   it('surfaces a single subscriptions entrypoint instead of provider-specific connection rows', () => {
@@ -193,6 +208,68 @@ describe('SettingsScreen subscriptions entrypoint', () => {
     expect(() =>
       renderer!.root.findByProps({ testID: 'settings-subscriptions-alert-dot' })
     ).not.toThrow();
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('SettingsScreen header', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(false);
+  });
+
+  it('adds a header back button when a parent navigator can go back', () => {
+    mockCanGoBack.mockReturnValue(true);
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<SettingsScreen />);
+    });
+
+    expect(renderer!).toBeDefined();
+
+    const stackScreenProps = mockStackScreen.mock.calls.at(-1)?.[0] as {
+      options: {
+        headerLeft?: (props: Record<string, unknown>) => React.ReactElement;
+      };
+    };
+
+    expect(stackScreenProps.options.headerLeft).toBeDefined();
+
+    const headerLeft = stackScreenProps.options.headerLeft!;
+    const backButton = headerLeft({ tintColor: '#111111' }) as React.ReactElement<{
+      onPress: () => void;
+      accessibilityLabel?: string;
+    }>;
+
+    expect(backButton.props.accessibilityLabel).toBe('Go back');
+
+    act(() => {
+      backButton.props.onPress();
+    });
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('leaves the header left slot empty when there is no back target', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<SettingsScreen />);
+    });
+
+    expect(renderer!).toBeDefined();
+
+    const stackScreenProps = mockStackScreen.mock.calls.at(-1)?.[0] as {
+      options: {
+        headerLeft?: unknown;
+      };
+    };
+
+    expect(stackScreenProps.options.headerLeft).toBeUndefined();
     consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Adds the same conditional mobile header back affordance to the Settings screen that other nested mobile pages use.

## Details

- Detects whether the parent navigator can go back from Settings.
- Renders a compact chevron header button that calls `router.back()` when a back target exists.
- Leaves the header left slot empty when Settings is opened as a root-level page.
- Adds focused Settings screen coverage for both header states.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- pre-push hook: format, mobile design-system check, typecheck, web tests, worker CI subset
