### PR TITLE
Fix Jump Back In grid layout and prevent navigation flash

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Platform, DynamicColorIOS } from 'react-native';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { AuthGuard } from '@/components/auth-guard';
+import { Colors } from '@/constants/theme';
 
 // Tab Layout - iOS 26 Native Tabs with Liquid Glass
 
@@ -35,8 +36,10 @@ export default function TabLayout() {
         labelStyle={{
           color: dynamicLabelColor,
         }}
+        backgroundColor={Colors.dark.background}
+        disableTransparentOnScrollEdge
       >
-        <NativeTabs.Trigger name="index">
+        <NativeTabs.Trigger name="index" contentStyle={{ backgroundColor: Colors.dark.background }}>
           <NativeTabs.Trigger.Label>Home</NativeTabs.Trigger.Label>
           <NativeTabs.Trigger.Icon
             sf={{ default: 'house', selected: 'house.fill' }}
@@ -44,7 +47,7 @@ export default function TabLayout() {
           />
         </NativeTabs.Trigger>
 
-        <NativeTabs.Trigger name="inbox">
+        <NativeTabs.Trigger name="inbox" contentStyle={{ backgroundColor: Colors.dark.background }}>
           <NativeTabs.Trigger.Label>Inbox</NativeTabs.Trigger.Label>
           <NativeTabs.Trigger.Icon
             sf={{ default: 'tray', selected: 'tray.fill' }}
@@ -52,11 +55,18 @@ export default function TabLayout() {
           />
         </NativeTabs.Trigger>
 
-        <NativeTabs.Trigger name="search" role="search">
+        <NativeTabs.Trigger
+          name="search"
+          role="search"
+          contentStyle={{ backgroundColor: Colors.dark.background }}
+        >
           <NativeTabs.Trigger.Label>Search</NativeTabs.Trigger.Label>
         </NativeTabs.Trigger>
 
-        <NativeTabs.Trigger name="library">
+        <NativeTabs.Trigger
+          name="library"
+          contentStyle={{ backgroundColor: Colors.dark.background }}
+        >
           <NativeTabs.Trigger.Label>Library</NativeTabs.Trigger.Label>
           <NativeTabs.Trigger.Icon
             sf={{ default: 'books.vertical', selected: 'books.vertical.fill' }}
@@ -65,7 +75,10 @@ export default function TabLayout() {
         </NativeTabs.Trigger>
 
         {isStorybookEnabled && (
-          <NativeTabs.Trigger name="storybook">
+          <NativeTabs.Trigger
+            name="storybook"
+            contentStyle={{ backgroundColor: Colors.dark.background }}
+          >
             <NativeTabs.Trigger.Label>Storybook</NativeTabs.Trigger.Label>
             <NativeTabs.Trigger.Icon sf={{ default: 'hammer', selected: 'hammer.fill' }} />
           </NativeTabs.Trigger>

--- a/apps/mobile/app/(tabs)/index/_layout.tsx
+++ b/apps/mobile/app/(tabs)/index/_layout.tsx
@@ -1,8 +1,10 @@
 import { Stack } from 'expo-router';
 
+import { lightweightHeaderStackScreenOptions } from '@/lib/native-large-title-header';
+
 export default function HomeLayout() {
   return (
-    <Stack>
+    <Stack screenOptions={lightweightHeaderStackScreenOptions}>
       <Stack.Screen name="index" options={{ title: 'Home' }} />
       <Stack.Screen name="collection/[id]" options={{ title: 'Collection', headerBackTitle: '' }} />
     </Stack>

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -30,7 +30,11 @@ import {
 } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
-import { getFeaturedGridItemWidth, getVisibleFeaturedGridItems } from '@/lib/home-layout';
+import {
+  getFeaturedGridItemWidth,
+  getFeaturedGridRows,
+  getVisibleFeaturedGridItems,
+} from '@/lib/home-layout';
 import { useInfiniteInboxItems, useHomeData } from '@/hooks/use-items-trpc';
 import {
   mapContentType,
@@ -515,12 +519,19 @@ export default function HomeScreen() {
             <View>
               <SectionHeader title={item.title} count={item.count} colors={colors} />
               <View style={styles.jumpBackInGrid}>
-                {item.items.map((sectionItem) => (
+                {getFeaturedGridRows(item.items).map((row) => (
                   <View
-                    key={sectionItem.id}
-                    style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                    key={row.map((sectionItem) => sectionItem.id).join(':')}
+                    style={styles.jumpBackInGridRow}
                   >
-                    <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                    {row.map((sectionItem) => (
+                      <View
+                        key={sectionItem.id}
+                        style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                      >
+                        <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                      </View>
+                    ))}
                   </View>
                 ))}
               </View>
@@ -622,12 +633,19 @@ export default function HomeScreen() {
                 onPress={() => handleOpenCollection(item.collectionId)}
               />
               <View style={styles.jumpBackInGrid}>
-                {item.items.map((sectionItem) => (
+                {getFeaturedGridRows(item.items).map((row) => (
                   <View
-                    key={sectionItem.id}
-                    style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                    key={row.map((sectionItem) => sectionItem.id).join(':')}
+                    style={styles.jumpBackInGridRow}
                   >
-                    <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                    {row.map((sectionItem) => (
+                      <View
+                        key={sectionItem.id}
+                        style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
+                      >
+                        <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                      </View>
+                    ))}
                   </View>
                 ))}
               </View>
@@ -820,11 +838,13 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.xl,
   },
   jumpBackInGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
     paddingHorizontal: Spacing.md,
     gap: Spacing.md,
     marginBottom: Spacing.xl,
+  },
+  jumpBackInGridRow: {
+    flexDirection: 'row',
+    gap: Spacing.md,
   },
   jumpBackInGridItem: {
     minWidth: 0,

--- a/apps/mobile/components/item-card.stories.tsx
+++ b/apps/mobile/components/item-card.stories.tsx
@@ -4,7 +4,7 @@ import { ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native'
 import { Spacing } from '@/constants/theme';
 import { createDarkCanvasDecorator } from '@/components/storybook/decorators';
 import { itemCardFixtures } from '@/components/storybook/fixtures';
-import { getFeaturedGridItemWidth } from '@/lib/home-layout';
+import { getFeaturedGridItemWidth, getFeaturedGridRows } from '@/lib/home-layout';
 import { ItemCard } from './item-card';
 
 const meta = {
@@ -42,20 +42,22 @@ export const FeaturedRow: Story = {
   render: function Render(args) {
     const { width } = useWindowDimensions();
     const featuredGridItemWidth = getFeaturedGridItemWidth(width - Spacing.md * 2, Spacing.md);
+    const items = [itemCardFixtures.article, itemCardFixtures.video];
 
     return (
       <View style={styles.featuredGrid}>
-        <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
-          <ItemCard {...args} />
-        </View>
-        <View style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}>
-          <ItemCard
-            item={itemCardFixtures.video}
-            shape="row"
-            rowStyle="featured"
-            onPress={args.onPress}
-          />
-        </View>
+        {getFeaturedGridRows(items).map((row) => (
+          <View key={row.map((item) => item.id).join(':')} style={styles.featuredGridRow}>
+            {row.map((item) => (
+              <View
+                key={item.id}
+                style={[styles.featuredGridItem, { width: featuredGridItemWidth }]}
+              >
+                <ItemCard {...args} item={item} />
+              </View>
+            ))}
+          </View>
+        ))}
       </View>
     );
   },
@@ -146,9 +148,11 @@ const styles = StyleSheet.create({
     gap: Spacing.md,
   },
   featuredGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
     paddingHorizontal: Spacing.md,
+    gap: Spacing.md,
+  },
+  featuredGridRow: {
+    flexDirection: 'row',
     gap: Spacing.md,
   },
   featuredGridItem: {

--- a/apps/mobile/lib/home-layout.test.ts
+++ b/apps/mobile/lib/home-layout.test.ts
@@ -1,5 +1,6 @@
 import {
   getFeaturedGridItemWidth,
+  getFeaturedGridRows,
   getValidFeaturedGridItems,
   getVisibleFeaturedGridItems,
 } from './home-layout';
@@ -69,5 +70,19 @@ describe('getFeaturedGridItemWidth', () => {
 
   it('clamps negative widths to zero', () => {
     expect(getFeaturedGridItemWidth(8, 16)).toBe(0);
+  });
+});
+
+describe('getFeaturedGridRows', () => {
+  it('groups featured items into rows of two', () => {
+    expect(getFeaturedGridRows([1, 2, 3, 4, 5, 6])).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('keeps an odd final row', () => {
+    expect(getFeaturedGridRows([1, 2, 3])).toEqual([[1, 2], [3]]);
   });
 });

--- a/apps/mobile/lib/home-layout.ts
+++ b/apps/mobile/lib/home-layout.ts
@@ -13,6 +13,16 @@ export function getFeaturedGridItemWidth(containerWidth: number, gap: number): n
   return Math.max(0, (containerWidth - gap * (FEATURED_GRID_COLUMNS - 1)) / FEATURED_GRID_COLUMNS);
 }
 
+export function getFeaturedGridRows<T>(items: readonly T[]): T[][] {
+  const rows: T[][] = [];
+
+  for (let index = 0; index < items.length; index += FEATURED_GRID_COLUMNS) {
+    rows.push(items.slice(index, index + FEATURED_GRID_COLUMNS));
+  }
+
+  return rows;
+}
+
 export function getVisibleFeaturedGridItems<T extends FeaturedGridItem>(
   items: readonly T[],
   contentTypeFilter: string | null


### PR DESCRIPTION
## Summary
- Render `Jump Back In` as explicit two-item rows so the section stays in a stable 2-column grid instead of collapsing into a single stacked column.
- Apply dark background defaults at the native tab and home stack layers to avoid the white flash during page navigation.
- Add coverage for the new featured-grid row grouping helper and keep the Storybook example aligned with the home layout.

## Testing
- `bun run --cwd apps/mobile test -- --runTestsByPath lib/home-layout.test.ts lib/home-screen.test.tsx lib/native-large-title-header.test.ts`
- `bun run design-system:check`
- `bun run --cwd apps/mobile lint`
- Verified in iOS Simulator/Expo Go after clearing the project React Query cache and reopening the current worktree app.