### PR TITLE
Use JSON object mode for enrichment AI

### DIFF
--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -74,7 +74,7 @@ describe('enrichWithQwen', () => {
     expect(run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
       expect.objectContaining({
-        response_format: expect.objectContaining({ type: 'json_schema' }),
+        response_format: { type: 'json_object' },
       })
     );
   });
@@ -89,32 +89,19 @@ describe('enrichWithQwen', () => {
     expect(run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
       expect.objectContaining({
-        response_format: {
-          type: 'json_schema',
-          json_schema: expect.objectContaining({
-            type: 'object',
-            properties: expect.objectContaining({
-              entities: expect.objectContaining({
-                items: expect.objectContaining({
-                  required: expect.arrayContaining(['relationship', 'evidenceText']),
-                }),
-              }),
-              summary: expect.any(Object),
-            }),
-          }),
-        },
+        response_format: { type: 'json_object' },
       })
     );
   });
 
-  it('does not use the OpenAI named schema wrapper for Workers AI JSON Mode', async () => {
+  it('does not send a JSON schema to Workers AI JSON Mode', async () => {
     const output = createValidModelOutput();
     const run = vi.fn().mockResolvedValue({ response: output });
 
     await enrichWithQwen({ AI: { run } } as never, createPromptInput());
 
-    expect(run.mock.calls[0][1].response_format.json_schema).not.toHaveProperty('name');
-    expect(run.mock.calls[0][1].response_format.json_schema).not.toHaveProperty('schema');
+    expect(run.mock.calls[0][1].response_format).toEqual({ type: 'json_object' });
+    expect(run.mock.calls[0][1].response_format).not.toHaveProperty('json_schema');
   });
 
   it('retries once when model output is invalid and accepts repaired JSON', async () => {

--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -9,18 +9,6 @@ import {
 } from './types';
 
 const llmLogger = logger.child('enrichment-llm');
-const ENTITY_RELATIONSHIPS = [
-  'HOST',
-  'CO_HOST',
-  'OWNER',
-  'CREATOR',
-  'AUTHOR',
-  'GUEST',
-  'INTERVIEWER',
-  'INTERVIEWEE',
-  'PRIMARY_SUBJECT',
-  'MENTIONED',
-];
 
 export class EnrichmentModelValidationError extends Error {
   constructor(message: string) {
@@ -112,108 +100,6 @@ function parseModelResponse(response: unknown): EnrichmentModelOutput {
   return validated.data;
 }
 
-function buildJsonModeSchema() {
-  return {
-    type: 'json_schema',
-    json_schema: {
-      type: 'object',
-      additionalProperties: false,
-      required: [
-        'summary',
-        'classification',
-        'topics',
-        'entities',
-        'suggestedTags',
-        'userContext',
-        'confidence',
-      ],
-      properties: {
-        summary: {
-          type: 'object',
-          required: ['short', 'detail'],
-          properties: {
-            short: { type: 'string' },
-            detail: { type: 'string' },
-          },
-        },
-        classification: {
-          type: 'object',
-          required: [
-            'primaryCategory',
-            'secondaryCategories',
-            'intent',
-            'difficulty',
-            'evergreenScore',
-            'timeSensitivity',
-          ],
-          properties: {
-            primaryCategory: { type: 'string' },
-            secondaryCategories: { type: 'array', items: { type: 'string' } },
-            intent: { type: 'string' },
-            difficulty: { type: 'string' },
-            evergreenScore: { type: 'number' },
-            timeSensitivity: { type: 'string' },
-          },
-        },
-        topics: {
-          type: 'array',
-          items: {
-            type: 'object',
-            required: ['name', 'confidence'],
-            properties: {
-              name: { type: 'string' },
-              confidence: { type: 'number' },
-            },
-          },
-        },
-        entities: {
-          type: 'array',
-          items: {
-            type: 'object',
-            required: ['name', 'type', 'relationship', 'confidence', 'evidenceText'],
-            properties: {
-              name: { type: 'string' },
-              type: { type: 'string' },
-              relationship: { type: 'string', enum: ENTITY_RELATIONSHIPS },
-              confidence: { type: 'number' },
-              evidenceText: { type: ['string', 'null'] },
-            },
-          },
-        },
-        suggestedTags: {
-          type: 'array',
-          items: {
-            type: 'object',
-            required: ['name', 'kind', 'confidence'],
-            properties: {
-              name: { type: 'string' },
-              kind: { type: 'string', enum: ['topic', 'entity', 'intent', 'format'] },
-              confidence: { type: 'number' },
-            },
-          },
-        },
-        userContext: {
-          type: 'object',
-          required: ['inferredSaveIntent', 'reasonToRevisit'],
-          properties: {
-            inferredSaveIntent: { type: 'string' },
-            reasonToRevisit: { type: 'string' },
-          },
-        },
-        confidence: {
-          type: 'object',
-          required: ['overall', 'summary', 'classification', 'tags'],
-          properties: {
-            overall: { type: 'number' },
-            summary: { type: 'number' },
-            classification: { type: 'number' },
-            tags: { type: 'number' },
-          },
-        },
-      },
-    },
-  };
-}
 async function runQwen(env: Bindings, input: unknown): Promise<unknown> {
   const ai = env.AI as unknown as WorkersAIRun | undefined;
   if (!ai) {
@@ -230,7 +116,9 @@ export async function enrichWithQwen(
   const messages = buildEnrichmentMessages(input);
   const request = {
     messages,
-    response_format: buildJsonModeSchema(),
+    // Workers AI JSON schema mode can reject larger nested schemas before returning output.
+    // Keep generation constrained to JSON and let the local Zod schema enforce the contract.
+    response_format: { type: 'json_object' },
     max_tokens: 1800,
   };
 


### PR DESCRIPTION
## Summary
- Switch enrichment AI generation from strict Workers AI `json_schema` mode to `json_object` mode.
- Keep the existing local Zod validation/repair path as the enforcement layer for the full enrichment schema.

## Why
The production v2 enrichment backfill hit Workers AI errors:

```text
5024: JSON Model couldn't be met
```

The first backfill batches stayed `PENDING` and retried. I paused `zine-enrichment-queue-prod` to avoid burning through the queued backfill jobs until this is deployed.

## Validation
- `bun test apps/worker/src/enrichment/llm.test.ts apps/worker/src/enrichment/prompt.test.ts apps/worker/src/enrichment/consumer.test.ts apps/worker/src/people/social-resolution.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker lint`
- Pre-push hook: format check, design-system check, typecheck, web tests, worker CI subset

## Rollout
After this deploys, resume `zine-enrichment-queue-prod` and watch schema v2 enrichment counts progress from `PENDING` to `COMPLETE`.
