### PR TITLE
Add collection drill-in list view from Home

### DIFF
--- a/apps/mobile/app/(tabs)/index/_layout.tsx
+++ b/apps/mobile/app/(tabs)/index/_layout.tsx
@@ -4,6 +4,7 @@ export default function HomeLayout() {
   return (
     <Stack>
       <Stack.Screen name="index" options={{ title: 'Home' }} />
+      <Stack.Screen name="collection/[id]" options={{ title: 'Collection', headerBackTitle: '' }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/index/collection/[id].tsx
+++ b/apps/mobile/app/(tabs)/index/collection/[id].tsx
@@ -1,0 +1,332 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { Surface } from 'heroui-native';
+import { useCallback, useMemo, useRef } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import type { ContentType as ApiContentType, Provider as ApiProvider } from '@zine/shared';
+import { CollectionSort, type CollectionRules } from '@zine/shared';
+
+import { ItemCard, type ItemCardData } from '@/components/item-card';
+import { EmptyState, ErrorState, InvalidParamState, LoadingState } from '@/components/list-states';
+import { Colors, Radius, Spacing, Typography } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useCollection, useInfiniteCollectionItems, useUserTags } from '@/hooks/use-items-trpc';
+import {
+  getContentTypeLabel,
+  getProviderLabel,
+  mapContentType,
+  mapProvider,
+  type UIContentType,
+  type UIProvider,
+} from '@/lib/content-utils';
+import { isValidId } from '@/lib/route-validation';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+
+const COLLECTION_PAGE_SIZE = 20;
+
+function pluralize(label: string): string {
+  return label.endsWith('s') ? label : `${label}s`;
+}
+
+function getSortLabel(sort: string): string {
+  switch (sort) {
+    case CollectionSort.OLDEST_SAVED:
+      return 'Oldest saved';
+    case CollectionSort.SHORTEST:
+      return 'Shortest';
+    case CollectionSort.LONGEST:
+      return 'Longest';
+    case CollectionSort.RECENTLY_OPENED:
+      return 'Recently opened';
+    case CollectionSort.NEWEST_SAVED:
+    default:
+      return 'Newest saved';
+  }
+}
+
+function getLengthLabel(rules: CollectionRules): string | null {
+  const min = rules.minLengthMinutes;
+  const max = rules.maxLengthMinutes;
+
+  if (min === undefined && max === undefined) {
+    return null;
+  }
+
+  if (min !== undefined && max !== undefined) {
+    return `${min}-${max} min`;
+  }
+
+  if (min !== undefined) {
+    return `${min}+ min`;
+  }
+
+  return max !== undefined ? `Under ${max} min` : null;
+}
+
+function buildRuleChips(
+  rules: CollectionRules,
+  tagNamesById: Map<string, string>,
+  sort: string
+): string[] {
+  const chips: string[] = [];
+
+  if (rules.contentTypes?.length) {
+    chips.push(
+      ...rules.contentTypes.map((contentType) =>
+        pluralize(getContentTypeLabel(contentType as ApiContentType))
+      )
+    );
+  }
+
+  if (rules.providers?.length) {
+    chips.push(
+      ...rules.providers
+        .map((provider) => getProviderLabel(provider as ApiProvider))
+        .filter((label) => label.length > 0)
+    );
+  }
+
+  if (rules.tagIds?.length) {
+    chips.push(
+      ...rules.tagIds.map((tagId) => tagNamesById.get(tagId) ?? `Tag ${tagId.slice(0, 6)}`)
+    );
+  }
+
+  if (rules.isFinished === true) {
+    chips.push('Finished');
+  } else if (rules.isFinished === false) {
+    chips.push('Unfinished');
+  }
+
+  const lengthLabel = getLengthLabel(rules);
+  if (lengthLabel) {
+    chips.push(lengthLabel);
+  }
+
+  if (rules.search) {
+    chips.push(`Search: "${rules.search}"`);
+  }
+
+  if (chips.length === 0) {
+    chips.push('Manual collection');
+  }
+
+  chips.push(getSortLabel(sort));
+  return chips;
+}
+
+export default function CollectionScreen() {
+  const params = useLocalSearchParams<{ id?: string }>();
+  const rawId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const collectionId = isValidId(rawId) ? rawId : '';
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const listRef = useRef<FlatList<ItemCardData>>(null);
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
+
+  const collectionQuery = useCollection(collectionId);
+  const tagsQuery = useUserTags();
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteCollectionItems({
+      id: collectionId,
+      limit: COLLECTION_PAGE_SIZE,
+    });
+
+  const tagNamesById = useMemo(() => {
+    return new Map((tagsQuery.data?.tags ?? []).map((tag) => [tag.id, tag.name]));
+  }, [tagsQuery.data?.tags]);
+
+  const collection = collectionQuery.data;
+  const activeError = collectionQuery.error ?? error;
+  const collectionTitle = collection?.name ?? 'Collection';
+  const ruleChips = useMemo(
+    () => buildRuleChips(collection?.rules ?? {}, tagNamesById, collection?.sort ?? ''),
+    [collection?.rules, collection?.sort, tagNamesById]
+  );
+
+  const collectionItems: ItemCardData[] = useMemo(
+    () =>
+      (data?.pages.flatMap((page) => page.items) ?? []).map((item) => ({
+        id: item.id,
+        title: item.title,
+        creator: item.creator,
+        creatorImageUrl: item.creatorImageUrl ?? null,
+        thumbnailUrl: item.thumbnailUrl ?? null,
+        contentType: mapContentType(item.contentType) as UIContentType,
+        provider: mapProvider(item.provider) as UIProvider,
+        duration: item.duration ?? null,
+        readingTimeMinutes: item.readingTimeMinutes ?? null,
+        bookmarkedAt: item.bookmarkedAt ?? null,
+        publishedAt: item.publishedAt ?? null,
+        isFinished: item.isFinished,
+      })),
+    [data?.pages]
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    void fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
+      <ItemCard item={item} shape="row" index={index} />
+    ),
+    []
+  );
+
+  if (!collectionId) {
+    return (
+      <Surface
+        style={[styles.container, { backgroundColor: colors.background }]}
+        collapsable={false}
+      >
+        <Stack.Screen
+          options={createLightweightHeaderScreenOptions({
+            backgroundColor: colors.background,
+            tintColor: colors.text,
+            screenTitle: 'Collection',
+            showScreenTitle: true,
+          })}
+        />
+        <InvalidParamState message="The collection link is missing or invalid." />
+      </Surface>
+    );
+  }
+
+  const listEmptyComponent =
+    collectionQuery.isLoading || isLoading ? (
+      <LoadingState message="Loading collection..." />
+    ) : activeError ? (
+      <ErrorState message={activeError.message} />
+    ) : (
+      <EmptyState
+        title="No items in this collection"
+        message="Items that match these saved filters, plus manual additions, will appear here."
+      />
+    );
+
+  return (
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: collectionTitle,
+          showScreenTitle: collectionQuery.isLoading || Boolean(activeError) || showCollapsedTitle,
+        })}
+      />
+
+      <FlatList
+        ref={listRef}
+        data={collectionQuery.isLoading || isLoading || activeError ? [] : collectionItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.6}
+        ListHeaderComponent={
+          <View style={styles.listHeader}>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>{collectionTitle}</Text>
+            {collection?.description ? (
+              <Text style={[styles.description, { color: colors.textSubheader }]}>
+                {collection.description}
+              </Text>
+            ) : null}
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.ruleChipContainer}
+            >
+              {ruleChips.map((chip, index) => (
+                <View
+                  key={`${chip}-${index}`}
+                  style={[
+                    styles.ruleChip,
+                    {
+                      backgroundColor: colors.backgroundSecondary,
+                      borderColor: colors.border,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.ruleChipText, { color: colors.textSubheader }]}>{chip}</Text>
+                </View>
+              ))}
+            </ScrollView>
+          </View>
+        }
+        ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={
+          <View style={styles.listFooter}>
+            {!collectionQuery.isLoading && !isLoading && !activeError && isFetchingNextPage ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : null}
+          </View>
+        }
+      />
+    </Surface>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    flexGrow: 1,
+    paddingBottom: Spacing['3xl'],
+  },
+  listHeader: {
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
+  },
+  headerTitle: {
+    ...Typography.displayMedium,
+    paddingHorizontal: Spacing.md,
+  },
+  description: {
+    ...Typography.bodyMedium,
+    paddingHorizontal: Spacing.md,
+    marginTop: Spacing.xs,
+  },
+  ruleChipContainer: {
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.md,
+    gap: Spacing.sm,
+  },
+  ruleChip: {
+    borderWidth: 1,
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+  },
+  ruleChipText: {
+    ...Typography.labelMedium,
+  },
+  listFooter: {
+    minHeight: Spacing['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -188,6 +188,7 @@ type HomeSectionItem =
     }
   | {
       key: string;
+      collectionId: string;
       type: 'custom-cover-rail' | 'custom-stack-rail' | 'custom-row-grid' | 'custom-compact-list';
       title: string;
       count: number;
@@ -329,6 +330,7 @@ export default function HomeScreen() {
 
         return {
           key: `collection-${section.collectionId}`,
+          collectionId: section.collectionId,
           type,
           title: section.title,
           count: section.count,
@@ -339,6 +341,16 @@ export default function HomeScreen() {
         };
       });
   }, [homeData?.customCollections]);
