### PR TITLE
[codex] Add mobile bookmark enrichment card

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -54,8 +54,17 @@ export default function ItemDetailScreen() {
   const [titleOffsetY, setTitleOffsetY] = useState<number | null>(null);
 
   const { id, isValid, message } = useItemDetailParams();
-  const { item, otherUnfinishedBookmarks, isLoading, error, refetch, creatorData } =
-    useItemDetailData({ id, isValid });
+  const {
+    item,
+    enrichment,
+    enrichmentLoading,
+    enrichmentError,
+    otherUnfinishedBookmarks,
+    isLoading,
+    error,
+    refetch,
+    creatorData,
+  } = useItemDetailData({ id, isValid });
   const {
     handleOpenLink,
     handleShare,
@@ -140,6 +149,9 @@ export default function ItemDetailScreen() {
         secondaryActionColor={viewState.secondaryActionColor}
         isSecondaryActionDisabled={viewState.isSecondaryActionDisabled}
         creatorData={creatorData}
+        enrichment={enrichment}
+        enrichmentLoading={enrichmentLoading}
+        enrichmentError={enrichmentError}
         showCollapsedTitle={showCollapsedTitle}
         onScroll={handleScroll}
         onContentLayout={handleContentLayout}
@@ -174,6 +186,9 @@ export default function ItemDetailScreen() {
       >
         <ItemDetailContent
           item={item}
+          enrichment={enrichment}
+          enrichmentLoading={enrichmentLoading}
+          enrichmentError={enrichmentError}
           colors={colors}
           creatorData={creatorData}
           creatorImageUrl={upgradedCreatorImageUrl}
@@ -214,6 +229,9 @@ export default function ItemDetailScreen() {
     >
       <ItemDetailContent
         item={item}
+        enrichment={enrichment}
+        enrichmentLoading={enrichmentLoading}
+        enrichmentError={enrichmentError}
         colors={colors}
         creatorData={creatorData}
         creatorImageUrl={item.creatorImageUrl}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -5,16 +5,25 @@ import Animated from 'react-native-reanimated';
 import { Surface } from '@/components/primitives/surface';
 
 import { styles } from '../../item-detail-styles';
-import type { ItemDetailColors, ItemDetailCreator, ItemDetailItem } from '../types';
+import type {
+  ItemDetailColors,
+  ItemDetailCreator,
+  ItemDetailEnrichment,
+  ItemDetailItem,
+} from '../types';
 import { ItemDetailActions } from './ItemDetailActions';
 import { ItemDetailCreatorRow } from './ItemDetailCreatorRow';
 import { ItemDetailDescription } from './ItemDetailDescription';
+import { ItemDetailEnrichmentCard } from './ItemDetailEnrichmentCard';
 import { ItemDetailHeader } from './ItemDetailHeader';
 import { ItemDetailMetaRow } from './ItemDetailMetaRow';
 import { ItemDetailOtherBookmarks } from './ItemDetailOtherBookmarks';
 
 type ItemDetailContentProps = {
   item: ItemDetailItem;
+  enrichment?: ItemDetailEnrichment;
+  enrichmentLoading?: boolean;
+  enrichmentError?: unknown;
   colors: ItemDetailColors;
   creatorData?: ItemDetailCreator;
   creatorImageUrl?: string | null;
@@ -41,6 +50,9 @@ type ItemDetailContentProps = {
 
 export function ItemDetailContent({
   item,
+  enrichment,
+  enrichmentLoading,
+  enrichmentError,
   colors,
   creatorData,
   creatorImageUrl,
@@ -118,6 +130,13 @@ export function ItemDetailContent({
           </Surface>
         </DescriptionContainer>
       )}
+
+      <ItemDetailEnrichmentCard
+        enrichment={enrichment}
+        isLoading={enrichmentLoading}
+        error={enrichmentError}
+        colors={colors}
+      />
 
       {onOtherBookmarkPress && (
         <ItemDetailOtherBookmarks

--- a/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
@@ -1,0 +1,249 @@
+import type { ReactNode } from 'react';
+import { View } from 'react-native';
+
+import { Badge } from '@/components/primitives/badge';
+import { Surface } from '@/components/primitives/surface';
+import { Text } from '@/components/primitives/text';
+
+import { styles } from '../../item-detail-styles';
+import type { ItemDetailColors, ItemDetailEnrichment } from '../types';
+
+type ItemDetailEnrichmentCardProps = {
+  enrichment?: ItemDetailEnrichment;
+  isLoading?: boolean;
+  error?: unknown;
+  colors: ItemDetailColors;
+};
+
+type EnrichmentTopic = NonNullable<ItemDetailEnrichment>['item']['topics'][number];
+type EnrichmentEntity = NonNullable<ItemDetailEnrichment>['item']['entities'][number];
+type SuggestedTag = NonNullable<ItemDetailEnrichment>['userItem']['suggestedTags'][number];
+
+function formatLabel(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatPercent(value: number | null | undefined): string | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+
+  return `${Math.round(value * 100)}%`;
+}
+
+function hasEnrichmentContent(
+  enrichment?: ItemDetailEnrichment
+): enrichment is NonNullable<ItemDetailEnrichment> {
+  if (!enrichment) return false;
+
+  const { item, userItem } = enrichment;
+
+  return Boolean(
+    item.summaryShort ||
+    item.primaryCategory ||
+    item.intent ||
+    item.difficulty ||
+    item.evergreenScore !== null ||
+    item.timeSensitivity ||
+    item.topics.length > 0 ||
+    item.entities.length > 0 ||
+    userItem.reasonToRevisit ||
+    userItem.suggestedTags.length > 0
+  );
+}
+
+function EnrichmentField({
+  label,
+  value,
+  colors,
+}: {
+  label: string;
+  value?: string | null;
+  colors: ItemDetailColors;
+}) {
+  if (!value) return null;
+
+  return (
+    <View style={styles.enrichmentField}>
+      <Text variant="labelSmall" tone="tertiary" colors={colors}>
+        {label}
+      </Text>
+      <Text variant="bodyMedium" tone="subheader" colors={colors}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function ChipGroup({
+  label,
+  children,
+  colors,
+}: {
+  label: string;
+  children: ReactNode;
+  colors: ItemDetailColors;
+}) {
+  return (
+    <View style={styles.enrichmentField}>
+      <Text variant="labelSmall" tone="tertiary" colors={colors}>
+        {label}
+      </Text>
+      <View style={styles.enrichmentChipWrap}>{children}</View>
+    </View>
+  );
+}
+
+function renderSuggestedTag(tag: SuggestedTag, colors: ItemDetailColors) {
+  const confidence = formatPercent(tag.confidence);
+  const label = confidence ? `${tag.name} ${confidence}` : tag.name;
+
+  return (
+    <Badge
+      key={`${tag.normalizedName}-${tag.kind}`}
+      label={label}
+      tone="subtle"
+      colors={colors}
+      style={styles.enrichmentChip}
+    />
+  );
+}
+
+function renderTopic(topic: EnrichmentTopic, colors: ItemDetailColors) {
+  const confidence = formatPercent(topic.confidence);
+  const label = confidence ? `${topic.name} ${confidence}` : topic.name;
+
+  return (
+    <Badge
+      key={topic.name}
+      label={label}
+      tone="subtle"
+      colors={colors}
+      style={styles.enrichmentChip}
+    />
+  );
+}
+
+function renderEntity(entity: EnrichmentEntity, colors: ItemDetailColors) {
+  const confidence = formatPercent(entity.confidence);
+  const label = [entity.name, formatLabel(entity.type), confidence].filter(Boolean).join(' / ');
+
+  return (
+    <Badge
+      key={`${entity.name}-${entity.type}`}
+      label={label}
+      tone="subtle"
+      colors={colors}
+      style={styles.enrichmentChip}
+    />
+  );
+}
+
+export function ItemDetailEnrichmentCard({
+  enrichment,
+  isLoading = false,
+  error,
+  colors,
+}: ItemDetailEnrichmentCardProps) {
+  if (isLoading) {
+    return (
+      <View style={styles.enrichmentContainer}>
+        <Surface
+          tone="subtle"
+          radius="lg"
+          padding="lg"
+          colors={colors}
+          style={styles.enrichmentSurface}
+        >
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
+            ENRICHMENT
+          </Text>
+          <Text variant="bodyMedium" tone="secondary" colors={colors}>
+            Loading enrichment...
+          </Text>
+        </Surface>
+      </View>
+    );
+  }
+
+  if (error || !hasEnrichmentContent(enrichment)) {
+    return null;
+  }
+
+  const { item, userItem } = enrichment;
+  const evergreenScore = formatPercent(item.evergreenScore);
+
+  return (
+    <View style={styles.enrichmentContainer}>
+      <Surface
+        tone="subtle"
+        radius="lg"
+        padding="lg"
+        colors={colors}
+        style={styles.enrichmentSurface}
+      >
+        <View style={styles.enrichmentHeader}>
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
+            ENRICHMENT
+          </Text>
+          {item.primaryCategory && (
+            <Badge label={formatLabel(item.primaryCategory)} tone="neutral" colors={colors} />
+          )}
+        </View>
+
+        <EnrichmentField label="Short Summary" value={item.summaryShort} colors={colors} />
+        <EnrichmentField
+          label="Reason To Revisit"
+          value={userItem.reasonToRevisit}
+          colors={colors}
+        />
+
+        {userItem.suggestedTags.length > 0 && (
+          <ChipGroup label="Suggested Tags" colors={colors}>
+            {userItem.suggestedTags.map((tag) => renderSuggestedTag(tag, colors))}
+          </ChipGroup>
+        )}
+
+        {item.topics.length > 0 && (
+          <ChipGroup label="Topics" colors={colors}>
+            {item.topics.map((topic) => renderTopic(topic, colors))}
+          </ChipGroup>
+        )}
+
+        <View style={styles.enrichmentGrid}>
+          <EnrichmentField
+            label="Primary Category"
+            value={item.primaryCategory ? formatLabel(item.primaryCategory) : null}
+            colors={colors}
+          />
+          <EnrichmentField
+            label="Intent"
+            value={item.intent ? formatLabel(item.intent) : null}
+            colors={colors}
+          />
+          <EnrichmentField
+            label="Difficulty"
+            value={item.difficulty ? formatLabel(item.difficulty) : null}
+            colors={colors}
+          />
+          <EnrichmentField label="Evergreen Score" value={evergreenScore} colors={colors} />
+          <EnrichmentField
+            label="Time Sensitivity"
+            value={item.timeSensitivity ? formatLabel(item.timeSensitivity) : null}
+            colors={colors}
+          />
+        </View>
+
+        {item.entities.length > 0 && (
+          <ChipGroup label="Entities" colors={colors}>
+            {item.entities.map((entity) => renderEntity(entity, colors))}
+          </ChipGroup>
+        )}
+      </Surface>
+    </View>
+  );
+}

--- a/apps/mobile/app/item/detail/hooks/useItemDetailData.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailData.ts
@@ -1,5 +1,9 @@
 import { useCreator } from '@/hooks/use-creator';
-import { useItem, useOtherUnfinishedBookmarksByCreator } from '@/hooks/use-items-trpc';
+import {
+  useItem,
+  useItemEnrichment,
+  useOtherUnfinishedBookmarksByCreator,
+} from '@/hooks/use-items-trpc';
 
 type ItemDetailDataInput = {
   id: string;
@@ -8,12 +12,20 @@ type ItemDetailDataInput = {
 
 export function useItemDetailData({ id, isValid }: ItemDetailDataInput) {
   const { data: item, isLoading, error, refetch } = useItem(isValid ? id : '');
+  const {
+    data: enrichment,
+    isLoading: enrichmentLoading,
+    error: enrichmentError,
+  } = useItemEnrichment(isValid ? id : '');
   const { data: otherBookmarksData } = useOtherUnfinishedBookmarksByCreator(isValid ? id : '');
 
   const { creator: creatorData } = useCreator(item?.creatorId ?? '');
 
   return {
     item,
+    enrichment,
+    enrichmentLoading,
+    enrichmentError,
     otherUnfinishedBookmarks: otherBookmarksData?.items ?? [],
     isLoading,
     error,

--- a/apps/mobile/app/item/detail/types.ts
+++ b/apps/mobile/app/item/detail/types.ts
@@ -1,7 +1,8 @@
 import type { Colors } from '@/constants/theme';
 import type { Creator } from '@/hooks/use-creator';
-import type { useItem } from '@/hooks/use-items-trpc';
+import type { useItem, useItemEnrichment } from '@/hooks/use-items-trpc';
 
 export type ItemDetailItem = NonNullable<ReturnType<typeof useItem>['data']>;
+export type ItemDetailEnrichment = ReturnType<typeof useItemEnrichment>['data'];
 export type ItemDetailCreator = Creator | undefined;
 export type ItemDetailColors = typeof Colors.dark;

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -14,9 +14,10 @@ import { formatRelativeTime } from '@/lib/format';
 import { logger } from '@/lib/logger';
 
 import { ItemDetailActions } from './detail/components/ItemDetailActions';
+import { ItemDetailEnrichmentCard } from './detail/components/ItemDetailEnrichmentCard';
 import { ItemDetailFloatingBack } from './detail/components/ItemDetailFloatingBack';
 import { ItemDetailOtherBookmarks } from './detail/components/ItemDetailOtherBookmarks';
-import type { ItemDetailItem } from './detail/types';
+import type { ItemDetailEnrichment, ItemDetailItem } from './detail/types';
 import { extractXHandle } from './item-detail-helpers';
 import { styles, xPostStyles } from './item-detail-styles';
 
@@ -85,6 +86,9 @@ export function LinkedText({
  */
 export function XPostBookmarkView({
   item,
+  enrichment,
+  enrichmentLoading,
+  enrichmentError,
   colors,
   insets,
   onBack,
@@ -121,6 +125,9 @@ export function XPostBookmarkView({
     provider: string;
     state: UserItemState;
   };
+  enrichment?: ItemDetailEnrichment;
+  enrichmentLoading?: boolean;
+  enrichmentError?: unknown;
   colors: typeof Colors.dark;
   insets: { top: number; bottom: number; left: number; right: number };
   onBack: () => void;
@@ -311,6 +318,13 @@ export function XPostBookmarkView({
           </View>
         </View>
       </Animated.View>
+
+      <ItemDetailEnrichmentCard
+        enrichment={enrichment}
+        isLoading={enrichmentLoading}
+        error={enrichmentError}
+        colors={colors}
+      />
 
       {onOtherBookmarkPress && (
         <ItemDetailOtherBookmarks

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -208,6 +208,35 @@ export const styles = StyleSheet.create({
     lineHeight: 24,
   },
 
+  // Enrichment
+  enrichmentContainer: {
+    marginTop: Spacing.md,
+    paddingHorizontal: Spacing.xl,
+  },
+  enrichmentSurface: {
+    gap: Spacing.lg,
+  },
+  enrichmentHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  enrichmentField: {
+    gap: Spacing.xs,
+  },
+  enrichmentChipWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  enrichmentChip: {
+    maxWidth: '100%',
+  },
+  enrichmentGrid: {
+    gap: Spacing.md,
+  },
+
   // Other bookmarks
   otherBookmarksContainer: {
     marginTop: Spacing.md,

--- a/apps/mobile/hooks/use-item-detail-data.test.ts
+++ b/apps/mobile/hooks/use-item-detail-data.test.ts
@@ -9,12 +9,14 @@ import { useItemDetailData } from '@/app/item/detail/hooks/useItemDetailData';
 // Module-level Mocks
 
 const mockUseItem = jest.fn();
+const mockUseItemEnrichment = jest.fn();
 const mockUseOtherUnfinishedBookmarksByCreator = jest.fn();
 const mockUseCreator = jest.fn();
 const mockRefetch = jest.fn();
 
 jest.mock('@/hooks/use-items-trpc', () => ({
   useItem: (id: string) => mockUseItem(id),
+  useItemEnrichment: (id: string) => mockUseItemEnrichment(id),
   useOtherUnfinishedBookmarksByCreator: (id: string) =>
     mockUseOtherUnfinishedBookmarksByCreator(id),
 }));
@@ -40,6 +42,11 @@ describe('useItemDetailData', () => {
       error: null,
       refetch: jest.fn(),
     });
+    mockUseItemEnrichment.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
     mockUseOtherUnfinishedBookmarksByCreator.mockReturnValue({
       data: { items: [] },
       isLoading: false,
@@ -51,6 +58,7 @@ describe('useItemDetailData', () => {
     const { result } = renderHook(() => useItemDetailData({ id: 'bad-id', isValid: false }));
 
     expect(mockUseItem).toHaveBeenCalledWith('');
+    expect(mockUseItemEnrichment).toHaveBeenCalledWith('');
     expect(mockUseOtherUnfinishedBookmarksByCreator).toHaveBeenCalledWith('');
     expect(mockUseCreator).toHaveBeenCalledWith('');
     expect(result.current.item).toBeNull();
@@ -77,6 +85,7 @@ describe('useItemDetailData', () => {
     const { result } = renderHook(() => useItemDetailData({ id: 'item-1', isValid: true }));
 
     expect(mockUseItem).toHaveBeenCalledWith('item-1');
+    expect(mockUseItemEnrichment).toHaveBeenCalledWith('item-1');
     expect(mockUseOtherUnfinishedBookmarksByCreator).toHaveBeenCalledWith('item-1');
     expect(mockUseCreator).toHaveBeenCalledWith('creator-1');
     expect(result.current.creatorData).toBe(creator);


### PR DESCRIPTION
## Summary

- add a mobile bookmark detail enrichment card backed by `items.getEnrichment`

- show short summary, revisit reason, suggested tags, topics, category, intent, difficulty, evergreen score, time sensitivity, and entities

- wire enrichment data through the normal and X-post item detail layouts


## Validation

- `bun run format:check`

- `bun run lint`
- `bun run test`

- `bun run build`

- pre-push hook: format, design-system check, typecheck, web tests, worker CI subset


