### PR TITLE
Tolerate enrichment enum drift

### DIFF
--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -139,6 +139,26 @@ describe('enrichWithQwen', () => {
     expect(result.confidence.overall).toBe(output.confidence.overall);
   });
 
+  it('normalizes common model enum drift before validation', async () => {
+    const output = createValidModelOutput();
+    output.entities = [
+      {
+        name: 'Example Publisher',
+        type: 'ORGANIZATION',
+        relationship: 'PUBLISHER',
+        confidence: 0.81,
+        evidenceText: 'Published by Example Publisher.',
+      },
+    ];
+    output.suggestedTags = [{ name: 'software design', kind: 'concept', confidence: 0.78 }];
+    const run = vi.fn().mockResolvedValue({ response: JSON.stringify(output) });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.entities[0]?.relationship).toBe('CREATOR');
+    expect(result.suggestedTags[0]?.kind).toBe('topic');
+  });
+
   it('throws validation error when both model attempts are invalid', async () => {
     const run = vi.fn().mockResolvedValue({ response: '{bad-json' });
 

--- a/apps/worker/src/enrichment/schema.ts
+++ b/apps/worker/src/enrichment/schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ENRICHMENT_SCHEMA_VERSION, type EnrichmentModelOutput, type SuggestedTag } from './types';
 
 const ConfidenceSchema = z.number().min(0).max(1);
-export const EntityRelationshipSchema = z.enum([
+const BaseEntityRelationshipSchema = z.enum([
   'HOST',
   'CO_HOST',
   'OWNER',
@@ -15,6 +15,53 @@ export const EntityRelationshipSchema = z.enum([
   'PRIMARY_SUBJECT',
   'MENTIONED',
 ]);
+const BaseSuggestedTagKindSchema = z.enum(['topic', 'entity', 'intent', 'format']);
+
+function normalizeEnumishString(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_');
+}
+
+export const EntityRelationshipSchema = z.preprocess((value) => {
+  if (typeof value !== 'string') return value;
+
+  const normalized = normalizeEnumishString(value);
+  switch (normalized) {
+    case 'PUBLISHER':
+    case 'PUBLICATION':
+    case 'SOURCE':
+      return 'CREATOR';
+    case 'PRESENTER':
+    case 'PRESENTED_BY':
+      return 'HOST';
+    default:
+      return normalized;
+  }
+}, BaseEntityRelationshipSchema);
+
+const SuggestedTagKindSchema = z.preprocess((value) => {
+  if (typeof value !== 'string') return value;
+
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+  switch (normalized) {
+    case 'concept':
+    case 'theme':
+    case 'keyword':
+      return 'topic';
+    case 'person':
+    case 'company':
+    case 'organization':
+    case 'organisation':
+      return 'entity';
+    default:
+      return normalized;
+  }
+}, BaseSuggestedTagKindSchema);
 
 export const EnrichmentQueueMessageSchema = z.object({
   itemId: z.string().min(1),
@@ -28,7 +75,7 @@ export const EnrichmentQueueMessageSchema = z.object({
 
 export const ModelSuggestedTagSchema = z.object({
   name: z.string().min(1).max(64),
-  kind: z.enum(['topic', 'entity', 'intent', 'format']),
+  kind: SuggestedTagKindSchema,
   confidence: ConfidenceSchema,
 });
 
@@ -80,10 +127,12 @@ export const EnrichmentModelOutputSchema = z.object({
     classification: ConfidenceSchema,
     tags: ConfidenceSchema,
   }),
-}) satisfies z.ZodType<EnrichmentModelOutput>;
+}) satisfies z.ZodType<EnrichmentModelOutput, z.ZodTypeDef, unknown>;
 
 export const SuggestedTagsSchema = z.array(SuggestedTagSchema).max(10) satisfies z.ZodType<
-  SuggestedTag[]
+  SuggestedTag[],
+  z.ZodTypeDef,
+  unknown
 >;
 
 export type EnrichmentQueueMessageInput = z.infer<typeof EnrichmentQueueMessageSchema>;


### PR DESCRIPTION
## Summary
- normalize common model enum drift before enrichment output validation
- map publisher/source relationships to CREATOR and presenter variants to HOST
- map concept/theme/keyword tag kinds to topic and entity-like kinds to entity
- add regression coverage for production failure shapes

## Verification
- bun run --cwd apps/worker test:run src/enrichment/llm.test.ts src/enrichment/prompt.test.ts
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/worker lint
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test:worker:ci
- bun run build
- bun run test