### PR TITLE
Add Qwen3 bookmark enrichment pipeline

### DIFF
--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -460,6 +460,13 @@ export function useItem(id: string) {
   return trpc.items.get.useQuery({ id }, { enabled: !!id });
 }
 
+/**
+ * Hook for fetching AI enrichment and advisory tag suggestions for an item.
+ */
+export function useItemEnrichment(id: string) {
+  return trpc.items.getEnrichment.useQuery({ id }, { enabled: !!id });
+}
+
 export function useOtherUnfinishedBookmarksByCreator(id: string) {
   return trpc.items.otherUnfinishedBookmarksByCreator.useQuery(
     { id },

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import type { ExtendedStackNavigationOptions } from 'expo-router/build/layouts/StackClient';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 
 import { Colors } from '@/constants/theme';
@@ -17,7 +17,7 @@ export function getCollapsedHeaderTitleThreshold(
   return Math.max(collapsedTitleThreshold, titleStartY - collapsedTitleThreshold);
 }
 
-export const lightweightHeaderStackScreenOptions: NativeStackNavigationOptions = {
+export const lightweightHeaderStackScreenOptions: ExtendedStackNavigationOptions = {
   headerBackButtonDisplayMode: 'minimal',
   headerShadowVisible: false,
   contentStyle: {
@@ -40,12 +40,12 @@ export function createLightweightHeaderScreenOptions({
   headerStyle,
   headerTitleStyle,
   ...options
-}: NativeStackNavigationOptions & {
+}: ExtendedStackNavigationOptions & {
   backgroundColor: string;
   tintColor: string;
   screenTitle: string;
   showScreenTitle?: boolean;
-}): NativeStackNavigationOptions {
+}): ExtendedStackNavigationOptions {
   return {
     headerLargeTitle: false,
     headerTransparent: false,

--- a/apps/worker/src/db/migrations/0009_add_item_enrichment.sql
+++ b/apps/worker/src/db/migrations/0009_add_item_enrichment.sql
@@ -1,0 +1,86 @@
+-- Created: 2026-04-30
+-- Add AI enrichment and embedding reference tables
+
+CREATE TABLE IF NOT EXISTS `item_enrichments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `item_id` text NOT NULL REFERENCES `items`(`id`),
+  `schema_version` integer NOT NULL,
+  `content_hash` text NOT NULL,
+  `status` text NOT NULL,
+  `model_provider` text,
+  `model_name` text,
+  `summary_short` text,
+  `summary_detail` text,
+  `primary_category` text,
+  `secondary_categories_json` text,
+  `topics_json` text,
+  `entities_json` text,
+  `intent` text,
+  `difficulty` text,
+  `evergreen_score` real,
+  `time_sensitivity` text,
+  `confidence_json` text,
+  `error_message` text,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  `enriched_at` integer
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `item_enrichments_item_schema_hash_idx`
+  ON `item_enrichments` (`item_id`, `schema_version`, `content_hash`);
+
+CREATE INDEX IF NOT EXISTS `item_enrichments_item_idx`
+  ON `item_enrichments` (`item_id`, `updated_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `item_enrichments_status_idx`
+  ON `item_enrichments` (`status`, `updated_at` DESC);
+
+CREATE TABLE IF NOT EXISTS `user_item_enrichments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `user_item_id` text NOT NULL REFERENCES `user_items`(`id`),
+  `item_id` text NOT NULL REFERENCES `items`(`id`),
+  `schema_version` integer NOT NULL,
+  `suggested_tags_json` text,
+  `inferred_save_intent` text,
+  `reason_to_revisit` text,
+  `status` text NOT NULL,
+  `error_message` text,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  `enriched_at` integer
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `user_item_enrichments_user_item_schema_idx`
+  ON `user_item_enrichments` (`user_item_id`, `schema_version`);
+
+CREATE INDEX IF NOT EXISTS `user_item_enrichments_user_idx`
+  ON `user_item_enrichments` (`user_id`, `updated_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `user_item_enrichments_item_idx`
+  ON `user_item_enrichments` (`item_id`, `updated_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `user_item_enrichments_status_idx`
+  ON `user_item_enrichments` (`status`, `updated_at` DESC);
+
+CREATE TABLE IF NOT EXISTS `item_embedding_refs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `item_id` text NOT NULL REFERENCES `items`(`id`),
+  `user_id` text REFERENCES `users`(`id`),
+  `vector_id` text NOT NULL,
+  `namespace` text NOT NULL,
+  `embedding_model` text NOT NULL,
+  `embedding_dimensions` integer NOT NULL,
+  `content_hash` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `item_embedding_refs_vector_id_idx`
+  ON `item_embedding_refs` (`vector_id`);
+
+CREATE INDEX IF NOT EXISTS `item_embedding_refs_item_idx`
+  ON `item_embedding_refs` (`item_id`, `updated_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `item_embedding_refs_user_idx`
+  ON `item_embedding_refs` (`user_id`, `updated_at` DESC);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1773705600000,
       "tag": "0008_add_weekly_recap_support",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777507200000,
+      "tag": "0009_add_item_enrichment",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -190,6 +190,111 @@ export const userItemTags = sqliteTable(
   ]
 );
 
+// Item Enrichments
+// Canonical AI-generated enrichment for a content item and content hash.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const itemEnrichments = sqliteTable(
+  'item_enrichments',
+  {
+    id: text('id').primaryKey(),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    schemaVersion: integer('schema_version').notNull(),
+    contentHash: text('content_hash').notNull(),
+    status: text('status').notNull(),
+    modelProvider: text('model_provider'),
+    modelName: text('model_name'),
+    summaryShort: text('summary_short'),
+    summaryDetail: text('summary_detail'),
+    primaryCategory: text('primary_category'),
+    secondaryCategoriesJson: text('secondary_categories_json'),
+    topicsJson: text('topics_json'),
+    entitiesJson: text('entities_json'),
+    intent: text('intent'),
+    difficulty: text('difficulty'),
+    evergreenScore: real('evergreen_score'),
+    timeSensitivity: text('time_sensitivity'),
+    confidenceJson: text('confidence_json'),
+    errorMessage: text('error_message'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+    enrichedAt: integer('enriched_at'),
+  },
+  (table) => [
+    uniqueIndex('item_enrichments_item_schema_hash_idx').on(
+      table.itemId,
+      table.schemaVersion,
+      table.contentHash
+    ),
+    index('item_enrichments_item_idx').on(table.itemId, table.updatedAt),
+    index('item_enrichments_status_idx').on(table.status, table.updatedAt),
+  ]
+);
+
+// User Item Enrichments
+// Per-user AI suggestions for a bookmarked item. Suggestions are advisory only.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const userItemEnrichments = sqliteTable(
+  'user_item_enrichments',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    userItemId: text('user_item_id')
+      .notNull()
+      .references(() => userItems.id),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    schemaVersion: integer('schema_version').notNull(),
+    suggestedTagsJson: text('suggested_tags_json'),
+    inferredSaveIntent: text('inferred_save_intent'),
+    reasonToRevisit: text('reason_to_revisit'),
+    status: text('status').notNull(),
+    errorMessage: text('error_message'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+    enrichedAt: integer('enriched_at'),
+  },
+  (table) => [
+    uniqueIndex('user_item_enrichments_user_item_schema_idx').on(
+      table.userItemId,
+      table.schemaVersion
+    ),
+    index('user_item_enrichments_user_idx').on(table.userId, table.updatedAt),
+    index('user_item_enrichments_item_idx').on(table.itemId, table.updatedAt),
+    index('user_item_enrichments_status_idx').on(table.status, table.updatedAt),
+  ]
+);
+
+// Item Embedding References
+// D1 reference records for vectors stored in Cloudflare Vectorize.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const itemEmbeddingRefs = sqliteTable(
+  'item_embedding_refs',
+  {
+    id: text('id').primaryKey(),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    userId: text('user_id').references(() => users.id),
+    vectorId: text('vector_id').notNull(),
+    namespace: text('namespace').notNull(),
+    embeddingModel: text('embedding_model').notNull(),
+    embeddingDimensions: integer('embedding_dimensions').notNull(),
+    contentHash: text('content_hash').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('item_embedding_refs_vector_id_idx').on(table.vectorId),
+    index('item_embedding_refs_item_idx').on(table.itemId, table.updatedAt),
+    index('item_embedding_refs_user_idx').on(table.userId, table.updatedAt),
+  ]
+);
+
 // Sources (User subscriptions)
 // NOTE: Legacy table using ISO8601 TEXT timestamps. New tables should use Unix ms INTEGER.
 // See docs/zine-tech-stack.md for timestamp standard.

--- a/apps/worker/src/enrichment/consumer.test.ts
+++ b/apps/worker/src/enrichment/consumer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { enrichmentConsumerInternals } from './consumer';
+
+describe('enrichment consumer helpers', () => {
+  it('normalizes, dedupes, caps, and matches suggested tags', () => {
+    const suggestions = enrichmentConsumerInternals.normalizeSuggestedTags(
+      [
+        { name: ' Cloudflare ', kind: 'topic', confidence: 0.9 },
+        { name: 'cloudflare', kind: 'entity', confidence: 0.7 },
+        {
+          name: 'This tag name is definitely longer than thirty two characters',
+          kind: 'topic',
+          confidence: 0.8,
+        },
+        { name: 'Workers AI', kind: 'entity', confidence: 0.85 },
+      ],
+      [
+        {
+          id: 'tag-cloudflare',
+          name: 'Cloudflare',
+          normalizedName: 'cloudflare',
+        },
+      ]
+    );
+
+    expect(suggestions).toEqual([
+      {
+        name: 'Cloudflare',
+        normalizedName: 'cloudflare',
+        kind: 'topic',
+        confidence: 0.9,
+        matchedExistingTagId: 'tag-cloudflare',
+      },
+      {
+        name: 'Workers AI',
+        normalizedName: 'workers ai',
+        kind: 'entity',
+        confidence: 0.85,
+        matchedExistingTagId: null,
+      },
+    ]);
+  });
+
+  it('builds fallback user suggestions from complete canonical enrichment', () => {
+    const modelTags = enrichmentConsumerInternals.buildTagsFromCanonical({
+      topicsJson: JSON.stringify([{ name: 'recommendations', confidence: 0.88 }]),
+      entitiesJson: JSON.stringify([{ name: 'Vectorize', confidence: 0.8 }]),
+      intent: 'reference',
+    } as never);
+
+    expect(modelTags).toEqual([
+      { name: 'recommendations', kind: 'topic', confidence: 0.88 },
+      { name: 'Vectorize', kind: 'entity', confidence: 0.8 },
+      { name: 'reference', kind: 'intent', confidence: 0.65 },
+    ]);
+  });
+});

--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -1,0 +1,506 @@
+import { ulid } from 'ulid';
+import { and, desc, eq } from 'drizzle-orm';
+
+import { createDb, type Database } from '../db';
+import {
+  creators,
+  itemEnrichments,
+  items,
+  tags,
+  userItemEnrichments,
+  userItems,
+} from '../db/schema';
+import { getArticleContent } from '../lib/article-storage';
+import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
+import { upsertItemEmbedding } from './embeddings';
+import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
+import { buildEmbeddingText, buildPromptInput } from './prompt';
+import { EnrichmentQueueMessageSchema } from './schema';
+import { computeItemContentHash } from './service';
+import {
+  type EnrichmentModelOutput,
+  type EnrichmentQueueMessage,
+  type EnrichmentSourceCreator,
+  type EnrichmentSourceItem,
+  type ModelSuggestedTag,
+  type SuggestedTag,
+} from './types';
+
+const enrichmentLogger = logger.child('enrichment-consumer');
+
+type EnrichmentMessage = Message<EnrichmentQueueMessage>;
+
+function normalizeTagName(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+function normalizeTagKey(value: string): string {
+  return normalizeTagName(value).toLowerCase();
+}
+
+function normalizeSuggestedTags(
+  modelTags: ModelSuggestedTag[],
+  existingTags: Array<{ id: string; name: string; normalizedName: string }>
+): SuggestedTag[] {
+  const existingByNormalized = new Map(existingTags.map((tag) => [tag.normalizedName, tag.id]));
+  const deduped = new Map<string, SuggestedTag>();
+
+  for (const tag of modelTags) {
+    const name = normalizeTagName(tag.name);
+    if (!name || name.length > 32) continue;
+
+    const normalizedName = normalizeTagKey(name);
+    if (deduped.has(normalizedName)) continue;
+
+    deduped.set(normalizedName, {
+      name,
+      normalizedName,
+      kind: tag.kind,
+      confidence: tag.confidence,
+      matchedExistingTagId: existingByNormalized.get(normalizedName) ?? null,
+    });
+
+    if (deduped.size >= 10) break;
+  }
+
+  return [...deduped.values()];
+}
+
+function parseJsonArray<T>(value: string | null): T[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function buildTagsFromCanonical(row: typeof itemEnrichments.$inferSelect): ModelSuggestedTag[] {
+  const tagsFromTopics = parseJsonArray<{ name?: string; confidence?: number }>(row.topicsJson).map(
+    (topic) => ({
+      name: String(topic.name ?? ''),
+      kind: 'topic' as const,
+      confidence: typeof topic.confidence === 'number' ? topic.confidence : 0.6,
+    })
+  );
+  const tagsFromEntities = parseJsonArray<{ name?: string; confidence?: number }>(
+    row.entitiesJson
+  ).map((entity) => ({
+    name: String(entity.name ?? ''),
+    kind: 'entity' as const,
+    confidence: typeof entity.confidence === 'number' ? entity.confidence : 0.6,
+  }));
+  const intentTag = row.intent
+    ? [{ name: row.intent, kind: 'intent' as const, confidence: 0.65 }]
+    : [];
+
+  return [...tagsFromTopics, ...tagsFromEntities, ...intentTag];
+}
+
+async function loadSource(
+  db: Database,
+  message: EnrichmentQueueMessage
+): Promise<{
+  item: EnrichmentSourceItem;
+  creator: EnrichmentSourceCreator | null;
+} | null> {
+  const rows = await db
+    .select({
+      userItemId: userItems.id,
+      itemId: items.id,
+      title: items.title,
+      canonicalUrl: items.canonicalUrl,
+      contentType: items.contentType,
+      provider: items.provider,
+      publisher: items.publisher,
+      summary: items.summary,
+      rawMetadata: items.rawMetadata,
+      articleContentKey: items.articleContentKey,
+      creatorName: creators.name,
+      creatorDescription: creators.description,
+      creatorHandle: creators.handle,
+    })
+    .from(userItems)
+    .innerJoin(items, eq(userItems.itemId, items.id))
+    .leftJoin(creators, eq(items.creatorId, creators.id))
+    .where(
+      and(
+        eq(userItems.id, message.userItemId),
+        eq(userItems.userId, message.userId),
+        eq(items.id, message.itemId)
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  const row = rows[0];
+
+  return {
+    item: {
+      id: row.itemId,
+      title: row.title,
+      canonicalUrl: row.canonicalUrl,
+      contentType: row.contentType,
+      provider: row.provider,
+      publisher: row.publisher,
+      summary: row.summary,
+      rawMetadata: row.rawMetadata,
+      articleContentKey: row.articleContentKey,
+    },
+    creator: row.creatorName
+      ? {
+          name: row.creatorName,
+          description: row.creatorDescription,
+          handle: row.creatorHandle,
+        }
+      : null,
+  };
+}
+
+async function loadExistingTags(
+  db: Database,
+  userId: string
+): Promise<Array<{ id: string; name: string; normalizedName: string }>> {
+  return db
+    .select({ id: tags.id, name: tags.name, normalizedName: tags.normalizedName })
+    .from(tags)
+    .where(eq(tags.userId, userId));
+}
+
+async function findCompleteCanonical(
+  db: Database,
+  message: EnrichmentQueueMessage
+): Promise<typeof itemEnrichments.$inferSelect | null> {
+  const rows = await db
+    .select()
+    .from(itemEnrichments)
+    .where(
+      and(
+        eq(itemEnrichments.itemId, message.itemId),
+        eq(itemEnrichments.schemaVersion, message.schemaVersion),
+        eq(itemEnrichments.contentHash, message.contentHash),
+        eq(itemEnrichments.status, 'COMPLETE')
+      )
+    )
+    .orderBy(desc(itemEnrichments.updatedAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+async function upsertCanonicalPending(db: Database, message: EnrichmentQueueMessage) {
+  const now = Date.now();
+  await db
+    .insert(itemEnrichments)
+    .values({
+      id: ulid(),
+      itemId: message.itemId,
+      schemaVersion: message.schemaVersion,
+      contentHash: message.contentHash,
+      status: 'PENDING',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [itemEnrichments.itemId, itemEnrichments.schemaVersion, itemEnrichments.contentHash],
+      set: {
+        status: 'PENDING',
+        errorMessage: null,
+        updatedAt: now,
+      },
+    });
+}
+
+async function writeCanonicalComplete(
+  db: Database,
+  message: EnrichmentQueueMessage,
+  output: EnrichmentModelOutput,
+  env: Bindings
+) {
+  const now = Date.now();
+  await db
+    .insert(itemEnrichments)
+    .values({
+      id: ulid(),
+      itemId: message.itemId,
+      schemaVersion: message.schemaVersion,
+      contentHash: message.contentHash,
+      status: 'COMPLETE',
+      modelProvider: 'cloudflare-workers-ai',
+      modelName: env.ENRICHMENT_MODEL || '@cf/qwen/qwen3-30b-a3b-fp8',
+      summaryShort: output.summary.short,
+      summaryDetail: output.summary.detail,
+      primaryCategory: output.classification.primaryCategory,
+      secondaryCategoriesJson: JSON.stringify(output.classification.secondaryCategories),
+      topicsJson: JSON.stringify(output.topics),
+      entitiesJson: JSON.stringify(output.entities),
+      intent: output.classification.intent,
+      difficulty: output.classification.difficulty,
+      evergreenScore: output.classification.evergreenScore,
+      timeSensitivity: output.classification.timeSensitivity,
+      confidenceJson: JSON.stringify(output.confidence),
+      createdAt: now,
+      updatedAt: now,
+      enrichedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [itemEnrichments.itemId, itemEnrichments.schemaVersion, itemEnrichments.contentHash],
+      set: {
+        status: 'COMPLETE',
+        modelProvider: 'cloudflare-workers-ai',
+        modelName: env.ENRICHMENT_MODEL || '@cf/qwen/qwen3-30b-a3b-fp8',
+        summaryShort: output.summary.short,
+        summaryDetail: output.summary.detail,
+        primaryCategory: output.classification.primaryCategory,
+        secondaryCategoriesJson: JSON.stringify(output.classification.secondaryCategories),
+        topicsJson: JSON.stringify(output.topics),
+        entitiesJson: JSON.stringify(output.entities),
+        intent: output.classification.intent,
+        difficulty: output.classification.difficulty,
+        evergreenScore: output.classification.evergreenScore,
+        timeSensitivity: output.classification.timeSensitivity,
+        confidenceJson: JSON.stringify(output.confidence),
+        errorMessage: null,
+        updatedAt: now,
+        enrichedAt: now,
+      },
+    });
+}
+
+async function writeCanonicalFailed(db: Database, message: EnrichmentQueueMessage, error: unknown) {
+  const now = Date.now();
+  const messageText = error instanceof Error ? error.message : String(error);
+  await db
+    .insert(itemEnrichments)
+    .values({
+      id: ulid(),
+      itemId: message.itemId,
+      schemaVersion: message.schemaVersion,
+      contentHash: message.contentHash,
+      status: 'FAILED',
+      errorMessage: messageText,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [itemEnrichments.itemId, itemEnrichments.schemaVersion, itemEnrichments.contentHash],
+      set: {
+        status: 'FAILED',
+        errorMessage: messageText,
+        updatedAt: now,
+      },
+    });
+}
+
+async function writeUserComplete(
+  db: Database,
+  message: EnrichmentQueueMessage,
+  input: {
+    suggestedTags: SuggestedTag[];
+    inferredSaveIntent: string | null;
+    reasonToRevisit: string | null;
+  }
+) {
+  const now = Date.now();
+  await db
+    .insert(userItemEnrichments)
+    .values({
+      id: ulid(),
+      userId: message.userId,
+      userItemId: message.userItemId,
+      itemId: message.itemId,
+      schemaVersion: message.schemaVersion,
+      suggestedTagsJson: JSON.stringify(input.suggestedTags),
+      inferredSaveIntent: input.inferredSaveIntent,
+      reasonToRevisit: input.reasonToRevisit,
+      status: 'COMPLETE',
+      createdAt: now,
+      updatedAt: now,
+      enrichedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [userItemEnrichments.userItemId, userItemEnrichments.schemaVersion],
+      set: {
+        suggestedTagsJson: JSON.stringify(input.suggestedTags),
+        inferredSaveIntent: input.inferredSaveIntent,
+        reasonToRevisit: input.reasonToRevisit,
+        status: 'COMPLETE',
+        errorMessage: null,
+        updatedAt: now,
+        enrichedAt: now,
+      },
+    });
+}
+
+async function writeUserFailed(db: Database, message: EnrichmentQueueMessage, error: unknown) {
+  const now = Date.now();
+  const messageText = error instanceof Error ? error.message : String(error);
+  await db
+    .insert(userItemEnrichments)
+    .values({
+      id: ulid(),
+      userId: message.userId,
+      userItemId: message.userItemId,
+      itemId: message.itemId,
+      schemaVersion: message.schemaVersion,
+      status: 'FAILED',
+      errorMessage: messageText,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [userItemEnrichments.userItemId, userItemEnrichments.schemaVersion],
+      set: {
+        status: 'FAILED',
+        errorMessage: messageText,
+        updatedAt: now,
+      },
+    });
+}
+
+async function processMessage(message: EnrichmentMessage, db: Database, env: Bindings) {
+  const parsed = EnrichmentQueueMessageSchema.safeParse(message.body);
+  if (!parsed.success) {
+    enrichmentLogger.error('Invalid enrichment message body', {
+      messageId: message.id,
+      error: parsed.error.message,
+    });
+    message.ack();
+    return;
+  }
+
+  const body = parsed.data;
+  const source = await loadSource(db, body);
+  if (!source) {
+    enrichmentLogger.warn('Enrichment source item missing; acking message', {
+      messageId: message.id,
+      itemId: body.itemId,
+      userItemId: body.userItemId,
+    });
+    message.ack();
+    return;
+  }
+
+  const contentHash = computeItemContentHash({
+    title: source.item.title,
+    canonicalUrl: source.item.canonicalUrl,
+    contentType: String(source.item.contentType),
+    provider: String(source.item.provider),
+    publisher: source.item.publisher,
+    summary: source.item.summary,
+    creatorName: source.creator?.name ?? null,
+    articleContentKey: source.item.articleContentKey,
+  });
+  const effectiveBody = { ...body, contentHash };
+  const existingTags = await loadExistingTags(db, body.userId);
+  const existingCanonical = await findCompleteCanonical(db, effectiveBody);
+
+  try {
+    if (existingCanonical) {
+      const suggestions = normalizeSuggestedTags(
+        buildTagsFromCanonical(existingCanonical),
+        existingTags
+      );
+
+      await writeUserComplete(db, effectiveBody, {
+        suggestedTags: suggestions,
+        inferredSaveIntent: 'Saved for later reference',
+        reasonToRevisit: existingCanonical.summaryShort,
+      });
+
+      message.ack();
+      return;
+    }
+
+    await upsertCanonicalPending(db, effectiveBody);
+
+    const articleContent = source.item.articleContentKey
+      ? await getArticleContent(env.ARTICLE_CONTENT, source.item.id)
+      : null;
+    const promptInput = buildPromptInput({
+      item: source.item,
+      creator: source.creator,
+      articleContent,
+    });
+    const output = await enrichWithQwen(env, promptInput);
+
+    await writeCanonicalComplete(db, effectiveBody, output, env);
+
+    const suggestedTags = normalizeSuggestedTags(output.suggestedTags, existingTags);
+    await writeUserComplete(db, effectiveBody, {
+      suggestedTags,
+      inferredSaveIntent: output.userContext.inferredSaveIntent,
+      reasonToRevisit: output.userContext.reasonToRevisit,
+    });
+
+    await upsertItemEmbedding(db, env, {
+      itemId: source.item.id,
+      userId: body.userId,
+      provider: String(source.item.provider),
+      contentType: String(source.item.contentType),
+      primaryCategory: output.classification.primaryCategory,
+      contentHash,
+      text: buildEmbeddingText({
+        item: source.item,
+        creator: source.creator,
+        output,
+        articleExcerpt: promptInput.articleExcerpt,
+      }),
+    });
+
+    message.ack();
+  } catch (error) {
+    if (error instanceof EnrichmentModelValidationError) {
+      await writeCanonicalFailed(db, effectiveBody, error);
+      await writeUserFailed(db, effectiveBody, error);
+      message.ack();
+      return;
+    }
+
+    enrichmentLogger.warn('Retrying enrichment message after transient failure', {
+      messageId: message.id,
+      attempts: message.attempts,
+      itemId: body.itemId,
+      userItemId: body.userItemId,
+      error,
+    });
+    message.retry();
+  }
+}
+
+export async function handleEnrichmentQueue(
+  batch: MessageBatch<EnrichmentQueueMessage>,
+  env: Bindings
+): Promise<void> {
+  enrichmentLogger.info('Processing enrichment queue batch', {
+    messageCount: batch.messages.length,
+    queue: batch.queue,
+  });
+
+  const db = createDb(env.DB);
+  for (const message of batch.messages) {
+    await processMessage(message, db, env);
+  }
+}
+
+export async function handleEnrichmentDLQ(
+  batch: MessageBatch<EnrichmentQueueMessage>,
+  _env: Bindings
+): Promise<void> {
+  enrichmentLogger.error('Enrichment messages reached DLQ', {
+    messageCount: batch.messages.length,
+    queue: batch.queue,
+    messageIds: batch.messages.map((message) => message.id),
+  });
+
+  for (const message of batch.messages) {
+    message.ack();
+  }
+}
+
+export const enrichmentConsumerInternals = {
+  normalizeSuggestedTags,
+  buildTagsFromCanonical,
+};

--- a/apps/worker/src/enrichment/embeddings.test.ts
+++ b/apps/worker/src/enrichment/embeddings.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildVectorId, getVectorVisibility } from './embeddings';
+
+describe('embedding privacy helpers', () => {
+  it('uses public vectors for non-private providers', () => {
+    expect(getVectorVisibility('WEB')).toBe('public');
+    expect(
+      buildVectorId({
+        itemId: 'item-1',
+        userId: 'user-1',
+        provider: 'WEB',
+      })
+    ).toBe('item:item-1');
+  });
+
+  it('uses user-scoped vectors for Gmail content', () => {
+    expect(getVectorVisibility('GMAIL')).toBe('user');
+    expect(
+      buildVectorId({
+        itemId: 'item-1',
+        userId: 'user-1',
+        provider: 'GMAIL',
+      })
+    ).toBe('user:user-1:item:item-1');
+  });
+});

--- a/apps/worker/src/enrichment/embeddings.ts
+++ b/apps/worker/src/enrichment/embeddings.ts
@@ -1,0 +1,150 @@
+import { ulid } from 'ulid';
+import { eq } from 'drizzle-orm';
+import { Provider } from '@zine/shared';
+
+import type { Bindings } from '../types';
+import type { Database } from '../db';
+import { itemEmbeddingRefs } from '../db/schema';
+import {
+  DEFAULT_EMBEDDING_DIMENSIONS,
+  DEFAULT_EMBEDDING_MODEL,
+  type EmbeddingUpsertInput,
+  type VectorVisibility,
+} from './types';
+
+type WorkersAIRun = {
+  run(model: string, input: unknown): Promise<unknown>;
+};
+
+type VectorizeUpsert = {
+  upsert(
+    vectors: Array<{
+      id: string;
+      values: number[];
+      metadata?: Record<string, unknown>;
+    }>
+  ): Promise<unknown>;
+};
+
+function getEmbeddingModel(env: Bindings): string {
+  return env.EMBEDDING_MODEL || DEFAULT_EMBEDDING_MODEL;
+}
+
+function getEmbeddingDimensions(env: Bindings): number {
+  const parsed = Number(env.EMBEDDING_DIMENSIONS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_EMBEDDING_DIMENSIONS;
+}
+
+function extractEmbedding(response: unknown): number[] {
+  if (!response || typeof response !== 'object') {
+    throw new Error('Embedding response was empty');
+  }
+
+  const record = response as Record<string, unknown>;
+  const data = record.data;
+  if (Array.isArray(data) && Array.isArray(data[0])) {
+    return data[0] as number[];
+  }
+  if (Array.isArray(data) && typeof data[0] === 'number') {
+    return data as number[];
+  }
+
+  const result = record.result;
+  if (result && typeof result === 'object') {
+    const nested = result as Record<string, unknown>;
+    if (Array.isArray(nested.data) && Array.isArray(nested.data[0])) {
+      return nested.data[0] as number[];
+    }
+  }
+
+  throw new Error('Embedding response did not contain vector data');
+}
+
+export function getVectorVisibility(provider: string): VectorVisibility {
+  return provider === Provider.GMAIL ? 'user' : 'public';
+}
+
+export function buildVectorId(input: Pick<EmbeddingUpsertInput, 'itemId' | 'userId' | 'provider'>) {
+  return getVectorVisibility(input.provider) === 'user'
+    ? `user:${input.userId}:item:${input.itemId}`
+    : `item:${input.itemId}`;
+}
+
+export async function upsertItemEmbedding(
+  db: Database,
+  env: Bindings,
+  input: EmbeddingUpsertInput
+): Promise<void> {
+  const ai = env.AI as unknown as WorkersAIRun | undefined;
+  const index = env.ITEM_VECTORS as unknown as VectorizeUpsert | undefined;
+
+  if (!ai) {
+    throw new Error('Workers AI binding is not configured');
+  }
+  if (!index) {
+    throw new Error('Vectorize binding is not configured');
+  }
+
+  const embeddingModel = getEmbeddingModel(env);
+  const dimensions = getEmbeddingDimensions(env);
+  const visibility = getVectorVisibility(input.provider);
+  const vectorId = buildVectorId(input);
+  const namespace = visibility === 'user' ? `user:${input.userId}` : 'public';
+
+  const embedding = extractEmbedding(
+    await ai.run(embeddingModel, {
+      text: [input.text],
+    })
+  );
+
+  await index.upsert([
+    {
+      id: vectorId,
+      values: embedding,
+      metadata: {
+        itemId: input.itemId,
+        userId: visibility === 'user' ? input.userId : null,
+        provider: input.provider,
+        contentType: input.contentType,
+        primaryCategory: input.primaryCategory,
+        visibility,
+      },
+    },
+  ]);
+
+  const now = Date.now();
+  const existing = await db
+    .select({ id: itemEmbeddingRefs.id })
+    .from(itemEmbeddingRefs)
+    .where(eq(itemEmbeddingRefs.vectorId, vectorId))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(itemEmbeddingRefs)
+      .set({
+        itemId: input.itemId,
+        userId: visibility === 'user' ? input.userId : null,
+        namespace,
+        embeddingModel,
+        embeddingDimensions: dimensions,
+        contentHash: input.contentHash,
+        updatedAt: now,
+      })
+      .where(eq(itemEmbeddingRefs.id, existing[0].id));
+    return;
+  }
+
+  await db.insert(itemEmbeddingRefs).values({
+    id: ulid(),
+    itemId: input.itemId,
+    userId: visibility === 'user' ? input.userId : null,
+    vectorId,
+    namespace,
+    embeddingModel,
+    embeddingDimensions: dimensions,
+    contentHash: input.contentHash,
+    createdAt: now,
+    updatedAt: now,
+  });
+}

--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
+import type { EnrichmentPromptInput } from './types';
+
+function createPromptInput(): EnrichmentPromptInput {
+  return {
+    item: {
+      id: 'item-1',
+      title: 'Testing Cloudflare Workers AI',
+      canonicalUrl: 'https://example.com/post',
+      contentType: 'ARTICLE',
+      provider: 'WEB',
+      publisher: 'Example',
+      summary: 'A short article about Workers AI.',
+      rawMetadata: null,
+      articleContentKey: null,
+    },
+    creator: {
+      name: 'Example Author',
+      description: null,
+      handle: null,
+    },
+    articleExcerpt: 'Workers AI can run models near a Cloudflare Worker.',
+  };
+}
+
+function createValidModelOutput() {
+  return {
+    summary: {
+      short: 'A guide to using Workers AI.',
+      detail: 'The article explains how Workers AI can enrich application data.',
+    },
+    classification: {
+      primaryCategory: 'software-engineering',
+      secondaryCategories: ['ai', 'cloudflare'],
+      intent: 'tutorial',
+      difficulty: 'intermediate',
+      evergreenScore: 0.8,
+      timeSensitivity: 'evergreen',
+    },
+    topics: [{ name: 'workers ai', confidence: 0.9 }],
+    entities: [{ name: 'Cloudflare Workers', type: 'technology', confidence: 0.9 }],
+    suggestedTags: [{ name: 'cloudflare', kind: 'topic', confidence: 0.9 }],
+    userContext: {
+      inferredSaveIntent: 'Learn Workers AI implementation details.',
+      reasonToRevisit: 'Useful when building enrichment pipelines.',
+    },
+    confidence: {
+      overall: 0.86,
+      summary: 0.9,
+      classification: 0.85,
+      tags: 0.8,
+    },
+  };
+}
+
+describe('enrichWithQwen', () => {
+  it('returns validated structured output from Workers AI JSON text', async () => {
+    const output = createValidModelOutput();
+    const run = vi.fn().mockResolvedValue({ response: JSON.stringify(output) });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.summary.short).toBe(output.summary.short);
+    expect(run).toHaveBeenCalledWith(
+      '@cf/qwen/qwen3-30b-a3b-fp8',
+      expect.objectContaining({
+        response_format: expect.objectContaining({ type: 'json_schema' }),
+      })
+    );
+  });
+
+  it('retries once when model output is invalid and accepts repaired JSON', async () => {
+    const output = createValidModelOutput();
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ response: '{bad-json' })
+      .mockResolvedValueOnce({ response: JSON.stringify(output) });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.classification.primaryCategory).toBe('software-engineering');
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws validation error when both model attempts are invalid', async () => {
+    const run = vi.fn().mockResolvedValue({ response: '{bad-json' });
+
+    await expect(enrichWithQwen({ AI: { run } } as never, createPromptInput())).rejects.toThrow(
+      EnrichmentModelValidationError
+    );
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -1,0 +1,215 @@
+import type { Bindings } from '../types';
+import { logger } from '../lib/logger';
+import { buildEnrichmentMessages } from './prompt';
+import { EnrichmentModelOutputSchema } from './schema';
+import {
+  DEFAULT_ENRICHMENT_MODEL,
+  type EnrichmentModelOutput,
+  type EnrichmentPromptInput,
+} from './types';
+
+const llmLogger = logger.child('enrichment-llm');
+
+export class EnrichmentModelValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EnrichmentModelValidationError';
+  }
+}
+
+type WorkersAIRun = {
+  run(model: string, input: unknown): Promise<unknown>;
+};
+
+function getEnrichmentModel(env: Bindings): string {
+  return env.ENRICHMENT_MODEL || DEFAULT_ENRICHMENT_MODEL;
+}
+
+function getResponseText(response: unknown): string | null {
+  if (typeof response === 'string') return response;
+  if (!response || typeof response !== 'object') return null;
+
+  const record = response as Record<string, unknown>;
+  if (typeof record.response === 'string') return record.response;
+  if (typeof record.result === 'string') return record.result;
+  if (record.result && typeof record.result === 'object') {
+    const nested = record.result as Record<string, unknown>;
+    if (typeof nested.response === 'string') return nested.response;
+  }
+
+  return null;
+}
+
+function parseModelResponse(response: unknown): EnrichmentModelOutput {
+  const direct = EnrichmentModelOutputSchema.safeParse(response);
+  if (direct.success) return direct.data;
+
+  const text = getResponseText(response);
+  if (!text) {
+    throw new EnrichmentModelValidationError('Workers AI response did not include JSON text');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new EnrichmentModelValidationError(
+      `Workers AI response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  const validated = EnrichmentModelOutputSchema.safeParse(parsed);
+  if (!validated.success) {
+    throw new EnrichmentModelValidationError(
+      `Workers AI JSON failed schema validation: ${validated.error.message}`
+    );
+  }
+
+  return validated.data;
+}
+
+function buildJsonModeSchema() {
+  return {
+    type: 'json_schema',
+    json_schema: {
+      name: 'zine_bookmark_enrichment',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'summary',
+          'classification',
+          'topics',
+          'entities',
+          'suggestedTags',
+          'userContext',
+          'confidence',
+        ],
+        properties: {
+          summary: {
+            type: 'object',
+            required: ['short', 'detail'],
+            properties: {
+              short: { type: 'string' },
+              detail: { type: 'string' },
+            },
+          },
+          classification: {
+            type: 'object',
+            required: [
+              'primaryCategory',
+              'secondaryCategories',
+              'intent',
+              'difficulty',
+              'evergreenScore',
+              'timeSensitivity',
+            ],
+            properties: {
+              primaryCategory: { type: 'string' },
+              secondaryCategories: { type: 'array', items: { type: 'string' } },
+              intent: { type: 'string' },
+              difficulty: { type: 'string' },
+              evergreenScore: { type: 'number' },
+              timeSensitivity: { type: 'string' },
+            },
+          },
+          topics: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['name', 'confidence'],
+              properties: {
+                name: { type: 'string' },
+                confidence: { type: 'number' },
+              },
+            },
+          },
+          entities: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['name', 'type', 'confidence'],
+              properties: {
+                name: { type: 'string' },
+                type: { type: 'string' },
+                confidence: { type: 'number' },
+              },
+            },
+          },
+          suggestedTags: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['name', 'kind', 'confidence'],
+              properties: {
+                name: { type: 'string' },
+                kind: { type: 'string', enum: ['topic', 'entity', 'intent', 'format'] },
+                confidence: { type: 'number' },
+              },
+            },
+          },
+          userContext: {
+            type: 'object',
+            required: ['inferredSaveIntent', 'reasonToRevisit'],
+            properties: {
+              inferredSaveIntent: { type: 'string' },
+              reasonToRevisit: { type: 'string' },
+            },
+          },
+          confidence: {
+            type: 'object',
+            required: ['overall', 'summary', 'classification', 'tags'],
+            properties: {
+              overall: { type: 'number' },
+              summary: { type: 'number' },
+              classification: { type: 'number' },
+              tags: { type: 'number' },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function runQwen(env: Bindings, input: unknown): Promise<unknown> {
+  const ai = env.AI as unknown as WorkersAIRun | undefined;
+  if (!ai) {
+    throw new Error('Workers AI binding is not configured');
+  }
+
+  return ai.run(getEnrichmentModel(env), input);
+}
+
+export async function enrichWithQwen(
+  env: Bindings,
+  input: EnrichmentPromptInput
+): Promise<EnrichmentModelOutput> {
+  const messages = buildEnrichmentMessages(input);
+  const request = {
+    messages,
+    response_format: buildJsonModeSchema(),
+    max_tokens: 1800,
+  };
+
+  try {
+    return parseModelResponse(await runQwen(env, request));
+  } catch (error) {
+    llmLogger.warn('Initial enrichment response invalid; retrying with repair prompt', {
+      error,
+    });
+
+    const repairRequest = {
+      ...request,
+      messages: [
+        ...messages,
+        {
+          role: 'user',
+          content:
+            'Retry. Return only valid JSON matching the schema exactly. No markdown or commentary.',
+        },
+      ],
+    };
+
+    return parseModelResponse(await runQwen(env, repairRequest));
+  }
+}

--- a/apps/worker/src/enrichment/prompt.ts
+++ b/apps/worker/src/enrichment/prompt.ts
@@ -1,0 +1,119 @@
+import type {
+  EnrichmentModelOutput,
+  EnrichmentPromptInput,
+  EnrichmentSourceCreator,
+  EnrichmentSourceItem,
+} from './types';
+
+const ARTICLE_EXCERPT_LIMIT = 5000;
+const METADATA_LIMIT = 2500;
+const EMBEDDING_TEXT_LIMIT = 6000;
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(value: string | null | undefined, max: number): string | null {
+  if (!value) return null;
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (!normalized) return null;
+  return normalized.length > max ? `${normalized.slice(0, max)}...` : normalized;
+}
+
+function parseMetadataExcerpt(rawMetadata: string | null): string | null {
+  if (!rawMetadata) return null;
+
+  try {
+    const parsed = JSON.parse(rawMetadata);
+    return truncate(JSON.stringify(parsed), METADATA_LIMIT);
+  } catch {
+    return truncate(rawMetadata, METADATA_LIMIT);
+  }
+}
+
+function formatCreator(creator: EnrichmentSourceCreator | null): string {
+  if (!creator) return 'Unknown';
+  return (
+    [creator.name, creator.handle, creator.description].filter(Boolean).join(' | ') || 'Unknown'
+  );
+}
+
+export function buildArticleExcerpt(content: string | null): string | null {
+  return truncate(stripHtml(content ?? ''), ARTICLE_EXCERPT_LIMIT);
+}
+
+export function buildPromptInput(params: {
+  item: EnrichmentSourceItem;
+  creator: EnrichmentSourceCreator | null;
+  articleContent: string | null;
+}): EnrichmentPromptInput {
+  return {
+    item: params.item,
+    creator: params.creator,
+    articleExcerpt: buildArticleExcerpt(params.articleContent),
+  };
+}
+
+export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
+  const metadataExcerpt = parseMetadataExcerpt(input.item.rawMetadata);
+
+  const userContent = {
+    task: 'Enrich this saved bookmark for a personal knowledge/recommendation app.',
+    constraints: [
+      'Return only JSON matching the requested schema.',
+      'Prefer stable categories and short lowercase tag names.',
+      'Do not invent facts not supported by the input.',
+      'Use confidence below 0.6 when the input is thin or ambiguous.',
+    ],
+    item: {
+      title: input.item.title,
+      url: input.item.canonicalUrl,
+      provider: input.item.provider,
+      contentType: input.item.contentType,
+      publisher: input.item.publisher,
+      creator: formatCreator(input.creator),
+      existingSummary: input.item.summary,
+      metadataExcerpt,
+      articleExcerpt: input.articleExcerpt,
+    },
+  };
+
+  return [
+    {
+      role: 'system',
+      content:
+        'You produce concise, valid JSON metadata for bookmarks. Keep tags useful for later recommendations.',
+    },
+    {
+      role: 'user',
+      content: JSON.stringify(userContent),
+    },
+  ];
+}
+
+export function buildEmbeddingText(params: {
+  item: EnrichmentSourceItem;
+  creator: EnrichmentSourceCreator | null;
+  output: EnrichmentModelOutput;
+  articleExcerpt: string | null;
+}): string {
+  const lines = [
+    `Title: ${params.item.title}`,
+    `Creator: ${formatCreator(params.creator)}`,
+    `Publisher: ${params.item.publisher ?? ''}`,
+    `Provider: ${params.item.provider}`,
+    `Content type: ${params.item.contentType}`,
+    `Summary: ${params.output.summary.short} ${params.output.summary.detail}`,
+    `Primary category: ${params.output.classification.primaryCategory}`,
+    `Topics: ${params.output.topics.map((topic) => topic.name).join(', ')}`,
+    `Entities: ${params.output.entities.map((entity) => entity.name).join(', ')}`,
+    params.articleExcerpt ? `Excerpt: ${params.articleExcerpt}` : '',
+  ];
+
+  return truncate(lines.filter(Boolean).join('\n'), EMBEDDING_TEXT_LIMIT) ?? '';
+}

--- a/apps/worker/src/enrichment/schema.ts
+++ b/apps/worker/src/enrichment/schema.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+import { ENRICHMENT_SCHEMA_VERSION, type EnrichmentModelOutput, type SuggestedTag } from './types';
+
+const ConfidenceSchema = z.number().min(0).max(1);
+
+export const EnrichmentQueueMessageSchema = z.object({
+  itemId: z.string().min(1),
+  userItemId: z.string().min(1),
+  userId: z.string().min(1),
+  trigger: z.enum(['manual_save', 'inbox_bookmark', 'backfill']),
+  schemaVersion: z.number().int().positive().default(ENRICHMENT_SCHEMA_VERSION),
+  contentHash: z.string().min(1),
+  enqueuedAt: z.number().int().nonnegative(),
+});
+
+export const ModelSuggestedTagSchema = z.object({
+  name: z.string().min(1).max(64),
+  kind: z.enum(['topic', 'entity', 'intent', 'format']),
+  confidence: ConfidenceSchema,
+});
+
+export const SuggestedTagSchema = ModelSuggestedTagSchema.extend({
+  normalizedName: z.string().min(1).max(32),
+  matchedExistingTagId: z.string().nullable(),
+});
+
+export const EnrichmentModelOutputSchema = z.object({
+  summary: z.object({
+    short: z.string().min(1).max(500),
+    detail: z.string().min(1).max(2000),
+  }),
+  classification: z.object({
+    primaryCategory: z.string().min(1).max(64),
+    secondaryCategories: z.array(z.string().min(1).max(64)).max(5),
+    intent: z.string().min(1).max(64),
+    difficulty: z.string().min(1).max(64),
+    evergreenScore: ConfidenceSchema,
+    timeSensitivity: z.string().min(1).max(64),
+  }),
+  topics: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(80),
+        confidence: ConfidenceSchema,
+      })
+    )
+    .max(15),
+  entities: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(120),
+        type: z.string().min(1).max(64),
+        confidence: ConfidenceSchema,
+      })
+    )
+    .max(20),
+  suggestedTags: z.array(ModelSuggestedTagSchema).max(20),
+  userContext: z.object({
+    inferredSaveIntent: z.string().min(1).max(500),
+    reasonToRevisit: z.string().min(1).max(500),
+  }),
+  confidence: z.object({
+    overall: ConfidenceSchema,
+    summary: ConfidenceSchema,
+    classification: ConfidenceSchema,
+    tags: ConfidenceSchema,
+  }),
+}) satisfies z.ZodType<EnrichmentModelOutput>;
+
+export const SuggestedTagsSchema = z.array(SuggestedTagSchema).max(10) satisfies z.ZodType<
+  SuggestedTag[]
+>;
+
+export type EnrichmentQueueMessageInput = z.infer<typeof EnrichmentQueueMessageSchema>;

