### PR TITLE
[codex] Boost contextual X profile linking

### DIFF
--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -141,6 +141,44 @@ describe('social profile resolution helpers', () => {
     expect(terms).toContain('executive');
   });
 
+  it('prioritizes person evidence and creator context before long summaries', () => {
+    const terms = socialResolutionInternals.extractContextTerms(
+      {
+        itemId: 'item-1',
+        title: 'Google I/O 2026 reactions | The Vergecast Livestream',
+        provider: 'YOUTUBE',
+        contentType: 'VIDEO',
+        publisher: null,
+        summary:
+          'Google I/O is upon us with keynote reactions, Android demos, Gemini updates, search announcements, hardware rumors, live chat, subscriber questions, and analysis from The Verge senior AI reporter Hayden Field and executive editor Jake Kastrenakes.',
+        rawMetadata: null,
+        creatorName: 'The Verge',
+        creatorDescription: 'Technology news and analysis from the Verge team.',
+        creatorHandle: '@theverge',
+      },
+      {
+        displayName: 'Jake Kastrenakes',
+        evidenceText: 'executive editor Jake Kastrenakes',
+      }
+    );
+
+    expect(terms.slice(0, 3)).toEqual(['executive', 'editor', 'verge']);
+
+    const scored = socialResolutionInternals.scoreXProfileCandidate({
+      personName: 'Jake Kastrenakes',
+      contextTerms: terms,
+      candidate: {
+        id: 'x-6',
+        name: 'Jake Kastrenakes',
+        username: 'jake_k',
+        description: 'executive editor @verge / contact me: https://t.co/52CumWCN0M',
+      },
+    });
+
+    expect(scored.matchedTerms).toEqual(expect.arrayContaining(['executive', 'editor', 'verge']));
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+  });
+
   it('generates common validated lookup handles from names', () => {
     const candidates = socialResolutionInternals.buildNameDerivedHandleCandidates({
       id: 'person-1',

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -267,17 +267,43 @@ function contextText(context: ItemContext, person: Pick<PersonForResolution, 'ev
     .join(' ');
 }
 
+function prioritizedContextTextParts(
+  context: ItemContext,
+  person: Pick<PersonForResolution, 'evidenceText'>
+) {
+  return [
+    person.evidenceText,
+    context.creatorName,
+    context.publisher,
+    context.title,
+    context.creatorHandle,
+    context.creatorDescription,
+    truncate(context.summary, ITEM_SUMMARY_CONTEXT_LIMIT),
+    parseMetadataText(context.rawMetadata),
+  ].filter((text): text is string => Boolean(text));
+}
+
 export function extractContextTerms(
   context: ItemContext,
   person: Pick<PersonForResolution, 'displayName' | 'evidenceText'>
 ) {
-  const words = normalizedWords(contextText(context, person));
   const personWords = new Set(normalizedWords(person.displayName));
-  const weighted = words.filter((word) => !personWords.has(word));
+  const terms: string[] = [];
 
-  return unique(weighted)
-    .filter((word) => !/^\d+$/.test(word))
-    .slice(0, 16);
+  for (const text of prioritizedContextTextParts(context, person)) {
+    for (const word of normalizedWords(text)) {
+      if (personWords.has(word) || /^\d+$/.test(word) || terms.includes(word)) {
+        continue;
+      }
+
+      terms.push(word);
+      if (terms.length >= 16) {
+        return terms;
+      }
+    }
+  }
+
+  return terms;
 }
 
 export function buildXSearchQueries(person: PersonForResolution, context: ItemContext): string[] {


### PR DESCRIPTION
## Summary
- Prioritize per-person evidence, creator, publisher, and title terms before long summaries when scoring X profile candidates.
- Add a regression case for the Vergecast/Jake Kastrenakes profile match so strong contextual profiles auto-link instead of staying candidates.

## Why
The user-context X search path was finding full-name matches like `jake_k`, but the scorer capped context terms before reaching high-signal evidence such as `executive editor` and `The Verge`. This kept obvious matches below the auto-link threshold.

## Validation
- `bun run --cwd apps/worker test:run src/people/social-resolution.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run format:check`
- `bun run lint`
- pre-push hook: `bun run format:check`, `bun run design-system:check`, `bun run typecheck`, `bun run --cwd apps/web test`, worker CI subset