### PR TITLE
Add private people index for bookmarked library content

### DIFF
--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/icons';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { LoadingState, ErrorState, EmptyState } from '@/components/list-states';
+import { PersonResultRow, type PersonResultRowData } from '@/components/person-result-row';
 import {
   Colors,
   Typography,
@@ -38,6 +39,7 @@ import {
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteLibraryItems } from '@/hooks/use-items-trpc';
+import { usePeople } from '@/hooks/use-people';
 import {
   mapContentType,
   mapProvider,
@@ -130,10 +132,16 @@ type LibraryScreenNavigation = {
   isFocused: () => boolean;
 };
 
+type LibraryMode = 'items' | 'people';
+
+type LibraryRow =
+  | { type: 'item'; item: ItemCardData }
+  | { type: 'person'; person: PersonResultRowData };
+
 export default function LibraryScreen() {
   const router = useRouter();
   const navigation = useNavigation() as LibraryScreenNavigation;
-  const listScrollRef = useRef<FlatList<ItemCardData>>(null);
+  const listScrollRef = useRef<FlatList<LibraryRow>>(null);
   const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -164,6 +172,7 @@ export default function LibraryScreen() {
   const [contentTypeFilter, setContentTypeFilter] = useState<ApiContentType | null>(
     () => preselectedContentType ?? null
   );
+  const [libraryMode, setLibraryMode] = useState<LibraryMode>('items');
   const [showCompletedOnly, setShowCompletedOnly] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
@@ -200,6 +209,18 @@ export default function LibraryScreen() {
       search: debouncedSearchQuery || undefined,
       limit: LIBRARY_PAGE_SIZE,
     });
+  const {
+    data: peopleData,
+    isLoading: peopleLoading,
+    error: peopleError,
+    fetchNextPage: fetchNextPeoplePage,
+    hasNextPage: hasNextPeoplePage,
+    isFetchingNextPage: isFetchingNextPeoplePage,
+  } = usePeople({
+    query: debouncedSearchQuery || undefined,
+    limit: LIBRARY_PAGE_SIZE,
+    sort: 'count',
+  });
 
   const libraryItems: ItemCardData[] = useMemo(
     () =>
@@ -219,27 +240,71 @@ export default function LibraryScreen() {
       })),
     [data?.pages]
   );
+  const people: PersonResultRowData[] = useMemo(
+    () =>
+      (peopleData?.pages.flatMap((page) => page.people) ?? []).map((person) => ({
+        id: person.id,
+        displayName: person.displayName,
+        itemCount: person.itemCount,
+        latestItemTitle: person.latestItemTitle,
+      })),
+    [peopleData?.pages]
+  );
+  const rows: LibraryRow[] = useMemo(
+    () =>
+      libraryMode === 'people'
+        ? people.map((person) => ({ type: 'person' as const, person }))
+        : libraryItems.map((item) => ({ type: 'item' as const, item })),
+    [libraryItems, libraryMode, people]
+  );
 
   const handleEndReached = useCallback(() => {
-    if (!hasNextPage || isFetchingNextPage) {
+    if (libraryMode === 'people') {
+      if (!hasNextPeoplePage || isFetchingNextPeoplePage) {
+        return;
+      }
+
+      void fetchNextPeoplePage();
       return;
     }
 
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
     void fetchNextPage();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [
+    fetchNextPage,
+    fetchNextPeoplePage,
+    hasNextPage,
+    hasNextPeoplePage,
+    isFetchingNextPage,
+    isFetchingNextPeoplePage,
+    libraryMode,
+  ]);
 
   const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
-      <ItemCard item={item} shape="row" index={index} />
-    ),
+    ({ item, index }: ListRenderItemInfo<LibraryRow>) =>
+      item.type === 'person' ? (
+        <PersonResultRow person={item.person} source="library" />
+      ) : (
+        <ItemCard item={item.item} shape="row" index={index} />
+      ),
     []
   );
 
-  const libraryCountLabel = isLoading
+  const isActiveLoading = libraryMode === 'people' ? peopleLoading : isLoading;
+  const activeError = libraryMode === 'people' ? peopleError : error;
+  const isActiveFetchingNextPage =
+    libraryMode === 'people' ? isFetchingNextPeoplePage : isFetchingNextPage;
+  const libraryCountLabel = isActiveLoading
     ? 'Loading...'
-    : hasNextPage
-      ? `${libraryItems.length}+ saved items`
-      : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`;
+    : libraryMode === 'people'
+      ? hasNextPeoplePage
+        ? `${people.length}+ people`
+        : `${people.length} ${people.length === 1 ? 'person' : 'people'}`
+      : hasNextPage
+        ? `${libraryItems.length}+ saved items`
+        : `${libraryItems.length} saved item${libraryItems.length === 1 ? '' : 's'}`;
 
   useEffect(() => {
     const tabNavigation = navigation.getParent?.() ?? navigation;
@@ -257,19 +322,29 @@ export default function LibraryScreen() {
 
       listScrollRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
-  }, [contentTypeFilter, navigation, showCompletedOnly]);
+  }, [contentTypeFilter, navigation, scrollOffsetYRef, showCompletedOnly]);
 
-  const listEmptyComponent = isLoading ? (
+  const listEmptyComponent = isActiveLoading ? (
     <LoadingState />
-  ) : error ? (
-    <ErrorState message={error.message} />
+  ) : activeError ? (
+    <ErrorState message={activeError.message} />
   ) : (
     <EmptyState
-      title={searchQuery.trim() ? 'No matches found' : 'No bookmarked items'}
+      title={
+        searchQuery.trim()
+          ? 'No matches found'
+          : libraryMode === 'people'
+            ? 'No people yet'
+            : 'No bookmarked items'
+      }
       message={
         searchQuery.trim()
-          ? 'Try a different title or creator name.'
-          : 'Bookmark content from your inbox to save it here for later.'
+          ? libraryMode === 'people'
+            ? 'Try a different person name.'
+            : 'Try a different title or creator name.'
+          : libraryMode === 'people'
+            ? 'People appear here after your saved items are enriched.'
+            : 'Bookmark content from your inbox to save it here for later.'
       }
     />
   );
@@ -281,7 +356,7 @@ export default function LibraryScreen() {
           backgroundColor: colors.background,
           tintColor: colors.text,
           screenTitle: 'Library',
-          showScreenTitle: isLoading || Boolean(error) || showCollapsedTitle,
+          showScreenTitle: isActiveLoading || Boolean(activeError) || showCollapsedTitle,
           headerRight: () => (
             <Pressable
               onPress={handleAddBookmark}
@@ -297,8 +372,10 @@ export default function LibraryScreen() {
 
       <FlatList
         ref={listScrollRef}
-        data={isLoading || error ? [] : libraryItems}
-        keyExtractor={(item) => item.id}
+        data={isActiveLoading || activeError ? [] : rows}
+        keyExtractor={(item) =>
+          item.type === 'person' ? `person:${item.person.id}` : item.item.id
+        }
         renderItem={renderItem}
         style={styles.listContainer}
         contentContainerStyle={styles.listContent}
@@ -314,6 +391,41 @@ export default function LibraryScreen() {
             <Text style={[styles.headerSubtitle, { color: colors.textSubheader }]}>
               {libraryCountLabel}
             </Text>
+
+            <View
+              style={[
+                styles.modeSwitcher,
+                {
+                  backgroundColor: colors.backgroundSecondary,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              {(['items', 'people'] as const).map((mode) => {
+                const isSelected = libraryMode === mode;
+                return (
+                  <Pressable
+                    key={mode}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: isSelected }}
+                    onPress={() => setLibraryMode(mode)}
+                    style={[
+                      styles.modeButton,
+                      isSelected && { backgroundColor: colors.surfaceRaised },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.modeButtonText,
+                        { color: isSelected ? colors.text : colors.textTertiary },
+                      ]}
+                    >
+                      {mode === 'items' ? 'Items' : 'People'}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
 
             <View style={styles.searchContainer}>
               <View
@@ -336,42 +448,44 @@ export default function LibraryScreen() {
               </View>
             </View>
 
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={styles.filterContainer}
-            >
-              <FilterChip
-                label="Completed"
-                isSelected={showCompletedOnly}
-                onPress={() => setShowCompletedOnly((prev) => !prev)}
-                icon={CheckOutlineIcon}
-                selectedColor={FilterChipPalette.completed.accent}
-                selectedSurfaceColor={FilterChipPalette.completed.surface}
-              />
-              {filterOptions.map((option) => (
+            {libraryMode === 'items' ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filterContainer}
+              >
                 <FilterChip
-                  key={option.id}
-                  label={option.label}
-                  isSelected={contentTypeFilter === option.contentType}
-                  onPress={() =>
-                    setContentTypeFilter((current) =>
-                      current === option.contentType ? null : option.contentType
-                    )
-                  }
-                  icon={option.icon}
-                  dotColor={option.color}
-                  selectedColor={option.selectedColor}
-                  selectedSurfaceColor={option.selectedSurfaceColor}
+                  label="Completed"
+                  isSelected={showCompletedOnly}
+                  onPress={() => setShowCompletedOnly((prev) => !prev)}
+                  icon={CheckOutlineIcon}
+                  selectedColor={FilterChipPalette.completed.accent}
+                  selectedSurfaceColor={FilterChipPalette.completed.surface}
                 />
-              ))}
-            </ScrollView>
+                {filterOptions.map((option) => (
+                  <FilterChip
+                    key={option.id}
+                    label={option.label}
+                    isSelected={contentTypeFilter === option.contentType}
+                    onPress={() =>
+                      setContentTypeFilter((current) =>
+                        current === option.contentType ? null : option.contentType
+                      )
+                    }
+                    icon={option.icon}
+                    dotColor={option.color}
+                    selectedColor={option.selectedColor}
+                    selectedSurfaceColor={option.selectedSurfaceColor}
+                  />
+                ))}
+              </ScrollView>
+            ) : null}
           </View>
         }
         ListEmptyComponent={listEmptyComponent}
         ListFooterComponent={
           <View style={styles.listFooter}>
-            {!isLoading && !error && isFetchingNextPage ? (
+            {!isActiveLoading && !activeError && isActiveFetchingNextPage ? (
               <ActivityIndicator size="small" color={colors.primary} />
             ) : null}
           </View>
@@ -409,6 +523,25 @@ const styles = StyleSheet.create({
   searchContainer: {
     paddingHorizontal: Spacing.md,
     marginBottom: Spacing.md,
+  },
+  modeSwitcher: {
+    flexDirection: 'row',
+    marginHorizontal: Spacing.md,
+    marginBottom: Spacing.md,
+    padding: Spacing.xs,
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    gap: Spacing.xs,
+  },
+  modeButton: {
+    flex: 1,
+    minHeight: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: Radius.md,
+  },
+  modeButtonText: {
+    ...Typography.labelMedium,
   },
   searchBar: {
     flexDirection: 'row',

--- a/apps/mobile/app/(tabs)/search/index.tsx
+++ b/apps/mobile/app/(tabs)/search/index.tsx
@@ -7,10 +7,15 @@ import type { SearchBarCommands } from 'react-native-screens';
 
 import { type ItemCardData, ItemCard } from '@/components/item-card';
 import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
+import { PersonResultRow } from '@/components/person-result-row';
 import { Colors, Spacing, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
-import { useSearchResults, type CreatorSearchResult } from '@/hooks/use-search';
+import {
+  useSearchResults,
+  type CreatorSearchResult,
+  type PersonSearchResult,
+} from '@/hooks/use-search';
 import {
   createLightweightHeaderScreenOptions,
   useCollapsedHeaderTitle,
@@ -21,6 +26,10 @@ type SearchRow =
   | {
       type: 'creator';
       creator: CreatorSearchResult;
+    }
+  | {
+      type: 'person';
+      person: PersonSearchResult;
     }
   | {
       type: 'item';
@@ -66,6 +75,13 @@ export default function SearchTabScreen() {
           return {
             type: 'creator',
             creator: result,
+          };
+        }
+
+        if (result.type === 'person') {
+          return {
+            type: 'person',
+            person: result,
           };
         }
 
@@ -117,6 +133,20 @@ export default function SearchTabScreen() {
       return <CreatorResultRow creator={item.creator} />;
     }
 
+    if (item.type === 'person') {
+      return (
+        <PersonResultRow
+          source="search"
+          person={{
+            id: item.person.personId,
+            displayName: item.person.displayName,
+            itemCount: item.person.itemCount,
+            latestItemTitle: item.person.latestItemTitle,
+          }}
+        />
+      );
+    }
+
     return <ItemCard item={item.item} shape="row" index={index} />;
   }, []);
 
@@ -161,7 +191,11 @@ export default function SearchTabScreen() {
         ref={listScrollRef}
         data={isShowingState ? [] : searchRows}
         keyExtractor={(item) =>
-          item.type === 'creator' ? `creator:${item.creator.creatorId}` : `item:${item.item.id}`
+          item.type === 'creator'
+            ? `creator:${item.creator.creatorId}`
+            : item.type === 'person'
+              ? `person:${item.person.personId}`
+              : `item:${item.item.id}`
         }
         renderItem={renderItem}
         style={styles.listContainer}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -78,6 +78,10 @@ export default function RootLayout() {
                     name="recap/weekly"
                     options={{ headerShown: true, title: 'Weekly Recap', headerBackTitle: '' }}
                   />
+                  <Stack.Screen
+                    name="person/[id]"
+                    options={{ headerShown: true, title: 'Person', headerBackTitle: '' }}
+                  />
                   <Stack.Screen name="handle-share" options={{ headerShown: false }} />
                   <Stack.Screen
                     name="add-link"

--- a/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { View } from 'react-native';
+import { Pressable, View } from 'react-native';
+import { useRouter, type Href } from 'expo-router';
 
 import { Badge } from '@/components/primitives/badge';
 import { Surface } from '@/components/primitives/surface';
@@ -128,9 +129,29 @@ function renderTopic(topic: EnrichmentTopic, colors: ItemDetailColors) {
   );
 }
 
-function renderEntity(entity: EnrichmentEntity, colors: ItemDetailColors) {
+function renderEntity(
+  entity: EnrichmentEntity,
+  colors: ItemDetailColors,
+  onPersonPress: (personId: string) => void
+) {
   const confidence = formatPercent(entity.confidence);
-  const label = [entity.name, formatLabel(entity.type), confidence].filter(Boolean).join(' / ');
+  const isResolvedPerson = Boolean(entity.personId);
+  const label = [entity.name, formatLabel(entity.type), isResolvedPerson ? null : confidence]
+    .filter(Boolean)
+    .join(' / ');
+
+  if (entity.personId) {
+    return (
+      <Pressable
+        key={`${entity.name}-${entity.type}`}
+        accessibilityRole="button"
+        accessibilityLabel={`View ${entity.name}`}
+        onPress={() => onPersonPress(entity.personId!)}
+      >
+        <Badge label={label} tone="subtle" colors={colors} style={styles.enrichmentChip} />
+      </Pressable>
+    );
+  }
 
   return (
     <Badge
@@ -149,6 +170,12 @@ export function ItemDetailEnrichmentCard({
   error,
   colors,
 }: ItemDetailEnrichmentCardProps) {
+  const router = useRouter();
+
+  const handlePersonPress = (personId: string) => {
+    router.push(`/person/${personId}?source=item` as Href);
+  };
+
   if (isLoading) {
     return (
       <View style={styles.enrichmentContainer}>
@@ -240,7 +267,7 @@ export function ItemDetailEnrichmentCard({
 
         {item.entities.length > 0 && (
           <ChipGroup label="Entities" colors={colors}>
-            {item.entities.map((entity) => renderEntity(entity, colors))}
+            {item.entities.map((entity) => renderEntity(entity, colors, handlePersonPress))}
           </ChipGroup>
         )}
       </Surface>

--- a/apps/mobile/app/person/[id].tsx
+++ b/apps/mobile/app/person/[id].tsx
@@ -1,0 +1,168 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { useCallback, useMemo } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { Surface } from 'heroui-native';
+
+import { ItemCard, type ItemCardData } from '@/components/item-card';
+import { EmptyState, ErrorState, LoadingState } from '@/components/list-states';
+import { Colors, Spacing, Typography } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { usePerson, usePersonItems } from '@/hooks/use-people';
+import { mapContentType, mapProvider, type ContentType, type Provider } from '@/lib/content-utils';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+
+const PAGE_SIZE = 20;
+
+function formatCount(count: number): string {
+  return `${count} saved ${count === 1 ? 'item' : 'items'}`;
+}
+
+function formatLatestSeen(value: number | null): string | null {
+  if (typeof value !== 'number') return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return `Latest seen ${date.toLocaleDateString()}`;
+}
+
+export default function PersonScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const personId = typeof id === 'string' ? id : '';
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'dark'];
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
+
+  const personQuery = usePerson(personId);
+  const itemsQuery = usePersonItems(personId, { limit: PAGE_SIZE });
+
+  const items: ItemCardData[] = useMemo(
+    () =>
+      (itemsQuery.data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        creator: item.creator,
+        creatorImageUrl: item.creatorImageUrl ?? null,
+        thumbnailUrl: item.thumbnailUrl ?? null,
+        contentType: mapContentType(item.contentType) as ContentType,
+        provider: mapProvider(item.provider) as Provider,
+        duration: item.duration ?? null,
+        readingTimeMinutes: item.readingTimeMinutes ?? null,
+        bookmarkedAt: item.bookmarkedAt ?? null,
+        publishedAt: item.publishedAt ?? null,
+        isFinished: item.isFinished,
+      })),
+    [itemsQuery.data?.pages]
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (!itemsQuery.hasNextPage || itemsQuery.isFetchingNextPage) return;
+    void itemsQuery.fetchNextPage();
+  }, [itemsQuery]);
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
+      <ItemCard item={item} shape="row" index={index} />
+    ),
+    []
+  );
+
+  const person = personQuery.data;
+  const latestSeen = formatLatestSeen(person?.latestSeenAt ?? null);
+  const isLoading = personQuery.isLoading || itemsQuery.isLoading;
+  const error = personQuery.error ?? itemsQuery.error;
+
+  const header = person ? (
+    <View style={styles.header}>
+      <Text style={[styles.title, { color: colors.text }]}>{person.displayName}</Text>
+      <Text style={[styles.subtitle, { color: colors.textSubheader }]}>
+        {[formatCount(person.itemCount), latestSeen].filter(Boolean).join(' · ')}
+      </Text>
+    </View>
+  ) : null;
+
+  const empty = isLoading ? (
+    <LoadingState />
+  ) : error ? (
+    <ErrorState message={error.message} onRetry={() => personQuery.refetch()} />
+  ) : (
+    <EmptyState
+      title="No saved items"
+      message="This person no longer appears in your active library."
+    />
+  );
+
+  return (
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: person?.displayName ?? 'Person',
+          showScreenTitle: Boolean(error) || showCollapsedTitle,
+        })}
+      />
+
+      <FlatList
+        data={isLoading || error ? [] : items}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.6}
+        ListHeaderComponent={header}
+        ListEmptyComponent={empty}
+        ListFooterComponent={
+          <View style={styles.footer}>
+            {!isLoading && !error && itemsQuery.isFetchingNextPage ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : null}
+          </View>
+        }
+      />
+    </Surface>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    flexGrow: 1,
+    paddingBottom: Spacing['3xl'],
+  },
+  header: {
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
+    gap: Spacing.xs,
+  },
+  title: {
+    ...Typography.displayMedium,
+  },
+  subtitle: {
+    ...Typography.bodyMedium,
+  },
+  footer: {
+    minHeight: Spacing['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/components/person-result-row.stories.tsx
+++ b/apps/mobile/components/person-result-row.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-native';
+import { View } from 'react-native';
+
+import { createDarkCanvasDecorator } from '@/components/storybook/decorators';
+import { Spacing } from '@/constants/theme';
+
+import { PersonResultRow } from './person-result-row';
+
+const meta = {
+  title: 'People/PersonResultRow',
+  component: PersonResultRow,
+  decorators: [createDarkCanvasDecorator({ height: 260, padding: Spacing.md })],
+  args: {
+    person: {
+      id: 'person-joe-rogan',
+      displayName: 'Joe Rogan',
+      itemCount: 12,
+      latestItemTitle: 'The economics of long-form interviews',
+    },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+    },
+  },
+} satisfies Meta<typeof PersonResultRow>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const List: Story = {
+  render: () => (
+    <View>
+      <PersonResultRow
+        person={{
+          id: 'person-joe-rogan',
+          displayName: 'Joe Rogan',
+          itemCount: 12,
+          latestItemTitle: 'The economics of long-form interviews',
+        }}
+      />
+      <PersonResultRow
+        person={{
+          id: 'person-mary-meeker',
+          displayName: 'Mary Meeker',
+          itemCount: 4,
+          latestItemTitle: null,
+        }}
+      />
+    </View>
+  ),
+};

--- a/apps/mobile/components/person-result-row.tsx
+++ b/apps/mobile/components/person-result-row.tsx
@@ -1,0 +1,94 @@
+import { useRouter, type Href } from 'expo-router';
+import { memo, useCallback, useMemo } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { Surface, Text } from '@/components/primitives';
+import { Radius, Spacing } from '@/constants/theme';
+import { useAppTheme } from '@/hooks/use-app-theme';
+
+export type PersonResultRowData = {
+  id: string;
+  displayName: string;
+  itemCount: number;
+  latestItemTitle?: string | null;
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function getCountText(count: number): string {
+  return `${count} saved ${count === 1 ? 'item' : 'items'}`;
+}
+
+export const PersonResultRow = memo(function PersonResultRow({
+  person,
+  source = 'library',
+}: {
+  person: PersonResultRowData;
+  source?: 'library' | 'search';
+}) {
+  const router = useRouter();
+  const { colors, motion } = useAppTheme();
+  const initials = useMemo(() => getInitials(person.displayName), [person.displayName]);
+
+  const handlePress = useCallback(() => {
+    router.push(`/person/${person.id}?source=${source}` as Href);
+  }, [person.id, router, source]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${person.displayName}, ${getCountText(person.itemCount)}`}
+      onPress={handlePress}
+      style={({ pressed }) => [styles.pressable, pressed && { opacity: motion.opacity.pressed }]}
+    >
+      <Surface tone="transparent" style={styles.row}>
+        <View style={[styles.avatar, { backgroundColor: colors.surfaceRaised }]}>
+          <Text variant="labelLarge" tone="secondary" transform="none">
+            {initials}
+          </Text>
+        </View>
+
+        <View style={styles.content}>
+          <Text variant="bodyMedium" tone="primary" numberOfLines={1}>
+            {person.displayName}
+          </Text>
+          <Text variant="bodySmall" tone="tertiary" numberOfLines={1}>
+            {getCountText(person.itemCount)}
+          </Text>
+        </View>
+      </Surface>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  pressable: {
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.xs,
+  },
+  row: {
+    minHeight: 72,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  avatar: {
+    width: 52,
+    height: 52,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    flex: 1,
+    minWidth: 0,
+    gap: Spacing.xs,
+  },
+});

