### PR TITLE
[codex] Remove Inbox list bounce animation

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -12,7 +12,7 @@ import {
   type NativeScrollEvent,
   type NativeSyntheticEvent,
 } from 'react-native';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { ContentType as ApiContentType } from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
@@ -394,7 +394,6 @@ export default function InboxScreen() {
           </View>
         }
         ListEmptyComponent={listEmptyComponent}
-        itemLayoutAnimation={LinearTransition.springify().damping(15).stiffness(100)}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.6}
         ListFooterComponent={

--- a/apps/mobile/components/swipeable-inbox-item.tsx
+++ b/apps/mobile/components/swipeable-inbox-item.tsx
@@ -18,7 +18,6 @@
  * - ReanimatedSwipeable runs gesture handling on UI thread (not JS thread)
  * - All interpolations use useAnimatedStyle worklets (UI thread)
  * - Exit animations use hardware-accelerated transforms (SlideOut)
- * - Layout animation uses spring physics with controlled damping (no bounce)
  * - Haptics are fire-and-forget (async, non-blocking)
  * - Callbacks wrapped in useCallback to prevent re-renders
  *
@@ -48,7 +47,6 @@ import Animated, {
   type SharedValue,
   SlideOutLeft,
   SlideOutRight,
-  Layout,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
@@ -416,7 +414,6 @@ export function SwipeableInboxItem({
   return (
     <Animated.View
       exiting={exitAnimation}
-      layout={Layout.springify().damping(15).stiffness(100)}
       accessible={true}
       accessibilityRole="button"
       accessibilityLabel={`${item.title}${item.creator ? ` by ${item.creator}` : ''}`}

--- a/apps/mobile/lib/swipeable-inbox-crossplatform.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-crossplatform.test.ts
@@ -542,10 +542,10 @@ describe('SwipeableInboxItem Cross-Platform Tests', () => {
       expect(gestureConflictResolution).toBe('vertical-scroll-priority');
     });
 
-    it('itemLayoutAnimation provides smooth collapse', () => {
-      // LinearTransition.springify() for list collapse animation
-      const layoutAnimation = 'LinearTransition.springify()';
-      expect(layoutAnimation).toContain('springify');
+    it('does not spring-animate item layout during list updates', () => {
+      // Rows render and reflow without the bouncy list animation.
+      const layoutAnimation = undefined;
+      expect(layoutAnimation).toBeUndefined();
     });
   });
 

--- a/apps/mobile/lib/swipeable-inbox-item.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-item.test.ts
@@ -658,21 +658,11 @@ describe('SwipeableInboxItem', () => {
       expect(initialExitDirection).toBeNull();
     });
 
-    it('layout animation uses spring physics for smooth collapse', () => {
-      // Per issue zine-av9: List should collapse smoothly
-      // Uses Layout.springify() with damping and stiffness
-      const layoutConfig = {
-        type: 'spring',
-        damping: 15,
-        stiffness: 100,
-      };
+    it('does not apply a row layout spring on render', () => {
+      // Rows should not bounce when they first render or when siblings reflow.
+      const layoutConfig = undefined;
 
-      // Damping controls oscillation (15 is moderate, no bouncing)
-      expect(layoutConfig.damping).toBeGreaterThan(10);
-      expect(layoutConfig.damping).toBeLessThan(20);
-
-      // Stiffness controls speed (100 is quick response)
-      expect(layoutConfig.stiffness).toBeGreaterThanOrEqual(100);
+      expect(layoutConfig).toBeUndefined();
     });
 
     it('exit animation direction maps correctly for both actions', () => {
@@ -733,20 +723,15 @@ describe('SwipeableInboxItem', () => {
       expect(exitAnimation).toBe('SlideOutRight');
     });
 
-    it('FlatList uses itemLayoutAnimation for smooth list collapse', () => {
-      // Per issue zine-av9: List items should animate when siblings are removed
-      // Animated.FlatList with itemLayoutAnimation prop
+    it('FlatList leaves itemLayoutAnimation unset', () => {
+      // Avoids the bouncy scroll/reflow animation when inbox rows render.
       const flatListConfig = {
         useAnimatedFlatList: true,
-        itemLayoutAnimation: 'LinearTransition.springify()',
-        layoutSpring: {
-          damping: 15,
-          stiffness: 100,
-        },
+        itemLayoutAnimation: undefined,
       };
 
       expect(flatListConfig.useAnimatedFlatList).toBe(true);
-      expect(flatListConfig.itemLayoutAnimation).toContain('springify');
+      expect(flatListConfig.itemLayoutAnimation).toBeUndefined();
     });
 
     it('sequential swipes process independently (no race conditions)', () => {

--- a/apps/mobile/lib/swipeable-inbox-performance.test.ts
+++ b/apps/mobile/lib/swipeable-inbox-performance.test.ts
@@ -55,10 +55,6 @@ const SWIPE_FRICTION = 2;
 const SWIPE_THRESHOLD = 100;
 const ACTION_WIDTH = 100;
 
-/** Layout animation spring configuration */
-const LAYOUT_SPRING_DAMPING = 15;
-const LAYOUT_SPRING_STIFFNESS = 100;
-
 // Tests
 
 describe('SwipeableInboxItem Performance Configuration', () => {
@@ -137,33 +133,20 @@ describe('SwipeableInboxItem Performance Configuration', () => {
     });
   });
 
-  describe('list collapse animation performance', () => {
-    it('layout animation uses spring physics with controlled damping', () => {
-      // Per issue zine-iln: List collapse should be smooth
-      // Damping of 15 prevents excessive oscillation
-      expect(LAYOUT_SPRING_DAMPING).toBe(15);
-      expect(LAYOUT_SPRING_DAMPING).toBeGreaterThan(10); // Prevents bouncing
-      expect(LAYOUT_SPRING_DAMPING).toBeLessThan(20); // Still responsive
-    });
+  describe('list render behavior', () => {
+    it('does not spring-animate FlatList item layout updates', () => {
+      // Inbox rows should render without the bouncy scroll/reflow animation.
+      const flatListItemLayoutAnimation = undefined;
+      const rowLayoutAnimation = undefined;
 
-    it('layout animation stiffness provides quick response', () => {
-      // Per issue zine-iln: Stiffness of 100 provides responsive feel
-      // Lower values feel sluggish, higher values can cause overshoot
-      expect(LAYOUT_SPRING_STIFFNESS).toBe(100);
-    });
-
-    it('uses LinearTransition for predictable list updates', () => {
-      // Per issue zine-iln: LinearTransition.springify() for FlatList
-      // This applies spring physics to item position changes
-      const layoutAnimation = 'LinearTransition.springify()';
-      expect(layoutAnimation).toContain('springify');
+      expect(flatListItemLayoutAnimation).toBeUndefined();
+      expect(rowLayoutAnimation).toBeUndefined();
     });
   });
 
   describe('Animated.FlatList performance', () => {
     it('uses Animated.FlatList (not regular FlatList)', () => {
-      // Per issue zine-iln: Animated.FlatList supports itemLayoutAnimation
-      // Required for smooth list collapse when items are removed
+      // Animated.FlatList is still used for compatibility with Reanimated rows.
       const useAnimatedFlatList = true;
       expect(useAnimatedFlatList).toBe(true);
     });
@@ -399,11 +382,10 @@ describe('InboxScreen Performance Configuration', () => {
       expect(showsVerticalScrollIndicator).toBe(false);
     });
 
-    it('itemLayoutAnimation is configured', () => {
-      // Per inbox.tsx: itemLayoutAnimation={LinearTransition...}
-      // Required for smooth list collapse
-      const hasItemLayoutAnimation = true;
-      expect(hasItemLayoutAnimation).toBe(true);
+    it('itemLayoutAnimation is not configured', () => {
+      // Per inbox.tsx: leave itemLayoutAnimation unset to avoid bouncy row renders.
+      const hasItemLayoutAnimation = false;
+      expect(hasItemLayoutAnimation).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove the Inbox FlatList item layout spring that caused rows to bounce/reflow when rendered.
- Remove the row wrapper layout spring from swipeable Inbox items.
- Update Inbox swipeable characterization tests to lock in the no-bounce behavior.

## Validation
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build

## Notes
The generated Storybook file apps/mobile/.rnstorybook/storybook.requires.ts had pre-existing local changes and is intentionally not included in this PR.