### PR TITLE
Add bookmark enrichment details card

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -367,6 +367,69 @@ describe('BookmarksPage', () => {
     expect(invalidateSpies.itemsHomeInvalidate).toHaveBeenCalled();
   });
 
+  test('renders enrichment data beneath the bookmark detail when extracted data exists', () => {
+    hookSpies.itemsGetEnrichmentUseQuery.mockImplementation((input) => ({
+      data:
+        input.id === videoItem.id
+          ? {
+              item: {
+                status: 'COMPLETE',
+                modelProvider: 'cloudflare',
+                modelName: '@cf/qwen/qwen3-30b-a3b-fp8',
+                summaryShort: 'A compact overview of design system scaling.',
+                summaryDetail:
+                  'Explains how stable primitives, tokens, and review habits keep interfaces coherent.',
+                primaryCategory: 'Design systems',
+                secondaryCategories: ['Frontend architecture', 'Product craft'],
+                topics: [{ name: 'Design tokens', confidence: 0.92 }],
+                entities: [{ name: 'Zine', type: 'product', confidence: 0.81 }],
+                intent: 'Learn how to maintain UI consistency',
+                difficulty: 'intermediate',
+                evergreenScore: 0.88,
+                timeSensitivity: 'low',
+                confidence: {
+                  overall: 0.91,
+                  summary: 0.89,
+                  classification: 0.86,
+                  tags: 0.83,
+                },
+                enrichedAt: 1777587600000,
+              },
+              userItem: {
+                status: 'COMPLETE',
+                suggestedTags: [
+                  {
+                    name: 'Design systems',
+                    normalizedName: 'design systems',
+                    kind: 'topic',
+                    confidence: 0.94,
+                    matchedExistingTagId: null,
+                  },
+                ],
+                inferredSaveIntent: 'Use as a reference for future UI work.',
+                reasonToRevisit: 'Revisit before changing shared primitives.',
+                enrichedAt: 1777587600000,
+              },
+            }
+          : undefined,
+      isLoading: false,
+      error: null,
+    }));
+
+    renderRoute(<BookmarksPage />, {
+      route: `/bookmarks/${videoItem.id}`,
+      path: '/bookmarks/:bookmarkId',
+    });
+
+    expect(screen.getByText('Enrichment')).toBeVisible();
+    expect(screen.getByText('A compact overview of design system scaling.')).toBeVisible();
+    expect(screen.getByText('Design tokens 92%')).toBeVisible();
+    expect(screen.getByText('Zine · Product · 81%')).toBeVisible();
+    expect(screen.getByText('Use as a reference for future UI work.')).toBeVisible();
+    expect(screen.getByText('Overall 91%')).toBeVisible();
+    expect(screen.getByText('cloudflare · @cf/qwen/qwen3-30b-a3b-fp8')).toBeVisible();
+  });
+
   test('uses the mobile-complete green fill for finished bookmark icons in detail view', () => {
     const finishedVideoItem = createLibraryItem({
       ...videoItem,

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -203,6 +203,7 @@ type BookmarkDetailItem = Pick<
   | 'canonicalUrl'
 >;
 type CreatorProfile = RouterOutputs['creators']['get'];
+type BookmarkEnrichment = RouterOutputs['items']['getEnrichment'];
 
 function formatBookmarkRelativeTime(value?: string | number | null) {
   if (!value) {
@@ -326,6 +327,258 @@ function getBookmarkAboutLabel(contentType: ContentType) {
     default:
       return 'About this article';
   }
+}
+
+function formatEnrichmentLabel(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatEnrichmentScore(value: number) {
+  const normalized = value <= 1 ? value * 100 : value;
+  return `${Math.round(normalized)}%`;
+}
+
+function formatEnrichmentDate(value: number | null) {
+  if (!value) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function getStringEnrichmentValue(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function getConfidenceEntries(confidence: BookmarkEnrichment['item']['confidence']) {
+  if (!confidence) {
+    return [];
+  }
+
+  return Object.entries(confidence).flatMap(([key, value]) =>
+    typeof value === 'number' ? [{ label: formatEnrichmentLabel(key), value }] : []
+  );
+}
+
+function hasBookmarkEnrichment(enrichment: BookmarkEnrichment | undefined) {
+  if (!enrichment) {
+    return false;
+  }
+
+  return Boolean(
+    getStringEnrichmentValue(enrichment.item.summaryShort) ||
+    getStringEnrichmentValue(enrichment.item.summaryDetail) ||
+    getStringEnrichmentValue(enrichment.item.primaryCategory) ||
+    enrichment.item.secondaryCategories.length > 0 ||
+    enrichment.item.topics.length > 0 ||
+    enrichment.item.entities.length > 0 ||
+    getStringEnrichmentValue(enrichment.item.intent) ||
+    getStringEnrichmentValue(enrichment.item.difficulty) ||
+    typeof enrichment.item.evergreenScore === 'number' ||
+    getStringEnrichmentValue(enrichment.item.timeSensitivity) ||
+    getConfidenceEntries(enrichment.item.confidence).length > 0 ||
+    enrichment.userItem.suggestedTags.length > 0 ||
+    getStringEnrichmentValue(enrichment.userItem.inferredSaveIntent) ||
+    getStringEnrichmentValue(enrichment.userItem.reasonToRevisit)
+  );
+}
+
+function EnrichmentField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="new-page-bookmark-view__enrichment-field">
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+}
+
+function EnrichmentChipList({
+  items,
+  getLabel,
+}: {
+  items: readonly unknown[];
+  getLabel: (item: unknown) => string | null;
+}) {
+  const labels = items.map(getLabel).filter((label): label is string => Boolean(label));
+
+  if (labels.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="new-page-bookmark-view__enrichment-chips">
+      {labels.map((label) => (
+        <span key={label}>{label}</span>
+      ))}
+    </div>
+  );
+}
+
+function BookmarkEnrichmentCard({ enrichment }: { enrichment: BookmarkEnrichment }) {
+  if (!hasBookmarkEnrichment(enrichment)) {
+    return null;
+  }
+
+  const confidenceEntries = getConfidenceEntries(enrichment.item.confidence);
+  const enrichedAt =
+    formatEnrichmentDate(enrichment.userItem.enrichedAt) ??
+    formatEnrichmentDate(enrichment.item.enrichedAt);
+  const modelLabel = [enrichment.item.modelProvider, enrichment.item.modelName]
+    .filter((value): value is string => Boolean(value))
+    .join(' · ');
+
+  return (
+    <section className="new-page-bookmark-view__section new-page-bookmark-view__enrichment">
+      <div className="new-page-bookmark-view__enrichment-header">
+        <p className="eyebrow new-page-bookmark-view__section-label">Enrichment</p>
+        {enrichedAt ? <span>Extracted {enrichedAt}</span> : null}
+      </div>
+
+      <dl className="new-page-bookmark-view__enrichment-grid">
+        {getStringEnrichmentValue(enrichment.item.summaryShort) ? (
+          <EnrichmentField label="Short summary">
+            {getStringEnrichmentValue(enrichment.item.summaryShort)}
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.item.summaryDetail) ? (
+          <EnrichmentField label="Detailed summary">
+            {getStringEnrichmentValue(enrichment.item.summaryDetail)}
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.item.primaryCategory) ? (
+          <EnrichmentField label="Primary category">
+            {enrichment.item.primaryCategory}
+          </EnrichmentField>
+        ) : null}
+
+        {enrichment.item.secondaryCategories.length > 0 ? (
+          <EnrichmentField label="Secondary categories">
+            <EnrichmentChipList
+              items={enrichment.item.secondaryCategories}
+              getLabel={(item) => (typeof item === 'string' ? item : null)}
+            />
+          </EnrichmentField>
+        ) : null}
+
+        {enrichment.item.topics.length > 0 ? (
+          <EnrichmentField label="Topics">
+            <EnrichmentChipList
+              items={enrichment.item.topics}
+              getLabel={(item) => {
+                const topic = item as { name?: unknown; confidence?: unknown };
+                return typeof topic.name === 'string'
+                  ? typeof topic.confidence === 'number'
+                    ? `${topic.name} ${formatEnrichmentScore(topic.confidence)}`
+                    : topic.name
+                  : null;
+              }}
+            />
+          </EnrichmentField>
+        ) : null}
+
+        {enrichment.item.entities.length > 0 ? (
+          <EnrichmentField label="Entities">
+            <EnrichmentChipList
+              items={enrichment.item.entities}
+              getLabel={(item) => {
+                const entity = item as { name?: unknown; type?: unknown; confidence?: unknown };
+                if (typeof entity.name !== 'string') {
+                  return null;
+                }
+
+                const type =
+                  typeof entity.type === 'string' ? formatEnrichmentLabel(entity.type) : null;
+                const score =
+                  typeof entity.confidence === 'number'
+                    ? formatEnrichmentScore(entity.confidence)
+                    : null;
+                return [entity.name, type, score].filter(Boolean).join(' · ');
+              }}
+            />
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.item.intent) ? (
+          <EnrichmentField label="Content intent">{enrichment.item.intent}</EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.item.difficulty) ? (
+          <EnrichmentField label="Difficulty">
+            {formatEnrichmentLabel(getStringEnrichmentValue(enrichment.item.difficulty) ?? '')}
+          </EnrichmentField>
+        ) : null}
+
+        {typeof enrichment.item.evergreenScore === 'number' ? (
+          <EnrichmentField label="Evergreen score">
+            {formatEnrichmentScore(enrichment.item.evergreenScore)}
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.item.timeSensitivity) ? (
+          <EnrichmentField label="Time sensitivity">
+            {formatEnrichmentLabel(getStringEnrichmentValue(enrichment.item.timeSensitivity) ?? '')}
+          </EnrichmentField>
+        ) : null}
+
+        {enrichment.userItem.suggestedTags.length > 0 ? (
+          <EnrichmentField label="Suggested tags">
+            <EnrichmentChipList
+              items={enrichment.userItem.suggestedTags}
+              getLabel={(item) => {
+                const tag = item as { name?: unknown; kind?: unknown; confidence?: unknown };
+                if (typeof tag.name !== 'string') {
+                  return null;
+                }
+
+                const kind = typeof tag.kind === 'string' ? formatEnrichmentLabel(tag.kind) : null;
+                const score =
+                  typeof tag.confidence === 'number' ? formatEnrichmentScore(tag.confidence) : null;
+                return [tag.name, kind, score].filter(Boolean).join(' · ');
+              }}
+            />
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.userItem.inferredSaveIntent) ? (
+          <EnrichmentField label="Inferred save intent">
+            {enrichment.userItem.inferredSaveIntent}
+          </EnrichmentField>
+        ) : null}
+
+        {getStringEnrichmentValue(enrichment.userItem.reasonToRevisit) ? (
+          <EnrichmentField label="Reason to revisit">
+            {enrichment.userItem.reasonToRevisit}
+          </EnrichmentField>
+        ) : null}
+
+        {confidenceEntries.length > 0 ? (
+          <EnrichmentField label="Confidence">
+            <EnrichmentChipList
+              items={confidenceEntries}
+              getLabel={(item) => {
+                const entry = item as { label: string; value: number };
+                return `${entry.label} ${formatEnrichmentScore(entry.value)}`;
+              }}
+            />
+          </EnrichmentField>
+        ) : null}
+
+        {modelLabel ? <EnrichmentField label="Model">{modelLabel}</EnrichmentField> : null}
+      </dl>
+    </section>
+  );
 }
 
 function getBookmarkFabConfig(provider: Provider | string): {
@@ -612,6 +865,10 @@ export function BookmarksPage() {
   ]);
 
   const displayBookmark = selectedBookmarkDetailQuery.data ?? selectedBookmark;
+  const selectedBookmarkEnrichmentQuery = trpc.items.getEnrichment.useQuery(
+    { id: selectedBookmarkId ?? '' },
+    { enabled: Boolean(selectedBookmarkId) }
+  );
   const selectedBookmarkCreatorQuery = trpc.creators.get.useQuery(
     { creatorId: displayBookmark?.creatorId ?? '' },
     {
@@ -630,6 +887,7 @@ export function BookmarksPage() {
   const isPhonePostView = isPhoneLayout && displayBookmark?.contentType === ContentType.POST;
   const isPhoneDetailView = isPhoneLayout && Boolean(selectedBookmarkId);
   const bookmarkPlainSummary = displayBookmark ? formatPlainText(displayBookmark.summary) : null;
+  const bookmarkEnrichment = selectedBookmarkEnrichmentQuery.data;
   const bookmarkPostHandle =
     displayBookmark?.provider === Provider.X
       ? (selectedBookmarkCreatorQuery.data?.handle ?? extractXHandle(displayBookmark.canonicalUrl))
@@ -1308,6 +1566,10 @@ export function BookmarksPage() {
                           </p>
                         </section>
                       )}
+
+                      {bookmarkEnrichment ? (
+                        <BookmarkEnrichmentCard enrichment={bookmarkEnrichment} />
+                      ) : null}
 
                       {selectedBookmarkDetailQuery.isLoading ? (
                         <p className="new-page-bookmark-view__loading-copy">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1335,6 +1335,68 @@ img {
   line-height: 1.72;
 }
 
+.new-page-bookmark-view__enrichment {
+  gap: 1rem;
+}
+
+.new-page-bookmark-view__enrichment-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.new-page-bookmark-view__enrichment-header span {
+  color: var(--text-tertiary);
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.new-page-bookmark-view__enrichment-grid {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+}
+
+.new-page-bookmark-view__enrichment-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.new-page-bookmark-view__enrichment-field dt {
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+  font-weight: 650;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.new-page-bookmark-view__enrichment-field dd {
+  margin: 0;
+  color: var(--text-subheader);
+  font-size: 0.94rem;
+  line-height: 1.48;
+}
+
+.new-page-bookmark-view__enrichment-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.new-page-bookmark-view__enrichment-chips span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0.32rem 0.55rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--text-subheader);
+  font-size: 0.78rem;
+  line-height: 1.15;
+}
+
 .new-page-bookmark-view__post {
   display: grid;
   gap: 0.75rem;
@@ -4159,6 +4221,21 @@ input:focus {
   .new-page-bookmark-view__summary {
     font-size: 0.875rem;
     line-height: 1.43;
+  }
+
+  .new-page-bookmark-view__enrichment-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .new-page-bookmark-view__enrichment-field dd {
+    font-size: 0.85rem;
+    line-height: 1.42;
+  }
+
+  .new-page-bookmark-view__enrichment-chips {
+    gap: 0.35rem;
   }
 
   .new-page-bookmark-view__post {

--- a/apps/web/src/test/mocks/trpc.tsx
+++ b/apps/web/src/test/mocks/trpc.tsx
@@ -26,6 +26,10 @@ type ItemsGetInput = {
   id: string;
 };
 
+type ItemsGetEnrichmentInput = {
+  id: string;
+};
+
 type CreatorGetInput = {
   creatorId: string;
 };
@@ -111,6 +115,9 @@ export const hookSpies = {
   itemsGetUseQuery: vi.fn<(input: ItemsGetInput, options?: unknown) => QueryResult<unknown>>(
     (_input) => createQueryResult({})
   ),
+  itemsGetEnrichmentUseQuery: vi.fn<
+    (input: ItemsGetEnrichmentInput, options?: unknown) => QueryResult<unknown>
+  >((_input) => createQueryResult()),
   creatorsGetUseQuery: vi.fn<(input: CreatorGetInput, options?: unknown) => QueryResult<unknown>>(
     (_input) => createQueryResult({})
   ),
@@ -284,6 +291,9 @@ export function resetTrpcMocks() {
   hookSpies.itemsGetUseQuery.mockReset();
   hookSpies.itemsGetUseQuery.mockImplementation((_input) => createQueryResult());
 
+  hookSpies.itemsGetEnrichmentUseQuery.mockReset();
+  hookSpies.itemsGetEnrichmentUseQuery.mockImplementation((_input) => createQueryResult());
+
   hookSpies.creatorsGetUseQuery.mockReset();
   hookSpies.creatorsGetUseQuery.mockImplementation((_input) => createQueryResult());
 
@@ -453,6 +463,10 @@ export const trpc = {
     get: {
       useQuery: (input: ItemsGetInput, options?: unknown) =>
         hookSpies.itemsGetUseQuery(input, options),
+    },
+    getEnrichment: {
+      useQuery: (input: ItemsGetEnrichmentInput, options?: unknown) =>
+        hookSpies.itemsGetEnrichmentUseQuery(input, options),
     },
     listTags: {
       useQuery: () => hookSpies.itemsListTagsUseQuery(),

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -185,6 +185,17 @@ function parseJsonArray<T>(value: string | null): T[] {
   }
 }
 
+function parseJsonObjectValue(value: string | null): JsonObject | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value);
+    return isJsonObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 function getStringMetadataField(metadata: JsonObject, key: string): string | null {
   const value = metadata[key];
   return typeof value === 'string' && value.trim().length > 0 ? value : null;
@@ -827,6 +838,8 @@ export const itemsRouter = router({
       return {
         item: {
           status: canonical?.status ?? 'MISSING',
+          modelProvider: canonical?.modelProvider ?? null,
+          modelName: canonical?.modelName ?? null,
           summaryShort: canonical?.summaryShort ?? null,
           summaryDetail: canonical?.summaryDetail ?? null,
           primaryCategory: canonical?.primaryCategory ?? null,
@@ -841,12 +854,15 @@ export const itemsRouter = router({
           difficulty: canonical?.difficulty ?? null,
           evergreenScore: canonical?.evergreenScore ?? null,
           timeSensitivity: canonical?.timeSensitivity ?? null,
+          confidence: parseJsonObjectValue(canonical?.confidenceJson ?? null),
+          enrichedAt: canonical?.enrichedAt ?? null,
         },
         userItem: {
           status: userEnrichment?.status ?? 'MISSING',
           suggestedTags: parseJsonArray<SuggestedTag>(userEnrichment?.suggestedTagsJson ?? null),
           inferredSaveIntent: userEnrichment?.inferredSaveIntent ?? null,
           reasonToRevisit: userEnrichment?.reasonToRevisit ?? null,
+          enrichedAt: userEnrichment?.enrichedAt ?? null,
         },
       };
     }),


### PR DESCRIPTION
## Summary
- Add a bookmark detail card that shows extracted enrichment data when present
- Surface canonical and user enrichment fields from `items.getEnrichment`
- Cover the new rendering path with a focused bookmark page test and updated tRPC mocks

## Testing
- `bun run --cwd apps/web test bookmarks-page.test.tsx`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bun run format:check`