### PR TITLE
[codex] Expand bookmark description when alone

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -65,6 +65,7 @@ export function ItemDetailContent({
   onTitleLayout,
 }: ItemDetailContentProps) {
   const DescriptionContainer = useAnimatedDescription ? Animated.View : View;
+  const shouldExpandDescriptionByDefault = otherUnfinishedBookmarks.length === 0;
 
   return (
     <>
@@ -112,6 +113,7 @@ export function ItemDetailContent({
               summary={item.summary}
               label={descriptionLabel}
               colors={colors}
+              expandedByDefault={shouldExpandDescriptionByDefault}
             />
           </Surface>
         </DescriptionContainer>

--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Pressable, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -13,15 +13,25 @@ type ItemDetailDescriptionProps = {
   summary: string;
   label: string;
   colors: ItemDetailColors;
+  expandedByDefault?: boolean;
 };
 
 const COLLAPSED_DESCRIPTION_LINES = 4;
 const EXPANDABLE_DESCRIPTION_MIN_LENGTH = 160;
 
-export function ItemDetailDescription({ summary, label, colors }: ItemDetailDescriptionProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+export function ItemDetailDescription({
+  summary,
+  label,
+  colors,
+  expandedByDefault = false,
+}: ItemDetailDescriptionProps) {
+  const [isExpanded, setIsExpanded] = useState(expandedByDefault);
   const canExpand = summary.trim().length > EXPANDABLE_DESCRIPTION_MIN_LENGTH;
   const descriptionLines = canExpand && !isExpanded ? COLLAPSED_DESCRIPTION_LINES : undefined;
+
+  useEffect(() => {
+    setIsExpanded(expandedByDefault);
+  }, [expandedByDefault, summary]);
 
   return (
     <>

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -207,12 +207,38 @@ describe('ItemDetailContent other creator bookmarks', () => {
     ).toThrow();
   });
 
-  it('collapses and expands the description preview', () => {
+  it('expands the description preview by default when there are no other bookmarks', () => {
     const renderer = renderContent({
       item: createItem({
         summary:
           'Current bookmark summary with enough detail to preview four lines before expanding into the complete description. It continues with more context so there is hidden content behind the collapsed state.',
       }),
+    });
+
+    const toggleButton = renderer.root.findByProps({
+      accessibilityLabel: 'Toggle Description',
+    });
+    expect(toggleButton.props.accessibilityState).toEqual({ expanded: true });
+    expect(renderer.root.findByProps({ accessibilityLabel: 'icon-chevron-up' })).toBeTruthy();
+    expect(
+      findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines
+    ).toBeUndefined();
+  });
+
+  it('collapses and expands the description preview when other bookmarks are present', () => {
+    const renderer = renderContent({
+      item: createItem({
+        summary:
+          'Current bookmark summary with enough detail to preview four lines before expanding into the complete description. It continues with more context so there is hidden content behind the collapsed state.',
+      }),
+      otherUnfinishedBookmarks: [
+        createItem({
+          id: 'ui-next',
+          itemId: 'item-next',
+          title: 'Next bookmark',
+          summary: 'Another thing to read',
+        }),
+      ],
     });
 
     const toggleButton = renderer.root.findByProps({


### PR DESCRIPTION
## Summary

- Expand the mobile bookmark detail description card by default when there are no other unfinished bookmarks from the same creator.
- Keep the existing collapsed-by-default behavior when related bookmarks are present.
- Add focused coverage for both default states.

## Impact

Bookmark detail pages with no related bookmarks now surface the full description immediately, while pages with related bookmarks preserve the denser preview layout.

## Validation

- `bun run --cwd apps/mobile test item-detail-other-bookmarks.test.tsx`
- pre-push hook: `bun run format:check`
- pre-push hook: `bun run design-system:check`
- pre-push hook: `bun run typecheck`
- pre-push hook: `bun run test:web`
- pre-push hook: `cd apps/worker && bun run test:run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'`