--- a/apps/worker/src/enrichment/service.test.ts
+++ b/apps/worker/src/enrichment/service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeItemContentHash } from './service';
+
+describe('computeItemContentHash', () => {
+  it('is stable for equivalent inputs', () => {
+    const input = {
+      title: 'Title',
+      canonicalUrl: 'https://example.com/a',
+      contentType: 'ARTICLE',
+      provider: 'WEB',
+      publisher: 'Example',
+      summary: 'Summary',
+      creatorName: 'Author',
+      articleContentKey: 'articles/item.html',
+    };
+
+    expect(computeItemContentHash(input)).toBe(computeItemContentHash({ ...input }));
+  });
+
+  it('changes when meaningful enrichment inputs change', () => {
+    const base = {
+      title: 'Title',
+      canonicalUrl: 'https://example.com/a',
+      contentType: 'ARTICLE',
+      provider: 'WEB',
+      publisher: 'Example',
+      summary: 'Summary',
+      creatorName: 'Author',
+      articleContentKey: 'articles/item.html',
+    };
+
+    expect(computeItemContentHash(base)).not.toBe(
+      computeItemContentHash({ ...base, summary: 'Different summary' })
+    );
+  });
+});

--- a/apps/worker/src/enrichment/service.ts
+++ b/apps/worker/src/enrichment/service.ts
@@ -1,0 +1,141 @@
+import { and, eq } from 'drizzle-orm';
+
+import { creators, items, userItems } from '../db/schema';
+import { logger } from '../lib/logger';
+import type { TRPCContext } from '../trpc/context';
+import {
+  ENRICHMENT_SCHEMA_VERSION,
+  type EnrichmentQueueMessage,
+  type EnrichmentTrigger,
+} from './types';
+
+const enrichmentLogger = logger.child('enrichment-service');
+
+type EnrichmentQueue = Queue<EnrichmentQueueMessage>;
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function computeItemContentHash(input: {
+  title: string;
+  canonicalUrl: string;
+  contentType: string;
+  provider: string;
+  publisher: string | null;
+  summary: string | null;
+  creatorName: string | null;
+  articleContentKey: string | null;
+}): string {
+  return stableHash(
+    JSON.stringify({
+      title: input.title,
+      canonicalUrl: input.canonicalUrl,
+      contentType: input.contentType,
+      provider: input.provider,
+      publisher: input.publisher,
+      summary: input.summary,
+      creatorName: input.creatorName,
+      articleContentKey: input.articleContentKey,
+    })
+  );
+}
+
+export async function getItemContentHash(
+  db: TRPCContext['db'],
+  itemId: string
+): Promise<string | null> {
+  const rows = await db
+    .select({
+      title: items.title,
+      canonicalUrl: items.canonicalUrl,
+      contentType: items.contentType,
+      provider: items.provider,
+      publisher: items.publisher,
+      summary: items.summary,
+      articleContentKey: items.articleContentKey,
+      creatorName: creators.name,
+    })
+    .from(items)
+    .leftJoin(creators, eq(items.creatorId, creators.id))
+    .where(eq(items.id, itemId))
+    .limit(1);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return computeItemContentHash(rows[0]);
+}
+
+export async function enqueueBookmarkEnrichment(
+  ctx: Omit<Pick<TRPCContext, 'db' | 'env' | 'userId' | 'requestId' | 'traceId'>, 'userId'> & {
+    userId: string;
+  },
+  input: {
+    itemId: string;
+    userItemId: string;
+    trigger: EnrichmentTrigger;
+  }
+): Promise<void> {
+  const queue = ctx.env.ENRICHMENT_QUEUE as EnrichmentQueue | undefined;
+  if (!queue) {
+    enrichmentLogger.debug('Enrichment queue not configured; skipping enqueue', {
+      itemId: input.itemId,
+      userItemId: input.userItemId,
+      trigger: input.trigger,
+    });
+    return;
+  }
+
+  const ownedUserItem = await ctx.db
+    .select({ id: userItems.id })
+    .from(userItems)
+    .where(and(eq(userItems.id, input.userItemId), eq(userItems.userId, ctx.userId)))
+    .limit(1);
+
+  if (ownedUserItem.length === 0) {
+    enrichmentLogger.warn('Skipping enrichment enqueue for non-owned user item', {
+      itemId: input.itemId,
+      userItemId: input.userItemId,
+      userId: ctx.userId,
+    });
+    return;
+  }
+
+  const contentHash = await getItemContentHash(ctx.db, input.itemId);
+  if (!contentHash) {
+    enrichmentLogger.warn('Skipping enrichment enqueue for missing item', {
+      itemId: input.itemId,
+      userItemId: input.userItemId,
+    });
+    return;
+  }
+
+  const message: EnrichmentQueueMessage = {
+    itemId: input.itemId,
+    userItemId: input.userItemId,
+    userId: ctx.userId,
+    trigger: input.trigger,
+    schemaVersion: ENRICHMENT_SCHEMA_VERSION,
+    contentHash,
+    enqueuedAt: Date.now(),
+  };
+
+  await queue.send(message);
+
+  enrichmentLogger.info('Bookmark enrichment queued', {
+    itemId: input.itemId,
+    userItemId: input.userItemId,
+    trigger: input.trigger,
+    requestId: ctx.requestId,
+    traceId: ctx.traceId,
+  });
+}

