### PR TITLE
Show person avatars in item detail

### DIFF
--- a/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailPeopleCard.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Pressable, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { Image, Pressable, View } from 'react-native';
 
 import { Surface } from '@/components/primitives/surface';
 import { Text } from '@/components/primitives/text';
@@ -13,6 +14,7 @@ type EnrichmentEntity = NonNullable<ItemDetailEnrichment>['item']['entities'][nu
 type PersonEntity = {
   name: string;
   personId: string | null;
+  profileImageUrl: string | null;
   relationship: string;
   confidence: number;
 };
@@ -107,14 +109,22 @@ function toPeople(entities: EnrichmentEntity[]): PersonEntity[] {
     const next: PersonEntity = {
       name,
       personId: entity.personId ?? null,
+      profileImageUrl: entity.profileImageUrl ?? null,
       relationship: entity.relationship ?? 'MENTIONED',
       confidence: entity.confidence,
     };
-    const candidate = existing && !next.personId ? { ...next, personId: existing.personId } : next;
+    const candidate = existing
+      ? {
+          ...next,
+          personId: next.personId ?? existing.personId,
+          profileImageUrl: next.profileImageUrl ?? existing.profileImageUrl,
+        }
+      : next;
 
     if (
       !existing ||
       (!existing.personId && candidate.personId) ||
+      (!existing.profileImageUrl && candidate.profileImageUrl) ||
       relationshipPriority(candidate.relationship) > relationshipPriority(existing.relationship) ||
       (candidate.relationship === existing.relationship &&
         candidate.confidence > existing.confidence)
@@ -144,15 +154,31 @@ function PersonRow({
 }) {
   const initials = getInitials(person.name);
   const personId = person.personId;
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(person.profileImageUrl && !imageFailed);
   const isNavigable = Boolean(personId && onPersonPress);
   const relationship = formatRelationship(person.relationship);
   const label = relationship ? `${person.name} / ${relationship}` : person.name;
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [person.profileImageUrl]);
+
   const content = (
     <>
       <View style={[styles.peopleAvatar, { backgroundColor: colors.backgroundTertiary }]}>
-        <Text variant="labelSmall" tone="tertiary" colors={colors} transform="none">
-          {initials}
-        </Text>
+        {showImage ? (
+          <Image
+            source={{ uri: person.profileImageUrl! }}
+            style={styles.peopleAvatarImage}
+            onError={() => setImageFailed(true)}
+            accessibilityIgnoresInvertColors
+          />
+        ) : (
+          <Text variant="labelSmall" tone="tertiary" colors={colors} transform="none">
+            {initials}
+          </Text>
+        )}
       </View>
       <Text
         variant="bodyMedium"

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -240,6 +240,11 @@ export const styles = StyleSheet.create({
     borderRadius: Radius.full,
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  peopleAvatarImage: {
+    width: '100%',
+    height: '100%',
   },
   peopleName: {
     flex: 1,

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -1020,6 +1020,9 @@ export const itemsRouter = router({
               .select({
                 personId: userPeople.id,
                 normalizedName: userPeople.normalizedName,
+                profileImageUrl: userPeople.profileImageUrl,
+                profileImageSource: userPeople.profileImageSource,
+                xHandle: userPeople.xHandle,
               })
               .from(userPersonMentions)
               .innerJoin(userPeople, eq(userPersonMentions.userPersonId, userPeople.id))
@@ -1031,8 +1034,8 @@ export const itemsRouter = router({
                 )
               )
           : [];
-      const personIdByNormalizedName = new Map(
-        activePersonRows.map((row) => [row.normalizedName, row.personId])
+      const personByNormalizedName = new Map(
+        activePersonRows.map((row) => [row.normalizedName, row])
       );
 
       return {
@@ -1055,7 +1058,16 @@ export const itemsRouter = router({
               ...entity,
               name: isPerson ? normalizePersonDisplayName(entity.name) : entity.name,
               personId: normalizedPersonName
-                ? (personIdByNormalizedName.get(normalizedPersonName) ?? null)
+                ? (personByNormalizedName.get(normalizedPersonName)?.personId ?? null)
+                : null,
+              profileImageUrl: normalizedPersonName
+                ? (personByNormalizedName.get(normalizedPersonName)?.profileImageUrl ?? null)
+                : null,
+              profileImageSource: normalizedPersonName
+                ? (personByNormalizedName.get(normalizedPersonName)?.profileImageSource ?? null)
+                : null,
+              xHandle: normalizedPersonName
+                ? (personByNormalizedName.get(normalizedPersonName)?.xHandle ?? null)
                 : null,
             };
           }),


### PR DESCRIPTION
## Summary
- include person profile image metadata in items.getEnrichment entities
- render profile images in the mobile item-detail people card with initials fallback
- preserve existing person dedupe/sorting while carrying image URLs forward

## Notes
- Prod currently has profile images on 134 active people, including 63 with source X, but the item-detail people card was only receiving personId and rendering initials.
- The separate inferred person_social_profiles table is currently empty and should be investigated separately; this PR fixes the visible card path for images that already exist on user_people.

## Verification
- bun run format:check
- bun run typecheck
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/mobile lint
- bun run --cwd apps/worker lint
- bun run lint
- bun run build
- bun run test:worker:ci
- bun run test