### PR TITLE
Toggle selected bookmark cards from the list

### DIFF
--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -605,6 +605,37 @@ describe('BookmarksPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  test('toggles the selected bookmark card off from the desktop list', async () => {
+    const user = userEvent.setup();
+
+    const { container } = renderRoute(
+      <>
+        <BookmarksPage />
+        <LocationProbe />
+      </>,
+      {
+        route: `/bookmarks/${videoItem.id}`,
+        path: '/bookmarks/:bookmarkId?',
+      }
+    );
+
+    const selectedBookmarkCard = container.querySelector('.bookmark-row--selected');
+
+    expect(selectedBookmarkCard).toBeDefined();
+    expect(selectedBookmarkCard).toHaveTextContent(videoItem.title);
+    expect(screen.getByRole('heading', { name: videoItem.title })).toBeVisible();
+
+    await user.click(selectedBookmarkCard as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-path')).toHaveTextContent('/bookmarks');
+    });
+
+    expect(selectedBookmarkCard).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('heading', { name: videoItem.title })).not.toBeInTheDocument();
+    expect(screen.getByText('Select a bookmark')).toBeVisible();
+  });
+
   test('shows a mobile tab bar on phone widths and hides the sidebar', () => {
     setViewportWidth(390);
 

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -1208,7 +1208,12 @@ export function BookmarksPage() {
                         selectedBookmark?.id === item.id && 'bookmark-row--selected'
                       )}
                       onClick={() =>
-                        navigate(buildBookmarksLocation(item.id, bookmarkSearchString))
+                        navigate(
+                          buildBookmarksLocation(
+                            selectedBookmark?.id === item.id ? null : item.id,
+                            bookmarkSearchString
+                          )
+                        )
                       }
                     >
                       {item.thumbnailUrl ? (


### PR DESCRIPTION
## Summary
- Clicking a bookmark row now toggles the current selection off when the row is already open.
- Clicking any other row still opens that bookmark’s detail view.
- Added a regression test covering the deselect flow from the desktop list.

## Testing
- `bun run --cwd apps/web test bookmarks-page.test.tsx`