### PR TITLE
Add admin bookmark enrichment backfill and fix Workers AI JSON handling

### DIFF
--- a/apps/worker/src/admin/enrichment-backfill.test.ts
+++ b/apps/worker/src/admin/enrichment-backfill.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ENRICHMENT_SCHEMA_VERSION } from '../enrichment/types';
+import { computeItemContentHash } from '../enrichment/service';
+import { backfillBookmarkEnrichment } from './enrichment-backfill';
+
+const rows = [
+  {
+    user_item_id: 'ui_001',
+    user_id: 'user_001',
+    item_id: 'item_001',
+    title: 'First bookmark',
+    canonical_url: 'https://example.com/first',
+    content_type: 'ARTICLE',
+    provider: 'WEB',
+    publisher: 'Example',
+    summary: 'A useful article',
+    article_content_key: 'articles/item_001.html',
+    creator_name: 'Example Author',
+  },
+  {
+    user_item_id: 'ui_002',
+    user_id: 'user_001',
+    item_id: 'item_002',
+    title: 'Second bookmark',
+    canonical_url: 'https://example.com/second',
+    content_type: 'VIDEO',
+    provider: 'YOUTUBE',
+    publisher: null,
+    summary: null,
+    article_content_key: null,
+    creator_name: 'Video Creator',
+  },
+];
+
+function createEnv(resultRows = rows) {
+  const all = vi.fn().mockResolvedValue({ results: resultRows });
+  const bind = vi.fn().mockReturnValue({ all });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  const send = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    env: {
+      DB: { prepare },
+      ENRICHMENT_QUEUE: { send },
+    },
+    prepare,
+    bind,
+    all,
+    send,
+  };
+}
+
+describe('backfillBookmarkEnrichment', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-30T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns candidates without enqueueing in dry-run mode', async () => {
+    const { env, send } = createEnv();
+
+    const result = await backfillBookmarkEnrichment(env as never, { dryRun: true, limit: 2 });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      schemaVersion: ENRICHMENT_SCHEMA_VERSION,
+      limit: 2,
+      cursor: null,
+      nextCursor: 'ui_002',
+      scanned: 2,
+      enqueued: 0,
+    });
+    expect(result.candidates).toHaveLength(2);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('enqueues backfill messages with stable content hashes', async () => {
+    const { env, send } = createEnv([rows[0]]);
+
+    const result = await backfillBookmarkEnrichment(env as never, {
+      dryRun: false,
+      limit: 25,
+    });
+
+    expect(result.enqueued).toBe(1);
+    expect(send).toHaveBeenCalledWith({
+      itemId: 'item_001',
+      userItemId: 'ui_001',
+      userId: 'user_001',
+      trigger: 'backfill',
+      schemaVersion: ENRICHMENT_SCHEMA_VERSION,
+      contentHash: computeItemContentHash({
+        title: 'First bookmark',
+        canonicalUrl: 'https://example.com/first',
+        contentType: 'ARTICLE',
+        provider: 'WEB',
+        publisher: 'Example',
+        summary: 'A useful article',
+        creatorName: 'Example Author',
+        articleContentKey: 'articles/item_001.html',
+      }),
+      enqueuedAt: Date.now(),
+    });
+  });
+
+  it('passes the cursor into the paged query', async () => {
+    const { env, bind } = createEnv([]);
+
+    await backfillBookmarkEnrichment(env as never, {
+      dryRun: true,
+      limit: 10,
+      cursor: 'ui_099',
+    });
+
+    expect(bind).toHaveBeenCalledWith(ENRICHMENT_SCHEMA_VERSION, 'ui_099', 10);
+  });
+
+  it('only excludes complete enrichment rows so failed rows can be retried', async () => {
+    const { env, prepare } = createEnv([]);
+
+    await backfillBookmarkEnrichment(env as never, { dryRun: true });
+
+    expect(prepare.mock.calls[0][0]).toContain("AND uie.status = 'COMPLETE'");
+  });
+});

