### PR TITLE
Improve inferred X handle discovery

### DIFF
--- a/apps/worker/src/people/backfill.ts
+++ b/apps/worker/src/people/backfill.ts
@@ -4,9 +4,8 @@ import { UserItemState } from '@zine/shared';
 import type { Database } from '../db';
 import { userItems } from '../db/schema';
 import { logger } from '../lib/logger';
-import type { Bindings } from '../types';
 import { syncPeopleForUserItem } from './service';
-import { resolveXProfilesForItem } from './social-resolution';
+import { resolveXProfilesForItem, type XResolutionEnv } from './social-resolution';
 
 const backfillLogger = logger.child('people-backfill');
 
@@ -45,7 +44,7 @@ function normalizeLimit(value: number | undefined): number {
 
 export async function backfillPeopleIndex(
   db: Database,
-  env?: Pick<Bindings, 'X_BEARER_TOKEN'>,
+  env?: XResolutionEnv,
   options: PeopleBackfillOptions = {}
 ): Promise<PeopleBackfillResult> {
   const dryRun = options.dryRun ?? true;

--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getValidAccessToken } from '../lib/token-refresh';
 import { socialResolutionInternals } from './social-resolution';
 
+vi.mock('../lib/token-refresh', () => ({
+  getValidAccessToken: vi.fn(),
+}));
+
 describe('social profile resolution helpers', () => {
+  beforeEach(() => {
+    vi.mocked(getValidAccessToken).mockReset();
+  });
+
   it('scores exact X display-name matches higher when profile context matches content', () => {
     const scored = socialResolutionInternals.scoreXProfileCandidate({
       personName: 'Armin Ronacher',
@@ -190,5 +199,69 @@ describe('social profile resolution helpers', () => {
 
     expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
     expect(scored.inferredHandleSource).toBe('NAME_DERIVED');
+  });
+
+  it('uses a configured X service user connection for user-search access', async () => {
+    vi.mocked(getValidAccessToken).mockResolvedValueOnce('user-context-token');
+    const connection = {
+      id: 'connection-1',
+      userId: 'service-user-1',
+      provider: 'X',
+      providerUserId: 'x-user-1',
+      accessToken: 'encrypted-access',
+      refreshToken: 'encrypted-refresh',
+      tokenExpiresAt: Date.now() + 60_000,
+      scopes: 'tweet.read users.read offline.access',
+      connectedAt: Date.now(),
+      lastRefreshedAt: null,
+      status: 'ACTIVE',
+    };
+    const db = {
+      query: {
+        providerConnections: {
+          findFirst: vi.fn().mockResolvedValue(connection),
+        },
+      },
+    };
+
+    const tokens = await socialResolutionInternals.resolveXAccessTokens(db as never, {
+      DB: {} as D1Database,
+      OAUTH_STATE_KV: {} as KVNamespace,
+      ENCRYPTION_KEY: '0'.repeat(64),
+      X_CLIENT_ID: 'x-client-id',
+      X_PROFILE_SEARCH_USER_ID: 'service-user-1',
+      X_BEARER_TOKEN: 'app-only-token',
+    });
+
+    expect(db.query.providerConnections.findFirst).toHaveBeenCalledTimes(1);
+    expect(getValidAccessToken).toHaveBeenCalledWith(connection, expect.anything());
+    expect(tokens).toEqual({
+      userSearchAccessToken: 'user-context-token',
+      directLookupAccessToken: 'app-only-token',
+    });
+  });
+
+  it('falls back to app-only direct lookup when no X service user is configured', async () => {
+    const db = {
+      query: {
+        providerConnections: {
+          findFirst: vi.fn(),
+        },
+      },
+    };
+
+    const tokens = await socialResolutionInternals.resolveXAccessTokens(
+      db as never,
+      {
+        X_BEARER_TOKEN: 'app-only-token',
+      } as never
+    );
+
+    expect(db.query.providerConnections.findFirst).not.toHaveBeenCalled();
+    expect(getValidAccessToken).not.toHaveBeenCalled();
+    expect(tokens).toEqual({
+      userSearchAccessToken: null,
+      directLookupAccessToken: 'app-only-token',
+    });
   });
 });

--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -44,6 +44,7 @@ describe('social profile resolution helpers', () => {
       inferredHandle: {
         username: 'pmarca',
         confidence: 0.9,
+        source: 'AI_INFERRED',
         reason: 'Well-known X handle for Marc Andreessen.',
       },
       candidate: {
@@ -95,6 +96,7 @@ describe('social profile resolution helpers', () => {
         provider: 'SPOTIFY',
         contentType: 'PODCAST',
         publisher: null,
+        summary: 'Flask maintainer interview with Armin Ronacher.',
         rawMetadata: null,
         creatorName: 'The Changelog',
         creatorDescription: 'Developer podcast',
@@ -104,5 +106,89 @@ describe('social profile resolution helpers', () => {
 
     expect(queries[0]).toBe('"Armin Ronacher"');
     expect(queries.some((query) => query.includes('Flask') || query.includes('flask'))).toBe(true);
+  });
+
+  it('uses item summaries as social-resolution context', () => {
+    const terms = socialResolutionInternals.extractContextTerms(
+      {
+        itemId: 'item-1',
+        title: 'Google I/O reactions',
+        provider: 'YOUTUBE',
+        contentType: 'VIDEO',
+        publisher: null,
+        summary: 'The Verge executive editor Jake Kastrenakes joins the livestream.',
+        rawMetadata: null,
+        creatorName: 'The Verge',
+        creatorDescription: null,
+        creatorHandle: '@theverge',
+      },
+      {
+        displayName: 'Jake Kastrenakes',
+        evidenceText: 'executive editor Jake Kastrenakes',
+      }
+    );
+
+    expect(terms).toContain('verge');
+    expect(terms).toContain('executive');
+  });
+
+  it('generates common validated lookup handles from names', () => {
+    const candidates = socialResolutionInternals.buildNameDerivedHandleCandidates({
+      id: 'person-1',
+      userId: 'user-1',
+      displayName: 'Jake Kastrenakes',
+      normalizedName: 'jake kastrenakes',
+      profileImageSource: null,
+      xHandle: null,
+      relationship: 'GUEST',
+      evidenceText: 'executive editor Jake Kastrenakes',
+    });
+
+    expect(candidates.map((candidate) => candidate.username)).toContain('jake_k');
+  });
+
+  it('does not boost name-derived handles without profile context support', () => {
+    const scored = socialResolutionInternals.scoreInferredXProfileCandidate({
+      personName: 'James Smith',
+      contextTerms: ['podcast', 'venture'],
+      inferredHandle: {
+        username: 'jamessmith',
+        confidence: 0.72,
+        source: 'NAME_DERIVED',
+        reason: 'Generated from the person name.',
+      },
+      candidate: {
+        id: 'x-5',
+        name: 'James Smith',
+        username: 'jamessmith',
+        description: 'Personal account.',
+      },
+    });
+
+    expect(scored.confidence).toBeLessThan(0.82);
+  });
+
+  it('can boost name-derived handles when the validated profile matches item context', () => {
+    const scored = socialResolutionInternals.scoreInferredXProfileCandidate({
+      personName: 'Jake Kastrenakes',
+      contextTerms: ['verge', 'executive', 'editor'],
+      inferredHandle: {
+        username: 'jake_k',
+        confidence: 0.72,
+        source: 'NAME_DERIVED',
+        reason: 'Generated from the person name.',
+      },
+      candidate: {
+        id: 'x-6',
+        name: 'Jake Kastrenakes',
+        username: 'jake_k',
+        description: 'Executive editor at The Verge.',
+        profileImageUrl: 'https://pbs.twimg.com/profile_images/jake.jpg',
+        followersCount: 10000,
+      },
+    });
+
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+    expect(scored.inferredHandleSource).toBe('NAME_DERIVED');
   });
 });

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -24,6 +24,8 @@ const INFERRED_HANDLE_MIN_CONFIDENCE = 0.68;
 const MAX_SEARCH_QUERIES_PER_PERSON = 4;
 const MAX_CANDIDATES_PER_QUERY = 5;
 const MAX_INFERRED_HANDLES_PER_PERSON = 3;
+const MAX_DIRECT_LOOKUP_HANDLES_PER_PERSON = 12;
+const ITEM_SUMMARY_CONTEXT_LIMIT = 1200;
 
 type XResolutionEnv = Pick<Bindings, 'X_BEARER_TOKEN' | 'AI' | 'ENRICHMENT_MODEL'>;
 
@@ -44,6 +46,10 @@ const XHandleInferenceSchema = z.object({
 });
 
 type InferredXHandleCandidate = z.infer<typeof XHandleInferenceSchema>['candidates'][number];
+type XHandleCandidateSource = 'AI_INFERRED' | 'CONTEXT_EXPLICIT' | 'NAME_DERIVED';
+type XHandleLookupCandidate = InferredXHandleCandidate & {
+  source: XHandleCandidateSource;
+};
 
 const STOPWORDS = new Set([
   'about',
@@ -90,6 +96,7 @@ export type ItemContext = {
   provider: string;
   contentType: string;
   publisher: string | null;
+  summary: string | null;
   rawMetadata: string | null;
   creatorName: string | null;
   creatorDescription: string | null;
@@ -113,6 +120,7 @@ export type ScoredXProfileCandidate = XProfileCandidate & {
   negativeSignals: string[];
   inferredHandleConfidence?: number;
   inferredHandleReason?: string | null;
+  inferredHandleSource?: XHandleCandidateSource;
 };
 
 function compact(value: string): string {
@@ -129,6 +137,13 @@ function normalizedWords(value: string): string[] {
 
 function unique<T>(values: T[]): T[] {
   return [...new Set(values)];
+}
+
+function truncate(value: string | null | undefined, maxLength: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength - 3)}...`;
 }
 
 function normalizeXUsername(value: string): string | null {
@@ -214,6 +229,7 @@ function contextText(context: ItemContext, person: Pick<PersonForResolution, 'ev
   return [
     context.title,
     context.publisher,
+    truncate(context.summary, ITEM_SUMMARY_CONTEXT_LIMIT),
     context.creatorName,
     context.creatorDescription,
     context.creatorHandle,
@@ -330,7 +346,7 @@ export function scoreInferredXProfileCandidate(input: {
   personName: string;
   contextTerms: string[];
   candidate: XProfileCandidate;
-  inferredHandle: InferredXHandleCandidate;
+  inferredHandle: XHandleLookupCandidate;
 }): ScoredXProfileCandidate {
   const base = scoreXProfileCandidate(input);
   if (
@@ -342,6 +358,16 @@ export function scoreInferredXProfileCandidate(input: {
       ...base,
       inferredHandleConfidence: input.inferredHandle.confidence,
       inferredHandleReason: input.inferredHandle.reason ?? null,
+      inferredHandleSource: input.inferredHandle.source,
+    };
+  }
+
+  if (input.inferredHandle.source === 'NAME_DERIVED' && base.matchedTerms.length === 0) {
+    return {
+      ...base,
+      inferredHandleConfidence: input.inferredHandle.confidence,
+      inferredHandleReason: input.inferredHandle.reason ?? null,
+      inferredHandleSource: input.inferredHandle.source,
     };
   }
 
@@ -355,7 +381,73 @@ export function scoreInferredXProfileCandidate(input: {
     confidence: Math.max(base.confidence, Number(inferredConfidence.toFixed(3))),
     inferredHandleConfidence: input.inferredHandle.confidence,
     inferredHandleReason: input.inferredHandle.reason ?? null,
+    inferredHandleSource: input.inferredHandle.source,
   };
+}
+
+function normalizedNameParts(value: string): string[] {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function buildNameDerivedHandleCandidates(person: PersonForResolution): XHandleLookupCandidate[] {
+  const parts = normalizedNameParts(person.displayName);
+  if (parts.length < 2) return [];
+
+  const first = parts[0];
+  const last = parts[parts.length - 1];
+  const firstInitial = first[0];
+  const lastInitial = last[0];
+
+  return unique(
+    [
+      `${first}${last}`,
+      `${first}_${last}`,
+      `${firstInitial}${last}`,
+      `${firstInitial}_${last}`,
+      `${first}${lastInitial}`,
+      `${first}_${lastInitial}`,
+      `${last}${first}`,
+      `${last}_${first}`,
+      `${last}${firstInitial}`,
+      `${last}_${firstInitial}`,
+    ]
+      .map((candidate) => normalizeXUsername(candidate))
+      .filter((candidate): candidate is string => Boolean(candidate))
+  ).map((username) => ({
+    username,
+    confidence: 0.72,
+    source: 'NAME_DERIVED',
+    reason: 'Generated from the person name and validated by direct X profile lookup.',
+  }));
+}
+
+function extractExplicitHandleCandidates(
+  item: ItemContext,
+  person: PersonForResolution
+): XHandleLookupCandidate[] {
+  const text = contextText(item, person);
+  const handles = new Set<string>();
+  const handlePattern =
+    /(?:https?:\/\/(?:www\.)?(?:x|twitter)\.com\/|(?<![A-Za-z0-9_])@)([A-Za-z0-9_]{1,15})(?=$|[^A-Za-z0-9_])/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = handlePattern.exec(text)) !== null) {
+    const username = normalizeXUsername(match[1] ?? '');
+    if (username) handles.add(username);
+  }
+
+  return [...handles].map((username) => ({
+    username,
+    confidence: 0.92,
+    source: 'CONTEXT_EXPLICIT',
+    reason: 'Handle appears in the content context.',
+  }));
 }
 
 function toXProfileCandidate(user: XUser): XProfileCandidate {
@@ -382,6 +474,7 @@ async function loadResolutionContext(
       provider: items.provider,
       contentType: items.contentType,
       publisher: items.publisher,
+      summary: items.summary,
       rawMetadata: items.rawMetadata,
       creatorName: creators.name,
       creatorDescription: creators.description,
@@ -575,8 +668,20 @@ async function searchCandidatesForPerson(params: {
   );
 
   if (!hasSearchAutoLinkCandidate) {
+    const explicitHandles = extractExplicitHandleCandidates(params.item, params.person);
     const inferredHandles = await inferXHandleCandidates(params.env, params.person, params.item);
-    for (const inferredHandle of inferredHandles) {
+    const nameDerivedHandles = buildNameDerivedHandleCandidates(params.person);
+    const lookupHandlesByUsername = new Map<string, XHandleLookupCandidate>();
+    for (const candidate of [...explicitHandles, ...inferredHandles, ...nameDerivedHandles]) {
+      if (!lookupHandlesByUsername.has(candidate.username)) {
+        lookupHandlesByUsername.set(candidate.username, candidate);
+      }
+    }
+
+    for (const inferredHandle of [...lookupHandlesByUsername.values()].slice(
+      0,
+      MAX_DIRECT_LOOKUP_HANDLES_PER_PERSON
+    )) {
       try {
         const user = await lookupXUserByUsername({
           bearerToken: params.env.X_BEARER_TOKEN!,
@@ -614,7 +719,7 @@ async function inferXHandleCandidates(
   env: XResolutionEnv,
   person: PersonForResolution,
   item: ItemContext
-): Promise<InferredXHandleCandidate[]> {
+): Promise<XHandleLookupCandidate[]> {
   const ai = env.AI as unknown as WorkersAIRun | undefined;
   if (!ai) return [];
 
@@ -639,6 +744,7 @@ async function inferXHandleCandidates(
       provider: item.provider,
       contentType: item.contentType,
       publisher: item.publisher,
+      summary: truncate(item.summary, ITEM_SUMMARY_CONTEXT_LIMIT),
       creatorName: item.creatorName,
       creatorHandle: item.creatorHandle,
       creatorDescription: item.creatorDescription,
@@ -675,6 +781,7 @@ async function inferXHandleCandidates(
       .map((candidate) => ({
         ...candidate,
         username: normalizeXUsername(candidate.username) ?? '',
+        source: 'AI_INFERRED' as const,
       }))
       .filter(
         (candidate) =>
@@ -741,6 +848,7 @@ export async function resolveXProfilesForItem(
             negativeSignals: candidate.negativeSignals,
             inferredHandleConfidence: candidate.inferredHandleConfidence ?? null,
             inferredHandleReason: candidate.inferredHandleReason ?? null,
+            inferredHandleSource: candidate.inferredHandleSource ?? null,
           },
           now,
         });
@@ -773,7 +881,9 @@ export async function resolveXProfilesForItem(
 
 export const socialResolutionInternals = {
   buildXSearchQueries,
+  buildNameDerivedHandleCandidates,
   extractContextTerms,
+  extractExplicitHandleCandidates,
   normalizeXUsername,
   scoreInferredXProfileCandidate,
   scoreXProfileCandidate,

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -8,10 +8,16 @@ import {
   itemEnrichments,
   items,
   personSocialProfiles,
+  providerConnections,
   userPeople,
   userPersonMentions,
 } from '../db/schema';
 import { logger } from '../lib/logger';
+import {
+  getValidAccessToken,
+  type ProviderConnection,
+  type TokenRefreshEnv,
+} from '../lib/token-refresh';
 import { lookupXUserByUsername, searchXUsers, type XUser } from '../providers/x';
 import type { Bindings } from '../types';
 import { DEFAULT_ENRICHMENT_MODEL, ENRICHMENT_SCHEMA_VERSION } from '../enrichment/types';
@@ -27,7 +33,23 @@ const MAX_INFERRED_HANDLES_PER_PERSON = 3;
 const MAX_DIRECT_LOOKUP_HANDLES_PER_PERSON = 12;
 const ITEM_SUMMARY_CONTEXT_LIMIT = 1200;
 
-type XResolutionEnv = Pick<Bindings, 'X_BEARER_TOKEN' | 'AI' | 'ENRICHMENT_MODEL'>;
+export type XResolutionEnv = Pick<
+  Bindings,
+  | 'AI'
+  | 'DB'
+  | 'ENRICHMENT_MODEL'
+  | 'ENCRYPTION_KEY'
+  | 'GOOGLE_CLIENT_ID'
+  | 'GOOGLE_CLIENT_SECRET'
+  | 'OAUTH_STATE_KV'
+  | 'SPOTIFY_CLIENT_ID'
+  | 'SPOTIFY_CLIENT_SECRET'
+  | 'TOKEN_REFRESH_LOCK_WAIT_MS'
+  | 'X_BEARER_TOKEN'
+  | 'X_CLIENT_ID'
+  | 'X_CLIENT_SECRET'
+  | 'X_PROFILE_SEARCH_USER_ID'
+>;
 
 type WorkersAIRun = {
   run(model: string, input: unknown): Promise<unknown>;
@@ -49,6 +71,11 @@ type InferredXHandleCandidate = z.infer<typeof XHandleInferenceSchema>['candidat
 type XHandleCandidateSource = 'AI_INFERRED' | 'CONTEXT_EXPLICIT' | 'NAME_DERIVED';
 type XHandleLookupCandidate = InferredXHandleCandidate & {
   source: XHandleCandidateSource;
+};
+
+type XAccessTokens = {
+  userSearchAccessToken: string | null;
+  directLookupAccessToken: string | null;
 };
 
 const STOPWORDS = new Set([
@@ -463,6 +490,62 @@ function toXProfileCandidate(user: XUser): XProfileCandidate {
   };
 }
 
+async function getXUserSearchAccessToken(
+  db: Database,
+  env: XResolutionEnv
+): Promise<string | null> {
+  const serviceUserId = env.X_PROFILE_SEARCH_USER_ID?.trim();
+  if (!serviceUserId) return null;
+
+  if (!env.DB || !env.OAUTH_STATE_KV || !env.ENCRYPTION_KEY || !env.X_CLIENT_ID) {
+    socialLogger.warn('X profile search user configured without token refresh bindings', {
+      hasDb: !!env.DB,
+      hasOauthStateKv: !!env.OAUTH_STATE_KV,
+      hasEncryptionKey: !!env.ENCRYPTION_KEY,
+      hasXClientId: !!env.X_CLIENT_ID,
+    });
+    return null;
+  }
+
+  const connection = await db.query.providerConnections.findFirst({
+    where: and(
+      eq(providerConnections.userId, serviceUserId),
+      eq(providerConnections.provider, 'X'),
+      eq(providerConnections.status, 'ACTIVE')
+    ),
+  });
+
+  if (!connection) {
+    socialLogger.warn('X profile search user has no active X provider connection', {
+      serviceUserId,
+    });
+    return null;
+  }
+
+  try {
+    return await getValidAccessToken(
+      connection as ProviderConnection,
+      env as unknown as TokenRefreshEnv
+    );
+  } catch (error) {
+    socialLogger.warn('Failed to get X profile search user access token', {
+      serviceUserId,
+      connectionId: connection.id,
+      error,
+    });
+    return null;
+  }
+}
+
+async function resolveXAccessTokens(db: Database, env: XResolutionEnv): Promise<XAccessTokens> {
+  const userSearchAccessToken = await getXUserSearchAccessToken(db, env);
+  const appOnlyAccessToken = env.X_BEARER_TOKEN?.trim() || null;
+  return {
+    userSearchAccessToken,
+    directLookupAccessToken: appOnlyAccessToken ?? userSearchAccessToken,
+  };
+}
+
 async function loadResolutionContext(
   db: Database,
   itemId: string
@@ -628,6 +711,7 @@ async function upsertCandidate(
 
 async function searchCandidatesForPerson(params: {
   env: XResolutionEnv;
+  tokens: XAccessTokens;
   person: PersonForResolution;
   item: ItemContext;
 }): Promise<ScoredXProfileCandidate[]> {
@@ -635,31 +719,33 @@ async function searchCandidatesForPerson(params: {
   const contextTerms = extractContextTerms(params.item, params.person);
   const candidatesById = new Map<string, ScoredXProfileCandidate>();
 
-  for (const query of queries) {
-    try {
-      const users = await searchXUsers({
-        bearerToken: params.env.X_BEARER_TOKEN!,
-        query,
-        maxResults: MAX_CANDIDATES_PER_QUERY,
-      });
-
-      for (const user of users) {
-        const candidate = scoreXProfileCandidate({
-          personName: params.person.displayName,
-          contextTerms,
-          candidate: toXProfileCandidate(user),
+  if (params.tokens.userSearchAccessToken) {
+    for (const query of queries) {
+      try {
+        const users = await searchXUsers({
+          bearerToken: params.tokens.userSearchAccessToken,
+          query,
+          maxResults: MAX_CANDIDATES_PER_QUERY,
         });
-        if (candidate.confidence >= CANDIDATE_THRESHOLD) {
-          candidatesById.set(candidate.id, candidate);
+
+        for (const user of users) {
+          const candidate = scoreXProfileCandidate({
+            personName: params.person.displayName,
+            contextTerms,
+            candidate: toXProfileCandidate(user),
+          });
+          if (candidate.confidence >= CANDIDATE_THRESHOLD) {
+            candidatesById.set(candidate.id, candidate);
+          }
         }
+      } catch (error) {
+        socialLogger.warn('X user search failed during profile resolution', {
+          itemId: params.item.itemId,
+          userPersonId: params.person.id,
+          query,
+          error,
+        });
       }
-    } catch (error) {
-      socialLogger.warn('X user search failed during profile resolution', {
-        itemId: params.item.itemId,
-        userPersonId: params.person.id,
-        query,
-        error,
-      });
     }
   }
 
@@ -667,7 +753,7 @@ async function searchCandidatesForPerson(params: {
     (candidate) => candidate.confidence >= AUTO_LINK_THRESHOLD
   );
 
-  if (!hasSearchAutoLinkCandidate) {
+  if (!hasSearchAutoLinkCandidate && params.tokens.directLookupAccessToken) {
     const explicitHandles = extractExplicitHandleCandidates(params.item, params.person);
     const inferredHandles = await inferXHandleCandidates(params.env, params.person, params.item);
     const nameDerivedHandles = buildNameDerivedHandleCandidates(params.person);
@@ -684,7 +770,7 @@ async function searchCandidatesForPerson(params: {
     )) {
       try {
         const user = await lookupXUserByUsername({
-          bearerToken: params.env.X_BEARER_TOKEN!,
+          bearerToken: params.tokens.directLookupAccessToken,
           username: inferredHandle.username,
         });
         if (!user) continue;
@@ -806,7 +892,8 @@ export async function resolveXProfilesForItem(
   env: XResolutionEnv,
   input: { itemId: string }
 ): Promise<{ linked: number; candidates: number; skipped: number }> {
-  if (!env.X_BEARER_TOKEN) {
+  const tokens = await resolveXAccessTokens(db, env);
+  if (!tokens.userSearchAccessToken && !tokens.directLookupAccessToken) {
     return { linked: 0, candidates: 0, skipped: 1 };
   }
 
@@ -825,6 +912,7 @@ export async function resolveXProfilesForItem(
 
       const candidates = await searchCandidatesForPerson({
         env,
+        tokens,
         person,
         item: context.item,
       });
@@ -885,6 +973,7 @@ export const socialResolutionInternals = {
   extractContextTerms,
   extractExplicitHandleCandidates,
   normalizeXUsername,
+  resolveXAccessTokens,
   scoreInferredXProfileCandidate,
   scoreXProfileCandidate,
 };

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -58,6 +58,8 @@ export interface Bindings {
   X_CLIENT_SECRET?: string;
   /** X API bearer token for app-level public profile lookup */
   X_BEARER_TOKEN?: string;
+  /** Clerk user ID whose active X OAuth connection is used for user-context profile search */
+  X_PROFILE_SEARCH_USER_ID?: string;
   /** OAuth redirect URI */
   OAUTH_REDIRECT_URI?: string;
   /** Spotify episode fetch concurrency limit (default: 5) */

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -268,3 +268,4 @@ invocation_logs = true
 #
 # Optional Variables:
 # - CLERK_JWKS_URL: Override default JWKS URL for token verification
+# - X_PROFILE_SEARCH_USER_ID: Clerk user ID whose active X OAuth connection powers full-name X profile search


### PR DESCRIPTION
## Summary
- include item summaries in X profile resolution context and AI handle inference prompts
- add direct X username lookup for explicit and name-derived handle candidates, including patterns like first_last-initial
- add optional user-context X profile search via X_PROFILE_SEARCH_USER_ID so /2/users/search can use a connected X OAuth account
- require content-context support before boosting name-derived handles into auto-links

## Production setup
- connect X once with the service/admin account so provider_connections has an ACTIVE X row with users.read and offline.access
- set X_PROFILE_SEARCH_USER_ID to that Clerk user id in the Worker environment
- keep X_BEARER_TOKEN configured for app-only direct username lookup fallback

## Test Plan
- bun run --cwd apps/worker test:run src/people/social-resolution.test.ts
- bun run --cwd apps/worker typecheck
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build
- bun run test:worker:ci (passed once with all assertions; later local reruns failed in Miniflare/workerd startup/teardown before/after tests with fallback-service localhost errors)