### PR TITLE
Worker tech debt: type-safe Vectorize metadata payloads

### DIFF
--- a/apps/worker/src/enrichment/embeddings.test.ts
+++ b/apps/worker/src/enrichment/embeddings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildVectorId, getVectorVisibility } from './embeddings';
+import { buildVectorId, buildVectorMetadata, getVectorVisibility } from './embeddings';
 
 describe('embedding privacy helpers', () => {
   it('uses public vectors for non-private providers', () => {
@@ -23,5 +23,47 @@ describe('embedding privacy helpers', () => {
         provider: 'GMAIL',
       })
     ).toBe('user:user-1:item:item-1');
+  });
+
+  it('builds Vectorize-compatible public metadata without null fields', () => {
+    expect(
+      buildVectorMetadata(
+        {
+          itemId: 'item-1',
+          userId: 'user-1',
+          provider: 'WEB',
+          contentType: 'ARTICLE',
+          primaryCategory: null,
+        },
+        'public'
+      )
+    ).toEqual({
+      itemId: 'item-1',
+      provider: 'WEB',
+      contentType: 'ARTICLE',
+      visibility: 'public',
+    });
+  });
+
+  it('includes user and category metadata for private vectors', () => {
+    expect(
+      buildVectorMetadata(
+        {
+          itemId: 'item-1',
+          userId: 'user-1',
+          provider: 'GMAIL',
+          contentType: 'EMAIL',
+          primaryCategory: 'work',
+        },
+        'user'
+      )
+    ).toEqual({
+      itemId: 'item-1',
+      userId: 'user-1',
+      provider: 'GMAIL',
+      contentType: 'EMAIL',
+      primaryCategory: 'work',
+      visibility: 'user',
+    });
   });
 });

--- a/apps/worker/src/enrichment/embeddings.ts
+++ b/apps/worker/src/enrichment/embeddings.ts
@@ -16,16 +16,6 @@ type WorkersAIRun = {
   run(model: string, input: unknown): Promise<unknown>;
 };
 
-type VectorizeUpsert = {
-  upsert(
-    vectors: Array<{
-      id: string;
-      values: number[];
-      metadata?: Record<string, unknown>;
-    }>
-  ): Promise<unknown>;
-};
-
 function getEmbeddingModel(env: Bindings): string {
   return env.EMBEDDING_MODEL || DEFAULT_EMBEDDING_MODEL;
 }
@@ -70,13 +60,38 @@ export function buildVectorId(input: Pick<EmbeddingUpsertInput, 'itemId' | 'user
     : `item:${input.itemId}`;
 }
 
+export function buildVectorMetadata(
+  input: Pick<
+    EmbeddingUpsertInput,
+    'itemId' | 'userId' | 'provider' | 'contentType' | 'primaryCategory'
+  >,
+  visibility: VectorVisibility
+): NonNullable<VectorizeVector['metadata']> {
+  const metadata: NonNullable<VectorizeVector['metadata']> = {
+    itemId: input.itemId,
+    provider: input.provider,
+    contentType: input.contentType,
+    visibility,
+  };
+
+  if (visibility === 'user') {
+    metadata.userId = input.userId;
+  }
+
+  if (input.primaryCategory) {
+    metadata.primaryCategory = input.primaryCategory;
+  }
+
+  return metadata;
+}
+
 export async function upsertItemEmbedding(
   db: Database,
   env: Bindings,
   input: EmbeddingUpsertInput
 ): Promise<void> {
   const ai = env.AI as unknown as WorkersAIRun | undefined;
-  const index = env.ITEM_VECTORS as unknown as VectorizeUpsert | undefined;
+  const index = env.ITEM_VECTORS;
 
   if (!ai) {
     throw new Error('Workers AI binding is not configured');
@@ -101,14 +116,7 @@ export async function upsertItemEmbedding(
     {
       id: vectorId,
       values: embedding,
-      metadata: {
-        itemId: input.itemId,
-        userId: visibility === 'user' ? input.userId : null,
-        provider: input.provider,
-        contentType: input.contentType,
-        primaryCategory: input.primaryCategory,
-        visibility,
-      },
+      metadata: buildVectorMetadata(input, visibility),
     },
   ]);
 


### PR DESCRIPTION
## Summary
- remove the local  shim and use the real  binding type
- add  to build Vectorize metadata with explicit typing
- stop sending  metadata fields for public vectors; include optional fields only when present
- add focused tests for public/private metadata payload shapes

## Validation
- bun run --cwd apps/worker test:run src/enrichment/embeddings.test.ts
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- pre-push hooks also passed during push (, 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-05-07/apps/web

 ✓ src/lib/format.test.ts (5 tests) 2ms
 ✓ src/lib/query-persistence.test.ts (3 tests) 1ms
 ✓ src/protected-route.test.tsx (4 tests) 69ms
 ✓ src/lib/oauth.test.ts (4 tests) 48ms
 ✓ src/auth-page.test.tsx (4 tests) 96ms
 ✓ src/oauth-callback-page.test.tsx (4 tests) 102ms
 ✓ src/pwa-support.test.tsx (4 tests) 105ms
 ✓ src/app.test.tsx (4 tests) 115ms
 ✓ src/settings-page.test.tsx (7 tests) 239ms
 ✓ src/welcome-page.test.tsx (9 tests) 553ms
 ✓ src/bookmarks-page.test.tsx (21 tests) 747ms

 Test Files  11 passed (11)
      Tests  69 passed (69)
   Start at  05:33:55
   Duration  1.86s (transform 569ms, setup 1.43s, collect 1.74s, tests 2.08s, environment 4.92s, prepare 616ms), 
 RUN  v2.1.9 /Users/erikjohansson/.worktrees/zine/techdebt-2026-05-07/apps/worker

[vpw:inf] Starting isolated runtimes for vitest.config.ts...)
