### PR TITLE
test(worker): remove ts-expect-error from link parser null/undefined runtime tests

### DIFF
--- a/apps/worker/src/lib/link-parser.test.ts
+++ b/apps/worker/src/lib/link-parser.test.ts
@@ -30,10 +30,8 @@ describe('isValidUrl', () => {
     });
 
     it('rejects null/undefined', () => {
-      // @ts-expect-error - testing runtime behavior
-      expect(isValidUrl(null)).toBe(false);
-      // @ts-expect-error - testing runtime behavior
-      expect(isValidUrl(undefined)).toBe(false);
+      expect(isValidUrl(null as unknown as string)).toBe(false);
+      expect(isValidUrl(undefined as unknown as string)).toBe(false);
     });
 
     it('rejects plain text', () => {
@@ -405,10 +403,8 @@ describe('parseLink', () => {
     });
 
     it('handles null/undefined gracefully', () => {
-      // @ts-expect-error - testing runtime behavior
-      expect(parseLink(null)).toBe(null);
-      // @ts-expect-error - testing runtime behavior
-      expect(parseLink(undefined)).toBe(null);
+      expect(parseLink(null as unknown as string)).toBe(null);
+      expect(parseLink(undefined as unknown as string)).toBe(null);
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace `@ts-expect-error` usages in `link-parser.test.ts` runtime null/undefined tests with explicit `unknown as string` inputs
- keep runtime behavior coverage for invalid inputs while removing broad TypeScript suppression comments

## Why
This scoped tech-debt cleanup improves test clarity and avoids line-level compiler directives while still testing runtime guards.

## Validation
- `bun run --cwd apps/worker test:run src/lib/link-parser.test.ts`
- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `git push -u origin daily-techdebt-2026-05-02` (branch published)