--- a/apps/mobile/hooks/use-people.test.ts
+++ b/apps/mobile/hooks/use-people.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+const mockPeopleListUseInfiniteQuery = jest.fn();
+const mockPeopleGetUseQuery = jest.fn();
+const mockPeopleListItemsUseInfiniteQuery = jest.fn();
+
+jest.mock('../lib/trpc', () => ({
+  trpc: {
+    people: {
+      list: {
+        useInfiniteQuery: mockPeopleListUseInfiniteQuery,
+      },
+      get: {
+        useQuery: mockPeopleGetUseQuery,
+      },
+      listItems: {
+        useInfiniteQuery: mockPeopleListItemsUseInfiniteQuery,
+      },
+    },
+  },
+}));
+
+import { usePeople, usePerson, usePersonItems } from './use-people';
+
+describe('people hooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPeopleListUseInfiniteQuery.mockReturnValue({ data: undefined });
+    mockPeopleGetUseQuery.mockReturnValue({ data: undefined });
+    mockPeopleListItemsUseInfiniteQuery.mockReturnValue({ data: undefined });
+  });
+
+  it('requests people with default count sorting', () => {
+    renderHook(() => usePeople({ query: 'Joe', limit: 10 }));
+
+    expect(mockPeopleListUseInfiniteQuery).toHaveBeenCalledWith(
+      {
+        query: 'Joe',
+        limit: 10,
+        sort: 'count',
+      },
+      expect.objectContaining({
+        placeholderData: expect.any(Function),
+      })
+    );
+  });
+
+  it('disables person profile queries until an id is available', () => {
+    renderHook(() => usePerson(''));
+
+    expect(mockPeopleGetUseQuery).toHaveBeenCalledWith(
+      { personId: '' },
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it('requests person items with pagination enabled for valid ids', () => {
+    renderHook(() => usePersonItems('person-1', { limit: 5 }));
+
+    expect(mockPeopleListItemsUseInfiniteQuery).toHaveBeenCalledWith(
+      { personId: 'person-1', limit: 5 },
+      expect.objectContaining({ enabled: true })
+    );
+  });
+});

--- a/apps/mobile/hooks/use-people.ts
+++ b/apps/mobile/hooks/use-people.ts
@@ -1,0 +1,45 @@
+import { keepPreviousData } from '@tanstack/react-query';
+
+import { trpc } from '@/lib/trpc';
+import type { RouterOutputs } from '@/lib/trpc-types';
+
+export type PeopleListOutput = RouterOutputs['people']['list'];
+export type PersonListItem = PeopleListOutput['people'][number];
+export type PersonProfile = RouterOutputs['people']['get'];
+export type PersonItem = RouterOutputs['people']['listItems']['items'][number];
+
+export function usePeople(options?: { query?: string; limit?: number; sort?: 'count' | 'recent' }) {
+  return trpc.people.list.useInfiniteQuery(
+    {
+      query: options?.query,
+      limit: options?.limit ?? 20,
+      sort: options?.sort ?? 'count',
+    },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      placeholderData: keepPreviousData,
+    }
+  );
+}
+
+export function usePerson(personId: string) {
+  return trpc.people.get.useQuery(
+    { personId },
+    {
+      enabled: !!personId,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
+    }
+  );
+}
+
+export function usePersonItems(personId: string, options?: { limit?: number }) {
+  return trpc.people.listItems.useInfiniteQuery(
+    { personId, limit: options?.limit ?? 20 },
+    {
+      enabled: !!personId,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      placeholderData: keepPreviousData,
+    }
+  );
+}

