### PR TITLE
[codex] Update mobile subscription list interactions

### DIFF
--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -12,6 +12,7 @@ import {
   SourceSearchField,
   SourceSectionHeader,
   SourceSubscriptionRow,
+  SwipeableSourceSubscriptionRow,
 } from '@/components/subscriptions';
 import { Spacing } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
@@ -265,7 +266,7 @@ export default function ProviderDetailScreen() {
   ]);
 
   const handleSubscribe = useCallback(
-    (subscription: UnifiedSubscription) => {
+    (subscription: UnifiedSubscription, nextSubscribed?: boolean) => {
       if (processingIds.has(subscription.id)) {
         return;
       }
@@ -276,9 +277,20 @@ export default function ProviderDetailScreen() {
 
       setProcessingIds((current) => new Set(current).add(subscription.id));
 
-      if (subscription.isSubscribed && subscription.subscriptionId) {
+      const shouldSubscribe = nextSubscribed ?? !subscription.isSubscribed;
+
+      if (shouldSubscribe === subscription.isSubscribed) {
+        setProcessingIds((current) => {
+          const next = new Set(current);
+          next.delete(subscription.id);
+          return next;
+        });
+        return;
+      }
+
+      if (!shouldSubscribe && subscription.subscriptionId) {
         unsubscribe({ subscriptionId: subscription.subscriptionId });
-      } else {
+      } else if (shouldSubscribe) {
         subscribe({
           provider: provider === 'SPOTIFY' ? ProviderEnum.SPOTIFY : ProviderEnum.YOUTUBE,
           providerChannelId: subscription.id,
@@ -482,22 +494,19 @@ export default function ProviderDetailScreen() {
                 }
               />
             ) : (
-              <SourceSubscriptionRow
+              <SwipeableSourceSubscriptionRow
                 title={(item as UnifiedSubscription).title}
                 imageUrl={(item as UnifiedSubscription).imageUrl}
-                statusLabel={(item as UnifiedSubscription).isSubscribed ? 'Subscribed' : null}
-                primaryActionLabel={
-                  (item as UnifiedSubscription).isSubscribed ? 'Remove' : 'Subscribe'
-                }
-                onPrimaryAction={() => handleSubscribe(item as UnifiedSubscription)}
-                primaryActionVariant={
-                  (item as UnifiedSubscription).isSubscribed ? 'secondary' : 'primary'
-                }
-                primaryActionLoading={processingIds.has((item as UnifiedSubscription).id)}
+                isSubscribed={(item as UnifiedSubscription).isSubscribed}
+                isProcessing={processingIds.has((item as UnifiedSubscription).id)}
+                onAdd={() => handleSubscribe(item as UnifiedSubscription, true)}
+                onRemove={() => handleSubscribe(item as UnifiedSubscription, false)}
               />
             )
           }
-          ItemSeparatorComponent={() => <View style={styles.separator} />}
+          ItemSeparatorComponent={
+            provider === 'GMAIL' ? () => <View style={styles.separator} /> : undefined
+          }
         />
       )}
     </Surface>

--- a/apps/mobile/components/icons/index.tsx
+++ b/apps/mobile/components/icons/index.tsx
@@ -22,6 +22,7 @@ import {
   Sparkles,
   Square,
   SquareCheck,
+  Trash2,
   Tv,
 } from 'lucide-react-native';
 
@@ -125,6 +126,10 @@ export function PlusIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
 
 export function PlusCircleIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
   return <PlusCircle size={size} color={color} strokeWidth={2} />;
+}
+
+export function TrashIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {
+  return <Trash2 size={size} color={color} strokeWidth={2} />;
 }
 
 export function SearchIcon({ size = 24, color = DEFAULT_ICON_COLOR }: IconProps) {

--- a/apps/mobile/components/subscriptions/index.ts
+++ b/apps/mobile/components/subscriptions/index.ts
@@ -19,4 +19,5 @@ export {
   SourceSearchField,
   SourceSectionHeader,
   SourceSubscriptionRow,
+  SwipeableSourceSubscriptionRow,
 } from './source-ui';

--- a/apps/mobile/components/subscriptions/source-ui.stories.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.stories.tsx
@@ -12,6 +12,7 @@ import {
   SourceSearchField,
   SourceSectionHeader,
   SourceSubscriptionRow,
+  SwipeableSourceSubscriptionRow,
 } from './source-ui';
 
 const meta = {
@@ -53,7 +54,6 @@ export const Overview: Story = {
       />
       <SourceSearchField value="" onChangeText={() => {}} placeholder="Search subscriptions" />
       <SourceSubscriptionRow
-        source="RSS"
         title="Example Feed"
         subtitle="https://example.com/feed.xml"
         meta="Last synced Mar 22, 2026"
@@ -64,6 +64,13 @@ export const Overview: Story = {
         onSecondaryAction={() => {}}
         tertiaryActionLabel="Remove"
         onTertiaryAction={() => {}}
+      />
+      <SwipeableSourceSubscriptionRow
+        title="Design Details"
+        imageUrl={null}
+        isSubscribed={false}
+        onAdd={() => {}}
+        onRemove={() => {}}
       />
       <SourceEmptyState
         title="No subscriptions yet"

--- a/apps/mobile/components/subscriptions/source-ui.test.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.test.tsx
@@ -57,6 +57,44 @@ jest.mock('lucide-react-native', () => {
   };
 });
 
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: {
+    Light: 'Light',
+    Medium: 'Medium',
+  },
+  impactAsync: jest.fn(),
+}));
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const Swipeable = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children);
+
+  return {
+    __esModule: true,
+    default: Swipeable,
+  };
+});
+
+jest.mock('react-native-reanimated', () => {
+  const AnimatedView = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, children);
+
+  return {
+    __esModule: true,
+    default: {
+      View: AnimatedView,
+    },
+    Extrapolation: {
+      CLAMP: 'clamp',
+    },
+    interpolate: jest.fn(() => 0),
+    runOnJS: (fn: () => void) => fn,
+    useAnimatedReaction: jest.fn(),
+    useAnimatedStyle: jest.fn(() => ({})),
+    useSharedValue: (value: unknown) => ({ value }),
+  };
+});
+
 jest.mock('@/components/primitives', () => ({
   Badge: ({ label }: { label: string }) => React.createElement('span', null, label),
   Button: ({ label, onPress }: { label: string; onPress?: () => void }) =>

--- a/apps/mobile/components/subscriptions/source-ui.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.tsx
@@ -1,9 +1,30 @@
 import { FontAwesome5, Ionicons } from '@expo/vector-icons';
+import { useCallback, useRef } from 'react';
 import { View, Image, Pressable, StyleSheet, TextInput } from 'react-native';
 import { Rss } from 'lucide-react-native';
+import * as Haptics from 'expo-haptics';
+import ReanimatedSwipeable, {
+  type SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  runOnJS,
+  type SharedValue,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
 
-import { Badge, Button, Surface, Text } from '@/components/primitives';
-import { ChevronRightIcon, SearchIcon } from '@/components/icons';
+import { Badge, Button, IconButton, Surface, Text } from '@/components/primitives';
+import {
+  CheckIcon,
+  CheckOutlineIcon,
+  ChevronRightIcon,
+  PlusIcon,
+  SearchIcon,
+  TrashIcon,
+} from '@/components/icons';
 import { Radius, Spacing } from '@/constants/theme';
 import { useAppTheme } from '@/hooks/use-app-theme';
 import {
@@ -14,6 +35,16 @@ import {
 } from '@/lib/subscription-sources';
 
 const SOURCE_BRAND_ICON_COLOR = '#FFFFFF'; // design-system-exception: white brand glyphs
+const ACTION_LANE_WIDTH = 220;
+const ACTION_CIRCLE_SIZE = 64;
+const ACTION_ICON_SIZE = 24;
+const STRETCH_START_DISTANCE = 96;
+const COMMIT_DISTANCE = 164;
+const ACTION_STRETCHED_WIDTH = 156;
+const ACTION_MAX_WIDTH = 204;
+const SWIPE_THRESHOLD = COMMIT_DISTANCE;
+const SWIPE_FRICTION = 1.08;
+const OVERSHOOT_FRICTION = 8;
 
 // design-system-exception: brand colors matching FAB config in item-detail-helpers.tsx
 const SOURCE_BRAND: Record<SubscriptionSource, { bg: string; icon: React.ReactNode }> = {
@@ -76,6 +107,192 @@ function Avatar({ imageUrl, title }: { imageUrl?: string | null; title: string }
         {title.charAt(0).toUpperCase()}
       </Text>
     </View>
+  );
+}
+
+interface SwipeActionPanelProps {
+  progress: SharedValue<number>;
+  translation: SharedValue<number>;
+  releaseLocked: SharedValue<boolean>;
+}
+
+type SwipeCapsuleProps = SwipeActionPanelProps & {
+  direction: 'left' | 'right';
+  color: string;
+  children: React.ReactNode;
+};
+
+function triggerSwipeCommitHaptic() {
+  void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+}
+
+function SwipeActionCapsule({
+  progress,
+  translation,
+  releaseLocked,
+  direction,
+  color,
+  children,
+}: SwipeCapsuleProps) {
+  const isLeft = direction === 'left';
+  const frozenWidth = useSharedValue(-1);
+
+  const getDragDistance = () => {
+    'worklet';
+    return isLeft ? Math.max(translation.value, 0) : Math.max(-translation.value, 0);
+  };
+
+  const getCapsuleWidth = (dragDistance: number) => {
+    'worklet';
+    return interpolate(
+      dragDistance,
+      [0, STRETCH_START_DISTANCE, COMMIT_DISTANCE, ACTION_LANE_WIDTH],
+      [ACTION_CIRCLE_SIZE, ACTION_CIRCLE_SIZE, ACTION_STRETCHED_WIDTH, ACTION_MAX_WIDTH],
+      Extrapolation.CLAMP
+    );
+  };
+
+  useAnimatedReaction(
+    () => {
+      const dragDistance = isLeft
+        ? Math.max(translation.value, 0)
+        : Math.max(-translation.value, 0);
+      return dragDistance >= COMMIT_DISTANCE;
+    },
+    (isCommitted, wasCommitted) => {
+      if (isCommitted && !wasCommitted) {
+        runOnJS(triggerSwipeCommitHaptic)();
+      }
+    },
+    [isLeft]
+  );
+
+  useAnimatedReaction(
+    () => ({
+      dragDistance: getDragDistance(),
+      releaseLocked: releaseLocked.value,
+    }),
+    ({ dragDistance, releaseLocked: isReleaseLocked }) => {
+      if (!isReleaseLocked) {
+        frozenWidth.value = -1;
+        return;
+      }
+
+      if (frozenWidth.value < 0) {
+        frozenWidth.value = getCapsuleWidth(dragDistance);
+      }
+    },
+    [isLeft]
+  );
+
+  const capsuleStyle = useAnimatedStyle(() => {
+    const dragDistance = getDragDistance();
+    const width = frozenWidth.value >= 0 ? frozenWidth.value : getCapsuleWidth(dragDistance);
+    const scaleY = interpolate(
+      dragDistance,
+      [0, STRETCH_START_DISTANCE, COMMIT_DISTANCE, ACTION_LANE_WIDTH],
+      [1, 1, 1.035, 1.035],
+      Extrapolation.CLAMP
+    );
+    const opacity = interpolate(progress.value, [0, 0.18, 0.35], [0, 0.8, 1], Extrapolation.CLAMP);
+
+    return {
+      width,
+      opacity,
+      transform: [{ scaleY }],
+    };
+  });
+
+  const iconStyle = useAnimatedStyle(() => {
+    const dragDistance = getDragDistance();
+    const scaleX = interpolate(
+      dragDistance,
+      [0, STRETCH_START_DISTANCE, COMMIT_DISTANCE, ACTION_LANE_WIDTH],
+      [1, 1, 1.15, 1.28],
+      Extrapolation.CLAMP
+    );
+    const scaleY = interpolate(
+      dragDistance,
+      [0, STRETCH_START_DISTANCE, COMMIT_DISTANCE, ACTION_LANE_WIDTH],
+      [1, 1, 0.9, 0.84],
+      Extrapolation.CLAMP
+    );
+
+    return {
+      transform: [{ scaleX }, { scaleY }],
+    };
+  });
+
+  return (
+    <View style={[styles.actionPanel, isLeft ? styles.leftActionPanel : styles.rightActionPanel]}>
+      <Animated.View style={[styles.actionCapsule, { backgroundColor: color }, capsuleStyle]}>
+        <Animated.View style={iconStyle}>{children}</Animated.View>
+      </Animated.View>
+    </View>
+  );
+}
+
+function AddActionPanel({ progress, translation, releaseLocked }: SwipeActionPanelProps) {
+  const { colors } = useAppTheme();
+
+  return (
+    <SwipeActionCapsule
+      progress={progress}
+      translation={translation}
+      releaseLocked={releaseLocked}
+      direction="left"
+      color={colors.statusSuccess}
+    >
+      <PlusIcon size={ACTION_ICON_SIZE} color={colors.overlayForeground} />
+    </SwipeActionCapsule>
+  );
+}
+
+function RemoveActionPanel({ progress, translation, releaseLocked }: SwipeActionPanelProps) {
+  const { colors } = useAppTheme();
+
+  return (
+    <SwipeActionCapsule
+      progress={progress}
+      translation={translation}
+      releaseLocked={releaseLocked}
+      direction="right"
+      color={colors.statusError}
+    >
+      <TrashIcon size={ACTION_ICON_SIZE} color={colors.overlayForeground} />
+    </SwipeActionCapsule>
+  );
+}
+
+function SubscriptionToggle({
+  checked,
+  disabled = false,
+  onPress,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+}) {
+  const { colors } = useAppTheme();
+
+  return (
+    <IconButton
+      size="sm"
+      variant="ghost"
+      disabled={disabled}
+      onPress={onPress}
+      accessibilityRole="switch"
+      accessibilityLabel={checked ? 'Remove subscription' : 'Add subscription'}
+      accessibilityState={{ checked, disabled }}
+      accessibilityHint={checked ? 'Turns this subscription off.' : 'Turns this subscription on.'}
+      style={styles.subscriptionToggle}
+    >
+      {checked ? (
+        <CheckIcon size={ACTION_ICON_SIZE} color={colors.statusSuccess} />
+      ) : (
+        <CheckOutlineIcon size={ACTION_ICON_SIZE} color={colors.textTertiary} />
+      )}
+    </IconButton>
   );
 }
 
@@ -288,11 +505,16 @@ export function SourceSearchField({
 }
 
 export function SourceSubscriptionRow({
+  source: _source,
+  variant = 'card',
   title,
   subtitle,
   meta,
   imageUrl,
   statusLabel,
+  toggleChecked,
+  onToggle,
+  toggleDisabled = false,
   primaryActionLabel,
   onPrimaryAction,
   primaryActionVariant = 'secondary',
@@ -306,13 +528,18 @@ export function SourceSubscriptionRow({
   onTertiaryAction,
   tertiaryActionTone = 'danger',
 }: {
+  source?: SubscriptionSource;
+  variant?: 'card' | 'flat';
   title: string;
   subtitle?: string | null;
   meta?: string | null;
   imageUrl?: string | null;
   statusLabel?: string | null;
-  primaryActionLabel: string;
-  onPrimaryAction: () => void;
+  toggleChecked?: boolean;
+  onToggle?: (() => void) | null;
+  toggleDisabled?: boolean;
+  primaryActionLabel?: string | null;
+  onPrimaryAction?: (() => void) | null;
   primaryActionVariant?: 'primary' | 'secondary' | 'outline' | 'ghost';
   primaryActionTone?: 'default' | 'danger';
   primaryActionLoading?: boolean;
@@ -325,9 +552,18 @@ export function SourceSubscriptionRow({
   tertiaryActionTone?: 'default' | 'danger';
 }) {
   const { colors } = useAppTheme();
+  const Container = variant === 'flat' ? View : Surface;
+  const containerProps =
+    variant === 'flat' ? {} : ({ tone: 'elevated', border: 'subtle', radius: 'xl' } as const);
 
   return (
-    <Surface tone="elevated" border="subtle" radius="xl" style={styles.subscriptionRow}>
+    <Container
+      {...containerProps}
+      style={[
+        variant === 'flat' ? styles.flatSubscriptionRow : styles.subscriptionRow,
+        variant === 'flat' ? { backgroundColor: colors.surfaceCanvas } : null,
+      ]}
+    >
       <Avatar imageUrl={imageUrl} title={title} />
 
       <View style={styles.subscriptionCopy}>
@@ -353,42 +589,154 @@ export function SourceSubscriptionRow({
         ) : null}
       </View>
 
-      <View style={styles.rowActions}>
-        <Button
-          label={primaryActionLabel}
-          onPress={onPrimaryAction}
-          variant={primaryActionVariant}
-          tone={primaryActionTone}
-          size="sm"
-          loading={primaryActionLoading}
-          disabled={primaryActionDisabled}
+      {primaryActionLabel && onPrimaryAction ? (
+        <View style={styles.rowActions}>
+          <Button
+            label={primaryActionLabel}
+            onPress={onPrimaryAction}
+            variant={primaryActionVariant}
+            tone={primaryActionTone}
+            size="sm"
+            loading={primaryActionLoading}
+            disabled={primaryActionDisabled}
+          />
+          {secondaryActionLabel && onSecondaryAction ? (
+            <Button
+              label={secondaryActionLabel}
+              onPress={onSecondaryAction}
+              variant="ghost"
+              tone={secondaryActionTone}
+              size="sm"
+              labelStyle={{
+                color: secondaryActionTone === 'danger' ? colors.statusError : colors.textSecondary,
+              }}
+            />
+          ) : null}
+          {tertiaryActionLabel && onTertiaryAction ? (
+            <Button
+              label={tertiaryActionLabel}
+              onPress={onTertiaryAction}
+              variant="ghost"
+              tone={tertiaryActionTone}
+              size="sm"
+              labelStyle={{
+                color: tertiaryActionTone === 'danger' ? colors.statusError : colors.textSecondary,
+              }}
+            />
+          ) : null}
+        </View>
+      ) : null}
+      {typeof toggleChecked === 'boolean' && onToggle ? (
+        <SubscriptionToggle checked={toggleChecked} disabled={toggleDisabled} onPress={onToggle} />
+      ) : null}
+      {variant === 'flat' ? (
+        <View style={[styles.flatRowSeparator, { backgroundColor: colors.borderDefault }]} />
+      ) : null}
+    </Container>
+  );
+}
+
+export function SwipeableSourceSubscriptionRow({
+  title,
+  imageUrl,
+  isSubscribed,
+  isProcessing = false,
+  onAdd,
+  onRemove,
+}: {
+  title: string;
+  imageUrl?: string | null;
+  isSubscribed: boolean;
+  isProcessing?: boolean;
+  onAdd: () => void;
+  onRemove: () => void;
+}) {
+  const swipeableRef = useRef<SwipeableMethods>(null);
+  const releaseLocked = useSharedValue(false);
+  const { colors } = useAppTheme();
+
+  const executeAction = useCallback(
+    (direction: 'left' | 'right') => {
+      if (
+        isProcessing ||
+        (direction === 'right' && isSubscribed) ||
+        (direction === 'left' && !isSubscribed)
+      ) {
+        swipeableRef.current?.close();
+        return;
+      }
+
+      if (direction === 'right') {
+        onAdd();
+      } else {
+        onRemove();
+      }
+
+      swipeableRef.current?.close();
+    },
+    [isProcessing, isSubscribed, onAdd, onRemove]
+  );
+
+  const renderLeftActions = (progress: SharedValue<number>, translation: SharedValue<number>) => (
+    <AddActionPanel progress={progress} translation={translation} releaseLocked={releaseLocked} />
+  );
+
+  const renderRightActions = (progress: SharedValue<number>, translation: SharedValue<number>) => (
+    <RemoveActionPanel
+      progress={progress}
+      translation={translation}
+      releaseLocked={releaseLocked}
+    />
+  );
+
+  const handleSwipeableWillOpen = useCallback(() => {
+    releaseLocked.value = true;
+  }, [releaseLocked]);
+
+  const handleSwipeableWillClose = useCallback(() => {
+    releaseLocked.value = false;
+  }, [releaseLocked]);
+
+  const handleSwipeableOpen = useCallback(
+    (direction: 'left' | 'right') => {
+      executeAction(direction);
+    },
+    [executeAction]
+  );
+
+  const handleToggle = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    executeAction(isSubscribed ? 'left' : 'right');
+  }, [executeAction, isSubscribed]);
+
+  return (
+    <Animated.View accessible={false}>
+      <ReanimatedSwipeable
+        ref={swipeableRef}
+        friction={SWIPE_FRICTION}
+        leftThreshold={SWIPE_THRESHOLD}
+        rightThreshold={SWIPE_THRESHOLD}
+        overshootLeft={true}
+        overshootRight={true}
+        overshootFriction={OVERSHOOT_FRICTION}
+        renderLeftActions={renderLeftActions}
+        renderRightActions={renderRightActions}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        onSwipeableWillClose={handleSwipeableWillClose}
+        onSwipeableOpen={handleSwipeableOpen}
+        containerStyle={styles.swipeableContainer}
+        childrenContainerStyle={{ backgroundColor: colors.surfaceCanvas }}
+      >
+        <SourceSubscriptionRow
+          variant="flat"
+          title={title}
+          imageUrl={imageUrl}
+          toggleChecked={isSubscribed}
+          toggleDisabled={isProcessing}
+          onToggle={handleToggle}
         />
-        {secondaryActionLabel && onSecondaryAction ? (
-          <Button
-            label={secondaryActionLabel}
-            onPress={onSecondaryAction}
-            variant="ghost"
-            tone={secondaryActionTone}
-            size="sm"
-            labelStyle={{
-              color: secondaryActionTone === 'danger' ? colors.statusError : colors.textSecondary,
-            }}
-          />
-        ) : null}
-        {tertiaryActionLabel && onTertiaryAction ? (
-          <Button
-            label={tertiaryActionLabel}
-            onPress={onTertiaryAction}
-            variant="ghost"
-            tone={tertiaryActionTone}
-            size="sm"
-            labelStyle={{
-              color: tertiaryActionTone === 'danger' ? colors.statusError : colors.textSecondary,
-            }}
-          />
-        ) : null}
-      </View>
-    </Surface>
+      </ReanimatedSwipeable>
+    </Animated.View>
   );
 }
 
@@ -489,6 +837,14 @@ const styles = StyleSheet.create({
     gap: Spacing.md,
     padding: Spacing.md,
   },
+  flatSubscriptionRow: {
+    minHeight: 76,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+  },
   avatarImage: {
     width: 48,
     height: 48,
@@ -516,9 +872,43 @@ const styles = StyleSheet.create({
   statusBadge: {
     maxWidth: 150,
   },
+  subscriptionToggle: {
+    flexShrink: 0,
+  },
   rowActions: {
     alignItems: 'flex-end',
     gap: Spacing.xs,
+  },
+  flatRowSeparator: {
+    position: 'absolute',
+    left: 80,
+    right: 0,
+    bottom: 0,
+    height: StyleSheet.hairlineWidth,
+  },
+  swipeableContainer: {
+    minHeight: 76,
+  },
+  actionPanel: {
+    width: ACTION_LANE_WIDTH,
+    flex: 1,
+    justifyContent: 'center',
+    overflow: 'visible',
+  },
+  leftActionPanel: {
+    alignItems: 'flex-start',
+    paddingLeft: Spacing.sm,
+  },
+  rightActionPanel: {
+    alignItems: 'flex-end',
+    paddingRight: Spacing.sm,
+  },
+  actionCapsule: {
+    height: ACTION_CIRCLE_SIZE,
+    minWidth: ACTION_CIRCLE_SIZE,
+    borderRadius: ACTION_CIRCLE_SIZE / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   emptyState: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary

- Replace the YouTube and Spotify subscription rows with swipeable flat list rows matching the mobile inbox/list treatment.
- Add right-swipe subscribe and left-swipe remove actions using the existing Reanimated swipe behavior.
- Replace the subscribed text badge with a toggleable check control that shares the same add/remove handlers as swipe.
- Keep Gmail/RSS subscription rows on their existing button/card interaction path.

## Validation

- `bun run format:check`
- `bun run --cwd apps/mobile lint` (passes with existing unrelated warning in `weekly-recap-card.test.tsx`)
- `bun run --cwd apps/mobile test -- source-ui.test.tsx subscriptions-screen.test.tsx --runInBand`
- `bun run build`
- `bun run test` partially completed: mobile suite passed 61/61, then local worker lane failed in Cloudflare `workerd`/Miniflare startup with `EADDRNOTAVAIL`/module fetch errors before application assertions.
- `bun run test:worker:ci` reproduced the same local Cloudflare worker runtime startup failure.