--- a/apps/worker/src/enrichment/types.ts
+++ b/apps/worker/src/enrichment/types.ts
@@ -1,0 +1,108 @@
+import type { ContentType, Provider } from '@zine/shared';
+
+export const ENRICHMENT_SCHEMA_VERSION = 1;
+export const DEFAULT_ENRICHMENT_MODEL = '@cf/qwen/qwen3-30b-a3b-fp8';
+export const DEFAULT_EMBEDDING_MODEL = '@cf/qwen/qwen3-embedding-0.6b';
+export const DEFAULT_EMBEDDING_DIMENSIONS = 1024;
+
+export type EnrichmentStatus = 'PENDING' | 'COMPLETE' | 'FAILED';
+export type EnrichmentTrigger = 'manual_save' | 'inbox_bookmark' | 'backfill';
+export type VectorVisibility = 'public' | 'user';
+export type SuggestedTagKind = 'topic' | 'entity' | 'intent' | 'format';
+
+export interface EnrichmentQueueMessage {
+  itemId: string;
+  userItemId: string;
+  userId: string;
+  trigger: EnrichmentTrigger;
+  schemaVersion: number;
+  contentHash: string;
+  enqueuedAt: number;
+}
+
+export interface EnrichmentTopic {
+  name: string;
+  confidence: number;
+}
+
+export interface EnrichmentEntity {
+  name: string;
+  type: string;
+  confidence: number;
+}
+
+export interface SuggestedTag {
+  name: string;
+  normalizedName: string;
+  kind: SuggestedTagKind;
+  confidence: number;
+  matchedExistingTagId: string | null;
+}
+
+export interface ModelSuggestedTag {
+  name: string;
+  kind: SuggestedTagKind;
+  confidence: number;
+}
+
+export interface EnrichmentModelOutput {
+  summary: {
+    short: string;
+    detail: string;
+  };
+  classification: {
+    primaryCategory: string;
+    secondaryCategories: string[];
+    intent: string;
+    difficulty: string;
+    evergreenScore: number;
+    timeSensitivity: string;
+  };
+  topics: EnrichmentTopic[];
+  entities: EnrichmentEntity[];
+  suggestedTags: ModelSuggestedTag[];
+  userContext: {
+    inferredSaveIntent: string;
+    reasonToRevisit: string;
+  };
+  confidence: {
+    overall: number;
+    summary: number;
+    classification: number;
+    tags: number;
+  };
+}
+
+export interface EnrichmentSourceItem {
+  id: string;
+  title: string;
+  canonicalUrl: string;
+  contentType: ContentType | string;
+  provider: Provider | string;
+  publisher: string | null;
+  summary: string | null;
+  rawMetadata: string | null;
+  articleContentKey: string | null;
+}
+
+export interface EnrichmentSourceCreator {
+  name: string | null;
+  description: string | null;
+  handle: string | null;
+}
+
+export interface EnrichmentPromptInput {
+  item: EnrichmentSourceItem;
+  creator: EnrichmentSourceCreator | null;
+  articleExcerpt: string | null;
+}
+
+export interface EmbeddingUpsertInput {
+  itemId: string;
+  userId: string;
+  provider: string;
+  contentType: string;
+  primaryCategory: string | null;
+  contentHash: string;
+  text: string;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -17,6 +17,8 @@ import type { Bindings, Env } from './types';
 import { pollProviderSubscriptions } from './polling/scheduler';
 import { pollGmailNewsletters } from './newsletters/gmail';
 import { pollRssFeeds } from './rss/service';
+import { handleEnrichmentDLQ, handleEnrichmentQueue } from './enrichment/consumer';
+import type { EnrichmentQueueMessage } from './enrichment/types';
 import { handleSyncQueue } from './sync/consumer';
 import { handleSyncDLQ } from './sync/dlq-consumer';
 import type { SyncQueueMessage } from './sync/types';
@@ -266,15 +268,17 @@ export default {
   },
 
   /**
-   * Queue handler for async pull-to-refresh sync and DLQ monitoring.
+   * Queue handler for async jobs and DLQ monitoring.
    *
-   * Handles two queues:
+   * Handles four queues:
    * 1. SYNC_QUEUE: Primary sync queue for processing subscriptions
    *    - Non-blocking pull-to-refresh (< 500ms response time)
    *    - Error isolation (one subscription failing doesn't affect others)
    *    - Automatic retries (3 attempts before DLQ)
    *
-   * 2. SYNC_DLQ: Dead Letter Queue for failed messages
+   * 2. SYNC_DLQ: Dead Letter Queue for failed sync messages
+   * 3. ENRICHMENT_QUEUE: Bookmark enrichment and embedding generation
+   * 4. ENRICHMENT_DLQ: Dead Letter Queue for failed enrichment messages
    *    - Captures messages that exhausted all retries
    *    - Logs at ERROR level for Cloudflare dashboard alerts
    *    - Stores entries in KV for investigation and potential replay
@@ -285,16 +289,24 @@ export default {
    * @see zine-m2oq: Task: Add monitoring/alerting for sync queue DLQ
    */
   async queue(
-    batch: MessageBatch<SyncQueueMessage>,
+    batch: MessageBatch<SyncQueueMessage | EnrichmentQueueMessage>,
     env: Bindings,
     _ctx: ExecutionContext
   ): Promise<void> {
-    // Route to appropriate handler based on queue name
-    // DLQ queue names end with '-dlq-{env}'
+    if (batch.queue.includes('enrichment-dlq')) {
+      await handleEnrichmentDLQ(batch as MessageBatch<EnrichmentQueueMessage>, env);
+      return;
+    }
+
+    if (batch.queue.includes('enrichment')) {
+      await handleEnrichmentQueue(batch as MessageBatch<EnrichmentQueueMessage>, env);
+      return;
+    }
+
     if (batch.queue.includes('-dlq-')) {
-      await handleSyncDLQ(batch, env);
+      await handleSyncDLQ(batch as MessageBatch<SyncQueueMessage>, env);
     } else {
-      await handleSyncQueue(batch, env);
+      await handleSyncQueue(batch as MessageBatch<SyncQueueMessage>, env);
     }
   },
 };

