### PR TITLE
chore(storybook): remove ts-ignore globals in mobile preview

### DIFF
--- a/apps/mobile/.rnstorybook/preview.tsx
+++ b/apps/mobile/.rnstorybook/preview.tsx
@@ -1,12 +1,16 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { withBackgrounds } from '@storybook/addon-ondevice-backgrounds';
 import type { Preview } from '@storybook/react-native';
 import { Platform } from 'react-native';
 
+declare global {
+  // Needed by the Storybook on-device actions addon on web.
+  // These globals are installed as no-op objects to satisfy runtime checks.
+  var ProgressTransitionRegister: Record<string, unknown>;
+  var UpdatePropsManager: Record<string, unknown>;
+}
+
 if (Platform.OS === 'web') {
-  // @ts-ignore Needed by the on-device actions addon on web.
   global.ProgressTransitionRegister = {};
-  // @ts-ignore Needed by the on-device actions addon on web.
   global.UpdatePropsManager = {};
 }
 


### PR DESCRIPTION
## Summary
- remove @ts-ignore usage in apps/mobile/.rnstorybook/preview.tsx
- add explicit global type declarations for ProgressTransitionRegister and UpdatePropsManager
- keep existing web-only runtime behavior while making intent/type-safety explicit

## Why
This is a scoped tech-debt cleanup that replaces suppression comments with typed declarations, improving maintainability without changing behavior.

## Validation
- `bunx tsc --noEmit -p apps/mobile/tsconfig.json` *(fails due pre-existing repo-wide tsconfig/dependency issues unrelated to this change)*
- `bun run --cwd apps/mobile lint` *(fails in this environment: expo command not found)*
