### PR TITLE
worker: allow bookmarks save without creator

### DIFF
--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -57,7 +57,8 @@ const SaveInputSchema = z.object({
   contentType: ContentTypeSchema,
   providerId: z.string().min(1, 'Provider ID is required'),
   title: z.string().min(1, 'Title is required'),
-  creator: z.string().min(1, 'Creator is required'),
+  // Some providers don't reliably return creator names; allow save without it.
+  creator: z.string().trim().min(1, 'Creator must not be empty').optional(),
   creatorImageUrl: z.string().url().nullable().optional(), // Channel/show/podcast image
   thumbnailUrl: z.string().url().nullable(),
   duration: z.number().int().min(0).nullable(),


### PR DESCRIPTION
## Summary\n- relax  input validation so  is optional\n- keep non-empty validation when  is present via \n- preserves existing creator backfill/fallback behavior in the router\n\n## Why\nSome providers/preview paths do not reliably return creator names. Requiring this field caused avoidable save failures.\n\n## Validation\n- \n- 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-04-30/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...
 ✓ src/trpc/routers/bookmarks.test.ts (19 tests) 51ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  05:32:56
   Duration  890ms (transform 39ms, setup 18ms, collect 48ms, tests 51ms, environment 0ms, prepare 138ms)

[vpw:dbg] Shutting down runtimes...\n- pre-push hooks passed:\n  - \n  - 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-04-30/apps/web

 ✓ src/lib/format.test.ts (5 tests) 5ms
 ✓ src/lib/query-persistence.test.ts (3 tests) 1ms
 ✓ src/lib/oauth.test.ts (4 tests) 58ms
 ✓ src/protected-route.test.tsx (4 tests) 190ms
 ✓ src/auth-page.test.tsx (4 tests) 211ms
 ✓ src/app.test.tsx (4 tests) 281ms
 ✓ src/pwa-support.test.tsx (4 tests) 277ms
 ✓ src/oauth-callback-page.test.tsx (4 tests) 269ms
 ✓ src/settings-page.test.tsx (7 tests) 480ms
 ✓ src/welcome-page.test.tsx (9 tests) 949ms
 ✓ src/bookmarks-page.test.tsx (18 tests) 1112ms

 Test Files  11 passed (11)
      Tests  66 passed (66)
   Start at  05:32:57
   Duration  2.98s (transform 998ms, setup 3.38s, collect 3.31s, tests 3.83s, environment 8.04s, prepare 546ms)\n  - 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-04-30/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...
 ✓ src/diagnostics/health.test.ts (2 tests) 323ms
 ✓ src/lib/cors.test.ts (4 tests) 376ms
 ✓ src/rss/url.test.ts (4 tests) 382ms
 ✓ src/newsletters/avatar.test.ts (5 tests) 433ms
 ✓ src/lib/telemetry.test.ts (2 tests) 168ms
 ✓ src/rss/parser.test.ts (4 tests) 328ms
 ✓ src/trpc/routers/latest-content-content-type.test.ts (3 tests) 210ms
 ✓ src/lib/weekly-recap.test.ts (7 tests) 738ms
 ✓ src/lib/pagination.test.ts (11 tests) 864ms
 ✓ src/rss/discovery.test.ts (3 tests) 178ms
 ✓ src/middleware/auth.test.ts (3 tests) 169ms
 ✓ src/lib/duration.test.ts (18 tests) 1173ms
 ✓ src/ingestion/processor/prepare.test.ts (3 tests) 188ms
 ✓ src/ingestion/processor/write.test.ts (4 tests) 215ms
 ✓ src/trpc/routers/newsletters.test.ts (1 test) 68ms
 ✓ src/lib/fxtwitter.test.ts (24 tests) 1318ms
 ✓ src/trpc/routers/search.test.ts (2 tests) 88ms
 ✓ src/rss/service.test.ts (5 tests) 192ms
 ✓ src/trpc/routers/bookmarks.test.ts (19 tests) 1065ms
 ✓ src/trpc/routers/rss.test.ts (7 tests) 236ms
 ✓ src/routes/auth.test.ts (10 tests) 416ms
 ✓ src/trpc/routers/connections.test.ts (27 tests) 1433ms
 ✓ src/newsletters/gmail.test.ts (15 tests) 481ms
 ✓ src/trpc/routers/sources.test.ts (27 tests) 1310ms
 ✓ src/lib/oembed.test.ts (34 tests) 1591ms
 ✓ src/lib/favicon.test.ts (31 tests) 1597ms
 ✓ src/lib/opengraph.test.ts (31 tests) 1594ms
 ✓ src/lib/auth.test.ts (25 tests) 899ms
 ✓ src/sync/consumer.test.ts (14 tests) 702ms
 ✓ src/polling/health.test.ts (32 tests) 1674ms
 ✓ src/lib/locks.test.ts (36 tests) 1692ms
 ✓ src/lib/rate-limiter.test.ts (33 tests) 1690ms
 ✓ src/polling/youtube-poller.test.ts (30 tests) 1389ms
 ✓ src/trpc/routers/subscriptions.test.ts (35 tests) 1635ms
 ✓ src/sync/dlq-consumer.test.ts (25 tests) 792ms
 ✓ src/lib/link-preview.test.ts (33 tests) 1450ms
 ✓ src/admin/repair-subscriptions.test.ts (22 tests) 955ms
 ✓ src/polling/adaptive.test.ts (29 tests) 991ms
 ✓ src/ingestion/validation.test.ts (41 tests) 1542ms
 ✓ src/ingestion/transformers.test.ts (38 tests) 1516ms
 ✓ src/lib/article-extractor.test.ts (44 tests) 1753ms
 ✓ src/utils/error-utils.test.ts (49 tests) 1924ms
 ✓ src/trpc/routers/creators.test.ts (55 tests) 1878ms
 ✓ src/db/helpers/creators.test.ts (43 tests) 1160ms
 ✓ src/lib/link-parser.test.ts (46 tests) 1758ms
 ✓ src/lib/token-refresh.test.ts (66 tests) 2072ms
 ✓ src/lib/crypto.test.ts (66 tests) 2099ms
 ✓ src/sync/service.test.ts (51 tests) 1178ms
 ✓ src/ingestion/processor.test.ts (46 tests) 1060ms
 ✓ src/trpc/routers/items.test.ts (56 tests) 995ms
 ✓ src/providers/youtube.test.ts (78 tests) 2169ms
 ✓ src/providers/spotify.test.ts (77 tests) 2206ms
 ✓ src/polling/spotify-poller.test.ts (45 tests) 2378ms
   ✓ Spotify Poller - Watermark Integrity > pollSingleSpotifySubscription > should NOT update lastPublishedAt when ingestion fails for all episodes 992ms

 Test Files  53 passed (53)
      Tests  1421 passed (1421)
   Start at  05:33:01
   Duration  8.18s (transform 12.89s, setup 4.32s, collect 41.49s, tests 56.69s, environment 6ms, prepare 45.12s)

[vpw:dbg] Shutting down runtimes...\n