### PR TITLE
Add previews to bookmark detail accordions

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pressable } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { Text } from '@/components/primitives/text';
@@ -15,31 +15,44 @@ type ItemDetailDescriptionProps = {
   colors: ItemDetailColors;
 };
 
+const COLLAPSED_DESCRIPTION_LINES = 4;
+const EXPANDABLE_DESCRIPTION_MIN_LENGTH = 160;
+
 export function ItemDetailDescription({ summary, label, colors }: ItemDetailDescriptionProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const canExpand = summary.trim().length > EXPANDABLE_DESCRIPTION_MIN_LENGTH;
+  const descriptionLines = canExpand && !isExpanded ? COLLAPSED_DESCRIPTION_LINES : undefined;
 
   return (
     <>
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={`Toggle ${label}`}
-        accessibilityState={{ expanded: isExpanded }}
-        onPress={() => setIsExpanded((current) => !current)}
-        style={({ pressed }) => [styles.descriptionHeader, pressed ? { opacity: 0.72 } : null]}
-      >
-        <Text variant="labelSmall" tone="tertiary" colors={colors}>
-          {label}
-        </Text>
-        <Ionicons
-          name={isExpanded ? 'chevron-up' : 'chevron-down'}
-          size={IconSizes.sm}
-          color={colors.textTertiary}
-        />
-      </Pressable>
+      {canExpand ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Toggle ${label}`}
+          accessibilityState={{ expanded: isExpanded }}
+          onPress={() => setIsExpanded((current) => !current)}
+          style={({ pressed }) => [styles.descriptionHeader, pressed ? { opacity: 0.72 } : null]}
+        >
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
+            {label}
+          </Text>
+          <Ionicons
+            name={isExpanded ? 'chevron-up' : 'chevron-down'}
+            size={IconSizes.sm}
+            color={colors.textTertiary}
+          />
+        </Pressable>
+      ) : (
+        <View style={styles.descriptionHeader}>
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
+            {label}
+          </Text>
+        </View>
+      )}
       <LinkedText
         style={[styles.description, { color: colors.textSubheader }]}
         linkColor={colors.primary}
-        numberOfLines={isExpanded ? undefined : 2}
+        numberOfLines={descriptionLines}
       >
         {summary}
       </LinkedText>

--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -1,4 +1,9 @@
+import { useState } from 'react';
+import { Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
 import { Text } from '@/components/primitives/text';
+import { IconSizes } from '@/constants/theme';
 
 import { LinkedText } from '../../item-detail-components';
 import { styles } from '../../item-detail-styles';
@@ -11,14 +16,30 @@ type ItemDetailDescriptionProps = {
 };
 
 export function ItemDetailDescription({ summary, label, colors }: ItemDetailDescriptionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   return (
     <>
-      <Text variant="labelSmall" tone="tertiary" colors={colors}>
-        {label}
-      </Text>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Toggle ${label}`}
+        accessibilityState={{ expanded: isExpanded }}
+        onPress={() => setIsExpanded((current) => !current)}
+        style={({ pressed }) => [styles.descriptionHeader, pressed ? { opacity: 0.72 } : null]}
+      >
+        <Text variant="labelSmall" tone="tertiary" colors={colors}>
+          {label}
+        </Text>
+        <Ionicons
+          name={isExpanded ? 'chevron-up' : 'chevron-down'}
+          size={IconSizes.sm}
+          color={colors.textTertiary}
+        />
+      </Pressable>
       <LinkedText
         style={[styles.description, { color: colors.textSubheader }]}
         linkColor={colors.primary}
+        numberOfLines={isExpanded ? undefined : 2}
       >
         {summary}
       </LinkedText>

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -57,11 +57,7 @@ export function ItemDetailOtherBookmarks({
           accessibilityLabel="Toggle other bookmarks from creator"
           accessibilityState={{ expanded: isExpanded }}
           onPress={() => setIsExpanded((current) => !current)}
-          style={({ pressed }) => [
-            styles.otherBookmarksHeader,
-            isExpanded ? styles.otherBookmarksHeaderExpanded : null,
-            pressed ? { opacity: 0.72 } : null,
-          ]}
+          style={({ pressed }) => [styles.otherBookmarksHeader, pressed ? { opacity: 0.72 } : null]}
         >
           <Text variant="labelSmall" tone="tertiary" colors={colors}>
             Your Bookmarks
@@ -73,17 +69,15 @@ export function ItemDetailOtherBookmarks({
           />
         </Pressable>
 
-        {isExpanded
-          ? items.map((item, index) => (
-              <ItemCard
-                key={item.id}
-                item={item}
-                shape="row"
-                index={index}
-                onPress={() => onBookmarkPress(item.id)}
-              />
-            ))
-          : null}
+        {(isExpanded ? items : items.slice(0, 1)).map((item, index) => (
+          <ItemCard
+            key={item.id}
+            item={item}
+            shape="row"
+            index={index}
+            onPress={() => onBookmarkPress(item.id)}
+          />
+        ))}
       </Surface>
     </View>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailOtherBookmarks.tsx
@@ -28,6 +28,7 @@ export function ItemDetailOtherBookmarks({
     return null;
   }
 
+  const canExpand = bookmarks.length > 1;
   const items: ItemCardData[] = bookmarks.map((bookmark) => ({
     id: bookmark.id,
     title: bookmark.title,
@@ -52,24 +53,35 @@ export function ItemDetailOtherBookmarks({
         style={styles.otherBookmarksSurface}
         accessibilityLabel="Other bookmarks from creator"
       >
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Toggle other bookmarks from creator"
-          accessibilityState={{ expanded: isExpanded }}
-          onPress={() => setIsExpanded((current) => !current)}
-          style={({ pressed }) => [styles.otherBookmarksHeader, pressed ? { opacity: 0.72 } : null]}
-        >
-          <Text variant="labelSmall" tone="tertiary" colors={colors}>
-            Your Bookmarks
-          </Text>
-          <Ionicons
-            name={isExpanded ? 'chevron-up' : 'chevron-down'}
-            size={IconSizes.sm}
-            color={colors.textTertiary}
-          />
-        </Pressable>
+        {canExpand ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Toggle other bookmarks from creator"
+            accessibilityState={{ expanded: isExpanded }}
+            onPress={() => setIsExpanded((current) => !current)}
+            style={({ pressed }) => [
+              styles.otherBookmarksHeader,
+              pressed ? { opacity: 0.72 } : null,
+            ]}
+          >
+            <Text variant="labelSmall" tone="tertiary" colors={colors}>
+              Your Bookmarks
+            </Text>
+            <Ionicons
+              name={isExpanded ? 'chevron-up' : 'chevron-down'}
+              size={IconSizes.sm}
+              color={colors.textTertiary}
+            />
+          </Pressable>
+        ) : (
+          <View style={styles.otherBookmarksHeader}>
+            <Text variant="labelSmall" tone="tertiary" colors={colors}>
+              Your Bookmarks
+            </Text>
+          </View>
+        )}
 
-        {(isExpanded ? items : items.slice(0, 1)).map((item, index) => (
+        {(isExpanded && canExpand ? items : items.slice(0, 1)).map((item, index) => (
           <ItemCard
             key={item.id}
             item={item}

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -28,10 +28,12 @@ export function LinkedText({
   children,
   style,
   linkColor,
+  numberOfLines,
 }: {
   children: string;
   style?: object;
   linkColor: string;
+  numberOfLines?: number;
 }) {
   const parts = children.split(URL_REGEX);
 
@@ -47,7 +49,7 @@ export function LinkedText({
   };
 
   return (
-    <Text style={style}>
+    <Text style={style} numberOfLines={numberOfLines}>
       {parts.map((part, index) => {
         if (URL_REGEX.test(part)) {
           // Reset regex lastIndex since we're reusing it

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -198,6 +198,11 @@ export const styles = StyleSheet.create({
   descriptionSurface: {
     gap: Spacing.md,
   },
+  descriptionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
   description: {
     ...Typography.bodyMedium,
     lineHeight: 24,
@@ -217,8 +222,6 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     paddingHorizontal: Spacing.lg,
-  },
-  otherBookmarksHeaderExpanded: {
     marginBottom: Spacing.md,
   },
 });

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -182,6 +182,17 @@ function textContent(node: { children: Array<string | { children: unknown[] }> }
     .join('');
 }
 
+type TestTextNode = {
+  children: Array<string | { children: unknown[] }>;
+  props: { numberOfLines?: number };
+};
+
+function findSpanContaining(renderer: ReturnType<typeof TestRenderer.create>, text: string) {
+  return (renderer.root.findAllByType('span') as TestTextNode[]).find((node) =>
+    textContent(node).includes(text)
+  );
+}
+
 describe('ItemDetailContent other creator bookmarks', () => {
   beforeEach(() => {
     mockPush.mockClear();
@@ -195,7 +206,31 @@ describe('ItemDetailContent other creator bookmarks', () => {
     ).toThrow();
   });
 
-  it('shows a collapsed other bookmarks card below the description and expands to navigate to a bookmark', () => {
+  it('collapses and expands the description preview', () => {
+    const renderer = renderContent({
+      item: createItem({
+        summary:
+          'Current bookmark summary with enough detail to preview two lines before expanding into the complete description.',
+      }),
+    });
+
+    const toggleButton = renderer.root.findByProps({
+      accessibilityLabel: 'Toggle Description',
+    });
+    expect(toggleButton.props.accessibilityState).toEqual({ expanded: false });
+    expect(findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines).toBe(2);
+
+    act(() => {
+      toggleButton.props.onPress();
+    });
+
+    expect(toggleButton.props.accessibilityState).toEqual({ expanded: true });
+    expect(
+      findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines
+    ).toBeUndefined();
+  });
+
+  it('shows a collapsed other bookmarks card below the description and expands to reveal more bookmarks', () => {
     const renderer = renderContent({
       otherUnfinishedBookmarks: [
         createItem({
@@ -203,6 +238,12 @@ describe('ItemDetailContent other creator bookmarks', () => {
           itemId: 'item-next',
           title: 'Next bookmark',
           summary: 'Another thing to read',
+        }),
+        createItem({
+          id: 'ui-second',
+          itemId: 'item-second',
+          title: 'Second bookmark',
+          summary: 'One more thing to read',
         }),
       ],
     });
@@ -212,7 +253,8 @@ describe('ItemDetailContent other creator bookmarks', () => {
       labels.indexOf('Your Bookmarks')
     );
     expect(labels).not.toContain('1 item');
-    expect(labels).not.toContain('Next bookmark');
+    expect(labels).toContain('Next bookmark');
+    expect(labels).not.toContain('Second bookmark');
 
     const toggleButton = renderer.root.findByProps({
       accessibilityLabel: 'Toggle other bookmarks from creator',
@@ -226,15 +268,16 @@ describe('ItemDetailContent other creator bookmarks', () => {
     expect(toggleButton.props.accessibilityState).toEqual({ expanded: true });
     const expandedLabels = renderer.root.findAllByType('span').map(textContent).join(' ');
     expect(expandedLabels).toContain('Next bookmark');
+    expect(expandedLabels).toContain('Second bookmark');
 
     const bookmarkButton = renderer.root.findByProps({
-      accessibilityLabel: 'Open bookmark Next bookmark',
+      accessibilityLabel: 'Open bookmark Second bookmark',
     });
 
     act(() => {
       bookmarkButton.props.onPress();
     });
 
-    expect(mockPush).toHaveBeenCalledWith('/item/ui-next');
+    expect(mockPush).toHaveBeenCalledWith('/item/ui-second');
   });
 });

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -68,7 +68,8 @@ jest.mock('react-native-reanimated', () => ({
 }));
 
 jest.mock('@expo/vector-icons', () => ({
-  Ionicons: () => null,
+  Ionicons: ({ name }: { name: string }) =>
+    React.createElement('span', { accessibilityLabel: `icon-${name}` }, name),
 }));
 
 jest.mock('expo-image', () => ({
@@ -210,7 +211,7 @@ describe('ItemDetailContent other creator bookmarks', () => {
     const renderer = renderContent({
       item: createItem({
         summary:
-          'Current bookmark summary with enough detail to preview two lines before expanding into the complete description.',
+          'Current bookmark summary with enough detail to preview four lines before expanding into the complete description. It continues with more context so there is hidden content behind the collapsed state.',
       }),
     });
 
@@ -218,16 +219,49 @@ describe('ItemDetailContent other creator bookmarks', () => {
       accessibilityLabel: 'Toggle Description',
     });
     expect(toggleButton.props.accessibilityState).toEqual({ expanded: false });
-    expect(findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines).toBe(2);
+    expect(renderer.root.findByProps({ accessibilityLabel: 'icon-chevron-down' })).toBeTruthy();
+    expect(findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines).toBe(4);
 
     act(() => {
       toggleButton.props.onPress();
     });
 
     expect(toggleButton.props.accessibilityState).toEqual({ expanded: true });
+    expect(renderer.root.findByProps({ accessibilityLabel: 'icon-chevron-up' })).toBeTruthy();
     expect(
       findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines
     ).toBeUndefined();
+  });
+
+  it('does not show a description chevron when the summary is too short to expand', () => {
+    const renderer = renderContent({
+      item: createItem({
+        summary: 'Short summary.',
+      }),
+    });
+
+    expect(() => renderer.root.findByProps({ accessibilityLabel: 'Toggle Description' })).toThrow();
+    expect(() => renderer.root.findByProps({ accessibilityLabel: 'icon-chevron-down' })).toThrow();
+    expect(findSpanContaining(renderer, 'Short summary.')?.props.numberOfLines).toBeUndefined();
+  });
+
+  it('does not show an other bookmarks chevron when there is only one preview item', () => {
+    const renderer = renderContent({
+      otherUnfinishedBookmarks: [
+        createItem({
+          id: 'ui-next',
+          itemId: 'item-next',
+          title: 'Next bookmark',
+          summary: 'Another thing to read',
+        }),
+      ],
+    });
+
+    const labels = renderer.root.findAllByType('span').map(textContent).join(' ');
+    expect(labels).toContain('Next bookmark');
+    expect(() =>
+      renderer.root.findByProps({ accessibilityLabel: 'Toggle other bookmarks from creator' })
+    ).toThrow();
   });
 
   it('shows a collapsed other bookmarks card below the description and expands to reveal more bookmarks', () => {


### PR DESCRIPTION
## Summary
- Show a first related bookmark row while the creator bookmarks card is collapsed
- Make the About this Video card collapsible with a matching preview/header treatment
- Add component coverage for both accordion preview states

## Verification
- bun run --cwd apps/mobile test lib/item-detail-other-bookmarks.test.tsx --runInBand
- bun run format:check
- bun run design-system:check
- bun run typecheck
- bun run lint
- bun run build
- bun run test
- Manual iOS simulator verification on Expo Go: collapsed previews, About expansion, related bookmarks expansion, and related bookmark navigation