### PR TITLE
[codex] Update mobile content filters

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -1,18 +1,43 @@
 import { Stack, useNavigation } from 'expo-router';
 import { Surface, useToast } from 'heroui-native';
+import type { ComponentType } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, View, Text, StyleSheet, type ListRenderItemInfo } from 'react-native';
-import Animated, { FadeOut, LinearTransition } from 'react-native-reanimated';
+import {
+  ActivityIndicator,
+  ScrollView,
+  View,
+  Text,
+  StyleSheet,
+  type ListRenderItemInfo,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import Animated, { LinearTransition } from 'react-native-reanimated';
+import { ContentType as ApiContentType } from '@zine/shared';
 
-import { InboxArrowIcon } from '@/components/icons';
+import { FilterChip } from '@/components/filter-chip';
+import { ArticleIcon, InboxArrowIcon, PodcastIcon, PostIcon, VideoIcon } from '@/components/icons';
 import { type ItemCardData } from '@/components/item-card';
 import { LoadingState, ErrorState } from '@/components/list-states';
 import { SwipeableInboxItem, type EnterDirection } from '@/components/swipeable-inbox-item';
-import { Colors, Typography, Spacing, Radius } from '@/constants/theme';
+import {
+  Colors,
+  Typography,
+  Spacing,
+  Radius,
+  ContentColors,
+  FilterChipPalette,
+} from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteInboxItems, useArchiveItem, useBookmarkItem } from '@/hooks/use-items-trpc';
-import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
+import {
+  mapContentType,
+  mapProvider,
+  type ContentType,
+  type Provider,
+  type UIContentType,
+} from '@/lib/content-utils';
 import { useSyncAll } from '@/hooks/use-sync-all';
 import {
   addPendingDismissedId,
@@ -29,18 +54,76 @@ import {
 
 const REENTRY_CLEANUP_DELAY = 500;
 const INBOX_PAGE_SIZE = 20;
+const INBOX_TOP_THRESHOLD = 4;
 
-function InboxEmptyState({ colors }: { colors: (typeof Colors)['light'] }) {
+const contentTypeFilters: {
+  id: UIContentType;
+  label: string;
+  icon: ComponentType<{ size?: number; color?: string }>;
+  dotColor: string;
+  selectedColor: string;
+  selectedSurfaceColor: string;
+  contentType: ApiContentType;
+}[] = [
+  {
+    id: 'article',
+    label: 'Articles',
+    icon: ArticleIcon,
+    dotColor: ContentColors.article,
+    selectedColor: FilterChipPalette.article.accent,
+    selectedSurfaceColor: FilterChipPalette.article.surface,
+    contentType: ApiContentType.ARTICLE,
+  },
+  {
+    id: 'podcast',
+    label: 'Podcasts',
+    icon: PodcastIcon,
+    dotColor: ContentColors.podcast,
+    selectedColor: FilterChipPalette.podcast.accent,
+    selectedSurfaceColor: FilterChipPalette.podcast.surface,
+    contentType: ApiContentType.PODCAST,
+  },
+  {
+    id: 'video',
+    label: 'Videos',
+    icon: VideoIcon,
+    dotColor: ContentColors.video,
+    selectedColor: FilterChipPalette.video.accent,
+    selectedSurfaceColor: FilterChipPalette.video.surface,
+    contentType: ApiContentType.VIDEO,
+  },
+  {
+    id: 'post',
+    label: 'Posts',
+    icon: PostIcon,
+    dotColor: ContentColors.post,
+    selectedColor: FilterChipPalette.post.accent,
+    selectedSurfaceColor: FilterChipPalette.post.surface,
+    contentType: ApiContentType.POST,
+  },
+];
+
+function InboxEmptyState({
+  colors,
+  selectedFilterLabel,
+}: {
+  colors: (typeof Colors)['light'];
+  selectedFilterLabel?: string;
+}) {
+  const title = selectedFilterLabel
+    ? `No ${selectedFilterLabel.toLowerCase()}`
+    : 'Your inbox is clear';
+  const description = selectedFilterLabel
+    ? `New ${selectedFilterLabel.toLowerCase()} from your sources will appear here.`
+    : 'New content from your sources will appear here. Bookmark what you want to keep, archive the rest.';
+
   return (
     <Animated.View style={styles.emptyState}>
       <View style={[styles.emptyIcon, { backgroundColor: colors.backgroundSecondary }]}>
         <InboxArrowIcon size={48} color={colors.primary} />
       </View>
-      <Text style={[styles.emptyTitle, { color: colors.text }]}>Your inbox is clear</Text>
-      <Text style={[styles.emptyDescription, { color: colors.textSubheader }]}>
-        New content from your sources will appear here. Bookmark what you want to keep, archive the
-        rest.
-      </Text>
+      <Text style={[styles.emptyTitle, { color: colors.text }]}>{title}</Text>
+      <Text style={[styles.emptyDescription, { color: colors.textSubheader }]}>{description}</Text>
       <View style={[styles.emptyHint, { backgroundColor: colors.backgroundSecondary }]}>
         <Text style={[styles.emptyHintText, { color: colors.textTertiary }]}>
           Connect integrations in Settings to start receiving content
@@ -56,18 +139,43 @@ export default function InboxScreen() {
   const colors = Colors[colorScheme ?? 'light'];
   const { toast } = useToast();
   const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
+  const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
 
   useTabPrefetch('inbox');
 
+  const apiContentTypeFilter = contentTypeFilter
+    ? contentTypeFilters.find((filter) => filter.id === contentTypeFilter)?.contentType
+    : undefined;
+
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteInboxItems({ limit: INBOX_PAGE_SIZE });
+    useInfiniteInboxItems({
+      limit: INBOX_PAGE_SIZE,
+      ...(apiContentTypeFilter ? { filter: { contentType: apiContentTypeFilter } } : {}),
+    });
 
   const [reappearingItems, setReappearingItems] = useState<Map<string, EnterDirection>>(new Map());
   const [pendingDismissedItemIds, setPendingDismissedItemIds] = useState<Set<string>>(new Set());
   const listRef = useRef<Animated.FlatList<ItemCardData>>(null);
+  const scrollOffsetYRef = useRef(0);
+  const selectedContentTypeFilter = contentTypeFilters.find(
+    (filter) => filter.id === contentTypeFilter
+  );
 
   const archiveMutation = useArchiveItem();
   const bookmarkMutation = useBookmarkItem();
+
+  const handleContentTypeFilterPress = useCallback((id: UIContentType) => {
+    setContentTypeFilter((current) => (current === id ? null : id));
+    listRef.current?.scrollToOffset({ offset: 0, animated: true });
+  }, []);
+
+  const handleInboxScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollOffsetYRef.current = event.nativeEvent.contentOffset.y;
+      handleScroll(event);
+    },
+    [handleScroll]
+  );
 
   const markAsReappearing = useCallback((id: string, enterFrom: EnterDirection) => {
     setReappearingItems((prev) => new Map(prev).set(id, enterFrom));
@@ -114,7 +222,7 @@ export default function InboxScreen() {
     [bookmarkMutation, markAsReappearing, toast]
   );
 
-  const { syncAll, isLoading: isSyncing, progress: syncProgress, lastResult } = useSyncAll();
+  const { syncAll, isLoading: isSyncing, lastResult } = useSyncAll();
   const { isConnected, isInternetReachable } = useNetworkStatus();
   const isOffline = !isConnected || isInternetReachable === false;
 
@@ -201,13 +309,6 @@ export default function InboxScreen() {
     void fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  const inboxCountLabel =
-    visibleInboxItems.length === 0
-      ? 'Decide what to keep'
-      : hasNextPage
-        ? `${visibleInboxItems.length}+ items to triage`
-        : `${visibleInboxItems.length} item${visibleInboxItems.length === 1 ? '' : 's'} to triage`;
-
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
       <SwipeableInboxItem
@@ -222,19 +323,28 @@ export default function InboxScreen() {
   );
 
   useEffect(() => {
-    return navigation.addListener('tabPress', () => {
+    const tabNavigation = navigation.getParent?.() ?? navigation;
+
+    return tabNavigation.addListener('tabPress', () => {
       if (!navigation.isFocused()) return;
+
+      const isAtTop = scrollOffsetYRef.current <= INBOX_TOP_THRESHOLD;
+
+      if (contentTypeFilter !== null && isAtTop) {
+        setContentTypeFilter(null);
+        return;
+      }
 
       listRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
-  }, [navigation]);
+  }, [contentTypeFilter, navigation]);
 
   const listEmptyComponent = isLoading ? (
     <LoadingState />
   ) : error ? (
     <ErrorState message={error.message} />
   ) : (
-    <InboxEmptyState colors={colors} />
+    <InboxEmptyState colors={colors} selectedFilterLabel={selectedContentTypeFilter?.label} />
   );
 
   return (
@@ -256,24 +366,31 @@ export default function InboxScreen() {
         contentContainerStyle={styles.listContent}
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        onScroll={handleScroll}
+        onScroll={handleInboxScroll}
         scrollEventThrottle={32}
         onRefresh={handleRefresh}
         refreshing={isSyncing}
         ListHeaderComponent={
           <View style={styles.listHeader}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Inbox</Text>
-            {syncProgress && syncProgress.total > 0 ? (
-              <Animated.View exiting={FadeOut.duration(200)}>
-                <Text style={[styles.headerSubtitle, { color: colors.primary }]}>
-                  Syncing {syncProgress.completed}/{syncProgress.total}...
-                </Text>
-              </Animated.View>
-            ) : (
-              <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-                {inboxCountLabel}
-              </Text>
-            )}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.filterContainer}
+            >
+              {contentTypeFilters.map((filter) => (
+                <FilterChip
+                  key={filter.id}
+                  label={filter.label}
+                  isSelected={contentTypeFilter === filter.id}
+                  onPress={() => handleContentTypeFilterPress(filter.id)}
+                  icon={filter.icon}
+                  dotColor={filter.dotColor}
+                  selectedColor={filter.selectedColor}
+                  selectedSurfaceColor={filter.selectedSurfaceColor}
+                />
+              ))}
+            </ScrollView>
           </View>
         }
         ListEmptyComponent={listEmptyComponent}
@@ -306,10 +423,10 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     ...Typography.displayMedium,
-    marginBottom: Spacing.xs,
   },
-  headerSubtitle: {
-    ...Typography.bodyMedium,
+  filterContainer: {
+    paddingTop: Spacing.md,
+    gap: Spacing.sm,
   },
   listContent: {
     flexGrow: 1,

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -18,7 +18,7 @@ import Svg, { Path } from 'react-native-svg';
 import type { ContentType as ApiContentType } from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
-import { ArticleIcon, HeadphonesIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
+import { ArticleIcon, PodcastIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import {
   Colors,
@@ -31,7 +31,7 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { getFeaturedGridItemWidth, getVisibleFeaturedGridItems } from '@/lib/home-layout';
-import { useInfiniteInboxItems, useHomeData, useLibraryItems } from '@/hooks/use-items-trpc';
+import { useInfiniteInboxItems, useHomeData } from '@/hooks/use-items-trpc';
 import {
   mapContentType,
   mapProvider,
@@ -84,7 +84,7 @@ const contentTypeFilters: {
   {
     id: 'podcast',
     label: 'Podcasts',
-    icon: HeadphonesIcon,
+    icon: PodcastIcon,
     dotColor: ContentColors.podcast,
     selectedColor: FilterChipPalette.podcast.accent,
     selectedSurfaceColor: FilterChipPalette.podcast.surface,
@@ -197,7 +197,6 @@ export default function HomeScreen() {
   const { data: homeData, isLoading: isHomeLoading } = useHomeData(
     apiContentTypeFilter ? { filter: { contentType: apiContentTypeFilter } } : undefined
   );
-  const { data: libraryData } = useLibraryItems();
   const { data: connections } = useConnections();
   const { data: subscriptionsData } = useSubscriptions();
   const { hasAttention: hasSettingsAlert } = useMemo(
@@ -290,16 +289,6 @@ export default function HomeScreen() {
       readingTimeMinutes: item.readingTimeMinutes ?? null,
     }));
   }, [homeData?.byContentType.articles]);
-
-  const categoryCounts = useMemo(() => {
-    const items = libraryData?.items ?? [];
-    return {
-      podcast: items.filter((item) => item.contentType === 'PODCAST').length,
-      video: items.filter((item) => item.contentType === 'VIDEO').length,
-      article: items.filter((item) => item.contentType === 'ARTICLE').length,
-      post: items.filter((item) => item.contentType === 'POST').length,
-    };
-  }, [libraryData?.items]);
 
   const handleOpenSettings = useCallback(() => {
     router.push('/settings');
@@ -445,13 +434,12 @@ export default function HomeScreen() {
               dotColor={filter.dotColor}
               selectedColor={filter.selectedColor}
               selectedSurfaceColor={filter.selectedSurfaceColor}
-              count={categoryCounts[filter.id]}
             />
           ))}
         </ScrollView>
       </>
     ),
-    [categoryCounts, colors.text, colors.textSubheader, contentTypeFilter, greeting]
+    [colors.text, colors.textSubheader, contentTypeFilter, greeting]
   );
 
   const renderSection = useCallback(

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -21,7 +21,7 @@ import { FilterChip } from '@/components/filter-chip';
 import {
   ArticleIcon,
   CheckOutlineIcon,
-  HeadphonesIcon,
+  PodcastIcon,
   PostIcon,
   VideoIcon,
 } from '@/components/icons';
@@ -95,7 +95,7 @@ const filterOptions: {
     id: 'podcast',
     label: 'Podcasts',
     color: ContentColors.podcast,
-    icon: HeadphonesIcon,
+    icon: PodcastIcon,
     selectedColor: FilterChipPalette.podcast.accent,
     selectedSurfaceColor: FilterChipPalette.podcast.surface,
     contentType: ApiContentType.PODCAST,

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -235,12 +235,6 @@ export default function LibraryScreen() {
     []
   );
 
-  const libraryCountLabel = isLoading
-    ? 'Loading...'
-    : hasNextPage
-      ? `${libraryItems.length}+ saved items`
-      : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`;
-
   useEffect(() => {
     const tabNavigation = navigation.getParent?.() ?? navigation;
 
@@ -311,9 +305,6 @@ export default function LibraryScreen() {
         ListHeaderComponent={
           <View style={styles.listHeader}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Library</Text>
-            <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
-              {libraryCountLabel}
-            </Text>
 
             <View style={styles.searchContainer}>
               <View
@@ -390,11 +381,6 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     ...Typography.displayMedium,
-    paddingHorizontal: Spacing.md,
-    marginBottom: Spacing.xs,
-  },
-  headerSubtitle: {
-    ...Typography.bodyMedium,
     paddingHorizontal: Spacing.md,
     marginBottom: Spacing.md,
   },

--- a/apps/mobile/components/filter-chip.stories.tsx
+++ b/apps/mobile/components/filter-chip.stories.tsx
@@ -5,7 +5,7 @@ import { FilterChipPalette, Spacing } from '@/constants/theme';
 import {
   ArticleIcon,
   CheckOutlineIcon,
-  HeadphonesIcon,
+  PodcastIcon,
   PostIcon,
   VideoIcon,
 } from '@/components/icons';
@@ -18,7 +18,7 @@ const meta = {
   args: {
     label: 'Podcasts',
     isSelected: false,
-    icon: HeadphonesIcon,
+    icon: PodcastIcon,
     onPress: () => {},
   },
   decorators: [createDarkCanvasDecorator()],
@@ -45,10 +45,9 @@ export const Selected: Story = {
   },
 };
 
-export const WithCount: Story = {
+export const Article: Story = {
   args: {
     label: 'Articles',
-    count: 42,
     icon: ArticleIcon,
   },
 };
@@ -56,7 +55,6 @@ export const WithCount: Story = {
 export const SuccessSelection: Story = {
   args: {
     label: 'Completed',
-    count: 18,
     isSelected: true,
     icon: CheckOutlineIcon,
     selectedColor: FilterChipPalette.completed.accent,
@@ -78,7 +76,7 @@ export const TypePalette: Story = {
       <FilterChip
         label="Podcasts"
         isSelected={true}
-        icon={HeadphonesIcon}
+        icon={PodcastIcon}
         selectedColor={FilterChipPalette.podcast.accent}
         selectedSurfaceColor={FilterChipPalette.podcast.surface}
         onPress={() => {}}
@@ -111,15 +109,14 @@ export const SmallVsMedium: Story = {
           label="Podcasts"
           isSelected={false}
           size="small"
-          icon={HeadphonesIcon}
+          icon={PodcastIcon}
           onPress={() => {}}
         />
         <FilterChip
           label="Podcasts"
           isSelected={true}
           size="small"
-          count={12}
-          icon={HeadphonesIcon}
+          icon={PodcastIcon}
           onPress={() => {}}
         />
       </View>
@@ -135,7 +132,6 @@ export const SmallVsMedium: Story = {
           label="Articles"
           isSelected={true}
           size="medium"
-          count={7}
           icon={ArticleIcon}
           onPress={() => {}}
         />

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -41,15 +41,12 @@ export interface FilterChipProps {
   /** Optional selected surface color for type-associated selection states */
   selectedSurfaceColor?: string;
 
-  /** Optional count badge (e.g., "12") */
-  count?: number;
-
   /** Size variant */
   size?: 'small' | 'medium';
 }
 
 /**
- * FilterChip displays a selectable chip with optional icon and count.
+ * FilterChip displays a selectable chip with an optional icon.
  * Used for filtering content by type (Articles, Podcasts, Videos, etc.).
  *
  * @example
@@ -59,7 +56,7 @@ export interface FilterChipProps {
  *   label="Podcasts"
  *   isSelected={false}
  *   onPress={() => setFilter('podcast')}
- *   icon={HeadphonesIcon}
+ *   icon={PodcastIcon}
  * />
  *
  * // Selected state
@@ -78,7 +75,6 @@ export function FilterChip({
   dotColor,
   selectedColor,
   selectedSurfaceColor,
-  count,
   size = 'medium',
 }: FilterChipProps) {
   const { colors, motion } = useAppTheme();
@@ -92,7 +88,6 @@ export function FilterChip({
   const selectedForegroundColor = hasTintedSelection ? selectedColor : colors.textPrimary;
   const unselectedForegroundColor = colors.textSubheader;
   const iconColor = isSelected ? selectedForegroundColor : unselectedForegroundColor;
-  const displayedCount = count && count > 0 ? (count > 99 ? '99+' : String(count)) : null;
 
   const sizeStyles = size === 'small' ? styles.chipSmall : styles.chipMedium;
   const textStyles = size === 'small' ? styles.textSmall : styles.textMedium;
@@ -129,18 +124,6 @@ export function FilterChip({
       >
         {label}
       </Text>
-      {displayedCount ? (
-        <Text
-          variant="bodySmall"
-          tone={isSelected ? 'primary' : 'subheader'}
-          style={[
-            styles.count,
-            { color: isSelected ? selectedForegroundColor : unselectedForegroundColor },
-          ]}
-        >
-          {displayedCount}
-        </Text>
-      ) : null}
     </Pressable>
   );
 }
@@ -172,9 +155,5 @@ const styles = StyleSheet.create({
   },
   textMedium: {
     ...Typography.labelMedium,
-  },
-  count: {
-    ...Typography.bodySmall,
-    minWidth: 18,
   },
 });

--- a/apps/mobile/components/icons/index.stories.tsx
+++ b/apps/mobile/components/icons/index.stories.tsx
@@ -14,8 +14,8 @@ import {
   CheckboxIcon,
   ChevronRightIcon,
   FilterIcon,
-  HeadphonesIcon,
   InboxArrowIcon,
+  PodcastIcon,
   PostIcon,
   PlayIcon,
   PlusCircleIcon,
@@ -40,7 +40,7 @@ type IconEntry = {
 
 const iconEntries: IconEntry[] = [
   { label: 'Article', Icon: ArticleIcon },
-  { label: 'Headphones', Icon: HeadphonesIcon },
+  { label: 'Podcast', Icon: PodcastIcon },
   { label: 'Video', Icon: VideoIcon },
   { label: 'Post', Icon: PostIcon },
   { label: 'Checkbox', Icon: CheckboxIcon },

--- a/apps/mobile/components/icons/index.tsx
+++ b/apps/mobile/components/icons/index.tsx
@@ -7,14 +7,14 @@ import {
   CheckCircle,
   ChevronRight,
   CircleCheck,
-  FileText,
   Filter,
-  Headphones,
   Inbox,
-  MessageSquare,
+  MessageCircle,
+  Newspaper,
   Play,
   Plus,
   PlusCircle,
+  Podcast,
   Rss,
   Search,
   Settings,
@@ -22,7 +22,7 @@ import {
   Sparkles,
   Square,
   SquareCheck,
-  Video,
+  Tv,
 } from 'lucide-react-native';
 
 import { Colors } from '@/constants/theme';
@@ -41,19 +41,21 @@ const DEFAULT_ICON_STROKE = Colors.dark.overlayForeground;
 // Content type icons
 
 export function ArticleIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
-  return <FileText size={size} color={color} fill={color} strokeWidth={0} />;
+  return <Newspaper size={size} color={color} strokeWidth={2} />;
 }
 
-export function HeadphonesIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
-  return <Headphones size={size} color={color} fill={color} strokeWidth={0} />;
+export function PodcastIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
+  return <Podcast size={size} color={color} strokeWidth={2} />;
 }
+
+export const HeadphonesIcon = PodcastIcon;
 
 export function VideoIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
-  return <Video size={size} color={color} fill={color} strokeWidth={0} />;
+  return <Tv size={size} color={color} strokeWidth={2} />;
 }
 
 export function PostIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
-  return <MessageSquare size={size} color={color} fill={color} strokeWidth={0} />;
+  return <MessageCircle size={size} color={color} strokeWidth={2} />;
 }
 
 // Selection icons


### PR DESCRIPTION
## Summary
- update mobile content-type icons used by shared chip/content helpers
- remove filter chip counts and Inbox/Library header count subtitles
- add content-type filter chips to Inbox with tab reselect behavior matching Home and Library

## Validation
- bun run format:check
- bun run lint
- bun run test
- bun run build
