### PR TITLE
[codex] Add iOS article WebView overlay

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -14,12 +14,15 @@
  */
 
 import { Image } from 'expo-image';
+import * as Haptics from 'expo-haptics';
 import { useRouter, type Href } from 'expo-router';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { Colors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { ContentType } from '@/hooks/use-items-trpc';
 import { upgradeSpotifyImageUrl, upgradeYouTubeImageUrl } from '@/lib/content-utils';
 import {
   COLLAPSED_TITLE_THRESHOLD,
@@ -29,6 +32,7 @@ import {
 
 import { XPostBookmarkView } from './item-detail-components';
 import { styles } from './item-detail-styles';
+import { ItemDetailArticleWebView } from './detail/components/ItemDetailArticleWebView';
 import { ItemDetailContent } from './detail/components/ItemDetailContent';
 import { ItemCollectionsSheet } from './detail/components/ItemCollectionsSheet';
 import {
@@ -54,12 +58,14 @@ export default function ItemDetailScreen() {
   const [contentTopY, setContentTopY] = useState<number | null>(null);
   const [titleOffsetY, setTitleOffsetY] = useState<number | null>(null);
   const [collectionsSheetOpen, setCollectionsSheetOpen] = useState(false);
+  const [articleWebViewOpen, setArticleWebViewOpen] = useState(false);
 
   const { id, isValid, message } = useItemDetailParams();
   const { item, enrichment, otherUnfinishedBookmarks, isLoading, error, refetch, creatorData } =
     useItemDetailData({ id, isValid });
   const {
     handleOpenLink,
+    handleMarkLinkOpened,
     handleShare,
     handleToggleBookmark,
     handleSecondaryAction,
@@ -105,6 +111,38 @@ export default function ItemDetailScreen() {
   const handleCloseCollectionsSheet = useCallback(() => {
     setCollectionsSheetOpen(false);
   }, []);
+  const shouldUsePreloadedArticleWebView =
+    Platform.OS === 'ios' &&
+    item?.contentType === ContentType.ARTICLE &&
+    item.provider !== 'SUBSTACK' &&
+    !!item.canonicalUrl;
+  const handleOpenPrimaryLink = useCallback(() => {
+    if (!shouldUsePreloadedArticleWebView) {
+      void handleOpenLink();
+      return;
+    }
+
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setArticleWebViewOpen(true);
+    handleMarkLinkOpened();
+  }, [handleMarkLinkOpened, handleOpenLink, shouldUsePreloadedArticleWebView]);
+  const handleCloseArticleWebView = useCallback(() => {
+    setArticleWebViewOpen(false);
+  }, []);
+
+  useEffect(() => {
+    setArticleWebViewOpen(false);
+  }, [item?.id]);
+
+  const articleWebViewOverlay = (
+    <ItemDetailArticleWebView
+      url={shouldUsePreloadedArticleWebView ? item?.canonicalUrl : null}
+      colors={colors}
+      insets={insets}
+      visible={articleWebViewOpen}
+      onClose={handleCloseArticleWebView}
+    />
+  );
 
   if (!isValid) {
     return (
@@ -134,7 +172,7 @@ export default function ItemDetailScreen() {
           colors={colors}
           insets={insets}
           onBack={() => router.back()}
-          onOpenLink={handleOpenLink}
+          onOpenLink={handleOpenPrimaryLink}
           onShare={handleShare}
           onBookmarkToggle={handleToggleBookmark}
           onSecondaryAction={handleSecondaryAction}
@@ -187,6 +225,7 @@ export default function ItemDetailScreen() {
           />
         }
         headerAspectRatio={viewState.headerAspectRatio}
+        overlay={articleWebViewOverlay}
       >
         <ItemDetailContent
           item={item}
@@ -208,7 +247,7 @@ export default function ItemDetailScreen() {
           onSecondaryAction={handleSecondaryAction}
           onManageTags={handleOpenCollectionsSheet}
           onShare={handleShare}
-          onOpenLink={handleOpenLink}
+          onOpenLink={handleOpenPrimaryLink}
           onPersonPress={(personId) => router.push(`/person/${personId}?source=item` as Href)}
           otherUnfinishedBookmarks={otherUnfinishedBookmarks}
           onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
@@ -235,6 +274,7 @@ export default function ItemDetailScreen() {
       onScroll={handleScroll}
       screenTitle={item.title}
       showCollapsedTitle={showCollapsedTitle}
+      overlay={articleWebViewOverlay}
     >
       <ItemDetailContent
         item={item}
@@ -256,7 +296,7 @@ export default function ItemDetailScreen() {
         onSecondaryAction={handleSecondaryAction}
         onManageTags={handleOpenCollectionsSheet}
         onShare={handleShare}
-        onOpenLink={handleOpenLink}
+        onOpenLink={handleOpenPrimaryLink}
         onPersonPress={(personId) => router.push(`/person/${personId}?source=item` as Href)}
         otherUnfinishedBookmarks={otherUnfinishedBookmarks}
         onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}

--- a/apps/mobile/app/item/detail/components/ItemDetailArticleWebView.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailArticleWebView.tsx
@@ -1,0 +1,246 @@
+import { Ionicons } from '@expo/vector-icons';
+import { WebView } from '@expo/dom-webview';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Animated,
+  Linking,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
+import type { EdgeInsets } from 'react-native-safe-area-context';
+import type { DomWebViewRef } from '@expo/dom-webview';
+
+import { Radius, Spacing } from '@/constants/theme';
+import { logger } from '@/lib/logger';
+
+import type { ItemDetailColors } from '../types';
+
+type ItemDetailArticleWebViewProps = {
+  url: string | null;
+  colors: ItemDetailColors;
+  insets: EdgeInsets;
+  visible: boolean;
+  onClose: () => void;
+};
+
+export function ItemDetailArticleWebView({
+  url,
+  colors,
+  insets,
+  visible,
+  onClose,
+}: ItemDetailArticleWebViewProps) {
+  const webViewRef = useRef<DomWebViewRef>(null);
+  const controlsOpacity = useRef(new Animated.Value(1)).current;
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [controlsHidden, setControlsHidden] = useState(false);
+
+  useEffect(() => {
+    setIsLoaded(false);
+    const timeout = setTimeout(() => setIsLoaded(true), 1200);
+    return () => clearTimeout(timeout);
+  }, [url]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    setControlsHidden(false);
+    requestAnimationFrame(() => {
+      webViewRef.current?.scrollTo({ x: 0, y: 0, animated: false });
+    });
+  }, [url, visible]);
+
+  useEffect(() => {
+    Animated.timing(controlsOpacity, {
+      toValue: controlsHidden ? 0 : 1,
+      duration: 160,
+      useNativeDriver: true,
+    }).start();
+  }, [controlsHidden, controlsOpacity]);
+
+  const handleReaderMessage = useCallback((event: { nativeEvent: { data: string } }) => {
+    try {
+      const message = JSON.parse(event.nativeEvent.data) as { type?: string; y?: number };
+      if (message.type === 'article-tap') {
+        setControlsHidden(false);
+        return;
+      }
+
+      if (message.type !== 'article-scroll' || typeof message.y !== 'number') return;
+
+      setControlsHidden((current) => {
+        if (current) {
+          return message.y > 8;
+        }
+
+        return message.y > 28;
+      });
+    } catch {
+      // Ignore messages that are not from the article scroll bridge.
+    }
+  }, []);
+
+  const handleOpenOriginal = useCallback(() => {
+    if (!url) return;
+
+    void Linking.openURL(url).catch((error) => {
+      logger.error('Failed to open original article URL', { error, url });
+    });
+  }, [url]);
+
+  if (Platform.OS !== 'ios' || !url) {
+    return null;
+  }
+
+  return (
+    <View
+      pointerEvents={visible ? 'auto' : 'none'}
+      accessibilityElementsHidden={!visible}
+      importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
+      style={[
+        componentStyles.overlay,
+        { backgroundColor: colors.background },
+        visible ? componentStyles.overlayVisible : componentStyles.overlayHidden,
+      ]}
+    >
+      <WebView
+        ref={webViewRef}
+        source={{ uri: url }}
+        style={componentStyles.webView}
+        containerStyle={componentStyles.webViewContainer}
+        bounces
+        scrollEnabled
+        showsVerticalScrollIndicator
+        onMessage={handleReaderMessage}
+        injectedJavaScriptBeforeContentLoaded={ARTICLE_SCROLL_BRIDGE_SCRIPT}
+        automaticallyAdjustsScrollIndicatorInsets={false}
+        contentInset={{ top: 0, left: 0, bottom: 0, right: 0 }}
+        contentInsetAdjustmentBehavior="never"
+      />
+
+      <Animated.View
+        pointerEvents={controlsHidden ? 'none' : 'auto'}
+        style={[
+          componentStyles.floatingControls,
+          { top: insets.top + Spacing.sm, left: Spacing.lg, right: Spacing.lg },
+          {
+            opacity: controlsOpacity,
+            transform: [
+              {
+                translateY: controlsOpacity.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [-6, 0],
+                }),
+              },
+            ],
+          },
+        ]}
+      >
+        <Pressable
+          onPress={onClose}
+          style={[componentStyles.iconButton, { backgroundColor: colors.backgroundSecondary }]}
+          accessibilityLabel="Close article"
+        >
+          <Ionicons name="close" size={22} color={colors.text} />
+        </Pressable>
+
+        <Pressable
+          onPress={handleOpenOriginal}
+          style={[componentStyles.iconButton, { backgroundColor: colors.backgroundSecondary }]}
+          accessibilityLabel="Open original article"
+        >
+          <Ionicons name="open-outline" size={20} color={colors.text} />
+        </Pressable>
+      </Animated.View>
+
+      {visible && !isLoaded && (
+        <View style={componentStyles.loadingOverlay} pointerEvents="none">
+          <ActivityIndicator color={colors.text} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const ARTICLE_SCROLL_BRIDGE_SCRIPT = `
+(function () {
+  if (window.__zineArticleScrollBridgeInstalled) return true;
+  window.__zineArticleScrollBridgeInstalled = true;
+
+  var lastSent = -1;
+  var rafId = null;
+
+  function sendScrollPosition() {
+    rafId = null;
+    var y = window.scrollY || document.documentElement.scrollTop || 0;
+    if (Math.abs(y - lastSent) < 8 && !(lastSent <= 28 && y <= 28)) {
+      return;
+    }
+
+    lastSent = y;
+    window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'article-scroll',
+      y: y
+    }));
+  }
+
+  window.addEventListener('scroll', function () {
+    if (rafId !== null) return;
+    rafId = window.requestAnimationFrame(sendScrollPosition);
+  }, { passive: true });
+
+  window.addEventListener('touchend', function () {
+    window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'article-tap'
+    }));
+  }, { passive: true });
+
+  sendScrollPosition();
+  return true;
+})();
+`;
+
+const componentStyles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  overlayVisible: {
+    opacity: 1,
+    zIndex: 300,
+  },
+  overlayHidden: {
+    opacity: 0,
+    zIndex: 0,
+  },
+  webViewContainer: {
+    flex: 1,
+  },
+  webView: {
+    flex: 1,
+  },
+  floatingControls: {
+    position: 'absolute',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  iconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.18,
+    shadowRadius: 8,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
@@ -18,6 +18,7 @@ type ItemDetailLayoutBaseProps = {
   onScroll: ScrollViewProps['onScroll'];
   screenTitle: string;
   showCollapsedTitle: boolean;
+  overlay?: ReactNode;
 };
 
 export function ItemDetailParallaxLayout({
@@ -28,6 +29,7 @@ export function ItemDetailParallaxLayout({
   onScroll,
   screenTitle,
   showCollapsedTitle,
+  overlay,
   headerImage,
   headerAspectRatio,
 }: ItemDetailLayoutBaseProps & {
@@ -55,6 +57,7 @@ export function ItemDetailParallaxLayout({
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
       />
+      {overlay}
     </View>
   );
 }
@@ -67,6 +70,7 @@ export function ItemDetailScrollLayout({
   onScroll,
   screenTitle,
   showCollapsedTitle,
+  overlay,
 }: ItemDetailLayoutBaseProps) {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -89,6 +93,7 @@ export function ItemDetailScrollLayout({
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
       />
+      {overlay}
     </View>
   );
 }

--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -26,6 +26,12 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
   const toggleFinishedMutation = useToggleFinished();
   const markOpenedMutation = useMarkItemOpened();
 
+  const handleMarkLinkOpened = useCallback(() => {
+    if (item?.state === UserItemState.BOOKMARKED) {
+      markOpenedMutation.mutate({ id: item.id });
+    }
+  }, [item?.id, item?.state, markOpenedMutation]);
+
   const handleOpenLink = useCallback(async () => {
     if (!item?.canonicalUrl) return;
 
@@ -56,13 +62,13 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
         }
       }
 
-      if (didOpen && item.state === UserItemState.BOOKMARKED) {
-        markOpenedMutation.mutate({ id: item.id });
+      if (didOpen) {
+        handleMarkLinkOpened();
       }
     } catch (err) {
       logger.error('Failed to open URL', { error: err });
     }
-  }, [item, markOpenedMutation]);
+  }, [handleMarkLinkOpened, item]);
 
   const handleShare = useCallback(async () => {
     if (!item) return;
@@ -120,6 +126,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
 
   return {
     handleOpenLink,
+    handleMarkLinkOpened,
     handleShare,
     handleToggleBookmark,
     handleSecondaryAction,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@clerk/clerk-expo": "^2.19.11",
+    "@expo/dom-webview": "55.0.3",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@react-native-async-storage/async-storage": "^2.2.0",

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@clerk/clerk-expo": "^2.19.11",
+        "@expo/dom-webview": "55.0.3",
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.6",
         "@react-native-async-storage/async-storage": "^2.2.0",


### PR DESCRIPTION
## Summary

- Adds an iOS-only article WebView overlay for article FAB opens, using `@expo/dom-webview` so the article page can be preloaded in the item detail screen.
- Keeps Substack and non-iOS paths on the existing external open behavior.
- Adds floating close/open-original controls that hide while scrolling and reappear when the article page is tapped.
- Marks bookmarked articles as opened when the in-app overlay is shown.

## Validation

- `bun run typecheck`
- `bun run --cwd apps/mobile test hooks/use-item-detail-data.test.ts hooks/use-item-detail-actions.test.ts`
- `bun run --cwd apps/mobile lint`
- Pre-push hook: `prettier --check`, mobile design-system check, `turbo run typecheck`, `apps/web` tests, and worker tests excluding `user-do`/`scheduler`