--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -21,6 +21,7 @@ import { getValidAccessToken, type TokenRefreshEnv } from '../../lib/token-refre
 import { extractArticle } from '../../lib/article-extractor';
 import { storeArticleContent } from '../../lib/article-storage';
 import { logger } from '../../lib/logger';
+import { enqueueBookmarkEnrichment } from '../../enrichment/service';
 import {
   findOrCreateCreator,
   extractCreatorFromMetadata,
@@ -329,6 +330,12 @@ export const bookmarksRouter = router({
         })
         .where(eq(userItems.id, existingUserItem.id));
 
+      await enqueueBookmarkEnrichment(ctx, {
+        itemId,
+        userItemId: existingUserItem.id,
+        trigger: 'manual_save',
+      });
+
       return {
         itemId,
         userItemId: existingUserItem.id,
@@ -364,6 +371,12 @@ export const bookmarksRouter = router({
       finishedAt: null,
       createdAt: now,
       updatedAt: now,
+    });
+
+    await enqueueBookmarkEnrichment(ctx, {
+      itemId,
+      userItemId,
+      trigger: 'manual_save',
     });
 
     return {

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -29,14 +29,18 @@ import {
   userItems,
   items,
   creators,
+  itemEnrichments,
   tags,
   userItemTags,
+  userItemEnrichments,
   userItemConsumptionEvents,
 } from '../../db/schema';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { getArticleContent } from '../../lib/article-storage';
 import type { Database } from '../../db';
 import { buildNewsletterAvatarUrl } from '../../newsletters/avatar';
+import { enqueueBookmarkEnrichment } from '../../enrichment/service';
+import { ENRICHMENT_SCHEMA_VERSION, type SuggestedTag } from '../../enrichment/types';
 
 export type ItemTag = {
   id: string;
@@ -168,6 +172,17 @@ function parseRawMetadata(rawMetadata: string | null): JsonObject {
   }
 
   return {};
+}
+
+function parseJsonArray<T>(value: string | null): T[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 function getStringMetadataField(metadata: JsonObject, key: string): string | null {
@@ -762,6 +777,81 @@ export const itemsRouter = router({
     }),
 
   /**
+   * Get AI enrichment and advisory tag suggestions for a user item.
+   */
+  getEnrichment: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ input, ctx }) => {
+      const owned = await ctx.db
+        .select({ userItemId: userItems.id, itemId: userItems.itemId })
+        .from(userItems)
+        .where(and(eq(userItems.id, input.id), eq(userItems.userId, ctx.userId)))
+        .limit(1);
+
+      if (owned.length === 0) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Item ${input.id} not found`,
+        });
+      }
+
+      const [canonicalRows, userRows] = await Promise.all([
+        ctx.db
+          .select()
+          .from(itemEnrichments)
+          .where(
+            and(
+              eq(itemEnrichments.itemId, owned[0].itemId),
+              eq(itemEnrichments.schemaVersion, ENRICHMENT_SCHEMA_VERSION)
+            )
+          )
+          .orderBy(desc(itemEnrichments.updatedAt))
+          .limit(1),
+        ctx.db
+          .select()
+          .from(userItemEnrichments)
+          .where(
+            and(
+              eq(userItemEnrichments.userItemId, input.id),
+              eq(userItemEnrichments.userId, ctx.userId),
+              eq(userItemEnrichments.schemaVersion, ENRICHMENT_SCHEMA_VERSION)
+            )
+          )
+          .orderBy(desc(userItemEnrichments.updatedAt))
+          .limit(1),
+      ]);
+
+      const canonical = canonicalRows[0] ?? null;
+      const userEnrichment = userRows[0] ?? null;
+
+      return {
+        item: {
+          status: canonical?.status ?? 'MISSING',
+          summaryShort: canonical?.summaryShort ?? null,
+          summaryDetail: canonical?.summaryDetail ?? null,
+          primaryCategory: canonical?.primaryCategory ?? null,
+          secondaryCategories: parseJsonArray<string>(canonical?.secondaryCategoriesJson ?? null),
+          topics: parseJsonArray<{ name: string; confidence: number }>(
+            canonical?.topicsJson ?? null
+          ),
+          entities: parseJsonArray<{ name: string; type: string; confidence: number }>(
+            canonical?.entitiesJson ?? null
+          ),
+          intent: canonical?.intent ?? null,
+          difficulty: canonical?.difficulty ?? null,
+          evergreenScore: canonical?.evergreenScore ?? null,
+          timeSensitivity: canonical?.timeSensitivity ?? null,
+        },
+        userItem: {
+          status: userEnrichment?.status ?? 'MISSING',
+          suggestedTags: parseJsonArray<SuggestedTag>(userEnrichment?.suggestedTagsJson ?? null),
+          inferredSaveIntent: userEnrichment?.inferredSaveIntent ?? null,
+          reasonToRevisit: userEnrichment?.reasonToRevisit ?? null,
+        },
+      };
+    }),
+
+  /**
    * List all tags for the current user.
    * Used by the bookmark detail tagging flow.
    */
@@ -954,7 +1044,7 @@ export const itemsRouter = router({
 
       // Verify the item exists and belongs to the user
       const existing = await ctx.db
-        .select({ id: userItems.id })
+        .select({ id: userItems.id, itemId: userItems.itemId, state: userItems.state })
         .from(userItems)
         .where(and(eq(userItems.id, input.id), eq(userItems.userId, ctx.userId)))
         .limit(1);
@@ -975,6 +1065,14 @@ export const itemsRouter = router({
           updatedAt: now,
         })
         .where(eq(userItems.id, input.id));
+
+      if (existing[0].state === UserItemState.INBOX) {
+        await enqueueBookmarkEnrichment(ctx, {
+          itemId: existing[0].itemId,
+          userItemId: existing[0].id,
+          trigger: 'inbox_bookmark',
+        });
+      }
 
       return { success: true as const };
     }),

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Context } from 'hono';
+import type { EnrichmentQueueMessage } from './enrichment/types';
 import type { SyncQueueMessage } from './sync/types';
 
 /**
@@ -21,8 +22,18 @@ export interface Bindings {
   CREATOR_CONTENT_CACHE: KVNamespace;
   /** R2 bucket for article content storage */
   ARTICLE_CONTENT: R2Bucket;
+  /** Workers AI binding for enrichment and embeddings */
+  AI?: Ai;
+  /** Cloudflare Vectorize index for item embeddings */
+  ITEM_VECTORS?: VectorizeIndex;
   /** Current environment (development, staging, production) */
   ENVIRONMENT: string;
+  /** Workers AI model used for bookmark enrichment */
+  ENRICHMENT_MODEL?: string;
+  /** Workers AI model used for item embeddings */
+  EMBEDDING_MODEL?: string;
+  /** Embedding vector dimensions */
+  EMBEDDING_DIMENSIONS?: string;
   /** Clerk publishable key */
   CLERK_PUBLISHABLE_KEY?: string;
   /** Clerk secret key for backend operations */
@@ -63,6 +74,8 @@ export interface Bindings {
   RELEASE_RING?: string;
   /** Queue for async pull-to-refresh sync (optional - not available in all envs) */
   SYNC_QUEUE?: Queue<SyncQueueMessage>;
+  /** Queue for async bookmark enrichment (optional - not available in all envs) */
+  ENRICHMENT_QUEUE?: Queue<EnrichmentQueueMessage>;
 }
 
 /**

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: {
-          configPath: './wrangler.toml',
+          configPath: './wrangler.test.toml',
         },
       },
     },

--- a/apps/worker/wrangler.test.toml
+++ b/apps/worker/wrangler.test.toml
@@ -1,0 +1,69 @@
+name = "zine-worker-test"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[kv_namespaces]]
+binding = "WEBHOOK_IDEMPOTENCY"
+id = "test-webhook-idempotency"
+
+[[kv_namespaces]]
+binding = "OAUTH_STATE_KV"
+id = "test-oauth-state"
+
+[[kv_namespaces]]
+binding = "SPOTIFY_CACHE"
+id = "test-spotify-cache"
+
+[[kv_namespaces]]
+binding = "CREATOR_CONTENT_CACHE"
+id = "test-creator-content-cache"
+
+[[r2_buckets]]
+binding = "ARTICLE_CONTENT"
+bucket_name = "zine-article-content-test"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "zine-db-test"
+database_id = "test-zine-db"
+migrations_dir = "src/db/migrations"
+
+[[queues.producers]]
+queue = "zine-sync-queue-test"
+binding = "SYNC_QUEUE"
+
+[[queues.producers]]
+queue = "zine-enrichment-queue-test"
+binding = "ENRICHMENT_QUEUE"
+
+[[queues.consumers]]
+queue = "zine-sync-queue-test"
+max_batch_size = 10
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-sync-dlq-test"
+
+[[queues.consumers]]
+queue = "zine-sync-dlq-test"
+max_batch_size = 10
+max_batch_timeout = 30
+
+[[queues.consumers]]
+queue = "zine-enrichment-queue-test"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-enrichment-dlq-test"
+
+[[queues.consumers]]
+queue = "zine-enrichment-dlq-test"
+max_batch_size = 5
+max_batch_timeout = 30
+
+[vars]
+ENVIRONMENT = "test"
+SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
+ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
+EMBEDDING_DIMENSIONS = "1024"

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -28,6 +28,13 @@ id = "959e6f30a4c84298a96f8060fd9b4cef"
 binding = "ARTICLE_CONTENT"
 bucket_name = "zine-article-content-dev"
 
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "ITEM_VECTORS"
+index_name = "zine-item-vectors-dev"
+
 # D1 Database binding (development)
 [[d1_databases]]
 binding = "DB"
@@ -48,6 +55,10 @@ crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
 queue = "zine-sync-queue-dev"
 binding = "SYNC_QUEUE"
 
+[[queues.producers]]
+queue = "zine-enrichment-queue-dev"
+binding = "ENRICHMENT_QUEUE"
+
 [[queues.consumers]]
 queue = "zine-sync-queue-dev"
 max_batch_size = 10
@@ -63,6 +74,18 @@ queue = "zine-sync-dlq-dev"
 max_batch_size = 10
 max_batch_timeout = 30
 
+[[queues.consumers]]
+queue = "zine-enrichment-queue-dev"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-enrichment-dlq-dev"
+
+[[queues.consumers]]
+queue = "zine-enrichment-dlq-dev"
+max_batch_size = 5
+max_batch_timeout = 30
+
 # Observability settings
 [observability]
 [observability.logs]
@@ -74,6 +97,9 @@ invocation_logs = true
 [vars]
 ENVIRONMENT = "development"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
+ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
+EMBEDDING_DIMENSIONS = "1024"
 # CLERK_JWKS_URL = "https://clerk.your-domain.com/.well-known/jwks.json"
 # CLERK_WEBHOOK_SECRET = "whsec_..." # From Clerk Dashboard > Webhooks
 
@@ -95,6 +121,11 @@ id = "9c5919333b6442a88f2762f797b05139"
 [[env.staging.r2_buckets]]
 binding = "ARTICLE_CONTENT"
 bucket_name = "zine-article-content-staging"
+[env.staging.ai]
+binding = "AI"
+[[env.staging.vectorize]]
+binding = "ITEM_VECTORS"
+index_name = "zine-item-vectors-staging"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "zine-db-staging"
@@ -103,12 +134,18 @@ migrations_dir = "src/db/migrations"
 [env.staging.vars]
 ENVIRONMENT = "staging"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
+ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
+EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.staging.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
 [[env.staging.queues.producers]]
 queue = "zine-sync-queue-staging"
 binding = "SYNC_QUEUE"
+[[env.staging.queues.producers]]
+queue = "zine-enrichment-queue-staging"
+binding = "ENRICHMENT_QUEUE"
 [[env.staging.queues.consumers]]
 queue = "zine-sync-queue-staging"
 max_batch_size = 10
@@ -120,6 +157,16 @@ dead_letter_queue = "zine-sync-dlq-staging"
 [[env.staging.queues.consumers]]
 queue = "zine-sync-dlq-staging"
 max_batch_size = 10
+max_batch_timeout = 30
+[[env.staging.queues.consumers]]
+queue = "zine-enrichment-queue-staging"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-enrichment-dlq-staging"
+[[env.staging.queues.consumers]]
+queue = "zine-enrichment-dlq-staging"
+max_batch_size = 5
 max_batch_timeout = 30
 [env.staging.observability]
 [env.staging.observability.logs]
@@ -149,6 +196,11 @@ id = "727509fe6a7640bca2c49eedefc2a52b"
 [[env.production.r2_buckets]]
 binding = "ARTICLE_CONTENT"
 bucket_name = "zine-article-content-prod"
+[env.production.ai]
+binding = "AI"
+[[env.production.vectorize]]
+binding = "ITEM_VECTORS"
+index_name = "zine-item-vectors-prod"
 [[env.production.d1_databases]]
 binding = "DB"
 database_name = "zine-db-production"
@@ -157,12 +209,18 @@ migrations_dir = "src/db/migrations"
 [env.production.vars]
 ENVIRONMENT = "production"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
+ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
+EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
 [[env.production.queues.producers]]
 queue = "zine-sync-queue-prod"
 binding = "SYNC_QUEUE"
+[[env.production.queues.producers]]
+queue = "zine-enrichment-queue-prod"
+binding = "ENRICHMENT_QUEUE"
 [[env.production.queues.consumers]]
 queue = "zine-sync-queue-prod"
 max_batch_size = 10
@@ -174,6 +232,16 @@ dead_letter_queue = "zine-sync-dlq-prod"
 [[env.production.queues.consumers]]
 queue = "zine-sync-dlq-prod"
 max_batch_size = 10
+max_batch_timeout = 30
+[[env.production.queues.consumers]]
+queue = "zine-enrichment-queue-prod"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-enrichment-dlq-prod"
+[[env.production.queues.consumers]]
+queue = "zine-enrichment-dlq-prod"
+max_batch_size = 5
 max_batch_timeout = 30
 [env.production.observability]
 [env.production.observability.logs]


### PR DESCRIPTION
## Summary
- add D1 enrichment, user suggestion, and embedding reference tables
- add async Cloudflare Queue consumer for Qwen3 metadata enrichment and Vectorize embedding upserts
- enqueue enrichment from bookmark transitions and expose items.getEnrichment plus the mobile useItemEnrichment hook
- add test Wrangler config and fix mobile header option typing so the full mobile Jest lane passes

## Verification
- bun run --cwd apps/worker test:run
- bun run --cwd apps/worker typecheck
- bun run typecheck
- bun run lint
- bun run format:check
- bun run build
- bun run test
- bunx wrangler deploy --dry-run --outdir /tmp/zine-worker-dry-run