### PR TITLE
[codex] Fix mobile collection navigation

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -345,7 +345,7 @@ export default function HomeScreen() {
   const handleOpenCollection = useCallback(
     (collectionId: string) => {
       router.push({
-        pathname: '/(tabs)/index/collection/[id]',
+        pathname: '/(tabs)/collection/[id]',
         params: { id: collectionId },
       });
     },

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -531,7 +531,7 @@ describe('HomeScreen', () => {
     });
 
     expect(mockPush).toHaveBeenCalledWith({
-      pathname: '/(tabs)/index/collection/[id]',
+      pathname: '/(tabs)/collection/[id]',
       params: { id: 'collection-1' },
     });
   });

--- a/apps/mobile/lib/native-large-title-header.ts
+++ b/apps/mobile/lib/native-large-title-header.ts
@@ -47,6 +47,7 @@ export function createLightweightHeaderScreenOptions({
   showScreenTitle?: boolean;
 }): ExtendedStackNavigationOptions {
   return {
+    headerBackButtonDisplayMode: 'minimal',
     headerLargeTitle: false,
     headerTransparent: false,
     headerShadowVisible: false,


### PR DESCRIPTION
## Summary

Fixes mobile Home custom collection title navigation and removes the inherited `Home` text from lightweight native back buttons.

## Root Cause

The Home custom collection link pushed `/(tabs)/index/collection/[id]`, but Expo Router flattens the Home tab's `index` segment. The addressable collection route is `/(tabs)/collection/[id]`.

## Changes

- Push custom collection links to `/(tabs)/collection/[id]`.
- Update the Home screen test expectation for that route.
- Set lightweight native headers to `headerBackButtonDisplayMode: 'minimal'` so collection detail screens show an icon-only back button.\n\n## Validation\n\n- `bun run format:check`\n- `bun run lint`\n- `bun run test`\n- `bun run typecheck`\n- `bun run build`\n- Pre-push hook: `format:check`, `design-system:check`, `typecheck`, `test:web`, worker CI subset