--- a/apps/worker/src/admin/enrichment-backfill.ts
+++ b/apps/worker/src/admin/enrichment-backfill.ts
@@ -1,0 +1,166 @@
+import { ENRICHMENT_SCHEMA_VERSION, type EnrichmentQueueMessage } from '../enrichment/types';
+import { computeItemContentHash } from '../enrichment/service';
+import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
+
+const backfillLogger = logger.child('admin:enrichment-backfill');
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+type EnrichmentQueue = Queue<EnrichmentQueueMessage>;
+
+interface BackfillRow {
+  user_item_id: string;
+  user_id: string;
+  item_id: string;
+  title: string;
+  canonical_url: string;
+  content_type: string;
+  provider: string;
+  publisher: string | null;
+  summary: string | null;
+  article_content_key: string | null;
+  creator_name: string | null;
+}
+
+export interface EnrichmentBackfillOptions {
+  dryRun?: boolean;
+  limit?: number;
+  cursor?: string | null;
+}
+
+export interface EnrichmentBackfillCandidate {
+  userItemId: string;
+  userId: string;
+  itemId: string;
+  contentHash: string;
+}
+
+export interface EnrichmentBackfillResult {
+  dryRun: boolean;
+  schemaVersion: number;
+  limit: number;
+  cursor: string | null;
+  nextCursor: string | null;
+  scanned: number;
+  enqueued: number;
+  candidates: EnrichmentBackfillCandidate[];
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(value)));
+}
+
+function mapCandidate(row: BackfillRow): EnrichmentBackfillCandidate {
+  return {
+    userItemId: row.user_item_id,
+    userId: row.user_id,
+    itemId: row.item_id,
+    contentHash: computeItemContentHash({
+      title: row.title,
+      canonicalUrl: row.canonical_url,
+      contentType: row.content_type,
+      provider: row.provider,
+      publisher: row.publisher,
+      summary: row.summary,
+      creatorName: row.creator_name,
+      articleContentKey: row.article_content_key,
+    }),
+  };
+}
+
+async function loadCandidates(
+  db: D1Database,
+  options: { limit: number; cursor: string | null }
+): Promise<EnrichmentBackfillCandidate[]> {
+  const cursorClause = options.cursor ? 'AND ui.id > ?' : '';
+  const statement = db.prepare(`
+    SELECT
+      ui.id AS user_item_id,
+      ui.user_id,
+      ui.item_id,
+      i.title,
+      i.canonical_url,
+      i.content_type,
+      i.provider,
+      i.publisher,
+      i.summary,
+      i.article_content_key,
+      c.name AS creator_name
+    FROM user_items ui
+    INNER JOIN items i ON i.id = ui.item_id
+    LEFT JOIN creators c ON c.id = i.creator_id
+    LEFT JOIN user_item_enrichments uie
+      ON uie.user_item_id = ui.id
+     AND uie.schema_version = ?
+     AND uie.status = 'COMPLETE'
+    WHERE ui.state = 'BOOKMARKED'
+      AND uie.id IS NULL
+      ${cursorClause}
+    ORDER BY ui.id
+    LIMIT ?
+  `);
+
+  const bound = options.cursor
+    ? statement.bind(ENRICHMENT_SCHEMA_VERSION, options.cursor, options.limit)
+    : statement.bind(ENRICHMENT_SCHEMA_VERSION, options.limit);
+  const result = await bound.all<BackfillRow>();
+
+  return (result.results ?? []).map(mapCandidate);
+}
+
+export async function backfillBookmarkEnrichment(
+  env: Pick<Bindings, 'DB' | 'ENRICHMENT_QUEUE'>,
+  options: EnrichmentBackfillOptions = {}
+): Promise<EnrichmentBackfillResult> {
+  const dryRun = options.dryRun ?? true;
+  const limit = normalizeLimit(options.limit);
+  const cursor = options.cursor ?? null;
+  const candidates = await loadCandidates(env.DB, { limit, cursor });
+  const queue = env.ENRICHMENT_QUEUE as EnrichmentQueue | undefined;
+
+  if (!dryRun && !queue) {
+    throw new Error('ENRICHMENT_QUEUE is not configured');
+  }
+
+  if (!dryRun && queue) {
+    for (const candidate of candidates) {
+      const message: EnrichmentQueueMessage = {
+        itemId: candidate.itemId,
+        userItemId: candidate.userItemId,
+        userId: candidate.userId,
+        trigger: 'backfill',
+        schemaVersion: ENRICHMENT_SCHEMA_VERSION,
+        contentHash: candidate.contentHash,
+        enqueuedAt: Date.now(),
+      };
+
+      await queue.send(message);
+    }
+  }
+
+  const nextCursor =
+    candidates.length === limit ? (candidates[candidates.length - 1]?.userItemId ?? null) : null;
+
+  backfillLogger.info('Bookmark enrichment backfill page processed', {
+    dryRun,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: candidates.length,
+    enqueued: dryRun ? 0 : candidates.length,
+  });
+
+  return {
+    dryRun,
+    schemaVersion: ENRICHMENT_SCHEMA_VERSION,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: candidates.length,
+    enqueued: dryRun ? 0 : candidates.length,
+    candidates,
+  };
+}

