### PR TITLE
mobile: harden ContextMenu native module fallback

### DIFF
--- a/apps/mobile/lib/context-menu.tsx
+++ b/apps/mobile/lib/context-menu.tsx
@@ -14,12 +14,17 @@ let ResolvedContextMenu: React.ComponentType<ContextMenuProps> = ContextMenuFall
 
 if (Platform.OS === 'ios' && UIManager.getViewManagerConfig('ContextMenu') != null) {
   // Avoid importing the native-only package when Expo renders the web/router-server bundle.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const contextMenuModule = require('react-native-context-menu-view') as {
-    default: React.ComponentType<ContextMenuProps>;
-  };
+  // If the native dependency is missing in a test/runtime edge case, gracefully fall back.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const contextMenuModule = require('react-native-context-menu-view') as {
+      default: React.ComponentType<ContextMenuProps>;
+    };
 
-  ResolvedContextMenu = contextMenuModule.default;
+    ResolvedContextMenu = contextMenuModule.default;
+  } catch {
+    ResolvedContextMenu = ContextMenuFallback;
+  }
 }
 
 export default function ContextMenu(props: ContextMenuProps) {


### PR DESCRIPTION
## Summary
- wrap dynamic  require in 
- fall back to  if native module resolution fails at runtime
- keep existing iOS + native view-manager gate behavior

## Why
This is a small tech-debt hardening change that prevents avoidable runtime crashes in edge environments (tests/misconfigured builds) where the optional native module cannot be resolved.

## Validation
- 
/Users/erikjohansson/.worktrees/zine/zine-techdebt-2026-05-18/apps/mobile/app/(tabs)/index/collection/[id].tsx
  13:77  warning  '/Users/erikjohansson/.worktrees/zine/zine-techdebt-2026-05-18/node_modules/@zine/shared/src/index.ts' imported multiple times  import/no-duplicates
  14:54  warning  '/Users/erikjohansson/.worktrees/zine/zine-techdebt-2026-05-18/node_modules/@zine/shared/src/index.ts' imported multiple times  import/no-duplicates

/Users/erikjohansson/.worktrees/zine/zine-techdebt-2026-05-18/apps/mobile/components/insights/weekly-recap-card.test.tsx
  8:13  warning  Array type using 'ReadonlyArray<unknown>' is forbidden. Use 'readonly unknown[]' instead  @typescript-eslint/array-type

✖ 3 problems (0 errors, 3 warnings)
  0 errors and 2 warnings potentially fixable with the `--fix` option.

mobile-design-system: OK
- 
