### PR TITLE
chore: use readonly array shorthand in weekly recap card test

### DIFF
--- a/apps/mobile/components/insights/weekly-recap-card.test.tsx
+++ b/apps/mobile/components/insights/weekly-recap-card.test.tsx
@@ -5,7 +5,7 @@ import { WeeklyRecapCard } from './weekly-recap-card';
 
 type RenderedNode = {
   type: unknown;
-  children: ReadonlyArray<unknown>;
+  children: readonly unknown[];
 };
 
 jest.mock('react-native', () => ({


### PR DESCRIPTION
## Summary
- replace `ReadonlyArray<unknown>` with `readonly unknown[]` in weekly recap card test helper typing
- aligns with `@typescript-eslint/array-type` preferred shorthand style

## Validation
- `bun run --cwd apps/mobile lint`
- `bun run --cwd apps/mobile test components/insights/weekly-recap-card.test.tsx`
- pre-push hook suite passed (`prettier --check`, design-system check, `turbo run typecheck`, `bun run --cwd apps/web test`, `bun run test:worker:ci`)
