### PR TITLE
Add X bookmarks sync integration

### DIFF
--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Alert, FlatList, StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter, type Href } from 'expo-router';
-import type { OAuthProvider } from '@zine/shared/types';
+import { Provider as ProviderEnum, type OAuthProvider } from '@zine/shared/types';
 
 import { ErrorState, LoadingState } from '@/components/list-states';
 import { Button, Surface } from '@/components/primitives';
@@ -30,11 +30,13 @@ import {
   getSubscriptionSourceConfig,
 } from '@/lib/subscription-sources';
 import { trpc } from '@/lib/trpc';
-import type { NewslettersListOutput } from '@/lib/trpc-types';
+import type { NewslettersListOutput, XBookmarksStatusOutput } from '@/lib/trpc-types';
 
-type Provider = OAuthProvider;
+type SourceProvider = OAuthProvider;
 type NewsletterFeed = NewslettersListOutput['items'][number];
+type XBookmarkStatus = XBookmarksStatusOutput;
 type ProviderSubscription = ReturnType<typeof useSubscriptions>['subscriptions'][number];
+type ListRow = NewsletterFeed | UnifiedSubscription;
 type UnifiedSubscription = {
   id: string;
   title: string;
@@ -53,12 +55,12 @@ export default function ProviderDetailScreen() {
   const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
 
   const providerValidation = validateAndConvertProvider(params.provider);
-  const provider: Provider = providerValidation.success ? providerValidation.data : 'YOUTUBE';
+  const provider: SourceProvider = providerValidation.success ? providerValidation.data : 'YOUTUBE';
   const sourceConfig = getSubscriptionSourceConfig(provider);
   const connectRoute = `/subscriptions/connect/${provider.toLowerCase()}` as Href;
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [disconnectingProvider, setDisconnectingProvider] = useState<Provider | null>(null);
+  const [disconnectingProvider, setDisconnectingProvider] = useState<SourceProvider | null>(null);
   const [processingIds, setProcessingIds] = useState<Set<string>>(new Set());
 
   const { data: connections, isLoading: connectionsLoading } = useConnections();
@@ -73,12 +75,13 @@ export default function ProviderDetailScreen() {
   const integrationState = getIntegrationState(provider, connection?.status ?? null);
   const isConnected = integrationState === 'connected';
 
-  const discoverProvider = provider === 'SPOTIFY' ? 'SPOTIFY' : 'YOUTUBE';
+  const discoverProvider = provider === 'SPOTIFY' ? ProviderEnum.SPOTIFY : ProviderEnum.YOUTUBE;
 
   const discoverQuery = trpc.subscriptions.discover.available.useQuery(
     { provider: discoverProvider },
     {
-      enabled: providerValidation.success && provider !== 'GMAIL' && isConnected,
+      enabled:
+        providerValidation.success && provider !== 'GMAIL' && provider !== 'X' && isConnected,
       staleTime: 5 * 60 * 1000,
     }
   );
@@ -96,10 +99,37 @@ export default function ProviderDetailScreen() {
       utils.subscriptions.newsletters.list.invalidate();
       utils.subscriptions.newsletters.stats.invalidate();
     },
-    onError: (error: Error) => {
+    onError: (error) => {
       Alert.alert('Sync failed', error.message || 'Failed to sync newsletters.');
     },
   });
+
+  const xBookmarksStatusQuery = trpc.subscriptions.xBookmarks.status.useQuery(undefined, {
+    enabled: providerValidation.success && provider === 'X',
+    staleTime: 60 * 1000,
+  });
+
+  const xBookmarksSyncMutation = trpc.subscriptions.xBookmarks.syncNow.useMutation({
+    onSuccess: () => {
+      utils.subscriptions.xBookmarks.status.invalidate();
+      utils.items.library.invalidate();
+      utils.items.home.invalidate();
+    },
+    onError: (error) => {
+      Alert.alert('Sync failed', error.message || 'Failed to sync X bookmarks.');
+    },
+  });
+
+  const updateXBookmarksSettingsMutation = trpc.subscriptions.xBookmarks.updateSettings.useMutation(
+    {
+      onSuccess: () => {
+        utils.subscriptions.xBookmarks.status.invalidate();
+      },
+      onError: (error) => {
+        Alert.alert('Update failed', error.message || 'Failed to update X bookmark settings.');
+      },
+    }
+  );
 
   const updateNewsletterStatusMutation = trpc.subscriptions.newsletters.updateStatus.useMutation({
     onSuccess: () => {
@@ -108,7 +138,7 @@ export default function ProviderDetailScreen() {
       utils.items.inbox.invalidate();
       utils.items.home.invalidate();
     },
-    onError: (error: Error) => {
+    onError: (error) => {
       Alert.alert('Update failed', error.message || 'Failed to update newsletter status.');
     },
   });
@@ -118,7 +148,7 @@ export default function ProviderDetailScreen() {
       utils.subscriptions.newsletters.list.invalidate();
       utils.subscriptions.newsletters.stats.invalidate();
     },
-    onError: (error: Error) => {
+    onError: (error) => {
       Alert.alert('Unsubscribe failed', error.message || 'Failed to unsubscribe from newsletter.');
     },
   });
@@ -178,9 +208,16 @@ export default function ProviderDetailScreen() {
     () => newslettersQuery.data?.items ?? [],
     [newslettersQuery.data]
   );
+  const listData: ListRow[] =
+    provider === 'GMAIL' ? newsletterFeeds : provider === 'X' ? [] : filteredSubscriptions;
 
+  const xBookmarkStatus = xBookmarksStatusQuery.data;
   const displayedCount =
-    provider === 'GMAIL' ? newsletterFeeds.length : availableSubscriptions.length;
+    provider === 'GMAIL'
+      ? newsletterFeeds.length
+      : provider === 'X'
+        ? (xBookmarkStatus?.importedCount ?? 0)
+        : availableSubscriptions.length;
   const hubSummary = getHubStatusText(provider, integrationState, displayedCount);
   const integrationCopy = getIntegrationCardCopy(provider, integrationState);
   const integrationDetail = buildIntegrationDetail(connection);
@@ -188,7 +225,11 @@ export default function ProviderDetailScreen() {
   const isLoading =
     connectionsLoading ||
     subscriptionsLoading ||
-    (provider === 'GMAIL' ? newslettersQuery.isLoading : discoverQuery.isLoading);
+    (provider === 'GMAIL'
+      ? newslettersQuery.isLoading
+      : provider === 'X'
+        ? xBookmarksStatusQuery.isLoading
+        : discoverQuery.isLoading);
 
   const isProcessingNewsletter =
     updateNewsletterStatusMutation.isPending || unsubscribeNewsletterMutation.isPending;
@@ -229,13 +270,17 @@ export default function ProviderDetailScreen() {
         return;
       }
 
+      if (provider !== 'YOUTUBE' && provider !== 'SPOTIFY') {
+        return;
+      }
+
       setProcessingIds((current) => new Set(current).add(subscription.id));
 
       if (subscription.isSubscribed && subscription.subscriptionId) {
         unsubscribe({ subscriptionId: subscription.subscriptionId });
       } else {
         subscribe({
-          provider,
+          provider: provider === 'SPOTIFY' ? ProviderEnum.SPOTIFY : ProviderEnum.YOUTUBE,
           providerChannelId: subscription.id,
           name: subscription.title,
           imageUrl: subscription.imageUrl ?? undefined,
@@ -301,6 +346,20 @@ export default function ProviderDetailScreen() {
     newslettersSyncMutation.mutate();
   }, [isConnected, newslettersSyncMutation]);
 
+  const handleXBookmarksSync = useCallback(() => {
+    if (!isConnected) {
+      Alert.alert('Integration required', 'Connect X before syncing bookmarks.');
+      return;
+    }
+
+    xBookmarksSyncMutation.mutate({});
+  }, [isConnected, xBookmarksSyncMutation]);
+
+  const handleXDailySyncToggle = useCallback(() => {
+    const nextValue = !(xBookmarksStatusQuery.data?.sync?.dailySyncEnabled ?? false);
+    updateXBookmarksSettingsMutation.mutate({ dailySyncEnabled: nextValue });
+  }, [updateXBookmarksSettingsMutation, xBookmarksStatusQuery.data?.sync?.dailySyncEnabled]);
+
   return (
     <Surface tone="canvas" style={styles.container} collapsable={false}>
       <Stack.Screen
@@ -318,7 +377,7 @@ export default function ProviderDetailScreen() {
       ) : (
         <FlatList
           style={styles.list}
-          data={provider === 'GMAIL' ? newsletterFeeds : filteredSubscriptions}
+          data={listData}
           keyExtractor={(item) => item.id}
           keyboardShouldPersistTaps="handled"
           showsVerticalScrollIndicator={false}
@@ -345,9 +404,15 @@ export default function ProviderDetailScreen() {
 
               <View style={styles.section}>
                 <SourceSectionHeader
-                  eyebrow="Subscriptions"
-                  title="Subscriptions"
-                  summary={isConnected ? formatSourceCount(provider, displayedCount) : undefined}
+                  eyebrow={provider === 'X' ? 'Bookmarks' : 'Subscriptions'}
+                  title={provider === 'X' ? 'Bookmark sync' : 'Subscriptions'}
+                  summary={
+                    provider === 'X'
+                      ? getXBookmarksSummary(xBookmarkStatus)
+                      : isConnected
+                        ? formatSourceCount(provider, displayedCount)
+                        : undefined
+                  }
                   trailing={
                     provider === 'GMAIL' && isConnected ? (
                       <Button
@@ -357,10 +422,30 @@ export default function ProviderDetailScreen() {
                         variant="secondary"
                         size="sm"
                       />
+                    ) : provider === 'X' && isConnected ? (
+                      <Button
+                        label="Sync now"
+                        onPress={handleXBookmarksSync}
+                        loading={xBookmarksSyncMutation.isPending}
+                        variant="secondary"
+                        size="sm"
+                      />
                     ) : null
                   }
                 />
-                {isConnected ? (
+                {provider === 'X' && isConnected ? (
+                  <Button
+                    label={
+                      xBookmarkStatus?.sync?.dailySyncEnabled
+                        ? 'Disable daily sync'
+                        : 'Enable daily sync'
+                    }
+                    onPress={handleXDailySyncToggle}
+                    loading={updateXBookmarksSettingsMutation.isPending}
+                    variant="outline"
+                    size="sm"
+                  />
+                ) : isConnected ? (
                   <SourceSearchField
                     value={searchQuery}
                     onChangeText={setSearchQuery}
@@ -379,7 +464,6 @@ export default function ProviderDetailScreen() {
           renderItem={({ item }) =>
             provider === 'GMAIL' ? (
               <SourceSubscriptionRow
-                source={provider}
                 title={(item as NewsletterFeed).displayName}
                 subtitle={(item as NewsletterFeed).fromAddress ?? null}
                 imageUrl={getNewsletterImageUrl(item as NewsletterFeed)}
@@ -399,7 +483,6 @@ export default function ProviderDetailScreen() {
               />
             ) : (
               <SourceSubscriptionRow
-                source={provider}
                 title={(item as UnifiedSubscription).title}
                 imageUrl={(item as UnifiedSubscription).imageUrl}
                 statusLabel={(item as UnifiedSubscription).isSubscribed ? 'Subscribed' : null}
@@ -445,6 +528,26 @@ function buildIntegrationDetail(connection: Connection | undefined): string | nu
   detailParts.push(`Connected ${formatDate(connection.createdAt)}`);
 
   return detailParts.join(' · ');
+}
+
+function getXBookmarksSummary(status: XBookmarkStatus | undefined): string | undefined {
+  if (!status?.connected) {
+    return undefined;
+  }
+
+  const parts = [formatSourceCount('X', status.importedCount), 'Latest 100 bookmarks per sync'];
+
+  if (status.sync?.lastSuccessAt) {
+    parts.push(`Last synced ${formatDate(new Date(status.sync.lastSuccessAt).toISOString())}`);
+  }
+
+  if (status.sync?.rateLimitedUntil && status.sync.rateLimitedUntil > Date.now()) {
+    parts.push(
+      `Rate limited until ${formatDate(new Date(status.sync.rateLimitedUntil).toISOString())}`
+    );
+  }
+
+  return parts.join(' · ');
 }
 
 function formatDate(dateString: string): string {
@@ -533,12 +636,16 @@ function getNewsletterPrimaryActionVariant(
 }
 
 function getEmptyTitle(
-  provider: Provider,
+  provider: SourceProvider,
   state: ReturnType<typeof getIntegrationState>,
   query: string
 ) {
   if (state !== 'connected') {
     return state === 'needsAttention' ? 'Reconnect integration' : 'Connect integration';
+  }
+
+  if (provider === 'X') {
+    return 'No X bookmarks imported yet';
   }
 
   if (query.trim()) {
@@ -549,14 +656,20 @@ function getEmptyTitle(
 }
 
 function getEmptyMessage(
-  provider: Provider,
+  provider: SourceProvider,
   state: ReturnType<typeof getIntegrationState>,
   query: string
 ) {
   const config = getSubscriptionSourceConfig(provider);
 
   if (state !== 'connected') {
-    return `Connect ${config.providerLabel} to import and manage subscriptions from this source.`;
+    return provider === 'X'
+      ? 'Connect X to import bookmarked posts into your library.'
+      : `Connect ${config.providerLabel} to import and manage subscriptions from this source.`;
+  }
+
+  if (provider === 'X') {
+    return 'Use Sync now to import the latest 100 bookmarked posts from X. Manual refresh is capped to once every 24 hours.';
   }
 
   if (query.trim()) {

--- a/apps/mobile/app/subscriptions/connect/_layout.tsx
+++ b/apps/mobile/app/subscriptions/connect/_layout.tsx
@@ -52,6 +52,13 @@ export default function ConnectLayout() {
           presentation: 'card',
         }}
       />
+      <Stack.Screen
+        name="x"
+        options={{
+          title: 'Connect X',
+          presentation: 'card',
+        }}
+      />
     </Stack>
   );
 }

--- a/apps/mobile/app/subscriptions/connect/_shared.tsx
+++ b/apps/mobile/app/subscriptions/connect/_shared.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { FileText, Headphones, LockKeyhole, Play, ShieldCheck } from 'lucide-react-native';
+import {
+  FileText,
+  Headphones,
+  LockKeyhole,
+  Play,
+  ShieldCheck,
+  Bookmark,
+} from 'lucide-react-native';
 import type { LucideIcon } from 'lucide-react-native';
 import { useRouter } from 'expo-router';
 
@@ -22,6 +29,7 @@ const PROVIDER_ICON: Record<ConnectProvider, LucideIcon> = {
   YOUTUBE: Play,
   SPOTIFY: Headphones,
   GMAIL: FileText,
+  X: Bookmark,
 };
 
 type IntegrationConnectScreenProps = {
@@ -63,6 +71,11 @@ export function IntegrationConnectScreen({
         await utils.subscriptions.newsletters.list.invalidate();
         await utils.subscriptions.newsletters.stats.invalidate();
       }
+      if (provider === 'X') {
+        await utils.subscriptions.xBookmarks.status.invalidate();
+        await utils.items.library.invalidate();
+        await utils.items.home.invalidate();
+      }
 
       router.replace(successRoute);
     } catch (err) {
@@ -80,6 +93,10 @@ export function IntegrationConnectScreen({
   const footerCopy = useMemo(() => {
     if (provider === 'GMAIL') {
       return 'Manage this integration and your newsletter subscriptions from the Newsletters source screen.';
+    }
+
+    if (provider === 'X') {
+      return 'Manage this integration and bookmark sync from the X Bookmarks source screen.';
     }
 
     return `Manage this integration and your ${sourceConfig.name.toLowerCase()} subscriptions from the source screen after you connect.`;

--- a/apps/mobile/app/subscriptions/connect/x.tsx
+++ b/apps/mobile/app/subscriptions/connect/x.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { useRouter } from 'expo-router';
+
+import { OAuthErrorBoundary } from '@/components/oauth-error-boundary';
+
+import { IntegrationConnectScreen } from './_shared';
+
+export default function XConnectScreen() {
+  const router = useRouter();
+
+  const handleRetry = useCallback(() => {
+    router.replace('/subscriptions/connect/x' as never);
+  }, [router]);
+
+  return (
+    <OAuthErrorBoundary provider="X" onRetry={handleRetry}>
+      <IntegrationConnectScreen
+        provider="X"
+        subtitle="Connect X to import bookmarked posts into your Zine library with a strict daily sync cap."
+        allowList={[
+          {
+            title: 'Bookmarked posts',
+            description: 'Import the latest bookmarked posts from your X account.',
+          },
+          {
+            title: 'Post and author metadata',
+            description: 'Read post text, author names, avatars, and basic media previews.',
+          },
+          {
+            title: 'Limited refreshes',
+            description: 'Sync is capped to the latest 100 bookmarks and at most once daily.',
+          },
+        ]}
+        restrictedList={[
+          {
+            title: 'No posting or following',
+            description: 'Zine cannot post, reply, repost, follow, or unfollow accounts.',
+          },
+          {
+            title: 'No bookmark edits',
+            description: 'Zine does not add, remove, or organize bookmarks in your X account.',
+          },
+        ]}
+        ctaLabel="Connect X"
+      />
+    </OAuthErrorBoundary>
+  );
+}

--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/lib/subscription-sources';
 import { trpc } from '@/lib/trpc';
 
-const SUBSCRIPTION_SOURCES: SubscriptionSource[] = ['YOUTUBE', 'SPOTIFY', 'GMAIL', 'RSS'];
+const SUBSCRIPTION_SOURCES: SubscriptionSource[] = ['YOUTUBE', 'SPOTIFY', 'GMAIL', 'X', 'RSS'];
 
 export default function SubscriptionsScreen() {
   const navigation = useNavigation();
@@ -52,16 +52,21 @@ export default function SubscriptionsScreen() {
   const rssStatsQuery = trpc.subscriptions.rss.stats.useQuery(undefined, {
     staleTime: 60 * 1000,
   });
+  const xBookmarksStatusQuery = trpc.subscriptions.xBookmarks.status.useQuery(undefined, {
+    staleTime: 60 * 1000,
+  });
 
   const isLoading =
     connectionsLoading ||
     subscriptionsLoading ||
     newsletterStatsQuery.isLoading ||
-    rssStatsQuery.isLoading;
+    rssStatsQuery.isLoading ||
+    xBookmarksStatusQuery.isLoading;
 
   const youtubeStatus = getConnectionStatus(connections, 'YOUTUBE');
   const spotifyStatus = getConnectionStatus(connections, 'SPOTIFY');
   const gmailStatus = getConnectionStatus(connections, 'GMAIL');
+  const xStatus = getConnectionStatus(connections, 'X');
 
   const youtubeCount = subscriptions.filter(
     (subscription) => subscription.provider === 'YOUTUBE'
@@ -70,6 +75,7 @@ export default function SubscriptionsScreen() {
     (subscription) => subscription.provider === 'SPOTIFY'
   ).length;
   const gmailCount = newsletterStatsQuery.data?.active ?? 0;
+  const xCount = xBookmarksStatusQuery.data?.importedCount ?? 0;
   const rssCount = rssStatsQuery.data?.active ?? 0;
 
   const sourceRows = useMemo(
@@ -82,7 +88,9 @@ export default function SubscriptionsScreen() {
               ? spotifyCount
               : source === 'GMAIL'
                 ? gmailCount
-                : rssCount;
+                : source === 'X'
+                  ? xCount
+                  : rssCount;
         const status =
           source === 'YOUTUBE'
             ? youtubeStatus
@@ -90,7 +98,9 @@ export default function SubscriptionsScreen() {
               ? spotifyStatus
               : source === 'GMAIL'
                 ? gmailStatus
-                : null;
+                : source === 'X'
+                  ? xStatus
+                  : null;
 
         return {
           source,
@@ -98,7 +108,17 @@ export default function SubscriptionsScreen() {
           summary: getHubStatusText(source, getIntegrationState(source, status), count),
         };
       }),
-    [gmailCount, gmailStatus, rssCount, spotifyCount, spotifyStatus, youtubeCount, youtubeStatus]
+    [
+      gmailCount,
+      gmailStatus,
+      rssCount,
+      spotifyCount,
+      spotifyStatus,
+      xCount,
+      xStatus,
+      youtubeCount,
+      youtubeStatus,
+    ]
   );
 
   return (

--- a/apps/mobile/components/oauth-error-boundary.tsx
+++ b/apps/mobile/components/oauth-error-boundary.tsx
@@ -18,6 +18,7 @@ interface OAuthErrorFallbackProps {
 function getProviderName(provider: OAuthProvider): string {
   if (provider === 'YOUTUBE') return 'YouTube';
   if (provider === 'SPOTIFY') return 'Spotify';
+  if (provider === 'X') return 'X';
   return 'Gmail';
 }
 

--- a/apps/mobile/components/subscriptions/source-ui.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.tsx
@@ -13,6 +13,8 @@ import {
   getSubscriptionSourceConfig,
 } from '@/lib/subscription-sources';
 
+const SOURCE_BRAND_ICON_COLOR = '#FFFFFF'; // design-system-exception: white brand glyphs
+
 // design-system-exception: brand colors matching FAB config in item-detail-helpers.tsx
 const SOURCE_BRAND: Record<SubscriptionSource, { bg: string; icon: React.ReactNode }> = {
   YOUTUBE: {
@@ -26,6 +28,14 @@ const SOURCE_BRAND: Record<SubscriptionSource, { bg: string; icon: React.ReactNo
   GMAIL: {
     bg: '#1A73E8', // design-system-exception: Gmail brand color
     icon: <Ionicons name="newspaper-outline" size={22} color="#FFFFFF" />, // design-system-exception: white on brand
+  },
+  X: {
+    bg: '#111111', // design-system-exception: X brand color
+    icon: (
+      <Text variant="labelLarge" style={{ color: SOURCE_BRAND_ICON_COLOR }}>
+        X
+      </Text>
+    ), // design-system-exception: white on brand
   },
   RSS: {
     bg: '#F59E0B', // design-system-exception: RSS accent color

--- a/apps/mobile/hooks/use-connections.ts
+++ b/apps/mobile/hooks/use-connections.ts
@@ -46,7 +46,7 @@ function transformConnection(
     id: `connection-${provider.toLowerCase()}`,
     provider,
     status: data.status as ConnectionStatus,
-    providerUserId: null,
+    providerUserId: data.providerUserId ?? null,
     createdAt: new Date(data.connectedAt).toISOString(),
     lastSyncAt: data.lastRefreshedAt ? new Date(data.lastRefreshedAt).toISOString() : null,
   };
@@ -63,6 +63,9 @@ function transformConnectionsResponse(response: ConnectionsListOutput): Connecti
   }
   if (response.GMAIL) {
     connections.push(transformConnection('GMAIL', response.GMAIL));
+  }
+  if (response.X) {
+    connections.push(transformConnection('X', response.X));
   }
 
   return connections;
@@ -249,6 +252,11 @@ export function useDisconnectConnection(options?: {
       if (isConnectionProvider(input.provider) && input.provider === 'GMAIL') {
         utils.subscriptions.newsletters.list.invalidate();
         utils.subscriptions.newsletters.stats.invalidate();
+      }
+      if (isConnectionProvider(input.provider) && input.provider === 'X') {
+        utils.subscriptions.xBookmarks.status.invalidate();
+        utils.items.library.invalidate();
+        utils.items.home.invalidate();
       }
       options?.onSuccess?.();
     },

--- a/apps/mobile/lib/oauth.ts
+++ b/apps/mobile/lib/oauth.ts
@@ -72,6 +72,11 @@ export const OAUTH_CONFIG = {
     authUrl: 'https://accounts.spotify.com/authorize',
     scopes: ['user-library-read'],
   },
+  X: {
+    clientId: process.env.EXPO_PUBLIC_X_CLIENT_ID ?? '',
+    authUrl: 'https://x.com/i/oauth2/authorize',
+    scopes: ['tweet.read', 'users.read', 'bookmark.read', 'offline.access'],
+  },
 } as const satisfies Record<
   OAuthProvider,
   {
@@ -97,6 +102,8 @@ function toProviderEnum(provider: OAuthProvider): Provider {
       return Provider.GMAIL;
     case 'SPOTIFY':
       return Provider.SPOTIFY;
+    case 'X':
+      return Provider.X;
   }
 }
 

--- a/apps/mobile/lib/route-validation.test.ts
+++ b/apps/mobile/lib/route-validation.test.ts
@@ -234,7 +234,8 @@ describe('route-validation', () => {
       expect(VALID_PROVIDER_ROUTES).toContain('youtube');
       expect(VALID_PROVIDER_ROUTES).toContain('spotify');
       expect(VALID_PROVIDER_ROUTES).toContain('gmail');
-      expect(VALID_PROVIDER_ROUTES.length).toBe(3);
+      expect(VALID_PROVIDER_ROUTES).toContain('x');
+      expect(VALID_PROVIDER_ROUTES.length).toBe(4);
     });
 
     it('keeps discovery providers limited to youtube/spotify', () => {

--- a/apps/mobile/lib/route-validation.ts
+++ b/apps/mobile/lib/route-validation.ts
@@ -1,7 +1,7 @@
 import type { OAuthProvider, Provider } from '@zine/shared/types';
 
 // Routes use lowercase provider slugs; the backend uses uppercase enum values.
-export const VALID_PROVIDER_ROUTES = ['youtube', 'spotify', 'gmail'] as const;
+export const VALID_PROVIDER_ROUTES = ['youtube', 'spotify', 'gmail', 'x'] as const;
 export type ProviderRoute = (typeof VALID_PROVIDER_ROUTES)[number];
 
 // Gmail uses newsletter detection instead of creator discovery.

--- a/apps/mobile/lib/subscription-sources.test.ts
+++ b/apps/mobile/lib/subscription-sources.test.ts
@@ -20,6 +20,19 @@ describe('subscription source helpers', () => {
     expect(formatSourceCount('RSS', 2)).toBe('2 feeds');
   });
 
+  it('formats X bookmark counts using bookmark terminology', () => {
+    expect(formatSourceCount('X', 2)).toBe('2 bookmarks');
+  });
+
+  it('returns X integration copy with the conservative sync cap', () => {
+    expect(getIntegrationCardCopy('X', 'notConnected')).toEqual({
+      title: 'Integration not connected',
+      description:
+        'Connect X to import bookmarked posts into your Zine library with a strict daily sync cap.',
+      actionLabel: 'Connect',
+    });
+  });
+
   it('returns reconnect copy for integrations that need attention', () => {
     expect(getIntegrationCardCopy('SPOTIFY', 'needsAttention')).toEqual({
       title: 'Integration needs attention',

--- a/apps/mobile/lib/subscription-sources.ts
+++ b/apps/mobile/lib/subscription-sources.ts
@@ -53,6 +53,18 @@ const SOURCE_CONFIG: Record<SubscriptionSource, SourceConfig> = {
     searchPlaceholder: 'Search newsletters',
     route: '/subscriptions/gmail',
   },
+  X: {
+    key: 'X',
+    name: 'X Bookmarks',
+    integrationName: 'X integration',
+    integrationDescription:
+      'Connect X to import bookmarked posts into your Zine library with a strict daily sync cap.',
+    sourceDescription: 'Bookmarked posts from X are imported as saved items in your library.',
+    providerLabel: 'X',
+    subscriptionNoun: 'bookmark',
+    searchPlaceholder: 'Search bookmarks',
+    route: '/subscriptions/x',
+  },
   RSS: {
     key: 'RSS',
     name: 'RSS',

--- a/apps/mobile/lib/subscriptions-screen.test.tsx
+++ b/apps/mobile/lib/subscriptions-screen.test.tsx
@@ -137,6 +137,14 @@ jest.mock('@/lib/trpc', () => ({
           }),
         },
       },
+      xBookmarks: {
+        status: {
+          useQuery: () => ({
+            data: { connected: false, importedCount: 0, sync: null },
+            isLoading: false,
+          }),
+        },
+      },
     },
   },
 }));

--- a/apps/mobile/lib/trpc-types.ts
+++ b/apps/mobile/lib/trpc-types.ts
@@ -28,4 +28,7 @@ export type RssStatsOutput = RouterOutputs['subscriptions']['rss']['stats'];
 export type RssDiscoverInput = RouterInputs['subscriptions']['rss']['discover'];
 export type RssDiscoverOutput = RouterOutputs['subscriptions']['rss']['discover'];
 
+export type XBookmarksStatusOutput = RouterOutputs['subscriptions']['xBookmarks']['status'];
+export type XBookmarksSyncOutput = RouterOutputs['subscriptions']['xBookmarks']['syncNow'];
+
 export type SyncStatusOutput = RouterOutputs['subscriptions']['syncStatus'];

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -4,3 +4,4 @@ export const API_URL = import.meta.env.VITE_API_URL?.trim() || fallbackApiUrl;
 export const CLERK_PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY?.trim() || '';
 export const YOUTUBE_CLIENT_ID = import.meta.env.VITE_YOUTUBE_CLIENT_ID?.trim() || '';
 export const SPOTIFY_CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID?.trim() || '';
+export const X_CLIENT_ID = import.meta.env.VITE_X_CLIENT_ID?.trim() || '';

--- a/apps/web/src/lib/oauth.test.ts
+++ b/apps/web/src/lib/oauth.test.ts
@@ -46,6 +46,7 @@ async function loadOAuthModule(envOverrides: Partial<Record<string, string>> = {
   vi.doMock('./env', () => ({
     API_URL: 'http://localhost:8787',
     SPOTIFY_CLIENT_ID: 'spotify-client',
+    X_CLIENT_ID: 'x-client',
     YOUTUBE_CLIENT_ID: 'google-client',
     ...envOverrides,
   }));

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -4,7 +4,7 @@ import superjson from 'superjson';
 
 import type { AppRouter } from '@zine/worker/trpc/router';
 
-import { API_URL, SPOTIFY_CLIENT_ID, YOUTUBE_CLIENT_ID } from './env';
+import { API_URL, SPOTIFY_CLIENT_ID, X_CLIENT_ID, YOUTUBE_CLIENT_ID } from './env';
 
 export type { OAuthProvider } from '@zine/shared/types';
 
@@ -35,6 +35,11 @@ const OAUTH_CONFIG = {
     authUrl: 'https://accounts.spotify.com/authorize',
     scopes: ['user-library-read'],
   },
+  X: {
+    clientId: X_CLIENT_ID,
+    authUrl: 'https://x.com/i/oauth2/authorize',
+    scopes: ['tweet.read', 'users.read', 'bookmark.read', 'offline.access'],
+  },
 } as const satisfies Record<
   OAuthProvider,
   {
@@ -52,6 +57,8 @@ function toProviderEnum(provider: OAuthProvider): Provider {
       return Provider.GMAIL;
     case 'SPOTIFY':
       return Provider.SPOTIFY;
+    case 'X':
+      return Provider.X;
   }
 }
 
@@ -117,7 +124,11 @@ export async function connectProvider(
   const config = OAUTH_CONFIG[provider];
   if (!config.clientId) {
     throw new Error(
-      provider === 'SPOTIFY' ? 'Missing VITE_SPOTIFY_CLIENT_ID.' : 'Missing VITE_YOUTUBE_CLIENT_ID.'
+      provider === 'SPOTIFY'
+        ? 'Missing VITE_SPOTIFY_CLIENT_ID.'
+        : provider === 'X'
+          ? 'Missing VITE_X_CLIENT_ID.'
+          : 'Missing VITE_YOUTUBE_CLIENT_ID.'
     );
   }
 

--- a/apps/web/src/lib/onboarding.ts
+++ b/apps/web/src/lib/onboarding.ts
@@ -1,12 +1,11 @@
-import {
-  SUBSCRIPTION_SOURCES,
-  isOAuthProvider,
-  type OAuthProvider,
-  type SubscriptionSource,
+import type {
+  OAuthProvider as SharedOAuthProvider,
+  SubscriptionSource as SharedSubscriptionSource,
 } from '@zine/shared/types';
 
-export type { SubscriptionSource };
-export type WizardStep = SubscriptionSource | 'DONE';
+export type OAuthProvider = Exclude<SharedOAuthProvider, 'X'>;
+export type SubscriptionSource = Exclude<SharedSubscriptionSource, 'X'>;
+export type WizardStep = 'SPOTIFY' | 'YOUTUBE' | 'GMAIL' | 'RSS' | 'DONE';
 
 export type OnboardingOAuthContext = {
   origin: 'welcome' | 'settings';
@@ -59,7 +58,7 @@ export const sourceConfigs: Record<SubscriptionSource, SourceConfig> = {
   },
 };
 
-export const supportedSources = SUBSCRIPTION_SOURCES;
+export const supportedSources = Object.keys(sourceConfigs) as SubscriptionSource[];
 
 export function setOnboardingOAuthContext(context: OnboardingOAuthContext) {
   sessionStorage.setItem(ONBOARDING_OAUTH_CONTEXT_KEY, JSON.stringify(context));
@@ -75,7 +74,9 @@ export function getOnboardingOAuthContext(): OnboardingOAuthContext | null {
     const parsed = JSON.parse(stored) as Partial<OnboardingOAuthContext>;
     if (
       (parsed.origin === 'welcome' || parsed.origin === 'settings') &&
-      isOAuthProvider(parsed.provider)
+      (parsed.provider === 'YOUTUBE' ||
+        parsed.provider === 'SPOTIFY' ||
+        parsed.provider === 'GMAIL')
     ) {
       return { origin: parsed.origin, provider: parsed.provider };
     }

--- a/apps/worker/src/db/migrations/0010_add_x_bookmark_syncs.sql
+++ b/apps/worker/src/db/migrations/0010_add_x_bookmark_syncs.sql
@@ -1,0 +1,39 @@
+CREATE TABLE `x_bookmark_syncs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL,
+  `provider_connection_id` text NOT NULL,
+  `status` text DEFAULT 'IDLE' NOT NULL,
+  `daily_sync_enabled` integer DEFAULT 0 NOT NULL,
+  `last_cursor` text,
+  `last_sync_at` integer,
+  `last_success_at` integer,
+  `last_error_at` integer,
+  `last_error` text,
+  `rate_limited_until` integer,
+  `last_estimated_billable_reads` integer DEFAULT 0 NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`provider_connection_id`) REFERENCES `provider_connections`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `x_bookmark_syncs_user_connection_idx` ON `x_bookmark_syncs` (`user_id`,`provider_connection_id`);
+--> statement-breakpoint
+CREATE INDEX `x_bookmark_syncs_daily_idx` ON `x_bookmark_syncs` (`daily_sync_enabled`,`status`,`last_sync_at`);
+--> statement-breakpoint
+CREATE TABLE `x_bookmark_items` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL,
+  `item_id` text NOT NULL,
+  `tweet_id` text NOT NULL,
+  `first_seen_at` integer NOT NULL,
+  `last_seen_at` integer NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `x_bookmark_items_user_tweet_idx` ON `x_bookmark_items` (`user_id`,`tweet_id`);
+--> statement-breakpoint
+CREATE INDEX `x_bookmark_items_user_seen_idx` ON `x_bookmark_items` (`user_id`,`last_seen_at`);
+--> statement-breakpoint
+CREATE INDEX `x_bookmark_items_item_idx` ON `x_bookmark_items` (`item_id`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777507200000,
       "tag": "0009_add_item_enrichment",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777593600000,
+      "tag": "0010_add_x_bookmark_syncs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -357,6 +357,64 @@ export const providerConnections = sqliteTable(
   ]
 );
 
+// X Bookmark Syncs
+// One conservative bookmark-import sync state per connected X account.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const xBookmarkSyncs = sqliteTable(
+  'x_bookmark_syncs',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    providerConnectionId: text('provider_connection_id')
+      .notNull()
+      .references(() => providerConnections.id),
+    status: text('status').notNull().default('IDLE'), // IDLE | RUNNING | SUCCESS | ERROR | RATE_LIMITED
+    dailySyncEnabled: integer('daily_sync_enabled', { mode: 'boolean' }).notNull().default(false),
+    lastCursor: text('last_cursor'),
+    lastSyncAt: integer('last_sync_at'),
+    lastSuccessAt: integer('last_success_at'),
+    lastErrorAt: integer('last_error_at'),
+    lastError: text('last_error'),
+    rateLimitedUntil: integer('rate_limited_until'),
+    lastEstimatedBillableReads: integer('last_estimated_billable_reads').notNull().default(0),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('x_bookmark_syncs_user_connection_idx').on(
+      table.userId,
+      table.providerConnectionId
+    ),
+    index('x_bookmark_syncs_daily_idx').on(table.dailySyncEnabled, table.status, table.lastSyncAt),
+  ]
+);
+
+// X Bookmark Items
+// Tracks imported X bookmark posts without using creator/channel subscriptions.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const xBookmarkItems = sqliteTable(
+  'x_bookmark_items',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    tweetId: text('tweet_id').notNull(),
+    firstSeenAt: integer('first_seen_at').notNull(),
+    lastSeenAt: integer('last_seen_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('x_bookmark_items_user_tweet_idx').on(table.userId, table.tweetId),
+    index('x_bookmark_items_user_seen_idx').on(table.userId, table.lastSeenAt),
+    index('x_bookmark_items_item_idx').on(table.itemId),
+  ]
+);
+
 // Gmail Mailboxes
 // One connected Gmail mailbox per user/provider connection.
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -19,6 +19,7 @@ import { pollGmailNewsletters } from './newsletters/gmail';
 import { pollRssFeeds } from './rss/service';
 import { handleEnrichmentDLQ, handleEnrichmentQueue } from './enrichment/consumer';
 import type { EnrichmentQueueMessage } from './enrichment/types';
+import { pollXBookmarkSyncs } from './x-bookmarks/service';
 import { handleSyncQueue } from './sync/consumer';
 import { handleSyncDLQ } from './sync/dlq-consumer';
 import type { SyncQueueMessage } from './sync/types';
@@ -238,6 +239,7 @@ export default {
    * - "15 * * * *" → Gmail newsletter polling at quarter past
    * - "30 * * * *" → Spotify polling at 30 minutes past
    * - "45 * * * *" → RSS feed polling at 45 minutes past
+   * - "5 8 * * *"  → opt-in X bookmark sync once daily
    *
    * Each provider has its own distributed lock for failure isolation.
    *
@@ -261,6 +263,11 @@ export default {
 
     if (event.cron === '45 * * * *') {
       ctx.waitUntil(pollRssFeeds(env, ctx));
+      return;
+    }
+
+    if (event.cron === '5 8 * * *') {
+      ctx.waitUntil(pollXBookmarkSyncs(env as Parameters<typeof pollXBookmarkSyncs>[0]));
       return;
     }
 

--- a/apps/worker/src/lib/auth.ts
+++ b/apps/worker/src/lib/auth.ts
@@ -121,6 +121,14 @@ interface SpotifyUserInfoResponse {
   display_name?: string;
 }
 
+interface XUserInfoResponse {
+  data: {
+    id: string;
+    name: string;
+    username: string;
+  };
+}
+
 function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === 'string';
 }
@@ -160,6 +168,21 @@ function isSpotifyUserInfoResponse(value: unknown): value is SpotifyUserInfoResp
     isOptionalString(candidate.display_name)
   );
 }
+
+function isXUserInfoResponse(value: unknown): value is XUserInfoResponse {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as XUserInfoResponse;
+  return (
+    !!candidate.data &&
+    typeof candidate.data === 'object' &&
+    typeof candidate.data.id === 'string' &&
+    typeof candidate.data.name === 'string' &&
+    typeof candidate.data.username === 'string'
+  );
+}
 const OAUTH_CONFIG = {
   YOUTUBE: {
     tokenUrl: 'https://oauth2.googleapis.com/token',
@@ -172,6 +195,10 @@ const OAUTH_CONFIG = {
   SPOTIFY: {
     tokenUrl: 'https://accounts.spotify.com/api/token',
     userInfoUrl: 'https://api.spotify.com/v1/me',
+  },
+  X: {
+    tokenUrl: 'https://api.x.com/2/oauth2/token',
+    userInfoUrl: 'https://api.x.com/2/users/me',
   },
 } as const;
 
@@ -188,8 +215,16 @@ export async function exchangeCodeForTokens(
   const config = OAUTH_CONFIG[provider];
 
   const isGoogleProvider = provider === 'YOUTUBE' || provider === 'GMAIL';
-  const clientId = isGoogleProvider ? env.GOOGLE_CLIENT_ID : env.SPOTIFY_CLIENT_ID;
-  const clientSecret = isGoogleProvider ? env.GOOGLE_CLIENT_SECRET : env.SPOTIFY_CLIENT_SECRET;
+  const clientId = isGoogleProvider
+    ? env.GOOGLE_CLIENT_ID
+    : provider === 'X'
+      ? env.X_CLIENT_ID
+      : env.SPOTIFY_CLIENT_ID;
+  const clientSecret = isGoogleProvider
+    ? env.GOOGLE_CLIENT_SECRET
+    : provider === 'X'
+      ? env.X_CLIENT_SECRET
+      : env.SPOTIFY_CLIENT_SECRET;
   const redirectUri = overrideRedirectUri || env.OAUTH_REDIRECT_URI || 'zine://oauth/callback';
 
   if (!clientId) {
@@ -275,6 +310,17 @@ export async function getProviderUserInfo(
       id: data.id,
       email: data.email,
       name: data.name,
+    };
+  }
+
+  if (provider === 'X') {
+    if (!isXUserInfoResponse(data)) {
+      throw new Error('Invalid X user info response');
+    }
+
+    return {
+      id: data.data.id,
+      name: `${data.data.name} (@${data.data.username})`,
     };
   }
 

--- a/apps/worker/src/lib/token-refresh.ts
+++ b/apps/worker/src/lib/token-refresh.ts
@@ -86,6 +86,8 @@ export interface TokenRefreshEnv {
   GOOGLE_CLIENT_SECRET?: string;
   SPOTIFY_CLIENT_ID: string;
   SPOTIFY_CLIENT_SECRET: string;
+  X_CLIENT_ID?: string;
+  X_CLIENT_SECRET?: string;
   /** Optional override for the lock handoff wait before re-reading the refreshed token (ms) */
   TOKEN_REFRESH_LOCK_WAIT_MS?: string | number;
 }
@@ -280,6 +282,15 @@ function getProviderConfig(
         tokenUrl: 'https://accounts.spotify.com/api/token',
         clientId: env.SPOTIFY_CLIENT_ID,
         clientSecret: env.SPOTIFY_CLIENT_SECRET,
+      };
+    case 'X':
+      if (!env.X_CLIENT_ID) {
+        throw new TokenRefreshError('INVALID_PROVIDER', 'X OAuth client ID is not configured');
+      }
+      return {
+        tokenUrl: 'https://api.x.com/2/oauth2/token',
+        clientId: env.X_CLIENT_ID,
+        clientSecret: env.X_CLIENT_SECRET,
       };
     default:
       throw new TokenRefreshError('INVALID_PROVIDER', `Unknown provider: ${provider}`);

--- a/apps/worker/src/providers/x.test.ts
+++ b/apps/worker/src/providers/x.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchXBookmarksPage, XAuthError } from './x';
+import type { XRateLimitError } from './x';
+
+describe('X provider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches one capped bookmark page with minimal display fields', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [{ id: 'tweet-1', text: 'Saved post', author_id: 'user-1' }],
+          includes: { users: [{ id: 'user-1', name: 'Author', username: 'author' }] },
+          meta: { result_count: 1 },
+        }),
+        {
+          status: 200,
+          headers: {
+            'x-rate-limit-limit': '180',
+            'x-rate-limit-remaining': '179',
+            'x-rate-limit-reset': '1700000100',
+          },
+        }
+      )
+    );
+
+    const result = await fetchXBookmarksPage({
+      accessToken: 'token',
+      userId: 'x-user-1',
+    });
+
+    const requestedUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestedUrl.pathname).toBe('/2/users/x-user-1/bookmarks');
+    expect(requestedUrl.searchParams.get('max_results')).toBe('100');
+    expect(requestedUrl.searchParams.get('tweet.fields')).toContain('text');
+    expect(requestedUrl.searchParams.get('expansions')).toContain('author_id');
+    expect(result.data?.[0].id).toBe('tweet-1');
+    expect(result.rateLimit.remaining).toBe(179);
+    expect(result.rateLimit.resetAt).toBe(1700000100 * 1000);
+  });
+
+  it('throws a structured rate-limit error for 429 responses', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ errors: [{ title: 'Too Many Requests' }] }), {
+        status: 429,
+        headers: {
+          'x-rate-limit-reset': '1700000200',
+        },
+      })
+    );
+
+    await expect(
+      fetchXBookmarksPage({ accessToken: 'token', userId: 'x-user-1' })
+    ).rejects.toMatchObject({
+      name: 'XRateLimitError',
+      resetAt: 1700000200 * 1000,
+    } satisfies Partial<XRateLimitError>);
+  });
+
+  it('throws an auth error for revoked or insufficient X access', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('Forbidden', { status: 403 }));
+
+    await expect(
+      fetchXBookmarksPage({ accessToken: 'token', userId: 'x-user-1' })
+    ).rejects.toBeInstanceOf(XAuthError);
+  });
+});

--- a/apps/worker/src/providers/x.ts
+++ b/apps/worker/src/providers/x.ts
@@ -1,0 +1,144 @@
+export type XRateLimitInfo = {
+  limit: number | null;
+  remaining: number | null;
+  resetAt: number | null;
+};
+
+export type XUser = {
+  id: string;
+  name: string;
+  username: string;
+  profile_image_url?: string;
+};
+
+export type XMedia = {
+  media_key: string;
+  type: string;
+  url?: string;
+  preview_image_url?: string;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+};
+
+export type XTweet = {
+  id: string;
+  text: string;
+  author_id?: string;
+  created_at?: string;
+  attachments?: {
+    media_keys?: string[];
+  };
+  public_metrics?: Record<string, number>;
+  note_tweet?: {
+    text?: string;
+  };
+};
+
+export type XBookmarksResponse = {
+  data?: XTweet[];
+  includes?: {
+    users?: XUser[];
+    media?: XMedia[];
+  };
+  meta?: {
+    result_count?: number;
+    next_token?: string;
+    previous_token?: string;
+  };
+  errors?: unknown[];
+};
+
+export type XBookmarksPage = XBookmarksResponse & {
+  rateLimit: XRateLimitInfo;
+};
+
+export class XRateLimitError extends Error {
+  readonly resetAt: number | null;
+  readonly rateLimit: XRateLimitInfo;
+
+  constructor(message: string, rateLimit: XRateLimitInfo) {
+    super(message);
+    this.name = 'XRateLimitError';
+    this.rateLimit = rateLimit;
+    this.resetAt = rateLimit.resetAt;
+  }
+}
+
+export class XAuthError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'XAuthError';
+    this.status = status;
+  }
+}
+
+export const X_BOOKMARKS_MAX_RESULTS = 100;
+
+function parseRateLimit(headers: Headers): XRateLimitInfo {
+  const limit = headers.get('x-rate-limit-limit');
+  const remaining = headers.get('x-rate-limit-remaining');
+  const reset = headers.get('x-rate-limit-reset');
+
+  return {
+    limit: limit ? Number(limit) : null,
+    remaining: remaining ? Number(remaining) : null,
+    resetAt: reset ? Number(reset) * 1000 : null,
+  };
+}
+
+export async function fetchXBookmarksPage(params: {
+  accessToken: string;
+  userId: string;
+  paginationToken?: string | null;
+  maxResults?: number;
+}): Promise<XBookmarksPage> {
+  const url = new URL(`https://api.x.com/2/users/${encodeURIComponent(params.userId)}/bookmarks`);
+  url.searchParams.set('max_results', String(params.maxResults ?? X_BOOKMARKS_MAX_RESULTS));
+  url.searchParams.set(
+    'tweet.fields',
+    ['attachments', 'author_id', 'created_at', 'id', 'note_tweet', 'public_metrics', 'text'].join(
+      ','
+    )
+  );
+  url.searchParams.set('expansions', ['attachments.media_keys', 'author_id'].join(','));
+  url.searchParams.set('user.fields', ['id', 'name', 'profile_image_url', 'username'].join(','));
+  url.searchParams.set(
+    'media.fields',
+    ['duration_ms', 'height', 'media_key', 'preview_image_url', 'type', 'url', 'width'].join(',')
+  );
+
+  if (params.paginationToken) {
+    url.searchParams.set('pagination_token', params.paginationToken);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: 'application/json',
+    },
+  });
+  const rateLimit = parseRateLimit(response.headers);
+
+  if (response.status === 429) {
+    throw new XRateLimitError('X bookmark lookup rate limit exceeded', rateLimit);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    const text = await response.text();
+    throw new XAuthError(response.status, text || `X bookmark lookup failed: ${response.status}`);
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`X bookmark lookup failed: ${response.status} ${text}`);
+  }
+
+  const body = (await response.json()) as XBookmarksResponse;
+  return {
+    ...body,
+    rateLimit,
+  };
+}

--- a/apps/worker/src/routes/auth.ts
+++ b/apps/worker/src/routes/auth.ts
@@ -14,7 +14,14 @@ import { Webhook } from 'svix';
 import { eq } from 'drizzle-orm';
 import type { Env, Bindings } from '../types';
 import { createDb } from '../db';
-import { users, userItems, sources, providerItemsSeen } from '../db/schema';
+import {
+  users,
+  userItems,
+  sources,
+  providerItemsSeen,
+  xBookmarkItems,
+  xBookmarkSyncs,
+} from '../db/schema';
 import { webhookLogger } from '../lib/logger';
 
 const auth = new Hono<Env>();
@@ -244,6 +251,8 @@ async function handleUserDeleted(
   // 4. Delete user record
 
   await db.delete(providerItemsSeen).where(eq(providerItemsSeen.userId, user.id));
+  await db.delete(xBookmarkItems).where(eq(xBookmarkItems.userId, user.id));
+  await db.delete(xBookmarkSyncs).where(eq(xBookmarkSyncs.userId, user.id));
   await db.delete(userItems).where(eq(userItems.userId, user.id));
   await db.delete(sources).where(eq(sources.userId, user.id));
   await db.delete(users).where(eq(users.id, user.id));
@@ -313,6 +322,8 @@ auth.delete('/account', async (c) => {
   // 4. Delete user record
 
   await db.delete(providerItemsSeen).where(eq(providerItemsSeen.userId, userId));
+  await db.delete(xBookmarkItems).where(eq(xBookmarkItems.userId, userId));
+  await db.delete(xBookmarkSyncs).where(eq(xBookmarkSyncs.userId, userId));
   await db.delete(userItems).where(eq(userItems.userId, userId));
   await db.delete(sources).where(eq(sources.userId, userId));
   await db.delete(users).where(eq(users.id, userId));

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -5,6 +5,7 @@ import { subscriptionsRouter } from './routers/subscriptions';
 import { connectionsRouter } from './routers/connections';
 import { newslettersRouter } from './routers/newsletters';
 import { rssRouter } from './routers/rss';
+import { xBookmarksRouter } from './routers/x-bookmarks';
 import { bookmarksRouter } from './routers/bookmarks';
 import { creatorsRouter } from './routers/creators';
 import { adminRouter } from './routers/admin';
@@ -59,6 +60,7 @@ export const appRouter = router({
     discover: subscriptionsRouter.discover,
     newsletters: newslettersRouter,
     rss: rssRouter,
+    xBookmarks: xBookmarksRouter,
   }),
   // Admin operations (data repair, diagnostics)
   admin: adminRouter,

--- a/apps/worker/src/trpc/routers/connections.ts
+++ b/apps/worker/src/trpc/routers/connections.ts
@@ -21,6 +21,8 @@ import {
   newsletterFeeds,
   newsletterFeedMessages,
   newsletterUnsubscribeEvents,
+  xBookmarkItems,
+  xBookmarkSyncs,
 } from '../../db/schema';
 import type { Bindings } from '../../types';
 import { authLogger } from '../../lib/logger';
@@ -327,6 +329,7 @@ export const connectionsRouter = router({
       where: eq(providerConnections.userId, ctx.userId),
       columns: {
         provider: true,
+        providerUserId: true,
         status: true,
         connectedAt: true,
         lastRefreshedAt: true,
@@ -339,6 +342,7 @@ export const connectionsRouter = router({
       YOUTUBE: connections.find((c) => c.provider === 'YOUTUBE') ?? null,
       SPOTIFY: connections.find((c) => c.provider === 'SPOTIFY') ?? null,
       GMAIL: connections.find((c) => c.provider === 'GMAIL') ?? null,
+      X: connections.find((c) => c.provider === 'X') ?? null,
     };
   }),
 
@@ -462,6 +466,18 @@ export const connectionsRouter = router({
         }
       }
 
+      if (input.provider === 'X') {
+        await ctx.db
+          .delete(xBookmarkSyncs)
+          .where(
+            and(
+              eq(xBookmarkSyncs.userId, ctx.userId),
+              eq(xBookmarkSyncs.providerConnectionId, connection.id)
+            )
+          );
+        await ctx.db.delete(xBookmarkItems).where(eq(xBookmarkItems.userId, ctx.userId));
+      }
+
       // 3. Delete connection from database
       await ctx.db.delete(providerConnections).where(eq(providerConnections.id, connection.id));
 
@@ -520,6 +536,25 @@ async function revokeProviderToken(
     if (!response.ok) {
       const text = await response.text();
       throw new Error(`YouTube token revocation failed: ${response.status} ${text}`);
+    }
+  }
+  if (provider === 'X') {
+    const body = new URLSearchParams({
+      token,
+      client_id: env.X_CLIENT_ID ?? '',
+    });
+
+    const response = await fetch('https://api.x.com/2/oauth2/revoke', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`X token revocation failed: ${response.status} ${text}`);
     }
   }
   // Spotify doesn't have a token revocation endpoint

--- a/apps/worker/src/trpc/routers/x-bookmarks.test.ts
+++ b/apps/worker/src/trpc/routers/x-bookmarks.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment miniflare
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { xBookmarksRouter } from './x-bookmarks';
+import { XBookmarkSyncBlockedError } from '../../x-bookmarks/service';
+import type * as XBookmarksService from '../../x-bookmarks/service';
+
+const mockGetStatus = vi.fn();
+const mockSync = vi.fn();
+const mockUpdateSettings = vi.fn();
+
+vi.mock('../../x-bookmarks/service', async () => {
+  const actual = await vi.importActual<typeof XBookmarksService>('../../x-bookmarks/service');
+  return {
+    ...actual,
+    getXBookmarkStatus: (...args: unknown[]) => mockGetStatus(...args),
+    syncXBookmarksForUser: (...args: unknown[]) => mockSync(...args),
+    updateXBookmarkSettings: (...args: unknown[]) => mockUpdateSettings(...args),
+  };
+});
+
+function createCaller(environment = 'test') {
+  return xBookmarksRouter.createCaller({
+    userId: 'user-1',
+    db: { query: {} },
+    env: {
+      ENVIRONMENT: environment,
+    },
+  } as never);
+}
+
+describe('xBookmarksRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns bookmark connection and sync status', async () => {
+    mockGetStatus.mockResolvedValue({
+      connected: true,
+      connectionStatus: 'ACTIVE',
+      importedCount: 12,
+      sync: {
+        status: 'SUCCESS',
+        dailySyncEnabled: false,
+      },
+    });
+
+    const result = await createCaller().status();
+
+    expect(result.importedCount).toBe(12);
+    expect(mockGetStatus).toHaveBeenCalledWith('user-1', expect.anything());
+  });
+
+  it('runs manual sync without bypass outside development', async () => {
+    mockSync.mockResolvedValue({
+      success: true,
+      returned: 1,
+      created: 1,
+      skipped: 0,
+      estimatedBillableReads: 1,
+      nextCursor: null,
+    });
+
+    await createCaller('production').syncNow({ bypassCooldown: true });
+
+    expect(mockSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'manual',
+        bypassCooldown: false,
+      })
+    );
+  });
+
+  it('maps cooldown blocks to a rate-limit tRPC error', async () => {
+    mockSync.mockRejectedValue(
+      new XBookmarkSyncBlockedError(
+        'COOLDOWN',
+        'X bookmarks can only be synced once every 24 hours.',
+        123
+      )
+    );
+
+    await expect(createCaller().syncNow({})).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+
+  it('updates daily sync settings', async () => {
+    mockUpdateSettings.mockResolvedValue({ success: true, dailySyncEnabled: true });
+
+    const result = await createCaller().updateSettings({ dailySyncEnabled: true });
+
+    expect(result.dailySyncEnabled).toBe(true);
+    expect(mockUpdateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        dailySyncEnabled: true,
+      })
+    );
+  });
+});

--- a/apps/worker/src/trpc/routers/x-bookmarks.ts
+++ b/apps/worker/src/trpc/routers/x-bookmarks.ts
@@ -1,0 +1,86 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { router, protectedProcedure } from '../trpc';
+import {
+  getXBookmarkStatus,
+  syncXBookmarksForUser,
+  updateXBookmarkSettings,
+  XBookmarkSyncBlockedError,
+} from '../../x-bookmarks/service';
+import { XAuthError, XRateLimitError } from '../../providers/x';
+import type { TokenRefreshEnv } from '../../lib/token-refresh';
+
+export const xBookmarksRouter = router({
+  status: protectedProcedure.query(async ({ ctx }) => {
+    return getXBookmarkStatus(ctx.userId, ctx.db);
+  }),
+
+  updateSettings: protectedProcedure
+    .input(z.object({ dailySyncEnabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await updateXBookmarkSettings({
+          userId: ctx.userId,
+          db: ctx.db,
+          dailySyncEnabled: input.dailySyncEnabled,
+        });
+      } catch (error) {
+        throw toTRPCError(error);
+      }
+    }),
+
+  syncNow: protectedProcedure
+    .input(z.object({ bypassCooldown: z.boolean().optional() }).optional())
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await syncXBookmarksForUser({
+          userId: ctx.userId,
+          db: ctx.db,
+          env: ctx.env as TokenRefreshEnv,
+          mode: 'manual',
+          bypassCooldown: ctx.env.ENVIRONMENT === 'development' && input?.bypassCooldown === true,
+        });
+      } catch (error) {
+        throw toTRPCError(error);
+      }
+    }),
+});
+
+function toTRPCError(error: unknown): TRPCError {
+  if (error instanceof XBookmarkSyncBlockedError) {
+    const code =
+      error.code === 'COOLDOWN' || error.code === 'RATE_LIMITED'
+        ? 'TOO_MANY_REQUESTS'
+        : 'PRECONDITION_FAILED';
+    return new TRPCError({
+      code,
+      message: error.message,
+      cause: { retryAt: error.retryAt, reason: error.code },
+    });
+  }
+
+  if (error instanceof XRateLimitError) {
+    return new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: error.message,
+      cause: { retryAt: error.resetAt },
+    });
+  }
+
+  if (error instanceof XAuthError) {
+    return new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'X connection needs to be reconnected before syncing bookmarks.',
+      cause: error,
+    });
+  }
+
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: error instanceof Error ? error.message : 'Failed to sync X bookmarks',
+    cause: error,
+  });
+}
+
+export type XBookmarksRouter = typeof xBookmarksRouter;

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -52,6 +52,10 @@ export interface Bindings {
   SPOTIFY_CLIENT_ID?: string;
   /** Spotify OAuth client secret */
   SPOTIFY_CLIENT_SECRET?: string;
+  /** X OAuth client ID */
+  X_CLIENT_ID?: string;
+  /** X OAuth client secret (optional for PKCE public clients) */
+  X_CLIENT_SECRET?: string;
   /** OAuth redirect URI */
   OAUTH_REDIRECT_URI?: string;
   /** Spotify episode fetch concurrency limit (default: 5) */

--- a/apps/worker/src/x-bookmarks/service.ts
+++ b/apps/worker/src/x-bookmarks/service.ts
@@ -1,0 +1,560 @@
+import { and, count, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/d1';
+import { ulid } from 'ulid';
+import { ContentType, Provider, UserItemState } from '@zine/shared';
+
+import * as schema from '../db/schema';
+import type { Database } from '../db';
+import { findOrCreateCreator } from '../db/helpers/creators';
+import {
+  items,
+  providerConnections,
+  users,
+  userItems,
+  xBookmarkItems,
+  xBookmarkSyncs,
+} from '../db/schema';
+import { logger } from '../lib/logger';
+import {
+  getValidAccessToken,
+  persistConnectionExpired,
+  type ProviderConnection,
+  type TokenRefreshEnv,
+} from '../lib/token-refresh';
+import {
+  fetchXBookmarksPage,
+  XAuthError,
+  X_BOOKMARKS_MAX_RESULTS,
+  XRateLimitError,
+  type XBookmarksPage,
+  type XMedia,
+  type XTweet,
+  type XUser,
+} from '../providers/x';
+
+const xBookmarksLogger = logger.child('x-bookmarks');
+
+export const X_BOOKMARK_SYNC_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+export type XBookmarkSyncStatus = 'IDLE' | 'RUNNING' | 'SUCCESS' | 'ERROR' | 'RATE_LIMITED';
+
+export type XBookmarkSyncResult = {
+  success: true;
+  returned: number;
+  created: number;
+  skipped: number;
+  estimatedBillableReads: number;
+  nextCursor: string | null;
+};
+
+export class XBookmarkSyncBlockedError extends Error {
+  readonly code: 'NOT_CONNECTED' | 'COOLDOWN' | 'RATE_LIMITED' | 'MISSING_PROVIDER_USER';
+  readonly retryAt?: number;
+
+  constructor(code: XBookmarkSyncBlockedError['code'], message: string, retryAt?: number) {
+    super(message);
+    this.name = 'XBookmarkSyncBlockedError';
+    this.code = code;
+    this.retryAt = retryAt;
+  }
+}
+
+export async function getXBookmarkStatus(userId: string, db: Database) {
+  const connection = await getXConnection(userId, db);
+  if (!connection) {
+    return {
+      connected: false as const,
+      connectionStatus: null,
+      importedCount: 0,
+      sync: null,
+    };
+  }
+
+  const sync = await ensureXBookmarkSync(userId, connection, db);
+  const importedCount = await countImportedBookmarks(userId, db);
+
+  return {
+    connected: connection.status === 'ACTIVE',
+    connectionStatus: connection.status,
+    importedCount,
+    sync: {
+      status: sync.status as XBookmarkSyncStatus,
+      dailySyncEnabled: Boolean(sync.dailySyncEnabled),
+      lastCursor: sync.lastCursor,
+      lastSyncAt: sync.lastSyncAt,
+      lastSuccessAt: sync.lastSuccessAt,
+      lastErrorAt: sync.lastErrorAt,
+      lastError: sync.lastError,
+      rateLimitedUntil: sync.rateLimitedUntil,
+      lastEstimatedBillableReads: sync.lastEstimatedBillableReads,
+      updatedAt: sync.updatedAt,
+    },
+  };
+}
+
+export async function updateXBookmarkSettings(params: {
+  userId: string;
+  db: Database;
+  dailySyncEnabled: boolean;
+}) {
+  const connection = await getXConnection(params.userId, params.db);
+  if (!connection) {
+    throw new XBookmarkSyncBlockedError(
+      'NOT_CONNECTED',
+      'Connect X before changing bookmark sync settings.'
+    );
+  }
+
+  const sync = await ensureXBookmarkSync(params.userId, connection, params.db);
+  const now = Date.now();
+  await params.db
+    .update(xBookmarkSyncs)
+    .set({ dailySyncEnabled: params.dailySyncEnabled, updatedAt: now })
+    .where(eq(xBookmarkSyncs.id, sync.id));
+
+  return { success: true as const, dailySyncEnabled: params.dailySyncEnabled };
+}
+
+export async function syncXBookmarksForUser(params: {
+  userId: string;
+  db: Database;
+  env: TokenRefreshEnv;
+  mode: 'manual' | 'daily';
+  bypassCooldown?: boolean;
+}): Promise<XBookmarkSyncResult> {
+  const connection = await getXConnection(params.userId, params.db);
+  if (!connection || connection.status !== 'ACTIVE') {
+    throw new XBookmarkSyncBlockedError('NOT_CONNECTED', 'Connect X before syncing bookmarks.');
+  }
+  if (!connection.providerUserId) {
+    throw new XBookmarkSyncBlockedError(
+      'MISSING_PROVIDER_USER',
+      'X connection is missing the authenticated user ID. Reconnect X and try again.'
+    );
+  }
+
+  const sync = await ensureXBookmarkSync(params.userId, connection, params.db);
+  const now = Date.now();
+
+  if (sync.rateLimitedUntil && sync.rateLimitedUntil > now) {
+    throw new XBookmarkSyncBlockedError(
+      'RATE_LIMITED',
+      'X bookmark sync is rate limited. Try again after the reset time.',
+      sync.rateLimitedUntil
+    );
+  }
+
+  if (
+    !params.bypassCooldown &&
+    sync.lastSyncAt &&
+    sync.lastSyncAt > now - X_BOOKMARK_SYNC_COOLDOWN_MS
+  ) {
+    throw new XBookmarkSyncBlockedError(
+      'COOLDOWN',
+      'X bookmarks can only be synced once every 24 hours.',
+      sync.lastSyncAt + X_BOOKMARK_SYNC_COOLDOWN_MS
+    );
+  }
+
+  await markSyncRunning(params.db, sync.id, now);
+
+  try {
+    const accessToken = await getValidAccessToken(connection, params.env);
+    const page = await fetchXBookmarksPage({
+      accessToken,
+      userId: connection.providerUserId,
+      maxResults: X_BOOKMARKS_MAX_RESULTS,
+    });
+    const result = await importBookmarksPage({
+      userId: params.userId,
+      db: params.db,
+      page,
+    });
+    const completedAt = Date.now();
+
+    await params.db
+      .update(xBookmarkSyncs)
+      .set({
+        status: 'SUCCESS',
+        lastSyncAt: completedAt,
+        lastSuccessAt: completedAt,
+        lastErrorAt: null,
+        lastError: null,
+        lastCursor: page.meta?.next_token ?? null,
+        rateLimitedUntil: null,
+        lastEstimatedBillableReads: result.estimatedBillableReads,
+        updatedAt: completedAt,
+      })
+      .where(eq(xBookmarkSyncs.id, sync.id));
+
+    xBookmarksLogger.info('X bookmark sync completed', {
+      operation: 'xBookmarks.sync',
+      event: 'xBookmarks.sync.completed',
+      userId: params.userId,
+      mode: params.mode,
+      returned: result.returned,
+      created: result.created,
+      skipped: result.skipped,
+      estimatedBillableReads: result.estimatedBillableReads,
+      rateLimitRemaining: page.rateLimit.remaining,
+      rateLimitResetAt: page.rateLimit.resetAt,
+    });
+
+    return {
+      success: true,
+      ...result,
+      nextCursor: page.meta?.next_token ?? null,
+    };
+  } catch (error) {
+    if (error instanceof XRateLimitError) {
+      const failedAt = Date.now();
+      await params.db
+        .update(xBookmarkSyncs)
+        .set({
+          status: 'RATE_LIMITED',
+          lastSyncAt: failedAt,
+          lastErrorAt: failedAt,
+          lastError: error.message,
+          rateLimitedUntil: error.resetAt,
+          updatedAt: failedAt,
+        })
+        .where(eq(xBookmarkSyncs.id, sync.id));
+
+      xBookmarksLogger.warn('X bookmark sync rate limited', {
+        operation: 'xBookmarks.sync',
+        event: 'xBookmarks.sync.rate_limited',
+        userId: params.userId,
+        resetAt: error.resetAt,
+        remaining: error.rateLimit.remaining,
+      });
+    } else if (error instanceof XAuthError) {
+      await persistConnectionExpired(connection.id, params.env);
+      await markSyncError(params.db, sync.id, error.message);
+    } else {
+      await markSyncError(
+        params.db,
+        sync.id,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    throw error;
+  }
+}
+
+export async function pollXBookmarkSyncs(env: TokenRefreshEnv): Promise<{
+  processed: number;
+  skipped: number;
+  failed: number;
+}> {
+  const db = drizzle(env.DB, { schema });
+  const now = Date.now();
+  const dueRows = await db.query.xBookmarkSyncs.findMany({
+    where: eq(xBookmarkSyncs.dailySyncEnabled, true),
+    limit: 25,
+  });
+
+  let processed = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const sync of dueRows) {
+    if (sync.status === 'RUNNING') {
+      skipped++;
+      continue;
+    }
+
+    if (sync.lastSyncAt && sync.lastSyncAt > now - X_BOOKMARK_SYNC_COOLDOWN_MS) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      await syncXBookmarksForUser({
+        userId: sync.userId,
+        db,
+        env,
+        mode: 'daily',
+      });
+      processed++;
+    } catch (error) {
+      failed++;
+      xBookmarksLogger.warn('Daily X bookmark sync failed', {
+        userId: sync.userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { processed, skipped, failed };
+}
+
+async function getXConnection(userId: string, db: Database): Promise<ProviderConnection | null> {
+  const connection = await db.query.providerConnections.findFirst({
+    where: and(
+      eq(providerConnections.userId, userId),
+      eq(providerConnections.provider, Provider.X)
+    ),
+  });
+
+  return (connection as ProviderConnection | undefined) ?? null;
+}
+
+async function ensureXBookmarkSync(userId: string, connection: ProviderConnection, db: Database) {
+  const existing = await db.query.xBookmarkSyncs.findFirst({
+    where: and(
+      eq(xBookmarkSyncs.userId, userId),
+      eq(xBookmarkSyncs.providerConnectionId, connection.id)
+    ),
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  const now = Date.now();
+  const id = ulid();
+  await db.insert(xBookmarkSyncs).values({
+    id,
+    userId,
+    providerConnectionId: connection.id,
+    status: 'IDLE',
+    dailySyncEnabled: false,
+    lastEstimatedBillableReads: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const created = await db.query.xBookmarkSyncs.findFirst({
+    where: eq(xBookmarkSyncs.id, id),
+  });
+
+  if (!created) {
+    throw new Error('Failed to create X bookmark sync state');
+  }
+
+  return created;
+}
+
+async function countImportedBookmarks(userId: string, db: Database): Promise<number> {
+  const rows = await db
+    .select({ value: count() })
+    .from(xBookmarkItems)
+    .where(eq(xBookmarkItems.userId, userId));
+  return rows[0]?.value ?? 0;
+}
+
+async function markSyncRunning(db: Database, syncId: string, now: number): Promise<void> {
+  await db
+    .update(xBookmarkSyncs)
+    .set({ status: 'RUNNING', lastError: null, updatedAt: now })
+    .where(eq(xBookmarkSyncs.id, syncId));
+}
+
+async function markSyncError(db: Database, syncId: string, message: string): Promise<void> {
+  const now = Date.now();
+  await db
+    .update(xBookmarkSyncs)
+    .set({
+      status: 'ERROR',
+      lastSyncAt: now,
+      lastErrorAt: now,
+      lastError: message,
+      updatedAt: now,
+    })
+    .where(eq(xBookmarkSyncs.id, syncId));
+}
+
+async function importBookmarksPage(params: {
+  userId: string;
+  db: Database;
+  page: XBookmarksPage;
+}): Promise<{
+  returned: number;
+  created: number;
+  skipped: number;
+  estimatedBillableReads: number;
+}> {
+  const tweets = params.page.data ?? [];
+  const usersById = new Map((params.page.includes?.users ?? []).map((user) => [user.id, user]));
+  const mediaByKey = new Map(
+    (params.page.includes?.media ?? []).map((media) => [media.media_key, media])
+  );
+  const now = Date.now();
+  const nowIso = new Date(now).toISOString();
+
+  await params.db
+    .insert(users)
+    .values({ id: params.userId, email: null, createdAt: nowIso, updatedAt: nowIso })
+    .onConflictDoNothing();
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const tweet of tweets) {
+    const author = tweet.author_id ? usersById.get(tweet.author_id) : undefined;
+    const media = firstTweetMedia(tweet, mediaByKey);
+    const itemId = await upsertXItem({
+      db: params.db,
+      tweet,
+      author,
+      media,
+      nowIso,
+    });
+    const userItemCreated = await upsertXUserItem({
+      db: params.db,
+      userId: params.userId,
+      itemId,
+      nowIso,
+    });
+
+    await params.db
+      .insert(xBookmarkItems)
+      .values({
+        id: ulid(),
+        userId: params.userId,
+        itemId,
+        tweetId: tweet.id,
+        firstSeenAt: now,
+        lastSeenAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [xBookmarkItems.userId, xBookmarkItems.tweetId],
+        set: { itemId, lastSeenAt: now },
+      });
+
+    if (userItemCreated) {
+      created++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return {
+    returned: tweets.length,
+    created,
+    skipped,
+    estimatedBillableReads: tweets.length,
+  };
+}
+
+async function upsertXItem(params: {
+  db: Database;
+  tweet: XTweet;
+  author?: XUser;
+  media?: XMedia;
+  nowIso: string;
+}): Promise<string> {
+  const existing = await params.db.query.items.findFirst({
+    where: and(eq(items.provider, Provider.X), eq(items.providerId, params.tweet.id)),
+  });
+  const creator = await findOrCreateCreator(
+    { db: params.db },
+    {
+      provider: Provider.X,
+      providerCreatorId:
+        params.author?.id ?? `unknown:${params.tweet.author_id ?? params.tweet.id}`,
+      name: params.author?.name ?? 'Unknown',
+      imageUrl: params.author?.profile_image_url,
+      handle: params.author?.username,
+      externalUrl: params.author ? `https://x.com/${params.author.username}` : undefined,
+    }
+  );
+
+  if (existing) {
+    if (!existing.creatorId) {
+      await params.db
+        .update(items)
+        .set({ creatorId: creator.id, updatedAt: params.nowIso })
+        .where(eq(items.id, existing.id));
+    }
+    return existing.id;
+  }
+
+  const itemId = ulid();
+  await params.db.insert(items).values({
+    id: itemId,
+    contentType: ContentType.POST,
+    provider: Provider.X,
+    providerId: params.tweet.id,
+    canonicalUrl: canonicalTweetUrl(params.tweet, params.author),
+    title: tweetTitle(params.tweet, params.author),
+    thumbnailUrl: mediaThumbnail(params.media) ?? params.author?.profile_image_url ?? null,
+    creatorId: creator.id,
+    publisher: 'X',
+    summary: tweetSummary(params.tweet),
+    duration: params.media?.duration_ms ? Math.round(params.media.duration_ms / 1000) : null,
+    publishedAt: params.tweet.created_at ?? null,
+    rawMetadata: JSON.stringify({
+      tweet: params.tweet,
+      author: params.author ?? null,
+      media: params.media ?? null,
+    }),
+    createdAt: params.nowIso,
+    updatedAt: params.nowIso,
+  });
+
+  return itemId;
+}
+
+async function upsertXUserItem(params: {
+  db: Database;
+  userId: string;
+  itemId: string;
+  nowIso: string;
+}): Promise<boolean> {
+  const existing = await params.db.query.userItems.findFirst({
+    where: and(eq(userItems.userId, params.userId), eq(userItems.itemId, params.itemId)),
+  });
+
+  if (existing) {
+    return false;
+  }
+
+  await params.db.insert(userItems).values({
+    id: ulid(),
+    userId: params.userId,
+    itemId: params.itemId,
+    state: UserItemState.BOOKMARKED,
+    ingestedAt: params.nowIso,
+    bookmarkedAt: params.nowIso,
+    createdAt: params.nowIso,
+    updatedAt: params.nowIso,
+  });
+
+  return true;
+}
+
+function firstTweetMedia(tweet: XTweet, mediaByKey: Map<string, XMedia>): XMedia | undefined {
+  const keys = tweet.attachments?.media_keys ?? [];
+  for (const key of keys) {
+    const media = mediaByKey.get(key);
+    if (media) return media;
+  }
+  return undefined;
+}
+
+function canonicalTweetUrl(tweet: XTweet, author?: XUser): string {
+  const username = author?.username ?? 'i';
+  return `https://x.com/${encodeURIComponent(username)}/status/${encodeURIComponent(tweet.id)}`;
+}
+
+function tweetText(tweet: XTweet): string {
+  return tweet.note_tweet?.text?.trim() || tweet.text?.trim() || '';
+}
+
+function tweetTitle(tweet: XTweet, author?: XUser): string {
+  const text = tweetText(tweet);
+  if (text) return text.length > 180 ? `${text.slice(0, 177)}...` : text;
+  return `Post by ${author?.name ?? 'Unknown'}`;
+}
+
+function tweetSummary(tweet: XTweet): string | null {
+  const text = tweetText(tweet);
+  return text || null;
+}
+
+function mediaThumbnail(media?: XMedia): string | null {
+  if (!media) return null;
+  return media.url ?? media.preview_image_url ?? null;
+}

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -46,7 +46,7 @@ migrations_dir = "src/db/migrations"
 # YouTube polls at :00, Gmail newsletters at :15, Spotify at :30, RSS at :45
 # Each provider has its own distributed lock for failure isolation
 [triggers]
-crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
 
 # Queue for async pull-to-refresh sync
 # Producer: subscriptions.syncAllAsync tRPC procedure
@@ -139,7 +139,7 @@ EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.staging.triggers]
-crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
 [[env.staging.queues.producers]]
 queue = "zine-sync-queue-staging"
 binding = "SYNC_QUEUE"
@@ -214,7 +214,7 @@ EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
-crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *"]
+crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
 [[env.production.queues.producers]]
 queue = "zine-sync-queue-prod"
 binding = "SYNC_QUEUE"

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -41,18 +41,20 @@ export type ProviderValue = `${Provider}`;
 export type UserItemStateValue = `${UserItemState}`;
 export type SubscriptionStatusValue = `${SubscriptionStatus}`;
 export type ProviderConnectionStatusValue = `${ProviderConnectionStatus}`;
-export type OAuthProvider = Extract<ProviderValue, 'YOUTUBE' | 'SPOTIFY' | 'GMAIL'>;
+export type OAuthProvider = Extract<ProviderValue, 'YOUTUBE' | 'SPOTIFY' | 'GMAIL' | 'X'>;
 export type SubscriptionSource = OAuthProvider | 'RSS';
 
 export const OAUTH_PROVIDERS = [
   'YOUTUBE',
   'SPOTIFY',
   'GMAIL',
+  'X',
 ] as const satisfies readonly OAuthProvider[];
 export const SUBSCRIPTION_SOURCES = [
   'SPOTIFY',
   'YOUTUBE',
   'GMAIL',
+  'X',
   'RSS',
 ] as const satisfies readonly SubscriptionSource[];
 export interface Item {


### PR DESCRIPTION
## Summary
- add X OAuth connection support and capped bookmark sync backend
- import X bookmarks as BOOKMARKED post items without touching the existing FxTwitter manual link path
- add mobile X source/connect/detail UX and conservative daily/manual sync controls

## Guardrails
- v1 fetches only the latest 100 bookmarks
- manual sync is blocked for 24h unless bypassed in development
- daily sync is opt-in and one page per connected user
- 429s store reset time and suppress follow-up attempts

## Tests
- bun run format:check
- bun run design-system:check
- bun run typecheck
- bun run --cwd apps/web test
- bun run --cwd apps/worker test:run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'
- bun run --cwd apps/mobile test -- lib/subscription-sources.test.ts --runInBand