### PR TITLE
[codex] Add subscription reconnect indicators

### DIFF
--- a/apps/mobile/app/subscriptions/index.tsx
+++ b/apps/mobile/app/subscriptions/index.tsx
@@ -15,6 +15,7 @@ import {
   createLightweightHeaderScreenOptions,
   useCollapsedHeaderTitle,
 } from '@/lib/native-large-title-header';
+import { getSubscriptionIntegrationAttention } from '@/lib/subscription-integration-attention';
 import {
   getHubStatusText,
   getIntegrationState,
@@ -77,6 +78,10 @@ export default function SubscriptionsScreen() {
   const gmailCount = newsletterStatsQuery.data?.active ?? 0;
   const xCount = xBookmarksStatusQuery.data?.importedCount ?? 0;
   const rssCount = rssStatsQuery.data?.active ?? 0;
+  const attentionProviders = useMemo(
+    () => new Set(getSubscriptionIntegrationAttention(connections, subscriptions).providers),
+    [connections, subscriptions]
+  );
 
   const sourceRows = useMemo(
     () =>
@@ -101,14 +106,20 @@ export default function SubscriptionsScreen() {
                 : source === 'X'
                   ? xStatus
                   : null;
+        const needsAttention = source !== 'RSS' && attentionProviders.has(source);
+        const integrationState = needsAttention
+          ? 'needsAttention'
+          : getIntegrationState(source, status);
 
         return {
           source,
           route: getSubscriptionSourceConfig(source).route,
-          summary: getHubStatusText(source, getIntegrationState(source, status), count),
+          summary: getHubStatusText(source, integrationState, count),
+          needsAttention,
         };
       }),
     [
+      attentionProviders,
       gmailCount,
       gmailStatus,
       rssCount,
@@ -156,6 +167,8 @@ export default function SubscriptionsScreen() {
                 key={row.source}
                 source={row.source}
                 summary={row.summary}
+                needsAttention={row.needsAttention}
+                attentionTestID={`subscriptions-${row.source.toLowerCase()}-attention-dot`}
                 onPress={() => router.push(row.route)}
               />
             ))}

--- a/apps/mobile/components/subscriptions/source-ui.stories.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.stories.tsx
@@ -36,7 +36,8 @@ export const Overview: Story = {
       <SourceHero source="YOUTUBE" summary="Integration connected · 12 subscriptions" />
       <SourceListRow
         source="GMAIL"
-        summary="Integration connected · 8 newsletters"
+        summary="Integration needs attention · 8 newsletters"
+        needsAttention
         onPress={() => {}}
       />
       <IntegrationCard

--- a/apps/mobile/components/subscriptions/source-ui.test.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.test.tsx
@@ -1,27 +1,31 @@
 import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 
-import { SourceHero } from './source-ui';
+import { SourceHero, SourceListRow } from './source-ui';
+
+type Renderer = ReturnType<typeof TestRenderer.create>;
 
 jest.mock('react-native', () => ({
   __esModule: true,
   Platform: {
     select: (options: Record<string, unknown>) => options.ios ?? options.default,
   },
-  View: ({ children }: { children?: React.ReactNode }) =>
-    React.createElement('div', null, children),
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
   Image: ({ children }: { children?: React.ReactNode }) =>
     React.createElement('img', null, children),
   Pressable: ({
     children,
     onPress,
+    accessibilityLabel,
   }: {
     children?: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
     onPress?: () => void;
+    accessibilityLabel?: string;
   }) =>
     React.createElement(
       'button',
-      { onClick: onPress, onPress },
+      { onClick: onPress, onPress, accessibilityLabel },
       typeof children === 'function' ? children({ pressed: false }) : children
     ),
   TextInput: ({
@@ -117,6 +121,7 @@ jest.mock('@/hooks/use-app-theme', () => ({
       textPrimary: '#ffffff',
       textTertiary: '#777777',
       statusInfo: '#33aaff',
+      statusWarning: '#ffaa33',
     },
     motion: {
       opacity: {
@@ -135,5 +140,27 @@ describe('SourceHero', () => {
         );
       });
     }).not.toThrow();
+  });
+});
+
+describe('SourceListRow', () => {
+  it('marks provider rows that need attention', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <SourceListRow
+          source="SPOTIFY"
+          summary="Integration needs attention"
+          needsAttention
+          attentionTestID="spotify-attention-dot"
+          onPress={() => {}}
+        />
+      );
+    });
+
+    expect(() => renderer!.root.findByProps({ testID: 'spotify-attention-dot' })).not.toThrow();
+    expect(renderer!.root.findByType('button').props.accessibilityLabel).toContain(
+      'needs attention'
+    );
   });
 });

