### PR TITLE
Add inferred X profile resolution for people

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailEnrichmentCard.tsx
@@ -136,7 +136,16 @@ function renderEntity(
 ) {
   const confidence = formatPercent(entity.confidence);
   const isResolvedPerson = Boolean(entity.personId);
-  const label = [entity.name, formatLabel(entity.type), isResolvedPerson ? null : confidence]
+  const relationship =
+    entity.relationship && entity.relationship !== 'MENTIONED'
+      ? formatLabel(entity.relationship)
+      : null;
+  const label = [
+    entity.name,
+    relationship,
+    formatLabel(entity.type),
+    isResolvedPerson ? null : confidence,
+  ]
     .filter(Boolean)
     .join(' / ');
 

--- a/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
@@ -13,6 +13,7 @@ type EnrichmentEntity = NonNullable<ItemDetailEnrichment>['item']['entities'][nu
 type PersonEntity = {
   name: string;
   personId: string | null;
+  relationship: string;
   confidence: number;
 };
 
@@ -31,6 +32,37 @@ function normalizeEntityType(value: string): string {
 
 function normalizePersonName(value: string): string {
   return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function formatRelationship(value: string | null | undefined): string | null {
+  if (!value || value === 'MENTIONED') {
+    return null;
+  }
+
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function relationshipPriority(value: string | null | undefined): number {
+  switch (value) {
+    case 'HOST':
+    case 'CO_HOST':
+    case 'OWNER':
+    case 'CREATOR':
+      return 4;
+    case 'AUTHOR':
+    case 'INTERVIEWER':
+    case 'INTERVIEWEE':
+    case 'GUEST':
+      return 3;
+    case 'PRIMARY_SUBJECT':
+      return 2;
+    default:
+      return 1;
+  }
 }
 
 function getInitials(name: string): string {
@@ -72,25 +104,31 @@ function toPeople(entities: EnrichmentEntity[]): PersonEntity[] {
     }
 
     const existing = peopleByName.get(normalizedName);
-    const next = {
+    const next: PersonEntity = {
       name,
       personId: entity.personId ?? null,
+      relationship: entity.relationship ?? 'MENTIONED',
       confidence: entity.confidence,
     };
+    const candidate = existing && !next.personId ? { ...next, personId: existing.personId } : next;
 
     if (
       !existing ||
-      (!existing.personId && next.personId) ||
-      next.confidence > existing.confidence
+      (!existing.personId && candidate.personId) ||
+      relationshipPriority(candidate.relationship) > relationshipPriority(existing.relationship) ||
+      (candidate.relationship === existing.relationship &&
+        candidate.confidence > existing.confidence)
     ) {
-      peopleByName.set(normalizedName, next);
+      peopleByName.set(normalizedName, candidate);
     }
   }
 
   return [...peopleByName.values()]
     .sort(
       (a, b) =>
-        Number(Boolean(b.personId)) - Number(Boolean(a.personId)) || b.confidence - a.confidence
+        Number(Boolean(b.personId)) - Number(Boolean(a.personId)) ||
+        relationshipPriority(b.relationship) - relationshipPriority(a.relationship) ||
+        b.confidence - a.confidence
     )
     .slice(0, MAX_VISIBLE_PEOPLE);
 }
@@ -107,6 +145,8 @@ function PersonRow({
   const initials = getInitials(person.name);
   const personId = person.personId;
   const isNavigable = Boolean(personId && onPersonPress);
+  const relationship = formatRelationship(person.relationship);
+  const label = relationship ? `${person.name} / ${relationship}` : person.name;
   const content = (
     <>
       <View style={[styles.peopleAvatar, { backgroundColor: colors.backgroundTertiary }]}>
@@ -122,7 +162,7 @@ function PersonRow({
         numberOfLines={1}
         style={styles.peopleName}
       >
-        {person.name}
+        {label}
       </Text>
       {isNavigable ? (
         <Ionicons name="chevron-forward" size={IconSizes.sm} color={colors.textTertiary} />

--- a/apps/worker/src/db/migrations/0015_add_person_social_profiles.sql
+++ b/apps/worker/src/db/migrations/0015_add_person_social_profiles.sql
@@ -1,0 +1,31 @@
+-- Created: 2026-05-19
+-- Store inferred social profiles for private per-user people records
+
+CREATE TABLE IF NOT EXISTS `person_social_profiles` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `user_person_id` text NOT NULL REFERENCES `user_people`(`id`),
+  `provider` text NOT NULL,
+  `provider_profile_id` text NOT NULL,
+  `handle` text NOT NULL,
+  `display_name` text NOT NULL,
+  `avatar_url` text,
+  `profile_url` text NOT NULL,
+  `description` text,
+  `verified` integer NOT NULL DEFAULT false,
+  `confidence` real NOT NULL,
+  `status` text NOT NULL,
+  `evidence_json` text,
+  `last_checked_at` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `person_social_profiles_person_provider_profile_idx`
+  ON `person_social_profiles` (`user_person_id`, `provider`, `provider_profile_id`);
+
+CREATE INDEX IF NOT EXISTS `person_social_profiles_person_status_idx`
+  ON `person_social_profiles` (`user_person_id`, `provider`, `status`, `confidence`);
+
+CREATE INDEX IF NOT EXISTS `person_social_profiles_provider_profile_idx`
+  ON `person_social_profiles` (`provider`, `provider_profile_id`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778025600000,
       "tag": "0014_add_home_collection_sections",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1779235200000,
+      "tag": "0015_add_person_social_profiles",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -422,6 +422,52 @@ export const userPersonMentions = sqliteTable(
   ]
 );
 
+// Inferred social profiles for private per-user people records.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const personSocialProfiles = sqliteTable(
+  'person_social_profiles',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    userPersonId: text('user_person_id')
+      .notNull()
+      .references(() => userPeople.id),
+    provider: text('provider').notNull(),
+    providerProfileId: text('provider_profile_id').notNull(),
+    handle: text('handle').notNull(),
+    displayName: text('display_name').notNull(),
+    avatarUrl: text('avatar_url'),
+    profileUrl: text('profile_url').notNull(),
+    description: text('description'),
+    verified: integer('verified', { mode: 'boolean' }).notNull().default(false),
+    confidence: real('confidence').notNull(),
+    status: text('status').notNull(),
+    evidenceJson: text('evidence_json'),
+    lastCheckedAt: integer('last_checked_at').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('person_social_profiles_person_provider_profile_idx').on(
+      table.userPersonId,
+      table.provider,
+      table.providerProfileId
+    ),
+    index('person_social_profiles_person_status_idx').on(
+      table.userPersonId,
+      table.provider,
+      table.status,
+      table.confidence
+    ),
+    index('person_social_profiles_provider_profile_idx').on(
+      table.provider,
+      table.providerProfileId
+    ),
+  ]
+);
+
 // Item Embedding References
 // D1 reference records for vectors stored in Cloudflare Vectorize.
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.

--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -14,6 +14,7 @@ import {
 import { getArticleContent } from '../lib/article-storage';
 import { logger } from '../lib/logger';
 import { syncPeopleForItem } from '../people/service';
+import { resolveXProfilesForItem } from '../people/social-resolution';
 import type { Bindings } from '../types';
 import { upsertItemEmbedding } from './embeddings';
 import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
@@ -407,11 +408,15 @@ async function processMessage(message: EnrichmentMessage, db: Database, env: Bin
 
       try {
         await syncPeopleForItem(db, { itemId: effectiveBody.itemId });
+        await resolveXProfilesForItem(db, env, { itemId: effectiveBody.itemId });
       } catch (error) {
-        enrichmentLogger.warn('People indexing failed for existing canonical enrichment', {
-          itemId: effectiveBody.itemId,
-          error,
-        });
+        enrichmentLogger.warn(
+          'People indexing or social profile resolution failed for existing canonical enrichment',
+          {
+            itemId: effectiveBody.itemId,
+            error,
+          }
+        );
       }
 
       message.ack();
@@ -434,11 +439,15 @@ async function processMessage(message: EnrichmentMessage, db: Database, env: Bin
 
     try {
       await syncPeopleForItem(db, { itemId: effectiveBody.itemId });
+      await resolveXProfilesForItem(db, env, { itemId: effectiveBody.itemId });
     } catch (error) {
-      enrichmentLogger.warn('People indexing failed after enrichment completion', {
-        itemId: effectiveBody.itemId,
-        error,
-      });
+      enrichmentLogger.warn(
+        'People indexing or social profile resolution failed after enrichment completion',
+        {
+          itemId: effectiveBody.itemId,
+          error,
+        }
+      );
     }
 
     const suggestedTags = normalizeSuggestedTags(output.suggestedTags, existingTags);

--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -40,7 +40,15 @@ function createValidModelOutput() {
       timeSensitivity: 'evergreen',
     },
     topics: [{ name: 'workers ai', confidence: 0.9 }],
-    entities: [{ name: 'Cloudflare Workers', type: 'technology', confidence: 0.9 }],
+    entities: [
+      {
+        name: 'Cloudflare Workers',
+        type: 'technology',
+        relationship: 'PRIMARY_SUBJECT',
+        confidence: 0.9,
+        evidenceText: 'Workers AI can run models near a Cloudflare Worker.',
+      },
+    ],
     suggestedTags: [{ name: 'cloudflare', kind: 'topic', confidence: 0.9 }],
     userContext: {
       inferredSaveIntent: 'Learn Workers AI implementation details.',
@@ -86,6 +94,11 @@ describe('enrichWithQwen', () => {
           json_schema: expect.objectContaining({
             type: 'object',
             properties: expect.objectContaining({
+              entities: expect.objectContaining({
+                items: expect.objectContaining({
+                  required: expect.arrayContaining(['relationship', 'evidenceText']),
+                }),
+              }),
               summary: expect.any(Object),
             }),
           }),

--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -9,6 +9,18 @@ import {
 } from './types';
 
 const llmLogger = logger.child('enrichment-llm');
+const ENTITY_RELATIONSHIPS = [
+  'HOST',
+  'CO_HOST',
+  'OWNER',
+  'CREATOR',
+  'AUTHOR',
+  'GUEST',
+  'INTERVIEWER',
+  'INTERVIEWEE',
+  'PRIMARY_SUBJECT',
+  'MENTIONED',
+];
 
 export class EnrichmentModelValidationError extends Error {
   constructor(message: string) {
@@ -158,11 +170,13 @@ function buildJsonModeSchema() {
           type: 'array',
           items: {
             type: 'object',
-            required: ['name', 'type', 'confidence'],
+            required: ['name', 'type', 'relationship', 'confidence', 'evidenceText'],
             properties: {
               name: { type: 'string' },
               type: { type: 'string' },
+              relationship: { type: 'string', enum: ENTITY_RELATIONSHIPS },
               confidence: { type: 'number' },
+              evidenceText: { type: ['string', 'null'] },
             },
           },
         },

--- a/apps/worker/src/enrichment/prompt.test.ts
+++ b/apps/worker/src/enrichment/prompt.test.ts
@@ -46,4 +46,16 @@ describe('enrichment prompt helpers', () => {
 
     expect(buildArticleExcerpt(articleContent)).not.toContain('tail-marker');
   });
+
+  it('asks the model to preserve show host and owner relationships', () => {
+    const messages = buildEnrichmentMessages(createPromptInput('Hosted by Casey Newton.'));
+    const userPayload = JSON.parse(String(messages[1].content)) as {
+      constraints: string[];
+    };
+
+    expect(userPayload.constraints.join(' ')).toContain('HOST');
+    expect(userPayload.constraints.join(' ')).toContain('co-hosts');
+    expect(userPayload.constraints.join(' ')).toContain('owners');
+    expect(userPayload.constraints.join(' ')).toContain('evidenceText');
+  });
 });

--- a/apps/worker/src/enrichment/prompt.ts
+++ b/apps/worker/src/enrichment/prompt.ts
@@ -73,6 +73,11 @@ export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
       'Prefer stable categories and short lowercase tag names.',
       'Do not invent facts not supported by the input.',
       'Use confidence below 0.6 when the input is thin or ambiguous.',
+      'For each entity, set relationship to its role in this item: HOST, CO_HOST, OWNER, CREATOR, AUTHOR, GUEST, INTERVIEWER, INTERVIEWEE, PRIMARY_SUBJECT, or MENTIONED.',
+      'For podcast, video, interview, and newsletter items, explicitly identify all supported human show hosts, co-hosts, owners, primary creators, and guests; do not collapse them into a generic person list.',
+      'Use HOST or CO_HOST only for people who are explicitly framed as running/presenting the show or episode. Use OWNER/CREATOR only when the input supports ownership or primary creator status.',
+      'If a show, publisher, or channel name is a brand rather than a human name, do not invent a person behind it.',
+      'Set evidenceText to a short supporting phrase from the title, creator, metadata, or content when available; otherwise null.',
     ],
     item: {
       title: input.item.title,
@@ -115,7 +120,9 @@ export function buildEmbeddingText(params: {
     `Summary: ${params.output.summary.short} ${params.output.summary.detail}`,
     `Primary category: ${params.output.classification.primaryCategory}`,
     `Topics: ${params.output.topics.map((topic) => topic.name).join(', ')}`,
-    `Entities: ${params.output.entities.map((entity) => entity.name).join(', ')}`,
+    `Entities: ${params.output.entities
+      .map((entity) => `${entity.name} (${entity.relationship})`)
+      .join(', ')}`,
     params.articleExcerpt ? `Excerpt: ${params.articleExcerpt}` : '',
   ];
 

--- a/apps/worker/src/enrichment/schema.ts
+++ b/apps/worker/src/enrichment/schema.ts
@@ -3,6 +3,18 @@ import { z } from 'zod';
 import { ENRICHMENT_SCHEMA_VERSION, type EnrichmentModelOutput, type SuggestedTag } from './types';
 
 const ConfidenceSchema = z.number().min(0).max(1);
+export const EntityRelationshipSchema = z.enum([
+  'HOST',
+  'CO_HOST',
+  'OWNER',
+  'CREATOR',
+  'AUTHOR',
+  'GUEST',
+  'INTERVIEWER',
+  'INTERVIEWEE',
+  'PRIMARY_SUBJECT',
+  'MENTIONED',
+]);
 
 export const EnrichmentQueueMessageSchema = z.object({
   itemId: z.string().min(1),
@@ -51,7 +63,9 @@ export const EnrichmentModelOutputSchema = z.object({
       z.object({
         name: z.string().min(1).max(120),
         type: z.string().min(1).max(64),
+        relationship: EntityRelationshipSchema,
         confidence: ConfidenceSchema,
+        evidenceText: z.string().min(1).max(300).nullable(),
       })
     )
     .max(20),

--- a/apps/worker/src/enrichment/types.ts
+++ b/apps/worker/src/enrichment/types.ts
@@ -1,6 +1,6 @@
 import type { ContentType, Provider } from '@zine/shared';
 
-export const ENRICHMENT_SCHEMA_VERSION = 1;
+export const ENRICHMENT_SCHEMA_VERSION = 2;
 export const DEFAULT_ENRICHMENT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 export const DEFAULT_EMBEDDING_MODEL = '@cf/qwen/qwen3-embedding-0.6b';
 export const DEFAULT_EMBEDDING_DIMENSIONS = 1024;
@@ -28,8 +28,22 @@ export interface EnrichmentTopic {
 export interface EnrichmentEntity {
   name: string;
   type: string;
+  relationship: EntityRelationship;
   confidence: number;
+  evidenceText: string | null;
 }
+
+export type EntityRelationship =
+  | 'HOST'
+  | 'CO_HOST'
+  | 'OWNER'
+  | 'CREATOR'
+  | 'AUTHOR'
+  | 'GUEST'
+  | 'INTERVIEWER'
+  | 'INTERVIEWEE'
+  | 'PRIMARY_SUBJECT'
+  | 'MENTIONED';
 
 export interface SuggestedTag {
   name: string;

--- a/apps/worker/src/people/backfill.ts
+++ b/apps/worker/src/people/backfill.ts
@@ -4,7 +4,9 @@ import { UserItemState } from '@zine/shared';
 import type { Database } from '../db';
 import { userItems } from '../db/schema';
 import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
 import { syncPeopleForUserItem } from './service';
+import { resolveXProfilesForItem } from './social-resolution';
 
 const backfillLogger = logger.child('people-backfill');
 
@@ -27,6 +29,8 @@ export interface PeopleBackfillResult {
   indexed: number;
   deactivated: number;
   skipped: number;
+  socialProfilesLinked: number;
+  socialProfileCandidates: number;
   candidates: Array<{
     userItemId: string;
     userId: string;
@@ -41,6 +45,7 @@ function normalizeLimit(value: number | undefined): number {
 
 export async function backfillPeopleIndex(
   db: Database,
+  env?: Pick<Bindings, 'X_BEARER_TOKEN'>,
   options: PeopleBackfillOptions = {}
 ): Promise<PeopleBackfillResult> {
   const dryRun = options.dryRun ?? true;
@@ -69,6 +74,8 @@ export async function backfillPeopleIndex(
   let indexed = 0;
   let deactivated = 0;
   let skipped = 0;
+  let socialProfilesLinked = 0;
+  let socialProfileCandidates = 0;
 
   if (!dryRun) {
     for (const row of rows) {
@@ -79,6 +86,12 @@ export async function backfillPeopleIndex(
       indexed += result.indexed;
       deactivated += result.deactivated;
       skipped += result.skipped;
+
+      if (env) {
+        const socialResult = await resolveXProfilesForItem(db, env, { itemId: row.itemId });
+        socialProfilesLinked += socialResult.linked;
+        socialProfileCandidates += socialResult.candidates;
+      }
     }
   }
 
@@ -93,6 +106,8 @@ export async function backfillPeopleIndex(
     indexed,
     deactivated,
     skipped,
+    socialProfilesLinked,
+    socialProfileCandidates,
   });
 
   return {
@@ -104,6 +119,8 @@ export async function backfillPeopleIndex(
     indexed,
     deactivated,
     skipped,
+    socialProfilesLinked,
+    socialProfileCandidates,
     candidates: rows,
   };
 }

--- a/apps/worker/src/people/service.test.ts
+++ b/apps/worker/src/people/service.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractPersonEntities,
   getProfileImageCandidateForPerson,
+  normalizePersonDisplayName,
   normalizePersonName,
 } from './service';
 
@@ -11,6 +12,16 @@ describe('people service helpers', () => {
     expect(normalizePersonName('  Joe   Rogan  ')).toBe('joe rogan');
     expect(normalizePersonName('"Sam Harris."')).toBe('sam harris');
     expect(normalizePersonName('Joseph Rogan')).toBe('joseph rogan');
+  });
+
+  it('capitalizes person display names', () => {
+    expect(normalizePersonDisplayName('armin ronacher')).toBe('Armin Ronacher');
+    expect(normalizePersonDisplayName('KEVIN ROOSE')).toBe('Kevin Roose');
+    expect(normalizePersonDisplayName("sara o'connor")).toBe("Sara O'Connor");
+    expect(normalizePersonDisplayName('ludwig van beethoven')).toBe('Ludwig van Beethoven');
+    expect(normalizePersonDisplayName('Paul McCartney')).toBe('Paul McCartney');
+    expect(normalizePersonDisplayName('g.k. chesterton')).toBe('G.K. Chesterton');
+    expect(normalizePersonDisplayName('G.K. Chesterton')).toBe('G.K. Chesterton');
   });
 
   it('extracts high-confidence PERSON entities and dedupes by normalized name', () => {
@@ -30,14 +41,69 @@ describe('people service helpers', () => {
         rawType: 'PERSON',
         displayName: 'Joe Rogan',
         normalizedName: 'joe rogan',
+        relationship: 'MENTIONED',
         confidence: 0.9,
+        evidenceText: null,
       },
       {
         rawName: 'Sam Harris',
         rawType: 'PERSON',
         displayName: 'Sam Harris',
         normalizedName: 'sam harris',
+        relationship: 'MENTIONED',
         confidence: 0.8,
+        evidenceText: null,
+      },
+    ]);
+  });
+
+  it('capitalizes lowercase person entities before indexing', () => {
+    const people = extractPersonEntities(
+      JSON.stringify([{ name: 'armin ronacher', type: 'PERSON', confidence: 0.9 }])
+    );
+
+    expect(people[0]?.displayName).toBe('Armin Ronacher');
+  });
+
+  it('preserves supported person relationships and prefers host roles when deduping', () => {
+    const people = extractPersonEntities(
+      JSON.stringify([
+        { name: 'Casey Newton', type: 'PERSON', relationship: 'MENTIONED', confidence: 0.95 },
+        {
+          name: 'Casey Newton',
+          type: 'PERSON',
+          relationship: 'HOST',
+          confidence: 0.82,
+          evidenceText: 'Hosted by Casey Newton and Kevin Roose',
+        },
+        {
+          name: 'Kevin Roose',
+          type: 'PERSON',
+          relationship: 'co-host',
+          confidence: 0.84,
+          evidenceText: 'Hosted by Casey Newton and Kevin Roose',
+        },
+      ])
+    );
+
+    expect(people).toEqual([
+      {
+        rawName: 'Casey Newton',
+        rawType: 'PERSON',
+        displayName: 'Casey Newton',
+        normalizedName: 'casey newton',
+        relationship: 'HOST',
+        confidence: 0.82,
+        evidenceText: 'Hosted by Casey Newton and Kevin Roose',
+      },
+      {
+        rawName: 'Kevin Roose',
+        rawType: 'PERSON',
+        displayName: 'Kevin Roose',
+        normalizedName: 'kevin roose',
+        relationship: 'CO_HOST',
+        confidence: 0.84,
+        evidenceText: 'Hosted by Casey Newton and Kevin Roose',
       },
     ]);
   });

--- a/apps/worker/src/people/service.ts
+++ b/apps/worker/src/people/service.ts
@@ -12,11 +12,29 @@ import {
   userPersonMentions,
 } from '../db/schema';
 import { logger } from '../lib/logger';
-import { ENRICHMENT_SCHEMA_VERSION } from '../enrichment/types';
+import { ENRICHMENT_SCHEMA_VERSION, type EntityRelationship } from '../enrichment/types';
 
 const peopleLogger = logger.child('people-service');
 
 export const PERSON_CONFIDENCE_THRESHOLD = 0.65;
+
+const LOWERCASE_NAME_PARTICLES = new Set([
+  'al',
+  'bin',
+  'da',
+  'de',
+  'del',
+  'der',
+  'di',
+  'dos',
+  'du',
+  'ibn',
+  'la',
+  'le',
+  'van',
+  'von',
+  'y',
+]);
 
 type UserItemPersonSource = {
   id: string;
@@ -40,7 +58,9 @@ type PersonEntityCandidate = {
   rawType: string;
   displayName: string;
   normalizedName: string;
+  relationship: EntityRelationship;
   confidence: number;
+  evidenceText: string | null;
 };
 
 type PersonProfileImageCandidate = {
@@ -66,6 +86,49 @@ function normalizeEntityType(value: string): string {
   return value.trim().toLowerCase().replace(/[_-]+/g, ' ');
 }
 
+function normalizeEntityRelationship(value: unknown): EntityRelationship {
+  if (typeof value !== 'string') return 'MENTIONED';
+
+  const normalized = value
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_');
+  switch (normalized) {
+    case 'HOST':
+    case 'CO_HOST':
+    case 'OWNER':
+    case 'CREATOR':
+    case 'AUTHOR':
+    case 'GUEST':
+    case 'INTERVIEWER':
+    case 'INTERVIEWEE':
+    case 'PRIMARY_SUBJECT':
+    case 'MENTIONED':
+      return normalized;
+    default:
+      return 'MENTIONED';
+  }
+}
+
+function relationshipPriority(relationship: EntityRelationship): number {
+  switch (relationship) {
+    case 'HOST':
+    case 'CO_HOST':
+    case 'OWNER':
+    case 'CREATOR':
+      return 4;
+    case 'AUTHOR':
+    case 'INTERVIEWER':
+    case 'INTERVIEWEE':
+    case 'GUEST':
+      return 3;
+    case 'PRIMARY_SUBJECT':
+      return 2;
+    case 'MENTIONED':
+      return 1;
+  }
+}
+
 export function normalizePersonName(value: string): string {
   return value
     .replace(/\s+/g, ' ')
@@ -78,13 +141,52 @@ export function normalizePersonName(value: string): string {
 }
 
 function normalizeDisplayName(value: string): string {
-  return value
+  const trimmed = value
     .replace(/\s+/g, ' ')
     .trim()
     .replace(/^[\s"'`.,;:!?()[\]{}<>]+/, '')
     .replace(/[\s"'`.,;:!?()[\]{}<>]+$/, '')
     .replace(/\s+/g, ' ')
     .trim();
+
+  return normalizePersonDisplayName(trimmed);
+}
+
+function capitalizeNameSegment(value: string): string {
+  if (!value) return value;
+  const rest = value.slice(1);
+  const shouldNormalizeRest = value === value.toLowerCase() || value === value.toUpperCase();
+  return `${value[0]?.toUpperCase() ?? ''}${shouldNormalizeRest ? rest.toLowerCase() : rest}`;
+}
+
+function capitalizeNameWord(value: string, wordIndex: number): string {
+  const lower = value.toLowerCase();
+  if (wordIndex > 0 && LOWERCASE_NAME_PARTICLES.has(lower)) {
+    return lower;
+  }
+  if (/^([a-z]\.)+[a-z]?\.?$/i.test(value)) {
+    return value.toUpperCase();
+  }
+
+  return value
+    .split('-')
+    .map((hyphenPart) =>
+      hyphenPart
+        .split("'")
+        .map((apostrophePart) => capitalizeNameSegment(apostrophePart))
+        .join("'")
+    )
+    .join('-');
+}
+
+export function normalizePersonDisplayName(value: string): string {
+  const trimmed = value.replace(/\s+/g, ' ').trim();
+  if (!trimmed) return '';
+
+  return trimmed
+    .split(' ')
+    .map((word, index) => capitalizeNameWord(word, index))
+    .join(' ');
 }
 
 export function extractPersonEntities(entitiesJson: string | null): PersonEntityCandidate[] {
@@ -104,7 +206,13 @@ export function extractPersonEntities(entitiesJson: string | null): PersonEntity
   for (const entity of parsed) {
     if (!entity || typeof entity !== 'object' || Array.isArray(entity)) continue;
 
-    const candidate = entity as { name?: unknown; type?: unknown; confidence?: unknown };
+    const candidate = entity as {
+      name?: unknown;
+      type?: unknown;
+      relationship?: unknown;
+      confidence?: unknown;
+      evidenceText?: unknown;
+    };
     if (typeof candidate.name !== 'string' || typeof candidate.type !== 'string') continue;
 
     const confidence = toFiniteConfidence(candidate.confidence);
@@ -121,10 +229,16 @@ export function extractPersonEntities(entitiesJson: string | null): PersonEntity
       rawType: candidate.type,
       displayName,
       normalizedName,
+      relationship: normalizeEntityRelationship(candidate.relationship),
       confidence,
+      evidenceText: typeof candidate.evidenceText === 'string' ? candidate.evidenceText : null,
     };
     const existing = deduped.get(normalizedName);
-    if (!existing || next.confidence > existing.confidence) {
+    if (
+      !existing ||
+      relationshipPriority(next.relationship) > relationshipPriority(existing.relationship) ||
+      (next.relationship === existing.relationship && next.confidence > existing.confidence)
+    ) {
       deduped.set(normalizedName, next);
     }
   }
@@ -175,6 +289,7 @@ async function upsertUserPerson(
   const existing = await db
     .select({
       id: userPeople.id,
+      displayName: userPeople.displayName,
       profileImageSource: userPeople.profileImageSource,
       profileImageUrl: userPeople.profileImageUrl,
     })
@@ -196,10 +311,19 @@ async function upsertUserPerson(
       await db
         .update(userPeople)
         .set({
+          displayName: input.displayName,
           profileImageUrl: profileImage.imageUrl,
           profileImageSource: profileImage.source,
           profileImageSourceUrl: profileImage.sourceUrl,
           xHandle: profileImage.xHandle,
+          updatedAt: input.now,
+        })
+        .where(eq(userPeople.id, existing[0].id));
+    } else if (existing[0].displayName !== input.displayName) {
+      await db
+        .update(userPeople)
+        .set({
+          displayName: input.displayName,
           updatedAt: input.now,
         })
         .where(eq(userPeople.id, existing[0].id));
@@ -352,9 +476,9 @@ async function syncPeopleForBookmarkedUserItem(
         itemEnrichmentId: enrichment.id,
         rawName: person.rawName,
         rawType: person.rawType,
-        relationship: 'MENTIONED',
+        relationship: person.relationship,
         confidence: person.confidence,
-        evidenceText: null,
+        evidenceText: person.evidenceText,
         seenAt,
         isActive: true,
         createdAt: now,
@@ -371,8 +495,9 @@ async function syncPeopleForBookmarkedUserItem(
           itemEnrichmentId: enrichment.id,
           rawName: person.rawName,
           rawType: person.rawType,
-          relationship: 'MENTIONED',
+          relationship: person.relationship,
           confidence: person.confidence,
+          evidenceText: person.evidenceText,
           seenAt,
           isActive: true,
           updatedAt: now,
@@ -536,6 +661,7 @@ export async function deactivatePeopleForUserItemBestEffort(
 export const peopleServiceInternals = {
   extractPersonEntities,
   getProfileImageCandidateForPerson,
+  normalizePersonDisplayName,
   normalizePersonName,
   recomputePeopleStats,
 };

--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { socialResolutionInternals } from './social-resolution';
+
+describe('social profile resolution helpers', () => {
+  it('scores exact X display-name matches higher when profile context matches content', () => {
+    const scored = socialResolutionInternals.scoreXProfileCandidate({
+      personName: 'Armin Ronacher',
+      contextTerms: ['flask', 'python', 'pallets'],
+      candidate: {
+        id: 'x-1',
+        name: 'Armin Ronacher',
+        username: 'mitsuhiko',
+        description: 'Creator of Flask and Pallets. Python developer.',
+        profileImageUrl: 'https://pbs.twimg.com/profile_images/armin.jpg',
+        verified: true,
+        followersCount: 100000,
+      },
+    });
+
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+    expect(scored.matchedTerms).toEqual(['flask', 'python', 'pallets']);
+  });
+
+  it('does not auto-link name-only matches without contextual evidence', () => {
+    const scored = socialResolutionInternals.scoreXProfileCandidate({
+      personName: 'James Smith',
+      contextTerms: ['podcast', 'venture'],
+      candidate: {
+        id: 'x-2',
+        name: 'James Smith',
+        username: 'jamessmith',
+        description: 'Personal account.',
+      },
+    });
+
+    expect(scored.confidence).toBeLessThan(0.82);
+  });
+
+  it('penalizes parody and fan accounts', () => {
+    const scored = socialResolutionInternals.scoreXProfileCandidate({
+      personName: 'Elon Musk',
+      contextTerms: ['tesla', 'spacex'],
+      candidate: {
+        id: 'x-3',
+        name: 'Elon Musk',
+        username: 'notelon',
+        description: 'Parody fan account for Tesla and SpaceX news.',
+      },
+    });
+
+    expect(scored.confidence).toBeLessThan(0.82);
+    expect(scored.negativeSignals).toContain('parody');
+  });
+
+  it('builds inferred search queries from person and content context', () => {
+    const queries = socialResolutionInternals.buildXSearchQueries(
+      {
+        id: 'person-1',
+        userId: 'user-1',
+        displayName: 'Armin Ronacher',
+        normalizedName: 'armin ronacher',
+        profileImageSource: null,
+        xHandle: null,
+        relationship: 'GUEST',
+        evidenceText: 'Interview with Armin Ronacher about Flask',
+      },
+      {
+        itemId: 'item-1',
+        title: 'Flask, Python, and open source maintainership',
+        provider: 'SPOTIFY',
+        contentType: 'PODCAST',
+        publisher: null,
+        rawMetadata: null,
+        creatorName: 'The Changelog',
+        creatorDescription: 'Developer podcast',
+        creatorHandle: null,
+      }
+    );
+
+    expect(queries[0]).toBe('"Armin Ronacher"');
+    expect(queries.some((query) => query.includes('Flask') || query.includes('flask'))).toBe(true);
+  });
+});

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -1,0 +1,495 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { ulid } from 'ulid';
+
+import type { Database } from '../db';
+import {
+  creators,
+  itemEnrichments,
+  items,
+  personSocialProfiles,
+  userPeople,
+  userPersonMentions,
+} from '../db/schema';
+import { logger } from '../lib/logger';
+import { searchXUsers, type XUser } from '../providers/x';
+import type { Bindings } from '../types';
+import { ENRICHMENT_SCHEMA_VERSION } from '../enrichment/types';
+
+const socialLogger = logger.child('people-social-resolution');
+
+const AUTO_LINK_THRESHOLD = 0.82;
+const CANDIDATE_THRESHOLD = 0.45;
+const MAX_SEARCH_QUERIES_PER_PERSON = 4;
+const MAX_CANDIDATES_PER_QUERY = 5;
+
+const STOPWORDS = new Set([
+  'about',
+  'after',
+  'also',
+  'and',
+  'are',
+  'but',
+  'for',
+  'from',
+  'how',
+  'into',
+  'its',
+  'new',
+  'not',
+  'now',
+  'of',
+  'on',
+  'or',
+  'podcast',
+  'show',
+  'the',
+  'this',
+  'video',
+  'with',
+  'you',
+  'your',
+]);
+
+export type PersonForResolution = {
+  id: string;
+  userId: string;
+  displayName: string;
+  normalizedName: string;
+  profileImageSource: string | null;
+  xHandle: string | null;
+  relationship: string;
+  evidenceText: string | null;
+};
+
+export type ItemContext = {
+  itemId: string;
+  title: string;
+  provider: string;
+  contentType: string;
+  publisher: string | null;
+  rawMetadata: string | null;
+  creatorName: string | null;
+  creatorDescription: string | null;
+  creatorHandle: string | null;
+};
+
+export type XProfileCandidate = {
+  id: string;
+  name: string;
+  username: string;
+  description?: string;
+  profileImageUrl?: string;
+  url?: string;
+  verified?: boolean;
+  followersCount?: number;
+};
+
+export type ScoredXProfileCandidate = XProfileCandidate & {
+  confidence: number;
+  matchedTerms: string[];
+  negativeSignals: string[];
+};
+
+function compact(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function normalizedWords(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9+#.]+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length >= 3 && !STOPWORDS.has(word));
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function parseMetadataText(rawMetadata: string | null): string {
+  if (!rawMetadata) return '';
+  try {
+    return JSON.stringify(JSON.parse(rawMetadata));
+  } catch {
+    return rawMetadata;
+  }
+}
+
+function contextText(context: ItemContext, person: Pick<PersonForResolution, 'evidenceText'>) {
+  return [
+    context.title,
+    context.publisher,
+    context.creatorName,
+    context.creatorDescription,
+    context.creatorHandle,
+    person.evidenceText,
+    parseMetadataText(context.rawMetadata),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function extractContextTerms(
+  context: ItemContext,
+  person: Pick<PersonForResolution, 'displayName' | 'evidenceText'>
+) {
+  const words = normalizedWords(contextText(context, person));
+  const personWords = new Set(normalizedWords(person.displayName));
+  const weighted = words.filter((word) => !personWords.has(word));
+
+  return unique(weighted)
+    .filter((word) => !/^\d+$/.test(word))
+    .slice(0, 16);
+}
+
+export function buildXSearchQueries(person: PersonForResolution, context: ItemContext): string[] {
+  const contextTerms = extractContextTerms(context, person).slice(0, 6);
+  const strongContext = [context.creatorName, context.publisher, ...contextTerms.slice(0, 3)]
+    .filter(Boolean)
+    .join(' ');
+
+  return unique(
+    [
+      `"${person.displayName}"`,
+      strongContext ? `"${person.displayName}" ${strongContext}` : null,
+      contextTerms[0] ? `${person.displayName} ${contextTerms[0]}` : null,
+      contextTerms[1] ? `${person.displayName} ${contextTerms[1]}` : null,
+    ].filter((query): query is string => Boolean(query))
+  ).slice(0, MAX_SEARCH_QUERIES_PER_PERSON);
+}
+
+function candidateText(candidate: XProfileCandidate): string {
+  return [candidate.name, candidate.username, candidate.description, candidate.url]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+function hasNegativeSignal(candidate: XProfileCandidate): string[] {
+  const text = candidateText(candidate);
+  return ['parody', 'fan account', 'fanpage', 'not affiliated', 'unofficial'].filter((signal) =>
+    text.includes(signal)
+  );
+}
+
+export function scoreXProfileCandidate(input: {
+  personName: string;
+  contextTerms: string[];
+  candidate: XProfileCandidate;
+}): ScoredXProfileCandidate {
+  const personCompact = compact(input.personName);
+  const candidateNameCompact = compact(input.candidate.name);
+  const usernameCompact = compact(input.candidate.username);
+  const personParts = normalizedWords(input.personName).map(compact);
+  const searchableText = candidateText(input.candidate);
+  const matchedTerms = input.contextTerms.filter((term) => searchableText.includes(term));
+  const negativeSignals = hasNegativeSignal(input.candidate);
+
+  let confidence = 0;
+  if (candidateNameCompact === personCompact) {
+    confidence += 0.72;
+  } else if (
+    candidateNameCompact.includes(personCompact) ||
+    personCompact.includes(candidateNameCompact)
+  ) {
+    confidence += 0.58;
+  } else if (
+    personParts.length > 1 &&
+    personParts.every((part) => candidateNameCompact.includes(part))
+  ) {
+    confidence += 0.48;
+  }
+
+  if (usernameCompact === personCompact) {
+    confidence += 0.06;
+  } else if (personParts.some((part) => part.length >= 4 && usernameCompact.includes(part))) {
+    confidence += 0.06;
+  }
+
+  confidence += Math.min(0.22, matchedTerms.length * 0.055);
+  if (input.candidate.verified) confidence += 0.03;
+  if ((input.candidate.followersCount ?? 0) >= 10_000) confidence += 0.02;
+  confidence -= negativeSignals.length * 0.25;
+
+  return {
+    ...input.candidate,
+    confidence: Math.max(0, Math.min(1, Number(confidence.toFixed(3)))),
+    matchedTerms,
+    negativeSignals,
+  };
+}
+
+function toXProfileCandidate(user: XUser): XProfileCandidate {
+  return {
+    id: user.id,
+    name: user.name,
+    username: user.username,
+    description: user.description,
+    profileImageUrl: user.profile_image_url,
+    url: user.url,
+    verified: user.verified,
+    followersCount: user.public_metrics?.followers_count,
+  };
+}
+
+async function loadResolutionContext(
+  db: Database,
+  itemId: string
+): Promise<{ item: ItemContext; people: PersonForResolution[] } | null> {
+  const itemRows = await db
+    .select({
+      itemId: items.id,
+      title: items.title,
+      provider: items.provider,
+      contentType: items.contentType,
+      publisher: items.publisher,
+      rawMetadata: items.rawMetadata,
+      creatorName: creators.name,
+      creatorDescription: creators.description,
+      creatorHandle: creators.handle,
+    })
+    .from(items)
+    .leftJoin(creators, eq(items.creatorId, creators.id))
+    .where(eq(items.id, itemId))
+    .limit(1);
+
+  const item = itemRows[0];
+  if (!item) return null;
+
+  const enrichmentRows = await db
+    .select({ id: itemEnrichments.id })
+    .from(itemEnrichments)
+    .where(
+      and(
+        eq(itemEnrichments.itemId, itemId),
+        eq(itemEnrichments.schemaVersion, ENRICHMENT_SCHEMA_VERSION),
+        eq(itemEnrichments.status, 'COMPLETE')
+      )
+    )
+    .orderBy(desc(itemEnrichments.updatedAt))
+    .limit(1);
+
+  const enrichment = enrichmentRows[0];
+  if (!enrichment) return null;
+
+  const peopleRows = await db
+    .select({
+      id: userPeople.id,
+      userId: userPeople.userId,
+      displayName: userPeople.displayName,
+      normalizedName: userPeople.normalizedName,
+      profileImageSource: userPeople.profileImageSource,
+      xHandle: userPeople.xHandle,
+      relationship: userPersonMentions.relationship,
+      evidenceText: userPersonMentions.evidenceText,
+    })
+    .from(userPersonMentions)
+    .innerJoin(userPeople, eq(userPersonMentions.userPersonId, userPeople.id))
+    .where(
+      and(
+        eq(userPersonMentions.itemId, itemId),
+        eq(userPersonMentions.itemEnrichmentId, enrichment.id),
+        eq(userPersonMentions.isActive, true)
+      )
+    );
+
+  const dedupedPeople = new Map<string, PersonForResolution>();
+  for (const person of peopleRows) {
+    if (person.profileImageSource === 'X' && person.xHandle) continue;
+    dedupedPeople.set(person.id, person);
+  }
+
+  return {
+    item,
+    people: [...dedupedPeople.values()],
+  };
+}
+
+async function hasLinkedXProfile(db: Database, userPersonId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: personSocialProfiles.id })
+    .from(personSocialProfiles)
+    .where(
+      and(
+        eq(personSocialProfiles.userPersonId, userPersonId),
+        eq(personSocialProfiles.provider, 'X'),
+        eq(personSocialProfiles.status, 'LINKED')
+      )
+    )
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+async function upsertCandidate(
+  db: Database,
+  input: {
+    person: PersonForResolution;
+    candidate: ScoredXProfileCandidate;
+    status: 'CANDIDATE' | 'LINKED';
+    evidence: unknown;
+    now: number;
+  }
+) {
+  const profileUrl = `https://x.com/${input.candidate.username}`;
+  await db
+    .insert(personSocialProfiles)
+    .values({
+      id: ulid(),
+      userId: input.person.userId,
+      userPersonId: input.person.id,
+      provider: 'X',
+      providerProfileId: input.candidate.id,
+      handle: input.candidate.username,
+      displayName: input.candidate.name,
+      avatarUrl: input.candidate.profileImageUrl ?? null,
+      profileUrl,
+      description: input.candidate.description ?? null,
+      verified: input.candidate.verified ?? false,
+      confidence: input.candidate.confidence,
+      status: input.status,
+      evidenceJson: JSON.stringify(input.evidence),
+      lastCheckedAt: input.now,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        personSocialProfiles.userPersonId,
+        personSocialProfiles.provider,
+        personSocialProfiles.providerProfileId,
+      ],
+      set: {
+        handle: input.candidate.username,
+        displayName: input.candidate.name,
+        avatarUrl: input.candidate.profileImageUrl ?? null,
+        profileUrl,
+        description: input.candidate.description ?? null,
+        verified: input.candidate.verified ?? false,
+        confidence: input.candidate.confidence,
+        status: input.status,
+        evidenceJson: JSON.stringify(input.evidence),
+        lastCheckedAt: input.now,
+        updatedAt: input.now,
+      },
+    });
+
+  if (input.status === 'LINKED' && input.candidate.profileImageUrl) {
+    await db
+      .update(userPeople)
+      .set({
+        profileImageUrl: input.candidate.profileImageUrl,
+        profileImageSource: 'X',
+        profileImageSourceUrl: profileUrl,
+        xHandle: input.candidate.username,
+        updatedAt: input.now,
+      })
+      .where(eq(userPeople.id, input.person.id));
+  }
+}
+
+async function searchCandidatesForPerson(params: {
+  bearerToken: string;
+  person: PersonForResolution;
+  item: ItemContext;
+}): Promise<ScoredXProfileCandidate[]> {
+  const queries = buildXSearchQueries(params.person, params.item);
+  const contextTerms = extractContextTerms(params.item, params.person);
+  const usersById = new Map<string, XProfileCandidate>();
+
+  for (const query of queries) {
+    const users = await searchXUsers({
+      bearerToken: params.bearerToken,
+      query,
+      maxResults: MAX_CANDIDATES_PER_QUERY,
+    });
+
+    for (const user of users) {
+      usersById.set(user.id, toXProfileCandidate(user));
+    }
+  }
+
+  return [...usersById.values()]
+    .map((candidate) =>
+      scoreXProfileCandidate({
+        personName: params.person.displayName,
+        contextTerms,
+        candidate,
+      })
+    )
+    .filter((candidate) => candidate.confidence >= CANDIDATE_THRESHOLD)
+    .sort((a, b) => b.confidence - a.confidence);
+}
+
+export async function resolveXProfilesForItem(
+  db: Database,
+  env: Pick<Bindings, 'X_BEARER_TOKEN'>,
+  input: { itemId: string }
+): Promise<{ linked: number; candidates: number; skipped: number }> {
+  if (!env.X_BEARER_TOKEN) {
+    return { linked: 0, candidates: 0, skipped: 1 };
+  }
+
+  const context = await loadResolutionContext(db, input.itemId);
+  if (!context || context.people.length === 0) {
+    return { linked: 0, candidates: 0, skipped: 1 };
+  }
+
+  const totals = { linked: 0, candidates: 0, skipped: 0 };
+  for (const person of context.people) {
+    try {
+      if (await hasLinkedXProfile(db, person.id)) {
+        totals.skipped += 1;
+        continue;
+      }
+
+      const candidates = await searchCandidatesForPerson({
+        bearerToken: env.X_BEARER_TOKEN,
+        person,
+        item: context.item,
+      });
+      const now = Date.now();
+      const best = candidates[0] ?? null;
+
+      for (const candidate of candidates.slice(0, 3)) {
+        const status =
+          candidate.id === best?.id && candidate.confidence >= AUTO_LINK_THRESHOLD
+            ? 'LINKED'
+            : 'CANDIDATE';
+        await upsertCandidate(db, {
+          person,
+          candidate,
+          status,
+          evidence: {
+            itemId: input.itemId,
+            relationship: person.relationship,
+            evidenceText: person.evidenceText,
+            matchedTerms: candidate.matchedTerms,
+            negativeSignals: candidate.negativeSignals,
+          },
+          now,
+        });
+      }
+
+      if (best && best.confidence >= AUTO_LINK_THRESHOLD) {
+        totals.linked += 1;
+      }
+      totals.candidates += candidates.length;
+    } catch (error) {
+      totals.skipped += 1;
+      socialLogger.warn('X profile resolution failed for person', {
+        itemId: input.itemId,
+        userPersonId: person.id,
+        error,
+      });
+    }
+  }
+
+  return totals;
+}
+
+export const socialResolutionInternals = {
+  buildXSearchQueries,
+  extractContextTerms,
+  scoreXProfileCandidate,
+};

--- a/apps/worker/src/providers/x.test.ts
+++ b/apps/worker/src/providers/x.test.ts
@@ -1,19 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchXBookmarksPage, XAuthError } from './x';
+import { fetchXBookmarksPage, searchXUsers, XAuthError } from './x';
 import type { XRateLimitError } from './x';
 
+type FetchMock = ReturnType<typeof vi.fn>;
+
 describe('X provider', () => {
+  const originalFetch = globalThis.fetch;
+
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn());
+    globalThis.fetch = vi.fn() as never;
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
   });
 
   it('fetches one capped bookmark page with minimal display fields', async () => {
-    const fetchMock = vi.mocked(fetch);
+    const fetchMock = globalThis.fetch as unknown as FetchMock;
     fetchMock.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -48,7 +52,7 @@ describe('X provider', () => {
   });
 
   it('throws a structured rate-limit error for 429 responses', async () => {
-    vi.mocked(fetch).mockResolvedValue(
+    (globalThis.fetch as unknown as FetchMock).mockResolvedValue(
       new Response(JSON.stringify({ errors: [{ title: 'Too Many Requests' }] }), {
         status: 429,
         headers: {
@@ -66,10 +70,50 @@ describe('X provider', () => {
   });
 
   it('throws an auth error for revoked or insufficient X access', async () => {
-    vi.mocked(fetch).mockResolvedValue(new Response('Forbidden', { status: 403 }));
+    (globalThis.fetch as unknown as FetchMock).mockResolvedValue(
+      new Response('Forbidden', { status: 403 })
+    );
 
     await expect(
       fetchXBookmarksPage({ accessToken: 'token', userId: 'x-user-1' })
     ).rejects.toBeInstanceOf(XAuthError);
+  });
+
+  it('searches X users with profile fields for inferred social resolution', async () => {
+    const fetchMock = globalThis.fetch as unknown as FetchMock;
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: 'user-1',
+              name: 'Armin Ronacher',
+              username: 'mitsuhiko',
+              description: 'Creator of Flask',
+              profile_image_url: 'https://pbs.twimg.com/profile_images/armin.jpg',
+              verified: true,
+            },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+
+    const users = await searchXUsers({
+      bearerToken: 'bearer',
+      query: '"Armin Ronacher" Flask',
+      maxResults: 5,
+    });
+
+    const requestedUrl = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(requestedUrl.pathname).toBe('/2/users/search');
+    expect(requestedUrl.searchParams.get('query')).toBe('"Armin Ronacher" Flask');
+    expect(requestedUrl.searchParams.get('user.fields')).toContain('profile_image_url');
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer bearer',
+      }),
+    });
+    expect(users[0].username).toBe('mitsuhiko');
   });
 });

--- a/apps/worker/src/providers/x.ts
+++ b/apps/worker/src/providers/x.ts
@@ -8,7 +8,13 @@ export type XUser = {
   id: string;
   name: string;
   username: string;
+  description?: string;
   profile_image_url?: string;
+  url?: string;
+  verified?: boolean;
+  public_metrics?: {
+    followers_count?: number;
+  };
 };
 
 export type XMedia = {
@@ -76,6 +82,7 @@ export class XAuthError extends Error {
 }
 
 export const X_BOOKMARKS_MAX_RESULTS = 100;
+export const X_USER_SEARCH_MAX_RESULTS = 10;
 
 function parseRateLimit(headers: Headers): XRateLimitInfo {
   const limit = headers.get('x-rate-limit-limit');
@@ -141,4 +148,52 @@ export async function fetchXBookmarksPage(params: {
     ...body,
     rateLimit,
   };
+}
+
+export async function searchXUsers(params: {
+  bearerToken: string;
+  query: string;
+  maxResults?: number;
+}): Promise<XUser[]> {
+  const url = new URL('https://api.x.com/2/users/search');
+  url.searchParams.set('query', params.query);
+  url.searchParams.set(
+    'user.fields',
+    [
+      'description',
+      'id',
+      'name',
+      'profile_image_url',
+      'public_metrics',
+      'url',
+      'username',
+      'verified',
+    ].join(',')
+  );
+  url.searchParams.set('max_results', String(params.maxResults ?? X_USER_SEARCH_MAX_RESULTS));
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${params.bearerToken}`,
+      Accept: 'application/json',
+    },
+  });
+  const rateLimit = parseRateLimit(response.headers);
+
+  if (response.status === 429) {
+    throw new XRateLimitError('X user search rate limit exceeded', rateLimit);
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    const text = await response.text();
+    throw new XAuthError(response.status, text || `X user search failed: ${response.status}`);
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`X user search failed: ${response.status} ${text}`);
+  }
+
+  const body = (await response.json()) as { data?: XUser[] };
+  return body.data ?? [];
 }

--- a/apps/worker/src/trpc/routers/admin.ts
+++ b/apps/worker/src/trpc/routers/admin.ts
@@ -196,7 +196,7 @@ export const adminRouter = router({
         cursor: input.cursor,
       });
 
-      return backfillPeopleIndex(ctx.db, {
+      return backfillPeopleIndex(ctx.db, ctx.env, {
         dryRun: input.dryRun,
         limit: input.limit,
         cursor: input.cursor ?? null,

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -56,6 +56,7 @@ import { enqueueBookmarkEnrichment } from '../../enrichment/service';
 import { ENRICHMENT_SCHEMA_VERSION, type SuggestedTag } from '../../enrichment/types';
 import {
   deactivatePeopleForUserItemBestEffort,
+  normalizePersonDisplayName,
   normalizePersonName,
   syncPeopleForUserItemBestEffort,
 } from '../../people/service';
@@ -1006,9 +1007,13 @@ export const itemsRouter = router({
 
       const canonical = canonicalRows[0] ?? null;
       const userEnrichment = userRows[0] ?? null;
-      const parsedEntities = parseJsonArray<{ name: string; type: string; confidence: number }>(
-        canonical?.entitiesJson ?? null
-      );
+      const parsedEntities = parseJsonArray<{
+        name: string;
+        type: string;
+        relationship?: string;
+        confidence: number;
+        evidenceText?: string | null;
+      }>(canonical?.entitiesJson ?? null);
       const activePersonRows =
         parsedEntities.length > 0
           ? await ctx.db
@@ -1042,13 +1047,18 @@ export const itemsRouter = router({
           topics: parseJsonArray<{ name: string; confidence: number }>(
             canonical?.topicsJson ?? null
           ),
-          entities: parsedEntities.map((entity) => ({
-            ...entity,
-            personId:
-              normalizePersonName(entity.name) && entity.type.trim().toLowerCase() === 'person'
-                ? (personIdByNormalizedName.get(normalizePersonName(entity.name)) ?? null)
+          entities: parsedEntities.map((entity) => {
+            const isPerson = entity.type.trim().toLowerCase() === 'person';
+            const normalizedPersonName = isPerson ? normalizePersonName(entity.name) : '';
+
+            return {
+              ...entity,
+              name: isPerson ? normalizePersonDisplayName(entity.name) : entity.name,
+              personId: normalizedPersonName
+                ? (personIdByNormalizedName.get(normalizedPersonName) ?? null)
                 : null,
-          })),
+            };
+          }),
           intent: canonical?.intent ?? null,
           difficulty: canonical?.difficulty ?? null,
           evergreenScore: canonical?.evergreenScore ?? null,

--- a/apps/worker/src/trpc/routers/people.ts
+++ b/apps/worker/src/trpc/routers/people.ts
@@ -8,6 +8,7 @@ import { creators, items, userItems, userPeople, userPersonMentions } from '../.
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { router, protectedProcedure } from '../trpc';
 import { toItemViewsWithTags } from './items';
+import { normalizePersonDisplayName } from '../../people/service';
 
 const PeopleListInputSchema = z.object({
   query: z.string().trim().max(100).optional(),
@@ -133,7 +134,7 @@ export const peopleRouter = router({
     return {
       people: pageRows.map((row) => ({
         id: row.id,
-        displayName: row.displayName,
+        displayName: normalizePersonDisplayName(row.displayName),
         profileImageUrl: row.profileImageUrl,
         profileImageSource: row.profileImageSource,
         xHandle: row.xHandle,
@@ -174,7 +175,10 @@ export const peopleRouter = router({
       throw new TRPCError({ code: 'NOT_FOUND', message: 'Person not found' });
     }
 
-    return person;
+    return {
+      ...person,
+      displayName: normalizePersonDisplayName(person.displayName),
+    };
   }),
 
   listItems: protectedProcedure.input(PersonItemsInputSchema).query(async ({ ctx, input }) => {

--- a/apps/worker/src/trpc/routers/search.ts
+++ b/apps/worker/src/trpc/routers/search.ts
@@ -6,6 +6,7 @@ import { UserItemState } from '@zine/shared';
 import { router, protectedProcedure } from '../trpc';
 import { creators, items, subscriptions, userItems, userPeople } from '../../db/schema';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import { normalizePersonDisplayName } from '../../people/service';
 import { toItemViewsWithTags, type ItemView } from './items';
 
 const DEFAULT_CREATORS_LIMIT = 5;
@@ -261,7 +262,7 @@ export function buildSearchResponse(input: {
       type: 'person' as const,
       id: row.id,
       personId: row.id,
-      displayName: row.displayName,
+      displayName: normalizePersonDisplayName(row.displayName),
       profileImageUrl: row.profileImageUrl,
       profileImageSource: row.profileImageSource,
       xHandle: row.xHandle,
@@ -443,7 +444,7 @@ export const searchRouter = router({
       personRows.push(
         ...matchedPeopleRows.map((row) => ({
           id: row.id,
-          displayName: row.displayName,
+          displayName: normalizePersonDisplayName(row.displayName),
           profileImageUrl: row.profileImageUrl,
           profileImageSource: row.profileImageSource,
           xHandle: row.xHandle,

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -56,6 +56,8 @@ export interface Bindings {
   X_CLIENT_ID?: string;
   /** X OAuth client secret (optional for PKCE public clients) */
   X_CLIENT_SECRET?: string;
+  /** X API bearer token for app-level public profile lookup */
+  X_BEARER_TOKEN?: string;
   /** OAuth redirect URI */
   OAUTH_REDIRECT_URI?: string;
   /** Spotify episode fetch concurrency limit (default: 5) */

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -254,6 +254,7 @@ invocation_logs = true
 # ============================================================================
 # - CLERK_WEBHOOK_SECRET: Signing secret from Clerk Dashboard > Webhooks
 # - ENRICHMENT_BACKFILL_SECRET: Bearer token for admin enrichment backfill route
+# - X_BEARER_TOKEN: X API bearer token for inferred profile/avatar resolution
 #
 # Required KV Namespace (create via `wrangler kv:namespace create WEBHOOK_IDEMPOTENCY`)
 # - WEBHOOK_IDEMPOTENCY: KV for webhook idempotency tracking

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:web": "bun run --cwd apps/web dev",
     "dev:worktree": "./scripts/dev.sh",
     "data:prod:local": "bun run ./scripts/sync-prod-user-to-local.mjs",
+    "data:people-names:prod": "bun run ./scripts/repair-prod-people-display-names.mjs",
     "design-system:check": "node ./scripts/check-mobile-design-system.mjs",
     "storybook:mobile": "bun run --cwd apps/mobile storybook",
     "storybook:web": "bun run --cwd apps/web storybook",

--- a/scripts/repair-prod-people-display-names.mjs
+++ b/scripts/repair-prod-people-display-names.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
+const WORKER_DIR = join(REPO_ROOT, 'apps/worker');
+const DEFAULT_DATABASE = 'zine-db-production';
+const DEFAULT_ENV = 'production';
+const CHUNK_SIZE = 50;
+
+const LOWERCASE_NAME_PARTICLES = new Set([
+  'al',
+  'bin',
+  'da',
+  'de',
+  'del',
+  'der',
+  'di',
+  'dos',
+  'du',
+  'ibn',
+  'la',
+  'le',
+  'van',
+  'von',
+  'y',
+]);
+
+const args = process.argv.slice(2);
+const dryRun = !args.includes('--yes');
+
+function argValue(name, fallback = null) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  return args[index + 1] ?? fallback;
+}
+
+const database = argValue('--database', DEFAULT_DATABASE);
+const env = argValue('--env', DEFAULT_ENV);
+const userId = argValue('--user-id');
+const sampleLimit = Number(argValue('--sample-limit', '20'));
+
+function sqlString(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function capitalizeNameSegment(value) {
+  if (!value) return value;
+  const rest = value.slice(1);
+  const shouldNormalizeRest = value === value.toLowerCase() || value === value.toUpperCase();
+  return `${value[0]?.toUpperCase() ?? ''}${shouldNormalizeRest ? rest.toLowerCase() : rest}`;
+}
+
+function capitalizeNameWord(value, wordIndex) {
+  const lower = value.toLowerCase();
+  if (wordIndex > 0 && LOWERCASE_NAME_PARTICLES.has(lower)) {
+    return lower;
+  }
+  if (/^([a-z]\.)+[a-z]?\.?$/i.test(value)) {
+    return value.toUpperCase();
+  }
+
+  return value
+    .split('-')
+    .map((hyphenPart) =>
+      hyphenPart
+        .split("'")
+        .map((apostrophePart) => capitalizeNameSegment(apostrophePart))
+        .join("'")
+    )
+    .join('-');
+}
+
+function normalizePersonDisplayName(value) {
+  const trimmed = String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!trimmed) return '';
+
+  return trimmed
+    .split(' ')
+    .map((word, index) => capitalizeNameWord(word, index))
+    .join(' ');
+}
+
+function runD1(command) {
+  const output = execFileSync(
+    'bun',
+    [
+      'wrangler',
+      'd1',
+      'execute',
+      database,
+      '--env',
+      env,
+      '--remote',
+      '--json',
+      '--command',
+      command,
+    ],
+    {
+      cwd: WORKER_DIR,
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 50,
+    }
+  );
+
+  const parsed = JSON.parse(output);
+  const statements = Array.isArray(parsed) ? parsed : [parsed];
+  const failed = statements.find((statement) => statement?.success === false);
+  if (failed) {
+    throw new Error(JSON.stringify(failed, null, 2));
+  }
+
+  return statements.flatMap((statement) => statement?.results ?? []);
+}
+
+function chunk(values, size) {
+  const chunks = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function buildUpdateSql(updates) {
+  const cases = updates
+    .map((update) => `WHEN ${sqlString(update.id)} THEN ${sqlString(update.nextDisplayName)}`)
+    .join('\n      ');
+  const ids = updates.map((update) => sqlString(update.id)).join(', ');
+
+  return `
+    UPDATE user_people
+    SET display_name = CASE id
+      ${cases}
+      ELSE display_name
+    END
+    WHERE id IN (${ids});
+  `;
+}
+
+const whereClause = userId ? `WHERE user_id = ${sqlString(userId)}` : '';
+const rows = runD1(`
+  SELECT id, user_id AS userId, display_name AS displayName
+  FROM user_people
+  ${whereClause}
+  ORDER BY user_id, display_name;
+`);
+
+const updates = rows
+  .map((row) => {
+    const current = String(row.displayName ?? '');
+    const next = normalizePersonDisplayName(current);
+    return {
+      id: String(row.id),
+      userId: String(row.userId),
+      currentDisplayName: current,
+      nextDisplayName: next,
+    };
+  })
+  .filter((row) => row.currentDisplayName && row.nextDisplayName !== row.currentDisplayName);
+
+console.log(
+  JSON.stringify(
+    {
+      database,
+      env,
+      dryRun,
+      scanned: rows.length,
+      updates: updates.length,
+      sample: updates.slice(0, Number.isFinite(sampleLimit) ? sampleLimit : 20),
+    },
+    null,
+    2
+  )
+);
+
+if (dryRun || updates.length === 0) {
+  if (dryRun) {
+    console.log('\nDry run only. Re-run with --yes to update production display names.');
+  }
+  process.exit(0);
+}
+
+for (const updatesChunk of chunk(updates, CHUNK_SIZE)) {
+  runD1(buildUpdateSql(updatesChunk));
+}
+
+console.log(`Updated ${updates.length} user_people display_name values.`);


### PR DESCRIPTION
## Summary
- Teach enrichment schema v2 to preserve person relationships like host, co-host, owner, guest, creator, author, and primary subject with evidence text.
- Normalize people display names to title case across indexing and API responses, plus add a production repair script for existing lowercase names.
- Add inferred X profile resolution for people: X user search provider, candidate scoring, profile persistence, avatar/handle updates for high-confidence matches, and backfill support.
- Surface relationship labels in mobile item detail people/entity UI.

## Rollout notes
- `X_BEARER_TOKEN` is expected as a Cloudflare Worker secret; it has already been configured in Wrangler for production.
- The production deploy workflow should run the new D1 migration before Worker deploy.
- After deploy, run `admin.backfillPeople` to resolve X profile candidates/links for existing people.
- I noticed local Wrangler migration listing looked inconsistent with direct production DB inspection earlier, so watch the migration step closely during deploy.

## Validation
- `bun run lint`
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Pre-push hook: format check, design-system check, typecheck, web tests, worker CI subset
