### PR TITLE
Add a people card to item detail screens

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -56,7 +56,7 @@ export default function ItemDetailScreen() {
   const [collectionsSheetOpen, setCollectionsSheetOpen] = useState(false);
 
   const { id, isValid, message } = useItemDetailParams();
-  const { item, otherUnfinishedBookmarks, isLoading, error, refetch, creatorData } =
+  const { item, enrichment, otherUnfinishedBookmarks, isLoading, error, refetch, creatorData } =
     useItemDetailData({ id, isValid });
   const {
     handleOpenLink,
@@ -190,6 +190,7 @@ export default function ItemDetailScreen() {
       >
         <ItemDetailContent
           item={item}
+          enrichment={enrichment}
           colors={colors}
           creatorData={creatorData}
           creatorImageUrl={upgradedCreatorImageUrl}
@@ -208,6 +209,7 @@ export default function ItemDetailScreen() {
           onManageTags={handleOpenCollectionsSheet}
           onShare={handleShare}
           onOpenLink={handleOpenLink}
+          onPersonPress={(personId) => router.push(`/person/${personId}?source=item` as Href)}
           otherUnfinishedBookmarks={otherUnfinishedBookmarks}
           onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
           useAnimatedActions
@@ -236,6 +238,7 @@ export default function ItemDetailScreen() {
     >
       <ItemDetailContent
         item={item}
+        enrichment={enrichment}
         colors={colors}
         creatorData={creatorData}
         creatorImageUrl={item.creatorImageUrl}
@@ -254,6 +257,7 @@ export default function ItemDetailScreen() {
         onManageTags={handleOpenCollectionsSheet}
         onShare={handleShare}
         onOpenLink={handleOpenLink}
+        onPersonPress={(personId) => router.push(`/person/${personId}?source=item` as Href)}
         otherUnfinishedBookmarks={otherUnfinishedBookmarks}
         onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
         useAnimatedActions={false}

--- a/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailContent.tsx
@@ -5,16 +5,23 @@ import Animated from 'react-native-reanimated';
 import { Surface } from '@/components/primitives/surface';
 
 import { styles } from '../../item-detail-styles';
-import type { ItemDetailColors, ItemDetailCreator, ItemDetailItem } from '../types';
+import type {
+  ItemDetailColors,
+  ItemDetailCreator,
+  ItemDetailEnrichment,
+  ItemDetailItem,
+} from '../types';
 import { ItemDetailActions } from './ItemDetailActions';
 import { ItemDetailCreatorRow } from './ItemDetailCreatorRow';
 import { ItemDetailDescription } from './ItemDetailDescription';
 import { ItemDetailHeader } from './ItemDetailHeader';
 import { ItemDetailMetaRow } from './ItemDetailMetaRow';
 import { ItemDetailOtherBookmarks } from './ItemDetailOtherBookmarks';
+import { ItemDetailPeopleCard } from './ItemDetailPeopleCard';
 
 type ItemDetailContentProps = {
   item: ItemDetailItem;
+  enrichment?: ItemDetailEnrichment;
   colors: ItemDetailColors;
   creatorData?: ItemDetailCreator;
   creatorImageUrl?: string | null;
@@ -31,6 +38,7 @@ type ItemDetailContentProps = {
   onManageTags: () => void;
   onShare: () => void;
   onOpenLink: () => void;
+  onPersonPress?: (personId: string) => void;
   otherUnfinishedBookmarks?: ItemDetailItem[];
   onOtherBookmarkPress?: (id: string) => void;
   useAnimatedDescription: boolean;
@@ -41,6 +49,7 @@ type ItemDetailContentProps = {
 
 export function ItemDetailContent({
   item,
+  enrichment,
   colors,
   creatorData,
   creatorImageUrl,
@@ -57,6 +66,7 @@ export function ItemDetailContent({
   onManageTags,
   onShare,
   onOpenLink,
+  onPersonPress,
   otherUnfinishedBookmarks = [],
   onOtherBookmarkPress,
   useAnimatedActions,
@@ -98,6 +108,13 @@ export function ItemDetailContent({
         onShare={onShare}
         onOpenLink={onOpenLink}
         useAnimatedContainer={useAnimatedActions}
+      />
+
+      <ItemDetailPeopleCard
+        item={item}
+        enrichment={enrichment}
+        colors={colors}
+        onPersonPress={onPersonPress}
       />
 
       {item.summary && (

--- a/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
@@ -1,0 +1,189 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Pressable, View } from 'react-native';
+
+import { Surface } from '@/components/primitives/surface';
+import { Text } from '@/components/primitives/text';
+import { IconSizes } from '@/constants/theme';
+
+import { styles } from '../../item-detail-styles';
+import type { ItemDetailColors, ItemDetailEnrichment, ItemDetailItem } from '../types';
+
+type EnrichmentEntity = NonNullable<ItemDetailEnrichment>['item']['entities'][number];
+
+type PersonEntity = {
+  name: string;
+  personId: string | null;
+  confidence: number;
+};
+
+type ItemDetailPeopleCardProps = {
+  enrichment?: ItemDetailEnrichment;
+  item: Pick<ItemDetailItem, 'contentType'>;
+  colors: ItemDetailColors;
+  onPersonPress?: (personId: string) => void;
+};
+
+const MAX_VISIBLE_PEOPLE = 5;
+
+function normalizeEntityType(value: string): string {
+  return value.trim().toLowerCase().replace(/[_-]+/g, ' ');
+}
+
+function normalizePersonName(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function getPeopleCardLabel(contentType: string): string {
+  switch (contentType.toUpperCase()) {
+    case 'VIDEO':
+      return 'People in this video';
+    case 'PODCAST':
+      return 'People in this episode';
+    case 'ARTICLE':
+      return 'People in this article';
+    case 'POST':
+      return 'People in this post';
+    default:
+      return 'People in this item';
+  }
+}
+
+function toPeople(entities: EnrichmentEntity[]): PersonEntity[] {
+  const peopleByName = new Map<string, PersonEntity>();
+
+  for (const entity of entities) {
+    if (normalizeEntityType(entity.type) !== 'person') {
+      continue;
+    }
+
+    const name = entity.name.replace(/\s+/g, ' ').trim();
+    const normalizedName = normalizePersonName(name);
+    if (!name || !normalizedName) {
+      continue;
+    }
+
+    const existing = peopleByName.get(normalizedName);
+    const next = {
+      name,
+      personId: entity.personId ?? null,
+      confidence: entity.confidence,
+    };
+
+    if (
+      !existing ||
+      (!existing.personId && next.personId) ||
+      next.confidence > existing.confidence
+    ) {
+      peopleByName.set(normalizedName, next);
+    }
+  }
+
+  return [...peopleByName.values()]
+    .sort(
+      (a, b) =>
+        Number(Boolean(b.personId)) - Number(Boolean(a.personId)) || b.confidence - a.confidence
+    )
+    .slice(0, MAX_VISIBLE_PEOPLE);
+}
+
+function PersonRow({
+  person,
+  colors,
+  onPersonPress,
+}: {
+  person: PersonEntity;
+  colors: ItemDetailColors;
+  onPersonPress?: (personId: string) => void;
+}) {
+  const initials = getInitials(person.name);
+  const personId = person.personId;
+  const isNavigable = Boolean(personId && onPersonPress);
+  const content = (
+    <>
+      <View style={[styles.peopleAvatar, { backgroundColor: colors.backgroundTertiary }]}>
+        <Text variant="labelSmall" tone="tertiary" colors={colors} transform="none">
+          {initials}
+        </Text>
+      </View>
+      <Text
+        variant="bodyMedium"
+        tone="primary"
+        colors={colors}
+        transform="none"
+        numberOfLines={1}
+        style={styles.peopleName}
+      >
+        {person.name}
+      </Text>
+      {isNavigable ? (
+        <Ionicons name="chevron-forward" size={IconSizes.sm} color={colors.textTertiary} />
+      ) : null}
+    </>
+  );
+
+  if (!isNavigable || !personId || !onPersonPress) {
+    return <View style={styles.peopleRow}>{content}</View>;
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`View ${person.name}`}
+      onPress={() => onPersonPress(personId)}
+      style={({ pressed }) => [styles.peopleRow, pressed ? { opacity: 0.72 } : null]}
+    >
+      {content}
+    </Pressable>
+  );
+}
+
+export function ItemDetailPeopleCard({
+  enrichment,
+  item,
+  colors,
+  onPersonPress,
+}: ItemDetailPeopleCardProps) {
+  const people = enrichment ? toPeople(enrichment.item.entities) : [];
+
+  if (people.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.peopleContainer}>
+      <Surface
+        tone="subtle"
+        radius="lg"
+        colors={colors}
+        style={styles.peopleSurface}
+        accessibilityLabel={getPeopleCardLabel(item.contentType)}
+      >
+        <View style={styles.peopleHeader}>
+          <Text variant="labelSmall" tone="tertiary" colors={colors}>
+            {getPeopleCardLabel(item.contentType)}
+          </Text>
+        </View>
+
+        <View style={styles.peopleList}>
+          {people.map((person) => (
+            <PersonRow
+              key={normalizePersonName(person.name)}
+              person={person}
+              colors={colors}
+              onPersonPress={onPersonPress}
+            />
+          ))}
+        </View>
+      </Surface>
+    </View>
+  );
+}

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -211,6 +211,41 @@ export const styles = StyleSheet.create({
     lineHeight: 24,
   },
 
+  // People
+  peopleContainer: {
+    marginTop: Spacing.md,
+    paddingHorizontal: Spacing.xl,
+  },
+  peopleSurface: {
+    paddingVertical: Spacing.lg,
+    overflow: 'hidden',
+  },
+  peopleHeader: {
+    paddingHorizontal: Spacing.lg,
+    marginBottom: Spacing.md,
+  },
+  peopleList: {
+    gap: Spacing.xs,
+  },
+  peopleRow: {
+    minHeight: 44,
+    paddingHorizontal: Spacing.lg,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  peopleAvatar: {
+    width: 32,
+    height: 32,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  peopleName: {
+    flex: 1,
+    minWidth: 0,
+  },
+
   // Enrichment
   enrichmentContainer: {
     marginTop: Spacing.md,


### PR DESCRIPTION
**Summary**
- Add a compact people card to the mobile item detail view that shows people extracted from the item’s enrichment data.
- Render person rows only when enrichment contains `PERSON` entities, and navigate to the person detail screen when a resolved `personId` is available.
- Wire the item detail route and shared content component to pass enrichment through and place the new card above the description section.

**Testing**
- `bun run typecheck`
- `bun run --cwd apps/mobile lint`
- `bun run --cwd apps/mobile test -- --runTestsByPath hooks/use-item-detail-data.test.ts hooks/use-item-detail-view-state.test.ts`
- Prettier check passed for the changed files