### PR TITLE
[codex] Use full article content for enrichment

### DIFF
--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -16,10 +16,11 @@ import { logger } from '../lib/logger';
 import type { Bindings } from '../types';
 import { upsertItemEmbedding } from './embeddings';
 import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
-import { buildEmbeddingText, buildPromptInput } from './prompt';
+import { buildArticleExcerpt, buildEmbeddingText, buildPromptInput } from './prompt';
 import { EnrichmentQueueMessageSchema } from './schema';
 import { computeItemContentHash } from './service';
 import {
+  DEFAULT_ENRICHMENT_MODEL,
   type EnrichmentModelOutput,
   type EnrichmentQueueMessage,
   type EnrichmentSourceCreator,
@@ -222,7 +223,7 @@ async function writeCanonicalComplete(
       contentHash: message.contentHash,
       status: 'COMPLETE',
       modelProvider: 'cloudflare-workers-ai',
-      modelName: env.ENRICHMENT_MODEL || '@cf/qwen/qwen3-30b-a3b-fp8',
+      modelName: env.ENRICHMENT_MODEL || DEFAULT_ENRICHMENT_MODEL,
       summaryShort: output.summary.short,
       summaryDetail: output.summary.detail,
       primaryCategory: output.classification.primaryCategory,
@@ -243,7 +244,7 @@ async function writeCanonicalComplete(
       set: {
         status: 'COMPLETE',
         modelProvider: 'cloudflare-workers-ai',
-        modelName: env.ENRICHMENT_MODEL || '@cf/qwen/qwen3-30b-a3b-fp8',
+        modelName: env.ENRICHMENT_MODEL || DEFAULT_ENRICHMENT_MODEL,
         summaryShort: output.summary.short,
         summaryDetail: output.summary.detail,
         primaryCategory: output.classification.primaryCategory,
@@ -439,7 +440,7 @@ async function processMessage(message: EnrichmentMessage, db: Database, env: Bin
         item: source.item,
         creator: source.creator,
         output,
-        articleExcerpt: promptInput.articleExcerpt,
+        articleExcerpt: buildArticleExcerpt(articleContent),
       }),
     });
 

--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -21,7 +21,7 @@ function createPromptInput(): EnrichmentPromptInput {
       description: null,
       handle: null,
     },
-    articleExcerpt: 'Workers AI can run models near a Cloudflare Worker.',
+    articleContent: 'Workers AI can run models near a Cloudflare Worker.',
   };
 }
 

--- a/apps/worker/src/enrichment/prompt.test.ts
+++ b/apps/worker/src/enrichment/prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildArticleExcerpt, buildEnrichmentMessages, buildPromptInput } from './prompt';
+import type { EnrichmentPromptInput } from './types';
+
+function createPromptInput(articleContent: string | null): EnrichmentPromptInput {
+  return {
+    item: {
+      id: 'item-1',
+      title: 'Long article',
+      canonicalUrl: 'https://example.com/long',
+      contentType: 'ARTICLE',
+      provider: 'WEB',
+      publisher: 'Example',
+      summary: null,
+      rawMetadata: null,
+      articleContentKey: 'article-1',
+    },
+    creator: null,
+    articleContent,
+  };
+}
+
+describe('enrichment prompt helpers', () => {
+  it('keeps full cleaned article content in the enrichment prompt', () => {
+    const longTail = 'tail-marker';
+    const articleContent = `<article><p>${'a'.repeat(5200)}</p><p>${longTail}</p></article>`;
+    const input = buildPromptInput({
+      item: createPromptInput(null).item,
+      creator: null,
+      articleContent,
+    });
+
+    const messages = buildEnrichmentMessages(input);
+    const userPayload = JSON.parse(String(messages[1].content)) as {
+      item: { articleContent: string };
+    };
+
+    expect(input.articleContent).toContain(longTail);
+    expect(userPayload.item.articleContent).toContain(longTail);
+    expect(userPayload.item.articleContent).not.toContain('<article>');
+  });
+
+  it('still caps article text used by embedding input', () => {
+    const articleContent = `${'a'.repeat(5200)}tail-marker`;
+
+    expect(buildArticleExcerpt(articleContent)).not.toContain('tail-marker');
+  });
+});

--- a/apps/worker/src/enrichment/prompt.ts
+++ b/apps/worker/src/enrichment/prompt.ts
@@ -5,7 +5,7 @@ import type {
   EnrichmentSourceItem,
 } from './types';
 
-const ARTICLE_EXCERPT_LIMIT = 5000;
+const EMBEDDING_ARTICLE_EXCERPT_LIMIT = 5000;
 const METADATA_LIMIT = 2500;
 const EMBEDDING_TEXT_LIMIT = 6000;
 
@@ -43,8 +43,12 @@ function formatCreator(creator: EnrichmentSourceCreator | null): string {
   );
 }
 
+export function buildArticleContent(content: string | null): string | null {
+  return stripHtml(content ?? '') || null;
+}
+
 export function buildArticleExcerpt(content: string | null): string | null {
-  return truncate(stripHtml(content ?? ''), ARTICLE_EXCERPT_LIMIT);
+  return truncate(stripHtml(content ?? ''), EMBEDDING_ARTICLE_EXCERPT_LIMIT);
 }
 
 export function buildPromptInput(params: {
@@ -55,7 +59,7 @@ export function buildPromptInput(params: {
   return {
     item: params.item,
     creator: params.creator,
-    articleExcerpt: buildArticleExcerpt(params.articleContent),
+    articleContent: buildArticleContent(params.articleContent),
   };
 }
 
@@ -79,7 +83,7 @@ export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
       creator: formatCreator(input.creator),
       existingSummary: input.item.summary,
       metadataExcerpt,
-      articleExcerpt: input.articleExcerpt,
+      articleContent: input.articleContent,
     },
   };
 

--- a/apps/worker/src/enrichment/types.ts
+++ b/apps/worker/src/enrichment/types.ts
@@ -94,7 +94,7 @@ export interface EnrichmentSourceCreator {
 export interface EnrichmentPromptInput {
   item: EnrichmentSourceItem;
   creator: EnrichmentSourceCreator | null;
-  articleExcerpt: string | null;
+  articleContent: string | null;
 }
 
 export interface EmbeddingUpsertInput {


### PR DESCRIPTION
## Summary

- send full cleaned article content to the bookmark enrichment LLM prompt instead of the previous 5000-character excerpt
- keep embedding text on the capped excerpt path so vectors stay bounded
- record canonical enrichment model names from the shared default model constant instead of a stale hard-coded fallback
- add prompt helper coverage for full enrichment context and capped embedding context

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run design-system:check`
- pre-push hook: format, design-system, typecheck, web tests, worker CI subset
