### PR TITLE
Add explicit enrichment JSON output contract

### DIFF
--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -136,7 +136,7 @@ export async function enrichWithQwen(
         {
           role: 'user',
           content:
-            'Retry. Return only valid JSON matching the schema exactly. No markdown or commentary.',
+            'Retry. Return only one valid JSON object with top-level keys summary, classification, topics, entities, suggestedTags, userContext, and confidence. No markdown or commentary.',
         },
       ],
     };

--- a/apps/worker/src/enrichment/prompt.test.ts
+++ b/apps/worker/src/enrichment/prompt.test.ts
@@ -51,11 +51,38 @@ describe('enrichment prompt helpers', () => {
     const messages = buildEnrichmentMessages(createPromptInput('Hosted by Casey Newton.'));
     const userPayload = JSON.parse(String(messages[1].content)) as {
       constraints: string[];
+      outputContract: {
+        entities: Array<{
+          relationship: string;
+          evidenceText: string;
+        }>;
+      };
     };
 
     expect(userPayload.constraints.join(' ')).toContain('HOST');
     expect(userPayload.constraints.join(' ')).toContain('co-hosts');
     expect(userPayload.constraints.join(' ')).toContain('owners');
     expect(userPayload.constraints.join(' ')).toContain('evidenceText');
+    expect(userPayload.outputContract.entities[0]?.relationship).toContain('PRIMARY_SUBJECT');
+    expect(userPayload.outputContract.entities[0]?.evidenceText).toContain('null');
+  });
+
+  it('includes the full top-level output contract in the prompt', () => {
+    const messages = buildEnrichmentMessages(createPromptInput('A short item.'));
+    const userPayload = JSON.parse(String(messages[1].content)) as {
+      constraints: string[];
+      outputContract: Record<string, unknown>;
+    };
+
+    expect(userPayload.constraints.join(' ')).toContain('exactly these top-level keys');
+    expect(Object.keys(userPayload.outputContract)).toEqual([
+      'summary',
+      'classification',
+      'topics',
+      'entities',
+      'suggestedTags',
+      'userContext',
+      'confidence',
+    ]);
   });
 });

--- a/apps/worker/src/enrichment/prompt.ts
+++ b/apps/worker/src/enrichment/prompt.ts
@@ -43,6 +43,49 @@ function formatCreator(creator: EnrichmentSourceCreator | null): string {
   );
 }
 
+const OUTPUT_CONTRACT = {
+  summary: {
+    short: 'string, 1-2 sentences',
+    detail: 'string, concise paragraph',
+  },
+  classification: {
+    primaryCategory: 'string',
+    secondaryCategories: ['string'],
+    intent: 'string',
+    difficulty: 'string',
+    evergreenScore: 'number from 0 to 1',
+    timeSensitivity: 'string',
+  },
+  topics: [{ name: 'string', confidence: 'number from 0 to 1' }],
+  entities: [
+    {
+      name: 'string',
+      type: 'person | organization | product | technology | place | concept | other',
+      relationship:
+        'HOST | CO_HOST | OWNER | CREATOR | AUTHOR | GUEST | INTERVIEWER | INTERVIEWEE | PRIMARY_SUBJECT | MENTIONED',
+      confidence: 'number from 0 to 1',
+      evidenceText: 'short supporting phrase or null',
+    },
+  ],
+  suggestedTags: [
+    {
+      name: 'string',
+      kind: 'topic | entity | intent | format',
+      confidence: 'number from 0 to 1',
+    },
+  ],
+  userContext: {
+    inferredSaveIntent: 'string',
+    reasonToRevisit: 'string',
+  },
+  confidence: {
+    overall: 'number from 0 to 1',
+    summary: 'number from 0 to 1',
+    classification: 'number from 0 to 1',
+    tags: 'number from 0 to 1',
+  },
+};
+
 export function buildArticleContent(content: string | null): string | null {
   return stripHtml(content ?? '') || null;
 }
@@ -69,7 +112,9 @@ export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
   const userContent = {
     task: 'Enrich this saved bookmark for a personal knowledge/recommendation app.',
     constraints: [
-      'Return only JSON matching the requested schema.',
+      'Return one JSON object with exactly these top-level keys: summary, classification, topics, entities, suggestedTags, userContext, confidence.',
+      'Do not return only an entity list, a wrapper object, markdown, commentary, or prose outside JSON.',
+      'Every entity must include name, type, relationship, confidence, and evidenceText.',
       'Prefer stable categories and short lowercase tag names.',
       'Do not invent facts not supported by the input.',
       'Use confidence below 0.6 when the input is thin or ambiguous.',
@@ -90,6 +135,7 @@ export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
       metadataExcerpt,
       articleContent: input.articleContent,
     },
+    outputContract: OUTPUT_CONTRACT,
   };
 
   return [


### PR DESCRIPTION
## Summary
- Add an explicit output contract to the enrichment prompt for JSON-object mode.
- Strengthen the repair prompt so Workers AI returns the full enrichment object, not a partial entity list.

## Why
After PR #270 switched away from strict Workers AI `json_schema`, production queue processing resumed but the model returned partial JSON objects. Those failed local validation because required top-level keys like `summary` and `classification` were missing.

`zine-enrichment-queue-prod` is paused again. Current observed state after the attempted resume was 23 v2 `FAILED` rows and 2 v2 `PENDING` rows.

## Validation
- `bun test apps/worker/src/enrichment/llm.test.ts apps/worker/src/enrichment/prompt.test.ts apps/worker/src/enrichment/consumer.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker lint`
- Pre-push hook: format check, design-system check, typecheck, web tests, worker CI subset

## Rollout
After deploy, re-enqueue incomplete v2 bookmark enrichment rows and resume `zine-enrichment-queue-prod`.
