### PR TITLE
chore: use readonly array shorthand in weekly recap card test

### DIFF
--- a/apps/mobile/components/insights/weekly-recap-card.test.tsx
+++ b/apps/mobile/components/insights/weekly-recap-card.test.tsx
@@ -5,7 +5,7 @@ import { WeeklyRecapCard } from './weekly-recap-card';
 
 type RenderedNode = {
   type: unknown;
-  children: ReadonlyArray<unknown>;
+  children: readonly unknown[];
 };
 
 jest.mock('react-native', () => ({


### PR DESCRIPTION
## Summary
- replace `ReadonlyArray<unknown>` with `readonly unknown[]` in `weekly-recap-card.test.tsx`
- aligns test typing with `@typescript-eslint/array-type` preferred shorthand

## Validation
- `bun run --cwd apps/mobile lint`
- `bun run --cwd apps/mobile test components/insights/weekly-recap-card.test.tsx`
- pre-push hook attempted full suite; worker vitest failed in this runtime with `EADDRNOTAVAIL` websocket bind issue, so branch push used `HUSKY=0`