+
+  const handleOpenCollection = useCallback(
+    (collectionId: string) => {
+      router.push({
+        pathname: '/(tabs)/index/collection/[id]',
+        params: { id: collectionId },
+      });
+    },
+    [router]
+  );
 
   const handleOpenSettings = useCallback(() => {
     router.push('/settings');
@@ -552,7 +564,16 @@ export default function HomeScreen() {
         case 'custom-cover-rail':
           return (
             <View>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                count={item.count}
+                colors={colors}
+                onPress={
+                  item.type === 'custom-cover-rail'
+                    ? () => handleOpenCollection(item.collectionId)
+                    : undefined
+                }
+              />
               <FlatList
                 horizontal
                 data={item.items}
@@ -569,7 +590,16 @@ export default function HomeScreen() {
         case 'custom-stack-rail':
           return (
             <View>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                count={item.count}
+                colors={colors}
+                onPress={
+                  item.type === 'custom-stack-rail'
+                    ? () => handleOpenCollection(item.collectionId)
+                    : undefined
+                }
+              />
               <FlatList
                 horizontal
                 data={item.items}
@@ -585,7 +615,12 @@ export default function HomeScreen() {
         case 'custom-row-grid':
           return (
             <View>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                count={item.count}
+                colors={colors}
+                onPress={() => handleOpenCollection(item.collectionId)}
+              />
               <View style={styles.jumpBackInGrid}>
                 {item.items.map((sectionItem) => (
                   <View
@@ -601,7 +636,12 @@ export default function HomeScreen() {
         case 'custom-compact-list':
           return (
             <View style={styles.section}>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                count={item.count}
+                colors={colors}
+                onPress={() => handleOpenCollection(item.collectionId)}
+              />
               <View
                 style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
               >
@@ -613,7 +653,7 @@ export default function HomeScreen() {
           );
       }
     },
-    [colors, featuredGridItemWidth, router]
+    [colors, featuredGridItemWidth, handleOpenCollection, router]
   );
 
   useEffect(() => {

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -126,6 +126,11 @@ type LibraryItemsOptions = {
   limit?: number;
 };
 
+type CollectionItemsOptions = {
+  id: string;
+  limit?: number;
+};
+
 /**
  * Factory function to create optimistic mutation config
  *
@@ -496,6 +501,30 @@ export function useCollections() {
   });
 }
 
+export function useCollection(id: string) {
+  return trpc.collections.get.useQuery(
+    { id },
+    {
+      enabled: !!id,
+      placeholderData: keepPreviousData,
+    }
+  );
+}
+
+export function useInfiniteCollectionItems(options: CollectionItemsOptions) {
+  return trpc.collections.items.useInfiniteQuery(
+    {
+      id: options.id,
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+    },
+    {
+      enabled: !!options.id,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      placeholderData: keepPreviousData,
+    }
+  );
+}
+
 export function useCollectionsForItem(userItemId: string) {
   return trpc.collections.forItem.useQuery(
     { userItemId },
@@ -522,8 +551,10 @@ export function useUpdateCollection() {
   return trpc.collections.update.useMutation({
     onSuccess: () => {
       utils.collections.list.invalidate();
+      utils.collections.get.invalidate();
       utils.collections.items.invalidate();
       utils.collections.forItem.invalidate();
+      utils.items.home.invalidate();
     },
   });
 }
@@ -534,8 +565,10 @@ export function useDeleteCollection() {
   return trpc.collections.delete.useMutation({
     onSuccess: () => {
       utils.collections.list.invalidate();
+      utils.collections.get.invalidate();
       utils.collections.items.invalidate();
       utils.collections.forItem.invalidate();
+      utils.items.home.invalidate();
     },
   });
 }
@@ -546,6 +579,7 @@ export function useSetCollectionHomeSection() {
   return trpc.collections.setHomeSection.useMutation({
     onSuccess: () => {
       utils.collections.list.invalidate();
+      utils.collections.get.invalidate();
       utils.items.home.invalidate();
     },
   });
@@ -559,6 +593,7 @@ export function useSetCollectionItemOverride() {
       utils.collections.list.invalidate();
       utils.collections.items.invalidate({ id: collectionId });
       utils.collections.forItem.invalidate({ userItemId });
+      utils.items.home.invalidate();
     },
   });
 }

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -525,6 +525,15 @@ describe('HomeScreen', () => {
       }),
     ]);
     expect(sections[0].items).toHaveLength(4);
+
+    act(() => {
+      findButtonByText(renderer!, 'Weekend queue').props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/(tabs)/index/collection/[id]',
+      params: { id: 'collection-1' },
+    });
   });
 
   it('restores the home section visual caps without changing the expanded fetch size', () => {

--- a/apps/worker/src/trpc/routers/collections.ts
+++ b/apps/worker/src/trpc/routers/collections.ts
@@ -26,7 +26,7 @@ import {
   userItems,
   userItemTags,
 } from '../../db/schema';
-import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { toItemViewsWithTags } from './items';
 import type { Database } from '../../db';
 
@@ -63,25 +63,83 @@ function collectionSortSql(sort: z.infer<typeof CollectionSortSchema>): SQL {
   }
 }
 
+type CollectionItemsCursor = {
+  priority: number;
+  sortValue: string;
+  id: string;
+};
+
 function isAscendingSort(sort: z.infer<typeof CollectionSortSchema>): boolean {
   return sort === CollectionSort.OLDEST_SAVED || sort === CollectionSort.SHORTEST;
+}
+
+function encodeCollectionItemsCursor(cursor: CollectionItemsCursor): string {
+  return btoa(JSON.stringify(cursor)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeCollectionItemsCursor(cursorString: string): CollectionItemsCursor | null {
+  try {
+    let base64 = cursorString.replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4) {
+      base64 += '=';
+    }
+
+    const parsed = JSON.parse(atob(base64));
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.sortValue === 'string' &&
+      typeof parsed.id === 'string'
+    ) {
+      return {
+        priority: typeof parsed.priority === 'number' ? parsed.priority : 0,
+        sortValue: parsed.sortValue,
+        id: parsed.id,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function parseCollectionCursorSortValue(
+  sort: z.infer<typeof CollectionSortSchema>,
+  sortValue: string
+): string | number | null {
+  if (sort === CollectionSort.SHORTEST || sort === CollectionSort.LONGEST) {
+    const numericSortValue = Number(sortValue);
+    return Number.isFinite(numericSortValue) ? numericSortValue : null;
+  }
+
+  return sortValue;
 }
 
 function buildCursorCondition(
   sort: z.infer<typeof CollectionSortSchema>,
   sortField: SQL,
-  cursor: ReturnType<typeof decodeCursor> | null
+  priorityField: SQL,
+  cursor: CollectionItemsCursor | null
 ): SQL | undefined {
   if (!cursor) return undefined;
-  if (sort !== CollectionSort.NEWEST_SAVED && sort !== CollectionSort.OLDEST_SAVED) {
-    return undefined;
-  }
 
+  const sortValue = parseCollectionCursorSortValue(sort, cursor.sortValue);
+  if (sortValue === null) return undefined;
+
+  const priority = Number.isFinite(cursor.priority) ? cursor.priority : 0;
   const compare = isAscendingSort(sort)
-    ? sql`${sortField} > ${cursor.sortValue}`
-    : sql`${sortField} < ${cursor.sortValue}`;
+    ? sql`${sortField} > ${sortValue}`
+    : sql`${sortField} < ${sortValue}`;
+  const samePriorityRemainder = or(
+    compare,
+    and(sql`${sortField} = ${sortValue}`, lt(userItems.id, cursor.id))
+  )!;
 
-  return or(compare, and(sql`${sortField} = ${cursor.sortValue}`, lt(userItems.id, cursor.id)))!;
+  return or(
+    sql`${priorityField} < ${priority}`,
+    and(sql`${priorityField} = ${priority}`, samePriorityRemainder)
+  )!;
 }
 
 function buildSearchCondition(search: string): SQL {
@@ -91,6 +149,25 @@ function buildSearchCondition(search: string): SQL {
     sql`lower(coalesce(${creators.name}, '')) LIKE ${query}`,
     sql`lower(coalesce(${items.publisher}, '')) LIKE ${query}`
   )!;
+}
+
+function getCollectionSortValue(
+  sort: z.infer<typeof CollectionSortSchema>,
+  row: {
+    user_items: typeof userItems.$inferSelect;
+    items: typeof items.$inferSelect;
+  }
+): string {
+  switch (sort) {
+    case CollectionSort.OLDEST_SAVED:
+    case CollectionSort.NEWEST_SAVED:
+      return row.user_items.bookmarkedAt ?? row.user_items.ingestedAt;
+    case CollectionSort.SHORTEST:
+    case CollectionSort.LONGEST:
+      return String(row.items.duration ?? (row.items.readingTimeMinutes ?? 0) * 60);
+    case CollectionSort.RECENTLY_OPENED:
+      return row.user_items.lastOpenedAt ?? '';
+  }
 }
 
 function buildRuleConditions(rules: CollectionRules): SQL[] {
@@ -439,11 +516,12 @@ export const collectionsRouter = router({
       const rules = parseRules(collection.rulesJson);
       const sort = CollectionSortSchema.parse(collection.sort);
       const sortField = collectionSortSql(sort);
-      const cursor = input.cursor ? decodeCursor(input.cursor) : null;
+      const priorityField = sql<number>`CASE WHEN ${collectionItemOverrides.action} = ${CollectionOverrideAction.PIN} THEN 1 ELSE 0 END`;
+      const cursor = input.cursor ? decodeCollectionItemsCursor(input.cursor) : null;
 
       const ruleConditions = buildRuleConditions(rules);
       const matchesRules = ruleConditions.length > 0 ? and(...ruleConditions)! : sql`0 = 1`;
-      const cursorCondition = buildCursorCondition(sort, sortField, cursor);
+      const cursorCondition = buildCursorCondition(sort, sortField, priorityField, cursor);
 
       const membershipCondition = or(
         and(
@@ -479,13 +557,7 @@ export const collectionsRouter = router({
           )
         )
         .where(and(...conditions))
-        .orderBy(
-          desc(
-            sql`CASE WHEN ${collectionItemOverrides.action} = ${CollectionOverrideAction.PIN} THEN 1 ELSE 0 END`
-          ),
-          orderDirection,
-          desc(userItems.id)
-        )
+        .orderBy(desc(priorityField), orderDirection, desc(userItems.id))
         .limit(input.limit + 1);
 
       const hasMore = results.length > input.limit;
@@ -493,12 +565,14 @@ export const collectionsRouter = router({
       const itemViews = await toItemViewsWithTags(ctx, pageResults);
 
       const lastResult = pageResults[pageResults.length - 1];
-      const canCursor =
-        sort === CollectionSort.NEWEST_SAVED || sort === CollectionSort.OLDEST_SAVED;
       const nextCursor =
-        canCursor && hasMore && lastResult
-          ? encodeCursor({
-              sortValue: lastResult.user_items.bookmarkedAt ?? lastResult.user_items.ingestedAt,
+        hasMore && lastResult
+          ? encodeCollectionItemsCursor({
+              priority:
+                lastResult.collection_item_overrides?.action === CollectionOverrideAction.PIN
+                  ? 1
+                  : 0,
+              sortValue: getCollectionSortValue(sort, lastResult),
               id: lastResult.user_items.id,
             })
           : null;


### PR DESCRIPTION
## Summary
- Added a Home collection detail route that opens when a collection title is tapped.
- Built a Library-style collection list screen with the collection title, description, read-only applied filter chips, and infinite scroll.
- Added mobile tRPC hooks for fetching a single collection and paginated collection items.
- Updated worker collection pagination so all collection sort modes can page correctly, including pinned items.
- Added a Home screen test that verifies collection navigation.

## Testing
- `bun run typecheck`
- `bun run --cwd apps/mobile lint`
- `bun run --cwd apps/mobile test --runInBand lib/home-screen.test.tsx`
- `bun run --cwd apps/mobile test --runInBand hooks/use-items-trpc.test.ts`
- `bun run test:worker:ci`