### PR TITLE
[codex] Expand mobile description card tap target

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailDescription.tsx
@@ -41,31 +41,45 @@ export function ItemDetailDescription({
           accessibilityLabel={`Toggle ${label}`}
           accessibilityState={{ expanded: isExpanded }}
           onPress={() => setIsExpanded((current) => !current)}
-          style={({ pressed }) => [styles.descriptionHeader, pressed ? { opacity: 0.72 } : null]}
+          style={({ pressed }) => [
+            styles.descriptionToggleContent,
+            pressed ? { opacity: 0.72 } : null,
+          ]}
         >
-          <Text variant="labelSmall" tone="tertiary" colors={colors}>
-            {label}
-          </Text>
-          <Ionicons
-            name={isExpanded ? 'chevron-up' : 'chevron-down'}
-            size={IconSizes.sm}
-            color={colors.textTertiary}
-          />
+          <View style={styles.descriptionHeader}>
+            <Text variant="labelSmall" tone="tertiary" colors={colors}>
+              {label}
+            </Text>
+            <Ionicons
+              name={isExpanded ? 'chevron-up' : 'chevron-down'}
+              size={IconSizes.sm}
+              color={colors.textTertiary}
+            />
+          </View>
+          <LinkedText
+            style={[styles.description, { color: colors.textSubheader }]}
+            linkColor={colors.primary}
+            numberOfLines={descriptionLines}
+          >
+            {summary}
+          </LinkedText>
         </Pressable>
       ) : (
-        <View style={styles.descriptionHeader}>
-          <Text variant="labelSmall" tone="tertiary" colors={colors}>
-            {label}
-          </Text>
-        </View>
+        <>
+          <View style={styles.descriptionHeader}>
+            <Text variant="labelSmall" tone="tertiary" colors={colors}>
+              {label}
+            </Text>
+          </View>
+          <LinkedText
+            style={[styles.description, { color: colors.textSubheader }]}
+            linkColor={colors.primary}
+            numberOfLines={descriptionLines}
+          >
+            {summary}
+          </LinkedText>
+        </>
       )}
-      <LinkedText
-        style={[styles.description, { color: colors.textSubheader }]}
-        linkColor={colors.primary}
-        numberOfLines={descriptionLines}
-      >
-        {summary}
-      </LinkedText>
     </>
   );
 }

--- a/apps/mobile/app/item/item-detail-components.tsx
+++ b/apps/mobile/app/item/item-detail-components.tsx
@@ -1,7 +1,15 @@
 import { Ionicons } from '@expo/vector-icons';
 import { Image } from 'expo-image';
 import { Stack } from 'expo-router';
-import { View, Text, ScrollView, Pressable, Linking, type ScrollViewProps } from 'react-native';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  Linking,
+  type GestureResponderEvent,
+  type ScrollViewProps,
+} from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { SourceBadge, TypeBadge } from '@/components/badges';
@@ -38,7 +46,9 @@ export function LinkedText({
 }) {
   const parts = children.split(URL_REGEX);
 
-  const handleLinkPress = async (url: string) => {
+  const handleLinkPress = async (url: string, event?: GestureResponderEvent) => {
+    event?.stopPropagation();
+
     try {
       const supported = await Linking.canOpenURL(url);
       if (supported) {
@@ -59,7 +69,7 @@ export function LinkedText({
             <Text
               key={index}
               style={{ color: linkColor, textDecorationLine: 'underline' }}
-              onPress={() => handleLinkPress(part)}
+              onPress={(event) => handleLinkPress(part, event)}
             >
               {part}
             </Text>

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -198,6 +198,9 @@ export const styles = StyleSheet.create({
   descriptionSurface: {
     gap: Spacing.md,
   },
+  descriptionToggleContent: {
+    gap: Spacing.md,
+  },
   descriptionHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
+++ b/apps/mobile/lib/item-detail-other-bookmarks.test.tsx
@@ -259,6 +259,37 @@ describe('ItemDetailContent other creator bookmarks', () => {
     ).toBeUndefined();
   });
 
+  it('uses the whole expandable description card content as the collapse toggle', () => {
+    const summary =
+      'Current bookmark summary with enough detail to preview four lines before expanding into the complete description. It continues with more context so there is hidden content behind the collapsed state.';
+    const renderer = renderContent({
+      item: createItem({ summary }),
+      otherUnfinishedBookmarks: [
+        createItem({
+          id: 'ui-next',
+          itemId: 'item-next',
+          title: 'Next bookmark',
+          summary: 'Another thing to read',
+        }),
+      ],
+    });
+
+    const toggleButton = renderer.root.findByProps({
+      accessibilityLabel: 'Toggle Description',
+    });
+
+    expect(textContent(toggleButton)).toContain(summary);
+    expect(findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines).toBe(4);
+
+    act(() => {
+      toggleButton.props.onPress();
+    });
+
+    expect(
+      findSpanContaining(renderer, 'Current bookmark summary')?.props.numberOfLines
+    ).toBeUndefined();
+  });
+
   it('does not show a description chevron when the summary is too short to expand', () => {
     const renderer = renderContent({
       item: createItem({


### PR DESCRIPTION
## Summary

- Make the expandable mobile bookmark description card toggle when pressing anywhere in the description content, not only the header row.
- Preserve URL behavior by stopping link press propagation so tapping a link opens it without toggling collapse.
- Add focused coverage for the expanded press target behavior.

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Pre-push hook: format, design-system, typecheck, web tests, worker CI subset

Note: local lint reports two existing warnings unrelated to this change in `apps/mobile/app/(tabs)/library/index.tsx` and `apps/mobile/components/insights/weekly-recap-card.test.tsx`.