--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -479,10 +479,9 @@ export async function handleEnrichmentQueue(
     queue: batch.queue,
   });
 
-  const db = createDb(env.DB);
-  for (const message of batch.messages) {
-    await processMessage(message, db, env);
-  }
+  await Promise.all(
+    batch.messages.map((message) => processMessage(message, createDb(env.DB), env))
+  );
 }
 
 export async function handleEnrichmentDLQ(

--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -64,11 +64,44 @@ describe('enrichWithQwen', () => {
 
     expect(result.summary.short).toBe(output.summary.short);
     expect(run).toHaveBeenCalledWith(
-      '@cf/qwen/qwen3-30b-a3b-fp8',
+      '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
       expect.objectContaining({
         response_format: expect.objectContaining({ type: 'json_schema' }),
       })
     );
+  });
+
+  it('returns validated structured output from Workers AI JSON Mode object response', async () => {
+    const output = createValidModelOutput();
+    const run = vi.fn().mockResolvedValue({ response: output });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.summary.short).toBe(output.summary.short);
+    expect(run).toHaveBeenCalledWith(
+      '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+      expect.objectContaining({
+        response_format: {
+          type: 'json_schema',
+          json_schema: expect.objectContaining({
+            type: 'object',
+            properties: expect.objectContaining({
+              summary: expect.any(Object),
+            }),
+          }),
+        },
+      })
+    );
+  });
+
+  it('does not use the OpenAI named schema wrapper for Workers AI JSON Mode', async () => {
+    const output = createValidModelOutput();
+    const run = vi.fn().mockResolvedValue({ response: output });
+
+    await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(run.mock.calls[0][1].response_format.json_schema).not.toHaveProperty('name');
+    expect(run.mock.calls[0][1].response_format.json_schema).not.toHaveProperty('schema');
   });
 
   it('retries once when model output is invalid and accepts repaired JSON', async () => {
@@ -82,6 +115,28 @@ describe('enrichWithQwen', () => {
 
     expect(result.classification.primaryCategory).toBe('software-engineering');
     expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts OpenAI-style choices response content', async () => {
+    const output = createValidModelOutput();
+    const run = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify(output) } }],
+    });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.summary.detail).toBe(output.summary.detail);
+  });
+
+  it('accepts fenced JSON text', async () => {
+    const output = createValidModelOutput();
+    const run = vi.fn().mockResolvedValue({
+      response: `\`\`\`json\n${JSON.stringify(output)}\n\`\`\``,
+    });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.confidence.overall).toBe(output.confidence.overall);
   });
 
   it('throws validation error when both model attempts are invalid', async () => {

--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -32,17 +32,50 @@ function getResponseText(response: unknown): string | null {
   const record = response as Record<string, unknown>;
   if (typeof record.response === 'string') return record.response;
   if (typeof record.result === 'string') return record.result;
+  if (typeof record.text === 'string') return record.text;
+  if (typeof record.output_text === 'string') return record.output_text;
+  if (typeof record.content === 'string') return record.content;
   if (record.result && typeof record.result === 'object') {
     const nested = record.result as Record<string, unknown>;
     if (typeof nested.response === 'string') return nested.response;
+    if (typeof nested.text === 'string') return nested.text;
+    if (typeof nested.output_text === 'string') return nested.output_text;
+    if (typeof nested.content === 'string') return nested.content;
+  }
+  if (Array.isArray(record.choices)) {
+    for (const choice of record.choices) {
+      if (!choice || typeof choice !== 'object') continue;
+      const choiceRecord = choice as Record<string, unknown>;
+      if (typeof choiceRecord.text === 'string') return choiceRecord.text;
+      if (typeof choiceRecord.content === 'string') return choiceRecord.content;
+      if (choiceRecord.message && typeof choiceRecord.message === 'object') {
+        const message = choiceRecord.message as Record<string, unknown>;
+        if (typeof message.content === 'string') return message.content;
+      }
+    }
   }
 
   return null;
 }
 
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced?.[1]?.trim() ?? trimmed;
+}
+
 function parseModelResponse(response: unknown): EnrichmentModelOutput {
   const direct = EnrichmentModelOutputSchema.safeParse(response);
   if (direct.success) return direct.data;
+
+  if (response && typeof response === 'object') {
+    const record = response as Record<string, unknown>;
+    const nestedResponse = EnrichmentModelOutputSchema.safeParse(record.response);
+    if (nestedResponse.success) return nestedResponse.data;
+
+    const nestedResult = EnrichmentModelOutputSchema.safeParse(record.result);
+    if (nestedResult.success) return nestedResult.data;
+  }
 
   const text = getResponseText(response);
   if (!text) {
@@ -51,7 +84,7 @@ function parseModelResponse(response: unknown): EnrichmentModelOutput {
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(text) as unknown;
+    parsed = JSON.parse(stripJsonFence(text)) as unknown;
   } catch (error) {
     throw new EnrichmentModelValidationError(
       `Workers AI response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`
@@ -71,106 +104,102 @@ function buildJsonModeSchema() {
   return {
     type: 'json_schema',
     json_schema: {
-      name: 'zine_bookmark_enrichment',
-      schema: {
-        type: 'object',
-        additionalProperties: false,
-        required: [
-          'summary',
-          'classification',
-          'topics',
-          'entities',
-          'suggestedTags',
-          'userContext',
-          'confidence',
-        ],
-        properties: {
-          summary: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'summary',
+        'classification',
+        'topics',
+        'entities',
+        'suggestedTags',
+        'userContext',
+        'confidence',
+      ],
+      properties: {
+        summary: {
+          type: 'object',
+          required: ['short', 'detail'],
+          properties: {
+            short: { type: 'string' },
+            detail: { type: 'string' },
+          },
+        },
+        classification: {
+          type: 'object',
+          required: [
+            'primaryCategory',
+            'secondaryCategories',
+            'intent',
+            'difficulty',
+            'evergreenScore',
+            'timeSensitivity',
+          ],
+          properties: {
+            primaryCategory: { type: 'string' },
+            secondaryCategories: { type: 'array', items: { type: 'string' } },
+            intent: { type: 'string' },
+            difficulty: { type: 'string' },
+            evergreenScore: { type: 'number' },
+            timeSensitivity: { type: 'string' },
+          },
+        },
+        topics: {
+          type: 'array',
+          items: {
             type: 'object',
-            required: ['short', 'detail'],
+            required: ['name', 'confidence'],
             properties: {
-              short: { type: 'string' },
-              detail: { type: 'string' },
+              name: { type: 'string' },
+              confidence: { type: 'number' },
             },
           },
-          classification: {
+        },
+        entities: {
+          type: 'array',
+          items: {
             type: 'object',
-            required: [
-              'primaryCategory',
-              'secondaryCategories',
-              'intent',
-              'difficulty',
-              'evergreenScore',
-              'timeSensitivity',
-            ],
+            required: ['name', 'type', 'confidence'],
             properties: {
-              primaryCategory: { type: 'string' },
-              secondaryCategories: { type: 'array', items: { type: 'string' } },
-              intent: { type: 'string' },
-              difficulty: { type: 'string' },
-              evergreenScore: { type: 'number' },
-              timeSensitivity: { type: 'string' },
+              name: { type: 'string' },
+              type: { type: 'string' },
+              confidence: { type: 'number' },
             },
           },
-          topics: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: ['name', 'confidence'],
-              properties: {
-                name: { type: 'string' },
-                confidence: { type: 'number' },
-              },
-            },
-          },
-          entities: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: ['name', 'type', 'confidence'],
-              properties: {
-                name: { type: 'string' },
-                type: { type: 'string' },
-                confidence: { type: 'number' },
-              },
-            },
-          },
-          suggestedTags: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: ['name', 'kind', 'confidence'],
-              properties: {
-                name: { type: 'string' },
-                kind: { type: 'string', enum: ['topic', 'entity', 'intent', 'format'] },
-                confidence: { type: 'number' },
-              },
-            },
-          },
-          userContext: {
+        },
+        suggestedTags: {
+          type: 'array',
+          items: {
             type: 'object',
-            required: ['inferredSaveIntent', 'reasonToRevisit'],
+            required: ['name', 'kind', 'confidence'],
             properties: {
-              inferredSaveIntent: { type: 'string' },
-              reasonToRevisit: { type: 'string' },
+              name: { type: 'string' },
+              kind: { type: 'string', enum: ['topic', 'entity', 'intent', 'format'] },
+              confidence: { type: 'number' },
             },
           },
-          confidence: {
-            type: 'object',
-            required: ['overall', 'summary', 'classification', 'tags'],
-            properties: {
-              overall: { type: 'number' },
-              summary: { type: 'number' },
-              classification: { type: 'number' },
-              tags: { type: 'number' },
-            },
+        },
+        userContext: {
+          type: 'object',
+          required: ['inferredSaveIntent', 'reasonToRevisit'],
+          properties: {
+            inferredSaveIntent: { type: 'string' },
+            reasonToRevisit: { type: 'string' },
+          },
+        },
+        confidence: {
+          type: 'object',
+          required: ['overall', 'summary', 'classification', 'tags'],
+          properties: {
+            overall: { type: 'number' },
+            summary: { type: 'number' },
+            classification: { type: 'number' },
+            tags: { type: 'number' },
           },
         },
       },
     },
   };
 }
-
 async function runQwen(env: Bindings, input: unknown): Promise<unknown> {
   const ai = env.AI as unknown as WorkersAIRun | undefined;
   if (!ai) {

--- a/apps/worker/src/enrichment/types.ts
+++ b/apps/worker/src/enrichment/types.ts
@@ -1,7 +1,7 @@
 import type { ContentType, Provider } from '@zine/shared';
 
 export const ENRICHMENT_SCHEMA_VERSION = 1;
-export const DEFAULT_ENRICHMENT_MODEL = '@cf/qwen/qwen3-30b-a3b-fp8';
+export const DEFAULT_ENRICHMENT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 export const DEFAULT_EMBEDDING_MODEL = '@cf/qwen/qwen3-embedding-0.6b';
 export const DEFAULT_EMBEDDING_DIMENSIONS = 1024;
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -30,6 +30,7 @@ import authRoutes from './routes/auth';
 import { appRouter } from './trpc/router';
 import { createContext } from './trpc/context';
 import { getDependencyHealth, getQueueHealth } from './diagnostics/health';
+import { backfillBookmarkEnrichment } from './admin/enrichment-backfill';
 
 // Create Hono app with typed environment
 const app = new Hono<Env>();
@@ -162,6 +163,48 @@ app.get('/health/queues', async (c) => {
 
 // Mount auth routes first (webhook endpoint handles its own auth via Svix)
 app.route('/api/auth', authRoutes);
+
+app.post('/admin/enrichment/backfill', async (c) => {
+  const configuredSecret = c.env.ENRICHMENT_BACKFILL_SECRET;
+  if (!configuredSecret) {
+    return c.json(
+      {
+        error: 'Enrichment backfill is not configured',
+        code: 'BACKFILL_NOT_CONFIGURED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      503
+    );
+  }
+
+  const authHeader = c.req.header('Authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token || token !== configuredSecret) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const result = await backfillBookmarkEnrichment(c.env, {
+    dryRun: typeof body.dryRun === 'boolean' ? body.dryRun : true,
+    limit: typeof body.limit === 'number' ? body.limit : undefined,
+    cursor: typeof body.cursor === 'string' && body.cursor.length > 0 ? body.cursor : null,
+  });
+
+  return c.json({
+    ...result,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
 
 // tRPC Routes
 

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -72,6 +72,8 @@ export interface Bindings {
   RELEASE_DEPLOYED_AT?: string;
   /** Optional rollout ring or percentage */
   RELEASE_RING?: string;
+  /** Secret for privileged enrichment backfill operations */
+  ENRICHMENT_BACKFILL_SECRET?: string;
   /** Queue for async pull-to-refresh sync (optional - not available in all envs) */
   SYNC_QUEUE?: Queue<SyncQueueMessage>;
   /** Queue for async bookmark enrichment (optional - not available in all envs) */

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -97,7 +97,7 @@ invocation_logs = true
 [vars]
 ENVIRONMENT = "development"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
-ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 # CLERK_JWKS_URL = "https://clerk.your-domain.com/.well-known/jwks.json"
@@ -134,7 +134,7 @@ migrations_dir = "src/db/migrations"
 [env.staging.vars]
 ENVIRONMENT = "staging"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
-ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
@@ -209,7 +209,7 @@ migrations_dir = "src/db/migrations"
 [env.production.vars]
 ENVIRONMENT = "production"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
-ENRICHMENT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"
+ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
@@ -253,6 +253,7 @@ invocation_logs = true
 # Required Secrets (set via `wrangler secret put <NAME>`)
 # ============================================================================
 # - CLERK_WEBHOOK_SECRET: Signing secret from Clerk Dashboard > Webhooks
+# - ENRICHMENT_BACKFILL_SECRET: Bearer token for admin enrichment backfill route
 #
 # Required KV Namespace (create via `wrangler kv:namespace create WEBHOOK_IDEMPOTENCY`)
 # - WEBHOOK_IDEMPOTENCY: KV for webhook idempotency tracking


### PR DESCRIPTION
## Summary
- Add a protected admin endpoint to page bookmarked items into the existing enrichment queue for production backfills
- Include dry-run, cursor, and batch-size controls so backfills can be run incrementally and safely
- Fix enrichment parsing for Workers AI JSON Mode responses and switch the enrichment model to a supported JSON Mode model
- Process enrichment queue batches concurrently to improve backfill throughput

## Testing
- Added unit coverage for the backfill producer, including dry-run, pagination, and retryable failed rows
- Added unit coverage for enrichment response parsing across JSON text, fenced JSON, and JSON Mode object responses
- Ran worker typecheck, lint, and targeted Vitest suites