--- a/apps/mobile/components/subscriptions/source-ui.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.tsx
@@ -299,10 +299,14 @@ function SubscriptionToggle({
 export function SourceListRow({
   source,
   summary,
+  needsAttention = false,
+  attentionTestID,
   onPress,
 }: {
   source: SubscriptionSource;
   summary: string;
+  needsAttention?: boolean;
+  attentionTestID?: string;
   onPress: () => void;
 }) {
   const { colors, motion } = useAppTheme();
@@ -312,7 +316,7 @@ export function SourceListRow({
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`Open ${config.name} subscriptions`}
+      accessibilityLabel={`Open ${config.name} subscriptions${needsAttention ? ', needs attention' : ''}`}
       style={({ pressed }) => [pressed && { opacity: motion.opacity.pressed }]}
     >
       <Surface tone="elevated" border="subtle" radius="xl" style={styles.sourceRow}>
@@ -325,7 +329,17 @@ export function SourceListRow({
             {summary}
           </Text>
         </View>
-        <ChevronRightIcon size={18} color={colors.textTertiary} />
+        <View style={styles.sourceRowTrailing}>
+          {needsAttention ? (
+            <View
+              testID={attentionTestID}
+              accessibilityElementsHidden
+              importantForAccessibility="no"
+              style={[styles.attentionDot, { backgroundColor: colors.statusWarning }]}
+            />
+          ) : null}
+          <ChevronRightIcon size={18} color={colors.textTertiary} />
+        </View>
       </Surface>
     </Pressable>
   );
@@ -770,6 +784,16 @@ const styles = StyleSheet.create({
   sourceRowCopy: {
     flex: 1,
     gap: Spacing.xs,
+  },
+  sourceRowTrailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  attentionDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radius.full,
   },
   hero: {
     flexDirection: 'row',

--- a/apps/mobile/lib/subscriptions-screen.test.tsx
+++ b/apps/mobile/lib/subscriptions-screen.test.tsx
@@ -8,6 +8,8 @@ const mockBack = jest.fn();
 const mockCanGoBack = jest.fn();
 const mockStackScreen = jest.fn();
 let consoleErrorSpy: jest.SpyInstance;
+let mockConnections: Array<{ provider: string; status: string }> = [];
+let mockSubscriptions: Array<{ provider: string; status?: string }> = [];
 
 type Renderer = ReturnType<typeof TestRenderer.create>;
 
@@ -92,28 +94,34 @@ jest.mock('@/components/subscriptions', () => ({
   SourceListRow: ({
     source,
     summary,
+    needsAttention,
+    attentionTestID,
     onPress,
   }: {
     source: string;
     summary: string;
+    needsAttention?: boolean;
+    attentionTestID?: string;
     onPress: () => void;
-  }) => React.createElement('button', { onClick: onPress, onPress }, `${source}:${summary}`),
+  }) =>
+    React.createElement(
+      'button',
+      { onClick: onPress, onPress, 'data-needs-attention': needsAttention },
+      `${source}:${summary}`,
+      needsAttention ? React.createElement('span', { testID: attentionTestID }, 'attention') : null
+    ),
 }));
 
 jest.mock('@/hooks/use-connections', () => ({
   useConnections: () => ({
-    data: [
-      { provider: 'YOUTUBE', status: 'ACTIVE' },
-      { provider: 'SPOTIFY', status: 'ACTIVE' },
-      { provider: 'GMAIL', status: 'ACTIVE' },
-    ],
+    data: mockConnections,
     isLoading: false,
   }),
 }));
 
 jest.mock('@/hooks/use-subscriptions', () => ({
   useSubscriptions: () => ({
-    subscriptions: [{ provider: 'YOUTUBE' }, { provider: 'SPOTIFY' }, { provider: 'SPOTIFY' }],
+    subscriptions: mockSubscriptions,
     isLoading: false,
   }),
 }));
@@ -152,6 +160,16 @@ jest.mock('@/lib/trpc', () => ({
 describe('SubscriptionsScreen header', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockConnections = [
+      { provider: 'YOUTUBE', status: 'ACTIVE' },
+      { provider: 'SPOTIFY', status: 'ACTIVE' },
+      { provider: 'GMAIL', status: 'ACTIVE' },
+    ];
+    mockSubscriptions = [
+      { provider: 'YOUTUBE', status: 'ACTIVE' },
+      { provider: 'SPOTIFY', status: 'ACTIVE' },
+      { provider: 'SPOTIFY', status: 'ACTIVE' },
+    ];
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -209,5 +227,29 @@ describe('SubscriptionsScreen header', () => {
     };
 
     expect(stackScreenProps.options.headerLeft).toBeUndefined();
+  });
+
+  it('marks the provider row that needs reconnection', () => {
+    mockConnections = [
+      { provider: 'YOUTUBE', status: 'ACTIVE' },
+      { provider: 'SPOTIFY', status: 'EXPIRED' },
+      { provider: 'GMAIL', status: 'ACTIVE' },
+    ];
+    mockSubscriptions = [
+      { provider: 'YOUTUBE', status: 'ACTIVE' },
+      { provider: 'SPOTIFY', status: 'DISCONNECTED' },
+    ];
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<SubscriptionsScreen />);
+    });
+
+    expect(() =>
+      renderer!.root.findByProps({ testID: 'subscriptions-spotify-attention-dot' })
+    ).not.toThrow();
+    expect(() =>
+      renderer!.root.findByProps({ testID: 'subscriptions-youtube-attention-dot' })
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Adds a visible attention indicator to the mobile subscriptions hub so the affected provider row is clear when an integration or subscription needs reconnection.

## Changes

- Reuses the existing subscription integration attention logic on the subscriptions index screen.
- Marks source rows that need attention with a warning pip next to the chevron.
- Updates the row accessibility label to include the needs-attention state.
- Updates Storybook coverage and regression tests for the affected row state.

## Root Cause

The Settings entrypoint used `getSubscriptionIntegrationAttention` to show a reconnect pip, but the subscriptions hub did not pass that attention state into individual source rows. Users could see that something needed reconnecting, but not which source to open.

## Validation

- `bun run --cwd apps/mobile test -- source-ui.test.tsx subscriptions-screen.test.tsx subscription-integration-attention.test.ts --runInBand`
- `bun run --cwd apps/mobile lint`
- `bun run design-system:check`
- `git diff --check`
- Pre-push hook: `format:check`, `design-system:check`, `typecheck`, `test:web`, worker CI test subset