--- a/apps/mobile/hooks/use-search.test.ts
+++ b/apps/mobile/hooks/use-search.test.ts
@@ -28,6 +28,7 @@ describe('useSearchResults', () => {
         query: 'Joe Rogan',
         scope: 'library',
         creatorsLimit: 5,
+        peopleLimit: 5,
         itemsLimit: 20,
       },
       expect.objectContaining({

--- a/apps/mobile/hooks/use-search.ts
+++ b/apps/mobile/hooks/use-search.ts
@@ -6,12 +6,14 @@ import type { RouterOutputs } from '@/lib/trpc-types';
 export type SearchOutput = RouterOutputs['search']['query'];
 export type SearchResult = SearchOutput['results'][number];
 export type CreatorSearchResult = Extract<SearchResult, { type: 'creator' }>;
+export type PersonSearchResult = Extract<SearchResult, { type: 'person' }>;
 export type ItemSearchResult = Extract<SearchResult, { type: 'item' }>;
 
 export function useSearchResults(
   query: string,
   options?: {
     creatorsLimit?: number;
+    peopleLimit?: number;
     itemsLimit?: number;
   }
 ) {
@@ -23,6 +25,7 @@ export function useSearchResults(
       query: enabled ? trimmedQuery : ' ',
       scope: 'library',
       creatorsLimit: options?.creatorsLimit ?? 5,
+      peopleLimit: options?.peopleLimit ?? 5,
       itemsLimit: options?.itemsLimit ?? 20,
     },
     {

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -244,6 +244,23 @@ jest.mock('@/hooks/use-items-trpc', () => ({
   mapProvider: (value: string) => value,
 }));
 
+jest.mock('@/hooks/use-people', () => ({
+  usePeople: () => ({
+    data: {
+      pages: [
+        {
+          people: [],
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+
 const LibraryScreen = jest.requireActual('@/app/(tabs)/library').default;
 
 describe('LibraryScreen', () => {

--- a/apps/worker/src/db/migrations/0011_add_user_people.sql
+++ b/apps/worker/src/db/migrations/0011_add_user_people.sql
@@ -1,0 +1,52 @@
+-- Created: 2026-05-03
+-- Add private per-user people index derived from bookmark enrichment entities
+
+CREATE TABLE IF NOT EXISTS `user_people` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `display_name` text NOT NULL,
+  `normalized_name` text NOT NULL,
+  `item_count` integer NOT NULL DEFAULT 0,
+  `latest_seen_at` integer,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `user_people_user_normalized_idx`
+  ON `user_people` (`user_id`, `normalized_name`);
+
+CREATE INDEX IF NOT EXISTS `user_people_user_count_seen_idx`
+  ON `user_people` (`user_id`, `item_count` DESC, `latest_seen_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `user_people_user_seen_idx`
+  ON `user_people` (`user_id`, `latest_seen_at` DESC);
+
+CREATE TABLE IF NOT EXISTS `user_person_mentions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `user_person_id` text NOT NULL REFERENCES `user_people`(`id`),
+  `user_item_id` text NOT NULL REFERENCES `user_items`(`id`),
+  `item_id` text NOT NULL REFERENCES `items`(`id`),
+  `item_enrichment_id` text NOT NULL REFERENCES `item_enrichments`(`id`),
+  `raw_name` text NOT NULL,
+  `raw_type` text NOT NULL,
+  `relationship` text NOT NULL DEFAULT 'MENTIONED',
+  `confidence` real NOT NULL,
+  `evidence_text` text,
+  `seen_at` integer NOT NULL,
+  `is_active` integer NOT NULL DEFAULT 1,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `user_person_mentions_user_item_person_idx`
+  ON `user_person_mentions` (`user_id`, `user_item_id`, `user_person_id`);
+
+CREATE INDEX IF NOT EXISTS `user_person_mentions_person_active_idx`
+  ON `user_person_mentions` (`user_person_id`, `is_active`, `updated_at` DESC);
+
+CREATE INDEX IF NOT EXISTS `user_person_mentions_user_item_idx`
+  ON `user_person_mentions` (`user_id`, `item_id`);
+
+CREATE INDEX IF NOT EXISTS `user_person_mentions_user_active_confidence_idx`
+  ON `user_person_mentions` (`user_id`, `is_active`, `confidence` DESC);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777593600000,
       "tag": "0010_add_x_bookmark_syncs",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777766400000,
+      "tag": "0011_add_user_people",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -269,6 +269,82 @@ export const userItemEnrichments = sqliteTable(
   ]
 );
 
+// User People
+// Private per-user people index derived from bookmarked item enrichment.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const userPeople = sqliteTable(
+  'user_people',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    displayName: text('display_name').notNull(),
+    normalizedName: text('normalized_name').notNull(),
+    itemCount: integer('item_count').notNull().default(0),
+    latestSeenAt: integer('latest_seen_at'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('user_people_user_normalized_idx').on(table.userId, table.normalizedName),
+    index('user_people_user_count_seen_idx').on(table.userId, table.itemCount, table.latestSeenAt),
+    index('user_people_user_seen_idx').on(table.userId, table.latestSeenAt),
+  ]
+);
+
+// User Person Mentions
+// Active/deactivated per-user associations between bookmarked items and user_people.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const userPersonMentions = sqliteTable(
+  'user_person_mentions',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    userPersonId: text('user_person_id')
+      .notNull()
+      .references(() => userPeople.id),
+    userItemId: text('user_item_id')
+      .notNull()
+      .references(() => userItems.id),
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id),
+    itemEnrichmentId: text('item_enrichment_id')
+      .notNull()
+      .references(() => itemEnrichments.id),
+    rawName: text('raw_name').notNull(),
+    rawType: text('raw_type').notNull(),
+    relationship: text('relationship').notNull().default('MENTIONED'),
+    confidence: real('confidence').notNull(),
+    evidenceText: text('evidence_text'),
+    seenAt: integer('seen_at').notNull(),
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('user_person_mentions_user_item_person_idx').on(
+      table.userId,
+      table.userItemId,
+      table.userPersonId
+    ),
+    index('user_person_mentions_person_active_idx').on(
+      table.userPersonId,
+      table.isActive,
+      table.updatedAt
+    ),
+    index('user_person_mentions_user_item_idx').on(table.userId, table.itemId),
+    index('user_person_mentions_user_active_confidence_idx').on(
+      table.userId,
+      table.isActive,
+      table.confidence
+    ),
+  ]
+);
+
 // Item Embedding References
 // D1 reference records for vectors stored in Cloudflare Vectorize.
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.

--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -13,6 +13,7 @@ import {
 } from '../db/schema';
 import { getArticleContent } from '../lib/article-storage';
 import { logger } from '../lib/logger';
+import { syncPeopleForItem } from '../people/service';
 import type { Bindings } from '../types';
 import { upsertItemEmbedding } from './embeddings';
 import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
@@ -403,6 +404,15 @@ async function processMessage(message: EnrichmentMessage, db: Database, env: Bin
         reasonToRevisit: existingCanonical.summaryShort,
       });
 
+      try {
+        await syncPeopleForItem(db, { itemId: effectiveBody.itemId });
+      } catch (error) {
+        enrichmentLogger.warn('People indexing failed for existing canonical enrichment', {
+          itemId: effectiveBody.itemId,
+          error,
+        });
+      }
+
       message.ack();
       return;
     }
@@ -420,6 +430,15 @@ async function processMessage(message: EnrichmentMessage, db: Database, env: Bin
     const output = await enrichWithQwen(env, promptInput);
 
     await writeCanonicalComplete(db, effectiveBody, output, env);
+
+    try {
+      await syncPeopleForItem(db, { itemId: effectiveBody.itemId });
+    } catch (error) {
+      enrichmentLogger.warn('People indexing failed after enrichment completion', {
+        itemId: effectiveBody.itemId,
+        error,
+      });
+    }
 
     const suggestedTags = normalizeSuggestedTags(output.suggestedTags, existingTags);
     await writeUserComplete(db, effectiveBody, {

--- a/apps/worker/src/people/backfill.ts
+++ b/apps/worker/src/people/backfill.ts
@@ -1,0 +1,109 @@
+import { and, eq, gt } from 'drizzle-orm';
+import { UserItemState } from '@zine/shared';
+
+import type { Database } from '../db';
+import { userItems } from '../db/schema';
+import { logger } from '../lib/logger';
+import { syncPeopleForUserItem } from './service';
+
+const backfillLogger = logger.child('people-backfill');
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
+
+export interface PeopleBackfillOptions {
+  dryRun?: boolean;
+  limit?: number;
+  cursor?: string | null;
+  userId?: string | null;
+}
+
+export interface PeopleBackfillResult {
+  dryRun: boolean;
+  limit: number;
+  cursor: string | null;
+  nextCursor: string | null;
+  scanned: number;
+  indexed: number;
+  deactivated: number;
+  skipped: number;
+  candidates: Array<{
+    userItemId: string;
+    userId: string;
+    itemId: string;
+  }>;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(value)));
+}
+
+export async function backfillPeopleIndex(
+  db: Database,
+  options: PeopleBackfillOptions = {}
+): Promise<PeopleBackfillResult> {
+  const dryRun = options.dryRun ?? true;
+  const limit = normalizeLimit(options.limit);
+  const cursor = options.cursor ?? null;
+  const conditions = [eq(userItems.state, UserItemState.BOOKMARKED)];
+
+  if (cursor) {
+    conditions.push(gt(userItems.id, cursor));
+  }
+  if (options.userId) {
+    conditions.push(eq(userItems.userId, options.userId));
+  }
+
+  const rows = await db
+    .select({
+      userItemId: userItems.id,
+      userId: userItems.userId,
+      itemId: userItems.itemId,
+    })
+    .from(userItems)
+    .where(and(...conditions))
+    .orderBy(userItems.id)
+    .limit(limit);
+
+  let indexed = 0;
+  let deactivated = 0;
+  let skipped = 0;
+
+  if (!dryRun) {
+    for (const row of rows) {
+      const result = await syncPeopleForUserItem(db, {
+        userId: row.userId,
+        userItemId: row.userItemId,
+      });
+      indexed += result.indexed;
+      deactivated += result.deactivated;
+      skipped += result.skipped;
+    }
+  }
+
+  const nextCursor = rows.length === limit ? (rows[rows.length - 1]?.userItemId ?? null) : null;
+
+  backfillLogger.info('People backfill page processed', {
+    dryRun,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: rows.length,
+    indexed,
+    deactivated,
+    skipped,
+  });
+
+  return {
+    dryRun,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: rows.length,
+    indexed,
+    deactivated,
+    skipped,
+    candidates: rows,
+  };
+}

--- a/apps/worker/src/people/service.test.ts
+++ b/apps/worker/src/people/service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractPersonEntities, normalizePersonName } from './service';
+
+describe('people service helpers', () => {
+  it('normalizes person names conservatively', () => {
+    expect(normalizePersonName('  Joe   Rogan  ')).toBe('joe rogan');
+    expect(normalizePersonName('"Sam Harris."')).toBe('sam harris');
+    expect(normalizePersonName('Joseph Rogan')).toBe('joseph rogan');
+  });
+
+  it('extracts high-confidence PERSON entities and dedupes by normalized name', () => {
+    const people = extractPersonEntities(
+      JSON.stringify([
+        { name: 'Joe Rogan', type: 'PERSON', confidence: 0.9 },
+        { name: 'joe rogan', type: 'person', confidence: 0.7 },
+        { name: 'OpenAI', type: 'ORG', confidence: 0.95 },
+        { name: 'Low Confidence', type: 'PERSON', confidence: 0.4 },
+        { name: 'Sam Harris', type: 'PERSON', confidence: 0.8 },
+      ])
+    );
+
+    expect(people).toEqual([
+      {
+        rawName: 'Joe Rogan',
+        rawType: 'PERSON',
+        displayName: 'Joe Rogan',
+        normalizedName: 'joe rogan',
+        confidence: 0.9,
+      },
+      {
+        rawName: 'Sam Harris',
+        rawType: 'PERSON',
+        displayName: 'Sam Harris',
+        normalizedName: 'sam harris',
+        confidence: 0.8,
+      },
+    ]);
+  });
+
+  it('returns no candidates for malformed enrichment JSON', () => {
+    expect(extractPersonEntities('{not json')).toEqual([]);
+    expect(extractPersonEntities(JSON.stringify({ name: 'Joe Rogan' }))).toEqual([]);
+  });
+});

--- a/apps/worker/src/people/service.ts
+++ b/apps/worker/src/people/service.ts
@@ -1,0 +1,440 @@
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { ulid } from 'ulid';
+import { UserItemState } from '@zine/shared';
+
+import type { Database } from '../db';
+import { itemEnrichments, userItems, userPeople, userPersonMentions } from '../db/schema';
+import { logger } from '../lib/logger';
+import { ENRICHMENT_SCHEMA_VERSION } from '../enrichment/types';
+
+const peopleLogger = logger.child('people-service');
+
+export const PERSON_CONFIDENCE_THRESHOLD = 0.65;
+
+type UserItemPersonSource = {
+  id: string;
+  userId: string;
+  itemId: string;
+  state: string;
+  ingestedAt: string;
+  bookmarkedAt: string | null;
+};
+
+type CompleteEnrichment = typeof itemEnrichments.$inferSelect;
+
+export type PersonIndexStats = {
+  indexed: number;
+  deactivated: number;
+  skipped: number;
+};
+
+type PersonEntityCandidate = {
+  rawName: string;
+  rawType: string;
+  displayName: string;
+  normalizedName: string;
+  confidence: number;
+};
+
+function toFiniteConfidence(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeEntityType(value: string): string {
+  return value.trim().toLowerCase().replace(/[_-]+/g, ' ');
+}
+
+export function normalizePersonName(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[\s"'`.,;:!?()[\]{}<>]+/, '')
+    .replace(/[\s"'`.,;:!?()[\]{}<>]+$/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeDisplayName(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[\s"'`.,;:!?()[\]{}<>]+/, '')
+    .replace(/[\s"'`.,;:!?()[\]{}<>]+$/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function extractPersonEntities(entitiesJson: string | null): PersonEntityCandidate[] {
+  if (!entitiesJson) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(entitiesJson);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) return [];
+
+  const deduped = new Map<string, PersonEntityCandidate>();
+
+  for (const entity of parsed) {
+    if (!entity || typeof entity !== 'object' || Array.isArray(entity)) continue;
+
+    const candidate = entity as { name?: unknown; type?: unknown; confidence?: unknown };
+    if (typeof candidate.name !== 'string' || typeof candidate.type !== 'string') continue;
+
+    const confidence = toFiniteConfidence(candidate.confidence);
+    if (confidence === null || confidence < PERSON_CONFIDENCE_THRESHOLD) continue;
+
+    if (normalizeEntityType(candidate.type) !== 'person') continue;
+
+    const displayName = normalizeDisplayName(candidate.name);
+    const normalizedName = normalizePersonName(candidate.name);
+    if (!displayName || !normalizedName) continue;
+
+    const next: PersonEntityCandidate = {
+      rawName: candidate.name,
+      rawType: candidate.type,
+      displayName,
+      normalizedName,
+      confidence,
+    };
+    const existing = deduped.get(normalizedName);
+    if (!existing || next.confidence > existing.confidence) {
+      deduped.set(normalizedName, next);
+    }
+  }
+
+  return [...deduped.values()];
+}
+
+function parseIsoMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getSeenAt(userItem: Pick<UserItemPersonSource, 'bookmarkedAt' | 'ingestedAt'>): number {
+  return parseIsoMs(userItem.bookmarkedAt) ?? parseIsoMs(userItem.ingestedAt) ?? Date.now();
+}
+
+async function loadLatestCompleteEnrichment(
+  db: Database,
+  itemId: string
+): Promise<CompleteEnrichment | null> {
+  const rows = await db
+    .select()
+    .from(itemEnrichments)
+    .where(
+      and(
+        eq(itemEnrichments.itemId, itemId),
+        eq(itemEnrichments.schemaVersion, ENRICHMENT_SCHEMA_VERSION),
+        eq(itemEnrichments.status, 'COMPLETE')
+      )
+    )
+    .orderBy(desc(itemEnrichments.updatedAt))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+async function upsertUserPerson(
+  db: Database,
+  input: {
+    userId: string;
+    displayName: string;
+    normalizedName: string;
+    now: number;
+  }
+): Promise<string> {
+  const existing = await db
+    .select({ id: userPeople.id })
+    .from(userPeople)
+    .where(
+      and(eq(userPeople.userId, input.userId), eq(userPeople.normalizedName, input.normalizedName))
+    )
+    .limit(1);
+
+  if (existing[0]) return existing[0].id;
+
+  const id = ulid();
+  await db.insert(userPeople).values({
+    id,
+    userId: input.userId,
+    displayName: input.displayName,
+    normalizedName: input.normalizedName,
+    itemCount: 0,
+    latestSeenAt: null,
+    createdAt: input.now,
+    updatedAt: input.now,
+  });
+
+  return id;
+}
+
+async function recomputePeopleStats(db: Database, personIds: Iterable<string>): Promise<void> {
+  const uniqueIds = [...new Set(personIds)].filter(Boolean);
+
+  for (const personId of uniqueIds) {
+    const rows = await db
+      .select({
+        itemCount: sql<number>`count(*)`,
+        latestSeenAt: sql<number | null>`max(${userPersonMentions.seenAt})`,
+      })
+      .from(userPersonMentions)
+      .where(
+        and(eq(userPersonMentions.userPersonId, personId), eq(userPersonMentions.isActive, true))
+      )
+      .limit(1);
+
+    const row = rows[0];
+    const itemCount = Number(row?.itemCount ?? 0);
+    const latestSeenAt =
+      row?.latestSeenAt === null || row?.latestSeenAt === undefined
+        ? null
+        : Number(row.latestSeenAt);
+
+    await db
+      .update(userPeople)
+      .set({
+        itemCount,
+        latestSeenAt: Number.isFinite(latestSeenAt) ? latestSeenAt : null,
+        updatedAt: Date.now(),
+      })
+      .where(eq(userPeople.id, personId));
+  }
+}
+
+async function syncPeopleForBookmarkedUserItem(
+  db: Database,
+  userItem: UserItemPersonSource,
+  enrichment: CompleteEnrichment
+): Promise<PersonIndexStats> {
+  const now = Date.now();
+  const seenAt = getSeenAt(userItem);
+  const people = extractPersonEntities(enrichment.entitiesJson);
+  const activeBefore = await db
+    .select({ userPersonId: userPersonMentions.userPersonId })
+    .from(userPersonMentions)
+    .where(
+      and(
+        eq(userPersonMentions.userId, userItem.userId),
+        eq(userPersonMentions.userItemId, userItem.id),
+        eq(userPersonMentions.isActive, true)
+      )
+    );
+
+  const activeBeforeIds = new Set(activeBefore.map((row) => row.userPersonId));
+  const desiredPersonIds = new Set<string>();
+  const affectedPersonIds = new Set(activeBeforeIds);
+
+  for (const person of people) {
+    const userPersonId = await upsertUserPerson(db, {
+      userId: userItem.userId,
+      displayName: person.displayName,
+      normalizedName: person.normalizedName,
+      now,
+    });
+
+    desiredPersonIds.add(userPersonId);
+    affectedPersonIds.add(userPersonId);
+
+    await db
+      .insert(userPersonMentions)
+      .values({
+        id: ulid(),
+        userId: userItem.userId,
+        userPersonId,
+        userItemId: userItem.id,
+        itemId: userItem.itemId,
+        itemEnrichmentId: enrichment.id,
+        rawName: person.rawName,
+        rawType: person.rawType,
+        relationship: 'MENTIONED',
+        confidence: person.confidence,
+        evidenceText: null,
+        seenAt,
+        isActive: true,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          userPersonMentions.userId,
+          userPersonMentions.userItemId,
+          userPersonMentions.userPersonId,
+        ],
+        set: {
+          itemId: userItem.itemId,
+          itemEnrichmentId: enrichment.id,
+          rawName: person.rawName,
+          rawType: person.rawType,
+          relationship: 'MENTIONED',
+          confidence: person.confidence,
+          seenAt,
+          isActive: true,
+          updatedAt: now,
+        },
+      });
+  }
+
+  const stalePersonIds = [...activeBeforeIds].filter((personId) => !desiredPersonIds.has(personId));
+  if (stalePersonIds.length > 0) {
+    await db
+      .update(userPersonMentions)
+      .set({ isActive: false, updatedAt: now })
+      .where(
+        and(
+          eq(userPersonMentions.userId, userItem.userId),
+          eq(userPersonMentions.userItemId, userItem.id),
+          inArray(userPersonMentions.userPersonId, stalePersonIds)
+        )
+      );
+  }
+
+  await recomputePeopleStats(db, affectedPersonIds);
+
+  return {
+    indexed: desiredPersonIds.size,
+    deactivated: stalePersonIds.length,
+    skipped: people.length === 0 ? 1 : 0,
+  };
+}
+
+export async function deactivatePeopleForUserItem(
+  db: Database,
+  input: { userId: string; userItemId: string }
+): Promise<PersonIndexStats> {
+  const activeMentions = await db
+    .select({ userPersonId: userPersonMentions.userPersonId })
+    .from(userPersonMentions)
+    .where(
+      and(
+        eq(userPersonMentions.userId, input.userId),
+        eq(userPersonMentions.userItemId, input.userItemId),
+        eq(userPersonMentions.isActive, true)
+      )
+    );
+
+  if (activeMentions.length === 0) {
+    return { indexed: 0, deactivated: 0, skipped: 1 };
+  }
+
+  await db
+    .update(userPersonMentions)
+    .set({ isActive: false, updatedAt: Date.now() })
+    .where(
+      and(
+        eq(userPersonMentions.userId, input.userId),
+        eq(userPersonMentions.userItemId, input.userItemId),
+        eq(userPersonMentions.isActive, true)
+      )
+    );
+
+  await recomputePeopleStats(
+    db,
+    activeMentions.map((row) => row.userPersonId)
+  );
+
+  return { indexed: 0, deactivated: activeMentions.length, skipped: 0 };
+}
+
+export async function syncPeopleForUserItem(
+  db: Database,
+  input: { userId: string; userItemId: string }
+): Promise<PersonIndexStats> {
+  const rows = await db
+    .select({
+      id: userItems.id,
+      userId: userItems.userId,
+      itemId: userItems.itemId,
+      state: userItems.state,
+      ingestedAt: userItems.ingestedAt,
+      bookmarkedAt: userItems.bookmarkedAt,
+    })
+    .from(userItems)
+    .where(and(eq(userItems.id, input.userItemId), eq(userItems.userId, input.userId)))
+    .limit(1);
+
+  const userItem = rows[0];
+  if (!userItem) return { indexed: 0, deactivated: 0, skipped: 1 };
+
+  if (userItem.state !== UserItemState.BOOKMARKED) {
+    return deactivatePeopleForUserItem(db, input);
+  }
+
+  const enrichment = await loadLatestCompleteEnrichment(db, userItem.itemId);
+  if (!enrichment) return { indexed: 0, deactivated: 0, skipped: 1 };
+
+  return syncPeopleForBookmarkedUserItem(db, userItem, enrichment);
+}
+
+export async function syncPeopleForItem(
+  db: Database,
+  input: { itemId: string }
+): Promise<PersonIndexStats> {
+  const enrichment = await loadLatestCompleteEnrichment(db, input.itemId);
+  if (!enrichment) return { indexed: 0, deactivated: 0, skipped: 1 };
+
+  const rows = await db
+    .select({
+      id: userItems.id,
+      userId: userItems.userId,
+      itemId: userItems.itemId,
+      state: userItems.state,
+      ingestedAt: userItems.ingestedAt,
+      bookmarkedAt: userItems.bookmarkedAt,
+    })
+    .from(userItems)
+    .where(and(eq(userItems.itemId, input.itemId), eq(userItems.state, UserItemState.BOOKMARKED)));
+
+  const totals: PersonIndexStats = { indexed: 0, deactivated: 0, skipped: 0 };
+  for (const userItem of rows) {
+    const result = await syncPeopleForBookmarkedUserItem(db, userItem, enrichment);
+    totals.indexed += result.indexed;
+    totals.deactivated += result.deactivated;
+    totals.skipped += result.skipped;
+  }
+
+  return totals;
+}
+
+export async function syncPeopleForUserItemBestEffort(
+  db: Database,
+  input: { userId: string; userItemId: string; operation: string }
+): Promise<void> {
+  try {
+    await syncPeopleForUserItem(db, input);
+  } catch (error) {
+    peopleLogger.warn('People indexing failed', {
+      operation: input.operation,
+      userId: input.userId,
+      userItemId: input.userItemId,
+      error,
+    });
+  }
+}
+
+export async function deactivatePeopleForUserItemBestEffort(
+  db: Database,
+  input: { userId: string; userItemId: string; operation: string }
+): Promise<void> {
+  try {
+    await deactivatePeopleForUserItem(db, input);
+  } catch (error) {
+    peopleLogger.warn('People deactivation failed', {
+      operation: input.operation,
+      userId: input.userId,
+      userItemId: input.userItemId,
+      error,
+    });
+  }
+}
+
+export const peopleServiceInternals = {
+  extractPersonEntities,
+  normalizePersonName,
+  recomputePeopleStats,
+};

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -11,6 +11,7 @@ import { creatorsRouter } from './routers/creators';
 import { adminRouter } from './routers/admin';
 import { insightsRouter } from './routers/insights';
 import { searchRouter } from './routers/search';
+import { peopleRouter } from './routers/people';
 
 /**
  * Root tRPC router
@@ -66,6 +67,7 @@ export const appRouter = router({
   admin: adminRouter,
   // Creator view operations
   creators: creatorsRouter,
+  people: peopleRouter,
   search: searchRouter,
   insights: insightsRouter,
 });

--- a/apps/worker/src/trpc/routers/admin.ts
+++ b/apps/worker/src/trpc/routers/admin.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure } from '../trpc';
 import { ProviderSchema } from '@zine/shared';
 import {
@@ -16,6 +17,7 @@ import {
   verifyRepairs,
   generateRepairReport,
 } from '../../admin/repair-subscriptions';
+import { backfillPeopleIndex } from '../../people/backfill';
 import { logger } from '../../lib/logger';
 
 const adminLogger = logger.child('admin');
@@ -48,6 +50,13 @@ const RepairInputSchema = z.object({
 const VerifyInputSchema = z.object({
   /** Provider to verify (default: SPOTIFY) */
   provider: ProviderSchema.optional(),
+});
+
+const BackfillPeopleInputSchema = z.object({
+  dryRun: z.boolean().default(true),
+  limit: z.number().int().min(1).max(500).default(100),
+  cursor: z.string().nullable().optional(),
+  userId: z.string().nullable().optional(),
 });
 
 // Router
@@ -168,6 +177,31 @@ export const adminRouter = router({
       });
 
       return result;
+    }),
+
+  backfillPeople: protectedProcedure
+    .input(BackfillPeopleInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (input.userId && input.userId !== ctx.userId) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'People backfill can only run for the current user',
+        });
+      }
+
+      adminLogger.info('backfillPeople called', {
+        userId: ctx.userId,
+        dryRun: input.dryRun,
+        limit: input.limit,
+        cursor: input.cursor,
+      });
+
+      return backfillPeopleIndex(ctx.db, {
+        dryRun: input.dryRun,
+        limit: input.limit,
+        cursor: input.cursor ?? null,
+        userId: ctx.userId,
+      });
     }),
 });
 

--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -22,6 +22,7 @@ import { extractArticle } from '../../lib/article-extractor';
 import { storeArticleContent } from '../../lib/article-storage';
 import { logger } from '../../lib/logger';
 import { enqueueBookmarkEnrichment } from '../../enrichment/service';
+import { syncPeopleForUserItemBestEffort } from '../../people/service';
 import {
   findOrCreateCreator,
   extractCreatorFromMetadata,
@@ -336,6 +337,12 @@ export const bookmarksRouter = router({
         trigger: 'manual_save',
       });
 
+      await syncPeopleForUserItemBestEffort(ctx.db, {
+        userId: ctx.userId,
+        userItemId: existingUserItem.id,
+        operation: 'bookmarks.save.rebookmark',
+      });
+
       return {
         itemId,
         userItemId: existingUserItem.id,
@@ -377,6 +384,12 @@ export const bookmarksRouter = router({
       itemId,
       userItemId,
       trigger: 'manual_save',
+    });
+
+    await syncPeopleForUserItemBestEffort(ctx.db, {
+      userId: ctx.userId,
+      userItemId,
+      operation: 'bookmarks.save.create',
     });
 
     return {

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -35,6 +35,8 @@ import {
   userItemTags,
   userItemEnrichments,
   userItemConsumptionEvents,
+  userPeople,
+  userPersonMentions,
 } from '../../db/schema';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { getArticleContent } from '../../lib/article-storage';
@@ -42,6 +44,11 @@ import type { Database } from '../../db';
 import { buildNewsletterAvatarUrl } from '../../newsletters/avatar';
 import { enqueueBookmarkEnrichment } from '../../enrichment/service';
 import { ENRICHMENT_SCHEMA_VERSION, type SuggestedTag } from '../../enrichment/types';
+import {
+  deactivatePeopleForUserItemBestEffort,
+  normalizePersonName,
+  syncPeopleForUserItemBestEffort,
+} from '../../people/service';
 
 export type ItemTag = {
   id: string;
@@ -827,6 +834,29 @@ export const itemsRouter = router({
 
       const canonical = canonicalRows[0] ?? null;
       const userEnrichment = userRows[0] ?? null;
+      const parsedEntities = parseJsonArray<{ name: string; type: string; confidence: number }>(
+        canonical?.entitiesJson ?? null
+      );
+      const activePersonRows =
+        parsedEntities.length > 0
+          ? await ctx.db
+              .select({
+                personId: userPeople.id,
+                normalizedName: userPeople.normalizedName,
+              })
+              .from(userPersonMentions)
+              .innerJoin(userPeople, eq(userPersonMentions.userPersonId, userPeople.id))
+              .where(
+                and(
+                  eq(userPersonMentions.userItemId, owned[0].userItemId),
+                  eq(userPersonMentions.userId, ctx.userId),
+                  eq(userPersonMentions.isActive, true)
+                )
+              )
+          : [];
+      const personIdByNormalizedName = new Map(
+        activePersonRows.map((row) => [row.normalizedName, row.personId])
+      );
 
       return {
         item: {
@@ -840,9 +870,13 @@ export const itemsRouter = router({
           topics: parseJsonArray<{ name: string; confidence: number }>(
             canonical?.topicsJson ?? null
           ),
-          entities: parseJsonArray<{ name: string; type: string; confidence: number }>(
-            canonical?.entitiesJson ?? null
-          ),
+          entities: parsedEntities.map((entity) => ({
+            ...entity,
+            personId:
+              normalizePersonName(entity.name) && entity.type.trim().toLowerCase() === 'person'
+                ? (personIdByNormalizedName.get(normalizePersonName(entity.name)) ?? null)
+                : null,
+          })),
           intent: canonical?.intent ?? null,
           difficulty: canonical?.difficulty ?? null,
           evergreenScore: canonical?.evergreenScore ?? null,
@@ -1083,6 +1117,12 @@ export const itemsRouter = router({
         });
       }
 
+      await syncPeopleForUserItemBestEffort(ctx.db, {
+        userId: ctx.userId,
+        userItemId: existing[0].id,
+        operation: 'items.bookmark',
+      });
+
       return { success: true as const };
     }),
 
@@ -1117,6 +1157,12 @@ export const itemsRouter = router({
           updatedAt: now,
         })
         .where(eq(userItems.id, input.id));
+
+      await deactivatePeopleForUserItemBestEffort(ctx.db, {
+        userId: ctx.userId,
+        userItemId: input.id,
+        operation: 'items.archive',
+      });
 
       return { success: true as const };
     }),
@@ -1162,6 +1208,12 @@ export const itemsRouter = router({
           updatedAt: now,
         })
         .where(eq(userItems.id, input.id));
+
+      await deactivatePeopleForUserItemBestEffort(ctx.db, {
+        userId: ctx.userId,
+        userItemId: input.id,
+        operation: 'items.unbookmark',
+      });
 
       return { success: true as const };
     }),

--- a/apps/worker/src/trpc/routers/people.ts
+++ b/apps/worker/src/trpc/routers/people.ts
@@ -1,0 +1,258 @@
+import { and, desc, eq, gt, lt, or, sql, type SQL } from 'drizzle-orm';
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { UserItemState } from '@zine/shared';
+
+import type { Database } from '../../db';
+import { creators, items, userItems, userPeople, userPersonMentions } from '../../db/schema';
+import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import { router, protectedProcedure } from '../trpc';
+import { toItemViewsWithTags } from './items';
+
+const PeopleListInputSchema = z.object({
+  query: z.string().trim().max(100).optional(),
+  limit: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+  cursor: z.string().optional(),
+  sort: z.enum(['count', 'recent']).default('count'),
+});
+
+const PersonIdInputSchema = z.object({
+  personId: z.string().min(1),
+});
+
+const PersonItemsInputSchema = PersonIdInputSchema.extend({
+  limit: z.number().int().min(1).max(50).default(DEFAULT_PAGE_SIZE),
+  cursor: z.string().optional(),
+});
+
+type PeopleOffsetCursor = {
+  offset: number;
+};
+
+function encodeOffsetCursor(offset: number): string {
+  return btoa(JSON.stringify({ offset }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function decodeOffsetCursor(value: string | undefined): PeopleOffsetCursor | null {
+  if (!value) return null;
+  try {
+    let base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4) base64 += '=';
+    const parsed = JSON.parse(atob(base64));
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof parsed.offset === 'number' &&
+      Number.isInteger(parsed.offset) &&
+      parsed.offset >= 0
+    ) {
+      return { offset: parsed.offset };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function buildPeopleSearchConditions(query: string): SQL[] {
+  const lowered = query.trim().toLowerCase();
+  if (!lowered) return [];
+  return [
+    sql`lower(${userPeople.displayName}) LIKE ${`%${lowered}%`}`,
+    sql`${userPeople.normalizedName} LIKE ${`%${lowered}%`}`,
+  ];
+}
+
+async function loadLatestItemTitles(
+  ctx: { db: Database },
+  people: Array<{ id: string }>
+): Promise<Map<string, string | null>> {
+  const titles = new Map<string, string | null>();
+
+  for (const person of people) {
+    const rows = await ctx.db
+      .select({ title: items.title })
+      .from(userPersonMentions)
+      .innerJoin(userItems, eq(userPersonMentions.userItemId, userItems.id))
+      .innerJoin(items, eq(userPersonMentions.itemId, items.id))
+      .where(
+        and(
+          eq(userPersonMentions.userPersonId, person.id),
+          eq(userPersonMentions.isActive, true),
+          eq(userItems.state, UserItemState.BOOKMARKED)
+        )
+      )
+      .orderBy(desc(userPersonMentions.seenAt), desc(userPersonMentions.updatedAt))
+      .limit(1);
+
+    titles.set(person.id, rows[0]?.title ?? null);
+  }
+
+  return titles;
+}
+
+export const peopleRouter = router({
+  list: protectedProcedure.input(PeopleListInputSchema).query(async ({ ctx, input }) => {
+    const limit = input.limit;
+    const cursor = decodeOffsetCursor(input.cursor);
+    const offset = cursor?.offset ?? 0;
+    const conditions = [eq(userPeople.userId, ctx.userId), gt(userPeople.itemCount, 0)];
+    const searchConditions = input.query ? buildPeopleSearchConditions(input.query) : [];
+    if (searchConditions.length > 0) {
+      conditions.push(or(...searchConditions)!);
+    }
+
+    const orderBy =
+      input.sort === 'recent'
+        ? [desc(userPeople.latestSeenAt), desc(userPeople.itemCount), userPeople.displayName]
+        : [desc(userPeople.itemCount), desc(userPeople.latestSeenAt), userPeople.displayName];
+
+    const rows = await ctx.db
+      .select({
+        id: userPeople.id,
+        displayName: userPeople.displayName,
+        itemCount: userPeople.itemCount,
+        latestSeenAt: userPeople.latestSeenAt,
+      })
+      .from(userPeople)
+      .where(and(...conditions))
+      .orderBy(...orderBy)
+      .limit(limit + 1)
+      .offset(offset);
+
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const latestTitles = await loadLatestItemTitles(ctx, pageRows);
+
+    return {
+      people: pageRows.map((row) => ({
+        id: row.id,
+        displayName: row.displayName,
+        itemCount: row.itemCount,
+        latestSeenAt: row.latestSeenAt,
+        latestItemTitle: latestTitles.get(row.id) ?? null,
+      })),
+      nextCursor: hasMore ? encodeOffsetCursor(offset + limit) : null,
+    };
+  }),
+
+  get: protectedProcedure.input(PersonIdInputSchema).query(async ({ ctx, input }) => {
+    const rows = await ctx.db
+      .select({
+        id: userPeople.id,
+        displayName: userPeople.displayName,
+        itemCount: userPeople.itemCount,
+        latestSeenAt: userPeople.latestSeenAt,
+        createdAt: userPeople.createdAt,
+        updatedAt: userPeople.updatedAt,
+      })
+      .from(userPeople)
+      .where(
+        and(
+          eq(userPeople.id, input.personId),
+          eq(userPeople.userId, ctx.userId),
+          gt(userPeople.itemCount, 0)
+        )
+      )
+      .limit(1);
+
+    const person = rows[0];
+    if (!person) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Person not found' });
+    }
+
+    return person;
+  }),
+
+  listItems: protectedProcedure.input(PersonItemsInputSchema).query(async ({ ctx, input }) => {
+    const person = await ctx.db
+      .select({ id: userPeople.id })
+      .from(userPeople)
+      .where(
+        and(
+          eq(userPeople.id, input.personId),
+          eq(userPeople.userId, ctx.userId),
+          gt(userPeople.itemCount, 0)
+        )
+      )
+      .limit(1);
+
+    if (person.length === 0) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'Person not found' });
+    }
+
+    const limit = input.limit;
+    const cursor = input.cursor ? decodeCursor(input.cursor) : null;
+    const sortField = sql`COALESCE(${userItems.bookmarkedAt}, ${userItems.ingestedAt})`;
+    const conditions = [
+      eq(userPersonMentions.userPersonId, input.personId),
+      eq(userPersonMentions.userId, ctx.userId),
+      eq(userPersonMentions.isActive, true),
+      eq(userItems.userId, ctx.userId),
+      eq(userItems.state, UserItemState.BOOKMARKED),
+    ];
+
+    if (cursor) {
+      conditions.push(
+        or(
+          sql`${sortField} < ${cursor.sortValue}`,
+          and(sql`${sortField} = ${cursor.sortValue}`, lt(userItems.id, cursor.id))
+        )!
+      );
+    }
+
+    const rows = await ctx.db
+      .select()
+      .from(userPersonMentions)
+      .innerJoin(userItems, eq(userPersonMentions.userItemId, userItems.id))
+      .innerJoin(items, eq(userItems.itemId, items.id))
+      .leftJoin(creators, eq(items.creatorId, creators.id))
+      .where(and(...conditions))
+      .orderBy(desc(sql`${sortField}`), desc(userItems.id))
+      .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const pageRows = hasMore ? rows.slice(0, limit) : rows;
+    const itemViews = await toItemViewsWithTags(
+      ctx,
+      pageRows.map((row) => ({
+        user_items: row.user_items,
+        items: row.items,
+        creators: row.creators,
+      }))
+    );
+
+    const mentionByUserItemId = new Map(
+      pageRows.map((row) => [
+        row.user_items.id,
+        {
+          relationship: row.user_person_mentions.relationship,
+          confidence: row.user_person_mentions.confidence,
+        },
+      ])
+    );
+
+    const nextCursor =
+      hasMore && pageRows.length > 0
+        ? encodeCursor({
+            sortValue:
+              pageRows[pageRows.length - 1].user_items.bookmarkedAt ??
+              pageRows[pageRows.length - 1].user_items.ingestedAt,
+            id: pageRows[pageRows.length - 1].user_items.id,
+          })
+        : null;
+
+    return {
+      items: itemViews.map((item) => ({
+        ...item,
+        personMention: mentionByUserItemId.get(item.id) ?? null,
+      })),
+      nextCursor,
+    };
+  }),
+});
+
+export type PeopleRouter = typeof peopleRouter;

--- a/apps/worker/src/trpc/routers/search.test.ts
+++ b/apps/worker/src/trpc/routers/search.test.ts
@@ -7,7 +7,12 @@
 import { describe, expect, it } from 'vitest';
 import { ContentType, Provider, UserItemState } from '@zine/shared';
 
-import { buildSearchResponse, type CreatorSearchRow, type SearchItemView } from './search';
+import {
+  buildSearchResponse,
+  type CreatorSearchRow,
+  type PersonSearchRow,
+  type SearchItemView,
+} from './search';
 
 const baseCreator: CreatorSearchRow = {
   id: 'creator_joe',
@@ -49,6 +54,14 @@ const baseItem: SearchItemView = {
   isFinished: false,
   finishedAt: null,
   tags: [],
+};
+
+const basePerson: PersonSearchRow = {
+  id: 'person_joe',
+  displayName: 'Joe Rogan',
+  itemCount: 7,
+  latestSeenAt: 1777593600000,
+  latestItemTitle: null,
 };
 
 describe('buildSearchResponse', () => {
@@ -102,6 +115,24 @@ describe('buildSearchResponse', () => {
       subscriptionId: 'sub_joe',
       libraryItemCount: 3,
       latestPublishedAt: '2026-04-01T00:00:00Z',
+    });
+  });
+
+  it('places person results after creators and before items', () => {
+    const response = buildSearchResponse({
+      query: 'Joe',
+      creatorRows: [baseCreator],
+      personRows: [basePerson],
+      items: [baseItem],
+      nextCursor: null,
+    });
+
+    expect(response.results.map((result) => result.type)).toEqual(['creator', 'person', 'item']);
+    expect(response.sections.people[0]).toMatchObject({
+      type: 'person',
+      personId: 'person_joe',
+      displayName: 'Joe Rogan',
+      itemCount: 7,
     });
   });
 });

--- a/apps/worker/src/trpc/routers/search.ts
+++ b/apps/worker/src/trpc/routers/search.ts
@@ -1,10 +1,10 @@
-import { and, desc, eq, lt, ne, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { and, desc, eq, gt, lt, ne, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { z } from 'zod';
 import type { Provider } from '@zine/shared';
 import { UserItemState } from '@zine/shared';
 
 import { router, protectedProcedure } from '../trpc';
-import { creators, items, subscriptions, userItems } from '../../db/schema';
+import { creators, items, subscriptions, userItems, userPeople } from '../../db/schema';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { toItemViewsWithTags, type ItemView } from './items';
 
@@ -14,6 +14,7 @@ const SearchInputSchema = z.object({
   query: z.string().trim().min(1).max(100),
   scope: z.enum(['library']).default('library'),
   creatorsLimit: z.number().int().min(0).max(10).default(DEFAULT_CREATORS_LIMIT),
+  peopleLimit: z.number().int().min(0).max(10).default(DEFAULT_CREATORS_LIMIT),
   itemsLimit: z.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
   cursor: z.string().optional(),
 });
@@ -52,6 +53,25 @@ export type CreatorSearchResult = {
   score: number;
 };
 
+export type PersonSearchRow = {
+  id: string;
+  displayName: string;
+  itemCount: number;
+  latestSeenAt: number | null;
+  latestItemTitle: string | null;
+};
+
+export type PersonSearchResult = {
+  type: 'person';
+  id: string;
+  personId: string;
+  displayName: string;
+  itemCount: number;
+  latestSeenAt: number | null;
+  latestItemTitle: string | null;
+  score: number;
+};
+
 export type SearchItemView = ItemView;
 
 export type ItemSearchResult = SearchItemView & {
@@ -59,12 +79,13 @@ export type ItemSearchResult = SearchItemView & {
   score: number;
 };
 
-export type SearchResult = CreatorSearchResult | ItemSearchResult;
+export type SearchResult = CreatorSearchResult | PersonSearchResult | ItemSearchResult;
 
 export type SearchResponse = {
   results: SearchResult[];
   sections: {
     creators: CreatorSearchResult[];
+    people: PersonSearchResult[];
     items: ItemSearchResult[];
   };
   nextCursor: string | null;
@@ -166,6 +187,12 @@ function scoreItem(query: string, item: SearchItemView): number {
   return Math.max(titleScore, creatorScore);
 }
 
+function scorePerson(query: string, person: PersonSearchRow): number {
+  const nameScore = scoreTextMatch(query, person.displayName);
+  const libraryBoost = person.itemCount > 0 ? Math.min(10, person.itemCount) : 0;
+  return nameScore + libraryBoost;
+}
+
 function mergeCreatorRows(query: string, rows: CreatorSearchRow[]): CreatorSearchResult[] {
   const merged = new Map<string, CreatorSearchRow>();
 
@@ -213,14 +240,30 @@ function mergeCreatorRows(query: string, rows: CreatorSearchRow[]): CreatorSearc
 export function buildSearchResponse(input: {
   query: string;
   creatorRows: CreatorSearchRow[];
+  personRows?: PersonSearchRow[];
   items: SearchItemView[];
   nextCursor: string | null;
   creatorsLimit?: number;
+  peopleLimit?: number;
 }): SearchResponse {
   const creatorsSection = mergeCreatorRows(input.query, input.creatorRows).slice(
     0,
     input.creatorsLimit ?? DEFAULT_CREATORS_LIMIT
   );
+  const peopleSection = (input.personRows ?? [])
+    .map((row) => ({
+      type: 'person' as const,
+      id: row.id,
+      personId: row.id,
+      displayName: row.displayName,
+      itemCount: row.itemCount,
+      latestSeenAt: row.latestSeenAt,
+      latestItemTitle: row.latestItemTitle,
+      score: scorePerson(input.query, row),
+    }))
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score || a.displayName.localeCompare(b.displayName))
+    .slice(0, input.peopleLimit ?? DEFAULT_CREATORS_LIMIT);
   const itemsSection = input.items.map((item) => ({
     ...item,
     type: 'item' as const,
@@ -228,9 +271,10 @@ export function buildSearchResponse(input: {
   }));
 
   return {
-    results: [...creatorsSection, ...itemsSection],
+    results: [...creatorsSection, ...peopleSection, ...itemsSection],
     sections: {
       creators: creatorsSection,
+      people: peopleSection,
       items: itemsSection,
     },
     nextCursor: input.nextCursor,
@@ -279,7 +323,12 @@ export const searchRouter = router({
     const cursor = input.cursor ? decodeCursor(input.cursor) : null;
     const searchConditions = buildSearchConditions(search, [items.title, creators.name]);
     const creatorSearchConditions = buildSearchConditions(search, [creators.name, creators.handle]);
+    const peopleSearchConditions = buildSearchConditions(search, [
+      userPeople.displayName,
+      userPeople.normalizedName,
+    ]);
     const creatorRows: CreatorSearchRow[] = [];
+    const personRows: PersonSearchRow[] = [];
 
     if (!cursor && input.creatorsLimit > 0) {
       const subscribedCreatorRows = await ctx.db
@@ -359,6 +408,37 @@ export const searchRouter = router({
       );
     }
 
+    if (!cursor && input.peopleLimit > 0) {
+      const matchedPeopleRows = await ctx.db
+        .select({
+          id: userPeople.id,
+          displayName: userPeople.displayName,
+          itemCount: userPeople.itemCount,
+          latestSeenAt: userPeople.latestSeenAt,
+          latestItemTitle: sql<string | null>`null`,
+        })
+        .from(userPeople)
+        .where(
+          and(
+            eq(userPeople.userId, ctx.userId),
+            gt(userPeople.itemCount, 0),
+            or(...peopleSearchConditions)!
+          )
+        )
+        .orderBy(desc(userPeople.itemCount), desc(userPeople.latestSeenAt), userPeople.displayName)
+        .limit(input.peopleLimit * 3);
+
+      personRows.push(
+        ...matchedPeopleRows.map((row) => ({
+          id: row.id,
+          displayName: row.displayName,
+          itemCount: Number(row.itemCount ?? 0),
+          latestSeenAt: row.latestSeenAt,
+          latestItemTitle: row.latestItemTitle,
+        }))
+      );
+    }
+
     const itemConditions = [
       eq(userItems.userId, ctx.userId),
       eq(userItems.state, UserItemState.BOOKMARKED),
@@ -402,9 +482,11 @@ export const searchRouter = router({
     return buildSearchResponse({
       query: search,
       creatorRows,
+      personRows,
       items: itemViews,
       nextCursor,
       creatorsLimit: input.creatorsLimit,
+      peopleLimit: input.peopleLimit,
     });
   }),
 });

--- a/docs/mobile/design-system/components.md
+++ b/docs/mobile/design-system/components.md
@@ -30,6 +30,7 @@ and which are dormant.
 | `apps/mobile/components/list-states.tsx`                          | `canonical` | `P0`           | Shared loading/error/empty/not-found state components.             |
 | `apps/mobile/components/item-card.tsx`                            | `canonical` | `P0`           | Primary card system organized around row, stack, and cover shapes. |
 | `apps/mobile/components/link-preview-card.tsx`                    | `canonical` | `P0`           | Add-link preview card and skeleton state.                          |
+| `apps/mobile/components/person-result-row.tsx`                    | `canonical` | `P1`           | Reusable person row for library/search people surfaces.            |
 | `apps/mobile/components/ParallaxScrollView.tsx`                   | `canonical` | `P1`           | Reusable parallax layout primitive for detail views.               |
 | `apps/mobile/components/error-boundary.tsx`                       | `canonical` | `P1`           | Base boundary used by specialized boundaries.                      |
 | `apps/mobile/components/subscriptions/channel-item.tsx`           | `canonical` | `P0`           | Reusable channel row in single and multi-select modes.             |

--- a/docs/people-in-my-library-prd.md
+++ b/docs/people-in-my-library-prd.md
@@ -1,0 +1,497 @@
+# PRD: People in My Library
+
+## Status
+
+Proposed for discussion.
+
+## Purpose
+
+Build a focused first version of people-aware enrichment in Zine:
+
+> Help users see which people appear across the content they have intentionally saved.
+
+This is not a global knowledge graph, public profile system, or external account resolver. V1 is a private, user-scoped index over the user's bookmarked library.
+
+---
+
+## Problem
+
+Zine already extracts useful entities during item enrichment, but those entities currently remain trapped inside item-level enrichment JSON. A user can see that one item mentions a person, but cannot answer broader library questions such as:
+
+1. Which people show up most often in the things I save?
+2. What saved items involve this person?
+3. Where did this person appear recently?
+4. Is this person a recurring interest in my library?
+
+Existing creator pages partially solve this for provider-native creators, but they do not cover people who are mentioned, interviewed, guests, subjects, or otherwise present in saved content.
+
+---
+
+## Goals
+
+1. Create a private "People in my library" index for each user.
+2. Convert high-confidence `PERSON` entities from enrichment into queryable rows.
+3. Let users browse and search people found in their bookmarked library.
+4. Let users open a person detail page and see bookmarked items involving that person.
+5. Keep matching conservative and explainable.
+6. Preserve a clean path toward aliases, manual merges, creator linking, and external profiles later.
+
+---
+
+## Non-Goals
+
+1. Global entity graph.
+2. Cross-user people popularity or recommendations.
+3. Automatic Twitter/X, YouTube, Spotify, Wikidata, or website linking.
+4. Internet crawling.
+5. Fuzzy person merges.
+6. Manual merge/split UI.
+7. People from Inbox or Archived items.
+8. Perfect named-entity recognition.
+9. Claims that a detected person is the official owner of an external account.
+10. Replacing the existing `creators` model or creator pages.
+
+---
+
+## User Stories
+
+1. As a user, I want to see people who frequently appear in my saved library, so I can understand recurring interests.
+2. As a user, I want to tap a person and see all saved items involving them, so I can revisit related content.
+3. As a user, I want person matches to feel trustworthy, so I do not see unrelated people incorrectly merged.
+4. As a user, I want item detail entity chips to be navigable when Zine can resolve them to a person in my library.
+5. As a user, I do not want private reading interests exposed to other users or global surfaces.
+
+---
+
+## Product Scope
+
+## V1 Definition
+
+V1 indexes people from bookmarked content only:
+
+- Source items: `user_items.state = BOOKMARKED`
+- Source enrichment: latest complete item enrichment for the canonical item
+- Entity filter: `type = PERSON` or a normalized equivalent
+- Confidence threshold: default `>= 0.65`
+- Identity rule: same user plus exact normalized name
+
+Example:
+
+- `Joe Rogan` and `joe rogan` resolve to the same `user_people` row.
+- `Joseph Rogan` does not auto-merge with `Joe Rogan`.
+- `Rogan` does not auto-merge with `Joe Rogan`.
+- `Sam Harris` is a separate private person record for that user, with no global assumption.
+
+## Primary Surfaces
+
+### Library People View
+
+Add a people-oriented library surface.
+
+Recommended entry points:
+
+- Library tab segmented view or filter: `Items | Tags | People`
+- Search result section: `People`
+
+Each person row should show:
+
+- display name
+- saved item count
+- latest saved item title or latest seen date
+- optional confidence/status treatment if needed
+
+### Person Detail Page
+
+Add a mobile route:
+
+- `apps/mobile/app/person/[id].tsx`
+
+Recommended sections:
+
+1. Header
+   - name
+   - saved item count
+   - latest seen date
+2. Saved items
+   - bookmarked items involving this person
+   - sorted by bookmarked date descending
+3. Optional relationship grouping
+   - only if relationship extraction is available with acceptable quality
+   - initial groups: `About`, `Created/Hosted`, `Mentioned`
+
+### Item Detail
+
+Update existing enrichment entity chips:
+
+- Person chips are tappable when they resolve to a `user_people` record.
+- Unresolved entity chips remain plain metadata.
+- Tapping navigates to `/person/[id]`.
+
+---
+
+## Data Model
+
+## New Tables
+
+### `user_people`
+
+One private person record per user-normalized-name pair.
+
+Suggested columns:
+
+- `id` TEXT PRIMARY KEY
+- `user_id` TEXT NOT NULL REFERENCES `users`(`id`)
+- `display_name` TEXT NOT NULL
+- `normalized_name` TEXT NOT NULL
+- `item_count` INTEGER NOT NULL DEFAULT 0
+- `latest_seen_at` INTEGER
+- `created_at` INTEGER NOT NULL
+- `updated_at` INTEGER NOT NULL
+
+Indexes:
+
+- unique `(user_id, normalized_name)`
+- index `(user_id, item_count, latest_seen_at)`
+- index `(user_id, latest_seen_at)`
+
+### `user_person_mentions`
+
+One row per user/person/item association. V1 should deduplicate repeated mentions of the same person within the same item.
+
+Suggested columns:
+
+- `id` TEXT PRIMARY KEY
+- `user_id` TEXT NOT NULL REFERENCES `users`(`id`)
+- `user_person_id` TEXT NOT NULL REFERENCES `user_people`(`id`)
+- `user_item_id` TEXT NOT NULL REFERENCES `user_items`(`id`)
+- `item_id` TEXT NOT NULL REFERENCES `items`(`id`)
+- `item_enrichment_id` TEXT NOT NULL REFERENCES `item_enrichments`(`id`)
+- `raw_name` TEXT NOT NULL
+- `raw_type` TEXT NOT NULL
+- `relationship` TEXT NOT NULL DEFAULT 'MENTIONED'
+- `confidence` REAL NOT NULL
+- `evidence_text` TEXT
+- `is_active` INTEGER NOT NULL DEFAULT 1
+- `created_at` INTEGER NOT NULL
+- `updated_at` INTEGER NOT NULL
+
+Indexes:
+
+- unique `(user_id, user_item_id, user_person_id)`
+- index `(user_person_id, is_active, updated_at)`
+- index `(user_id, item_id)`
+- index `(user_id, is_active, confidence)`
+
+## Name Normalization
+
+Use a deliberately simple normalizer in V1:
+
+1. trim
+2. lowercase
+3. collapse whitespace
+4. remove surrounding punctuation
+5. preserve internal punctuation initially
+
+Do not remove middle initials, suffixes, nicknames, or titles in V1 unless the title is a simple honorific such as `Mr.`, `Ms.`, `Dr.` and this can be tested safely.
+
+---
+
+## Pipeline
+
+## Write Path
+
+After canonical item enrichment completes:
+
+1. Load all bookmarked `user_items` for the enriched `item_id`.
+2. Parse latest complete `item_enrichments.entities_json`.
+3. Filter to person-like entities above threshold.
+4. Normalize each person name.
+5. Upsert `user_people` by `(user_id, normalized_name)`.
+6. Upsert `user_person_mentions` by `(user_id, user_item_id, user_person_id)`.
+7. Recompute or increment `item_count` and `latest_seen_at`.
+
+`latest_seen_at` should be Unix ms derived from the user's library relationship, preferably `bookmarked_at` when present and `ingested_at` as fallback.
+
+## Backfill
+
+Add an admin/backfill path that:
+
+1. Scans bookmarked `user_items`.
+2. Finds the latest complete enrichment for each `item_id`.
+3. Indexes people using the same write path.
+4. Is idempotent and safe to rerun.
+
+Backfill should support:
+
+- `dryRun`
+- `limit`
+- optional `userId`
+- progress logging
+- retry-safe pagination
+
+## State Changes
+
+People counts must remain consistent when a user item leaves the library.
+
+Required handling:
+
+- On `BOOKMARKED -> ARCHIVED`, remove or deactivate the mention from active people counts.
+- On `ARCHIVED -> BOOKMARKED`, reindex the item if enrichment exists.
+- On item deletion/removal, remove or deactivate mentions.
+
+Use `is_active` on `user_person_mentions` instead of hard-deleting rows. This preserves provenance for debugging and makes state transitions reversible.
+
+---
+
+## API Requirements
+
+## New Router
+
+Add a `people` tRPC router.
+
+### `people.list`
+
+Input:
+
+- `query?: string`
+- `limit?: number`
+- `cursor?: string`
+- `sort?: 'count' | 'recent'`
+
+Returns:
+
+- people
+- next cursor
+
+Person shape:
+
+- `id`
+- `displayName`
+- `itemCount`
+- `latestSeenAt`
+- `latestItemTitle`
+
+### `people.get`
+
+Input:
+
+- `personId`
+
+Returns:
+
+- person profile
+- aggregate counts
+
+### `people.listItems`
+
+Input:
+
+- `personId`
+- `limit`
+- `cursor`
+
+Returns:
+
+- bookmarked item views
+- mention metadata when available
+- next cursor
+
+## Existing API Updates
+
+### `items.getEnrichment`
+
+Augment person entities with `personId` when a resolved `user_people` row exists for the current user.
+
+Do not expose person IDs for other users.
+
+### `search.query`
+
+Optionally include a `people` section after the base people list exists.
+
+Search should only return people with:
+
+- `item_count > 0`
+- active bookmarked mentions
+
+---
+
+## UX Requirements
+
+1. People are a library browsing feature, not a social/profile feature.
+2. Empty state should explain that people appear after saved items are enriched.
+3. People rows should be dense and scannable, similar to creator search rows.
+4. Person detail should reuse existing item card patterns.
+5. Do not show confidence percentages in primary UI.
+6. Do not imply official identity or account ownership.
+7. If relationship labels are uncertain, use neutral wording like `Appears in`.
+
+---
+
+## Privacy and Safety
+
+1. All V1 people records are user-scoped.
+2. A user's people list must never include counts or items from other users.
+3. No cross-user aggregation.
+4. No public profile URLs.
+5. No external account inference.
+6. No analytics event should include raw person names unless analytics policy explicitly allows it.
+7. Logs should prefer IDs/counts over names where possible.
+
+---
+
+## Ranking
+
+Default list ranking:
+
+1. `item_count` descending
+2. `latest_seen_at` descending
+3. `display_name` ascending
+
+Person detail item ranking:
+
+1. bookmarked date descending
+2. ingested date descending
+3. mention confidence descending
+
+Future ranking signals:
+
+- title mention
+- creator/host/guest relationship
+- high salience
+- repeated appearances across categories
+- user opens/finishes involving that person
+
+---
+
+## Analytics
+
+Recommended events:
+
+- `people_library_opened`
+- `person_profile_opened`
+- `person_item_opened`
+- `item_person_chip_tapped`
+
+Event properties should use IDs and counts:
+
+- `personId`
+- `itemCount`
+- `source`
+- `provider`
+- `contentType`
+
+Avoid raw person names in analytics events.
+
+---
+
+## Success Metrics
+
+Product signals:
+
+1. Percentage of active users with at least one indexed person.
+2. People list open rate from Library/Search.
+3. Person detail open rate.
+4. Item opens from person detail.
+5. Item detail person-chip tap rate.
+
+Quality signals:
+
+1. Average people per bookmarked item.
+2. Percentage of person mentions above threshold.
+3. Duplicate-looking people rate from common normalized variants.
+4. Support/debug reports of incorrect people.
+
+Operational signals:
+
+1. Backfill completion rate.
+2. Enrichment-to-people-index latency.
+3. Failed indexing jobs.
+4. People count consistency after state changes.
+
+---
+
+## Edge Cases
+
+1. Enrichment missing: item contributes no people until enrichment completes.
+2. Low-confidence entity: ignored in V1.
+3. Same person appears multiple times in one item: one mention association.
+4. Person name changes across items: not merged in V1 unless normalized name is exact.
+5. Ambiguous names: not disambiguated in V1.
+6. Creator name equals person name: no automatic creator-person link in V1.
+7. Archived item: not counted.
+8. Re-enrichment removes a person: deactivate or remove stale mention for that user item.
+9. Re-enrichment changes confidence: update mention confidence.
+10. User has no people: show empty state.
+
+---
+
+## Implementation Phases
+
+## Phase 1: Indexing Foundation
+
+1. Add migrations and Drizzle schema for `user_people` and `user_person_mentions`.
+2. Add person normalization helper and tests.
+3. Add indexing service that consumes latest complete item enrichment.
+4. Call indexing after enrichment completion.
+5. Add admin backfill with dry-run support.
+
+Exit criteria:
+
+- Existing enriched bookmarked items can produce stable user-scoped people rows.
+- Re-running backfill is idempotent.
+
+## Phase 2: API
+
+1. Add `people` router.
+2. Add `people.list`, `people.get`, `people.listItems`.
+3. Augment `items.getEnrichment` with resolved `personId`.
+4. Add API tests for multi-tenant isolation.
+
+Exit criteria:
+
+- A user can query their people and related bookmarked items.
+- Another user cannot observe or infer those rows.
+
+## Phase 3: Mobile UX
+
+1. Add People library view or search section.
+2. Add person detail route.
+3. Make resolved person chips tappable on item detail.
+4. Add empty/loading/error states.
+
+Exit criteria:
+
+- A user can browse people and open saved items from a person page.
+
+## Phase 4: Quality Pass
+
+1. Run local backfill on seeded data.
+2. Inspect common names and false positives.
+3. Tune confidence threshold.
+4. Add telemetry for coverage and indexing failures.
+
+Exit criteria:
+
+- The feature is useful without creating noisy or misleading people pages.
+
+---
+
+## Open Questions
+
+1. Should V1 include only `BOOKMARKED`, or should it include unfinished Library items that were previously saved but archived later?
+2. Should person rows live in the Library tab, Search tab, or both at launch?
+3. Should item detail show all person chips, or only high-confidence resolved people?
+4. What confidence threshold produces the best balance on real local data?
+5. Should relationship labels ship in V1 if the current enrichment schema does not extract them explicitly?
+
+---
+
+## V2 Candidates
+
+1. Manual aliasing and merge/split.
+2. Creator-to-person linking within a user's library.
+3. Relationship extraction: author, host, guest, about, mentioned.
+4. External links only from explicit provider/source metadata.
+5. People-based recommendations.
+6. Weekly recap integration: recurring people this week.
+7. "People you save most" insights.


### PR DESCRIPTION
## Summary
- Add a user-scoped people index backed by bookmark enrichment entities
- Surface people in Library, Search, and item enrichment chips with navigation to person detail
- Add backfill, sync, and deactivation paths so counts stay tied to active bookmarked mentions
- Include backend and mobile tests for indexing, routing, and UI behavior

## Testing
- `bun run --cwd apps/worker test:run`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/mobile test`
- `bun run --cwd apps/mobile lint`
- `bun run design-system:check`
- `bun run format:check`