### PR TITLE
[codex] Rescore stored X profile candidates

### DIFF
--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -179,6 +179,25 @@ describe('social profile resolution helpers', () => {
     expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
   });
 
+  it('rescoring stored X candidates can promote previously conservative matches', () => {
+    const scored = socialResolutionInternals.scoreStoredXProfileCandidate({
+      personName: 'Jake Kastrenakes',
+      contextTerms: ['executive', 'editor', 'verge'],
+      profile: {
+        providerProfileId: '1973331',
+        handle: 'jake_k',
+        displayName: 'Jake Kastrenakes',
+        avatarUrl: 'https://pbs.twimg.com/profile_images/jake.jpg',
+        profileUrl: 'https://x.com/jake_k',
+        description: 'executive editor @verge / contact me: https://t.co/52CumWCN0M',
+        verified: false,
+      },
+    });
+
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+    expect(scored.matchedTerms).toEqual(['executive', 'editor', 'verge']);
+  });
+
   it('generates common validated lookup handles from names', () => {
     const candidates = socialResolutionInternals.buildNameDerivedHandleCandidates({
       id: 'person-1',

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -73,6 +73,17 @@ type XHandleLookupCandidate = InferredXHandleCandidate & {
   source: XHandleCandidateSource;
 };
 
+type StoredXProfileCandidate = Pick<
+  typeof personSocialProfiles.$inferSelect,
+  | 'providerProfileId'
+  | 'handle'
+  | 'displayName'
+  | 'avatarUrl'
+  | 'profileUrl'
+  | 'description'
+  | 'verified'
+>;
+
 type XAccessTokens = {
   userSearchAccessToken: string | null;
   directLookupAccessToken: string | null;
@@ -735,7 +746,65 @@ async function upsertCandidate(
   }
 }
 
+export function scoreStoredXProfileCandidate(input: {
+  personName: string;
+  contextTerms: string[];
+  profile: StoredXProfileCandidate;
+}): ScoredXProfileCandidate {
+  return scoreXProfileCandidate({
+    personName: input.personName,
+    contextTerms: input.contextTerms,
+    candidate: {
+      id: input.profile.providerProfileId,
+      name: input.profile.displayName,
+      username: input.profile.handle,
+      description: input.profile.description ?? undefined,
+      profileImageUrl: input.profile.avatarUrl ?? undefined,
+      url: input.profile.profileUrl,
+      verified: input.profile.verified,
+    },
+  });
+}
+
+async function loadStoredXProfileCandidates(
+  db: Database,
+  input: {
+    person: PersonForResolution;
+    contextTerms: string[];
+  }
+): Promise<ScoredXProfileCandidate[]> {
+  const rows = await db
+    .select({
+      providerProfileId: personSocialProfiles.providerProfileId,
+      handle: personSocialProfiles.handle,
+      displayName: personSocialProfiles.displayName,
+      avatarUrl: personSocialProfiles.avatarUrl,
+      profileUrl: personSocialProfiles.profileUrl,
+      description: personSocialProfiles.description,
+      verified: personSocialProfiles.verified,
+    })
+    .from(personSocialProfiles)
+    .where(
+      and(
+        eq(personSocialProfiles.userPersonId, input.person.id),
+        eq(personSocialProfiles.provider, 'X'),
+        eq(personSocialProfiles.status, 'CANDIDATE')
+      )
+    );
+
+  return rows
+    .map((profile) =>
+      scoreStoredXProfileCandidate({
+        personName: input.person.displayName,
+        contextTerms: input.contextTerms,
+        profile,
+      })
+    )
+    .filter((candidate) => candidate.confidence >= CANDIDATE_THRESHOLD);
+}
+
 async function searchCandidatesForPerson(params: {
+  db: Database;
   env: XResolutionEnv;
   tokens: XAccessTokens;
   person: PersonForResolution;
@@ -744,6 +813,13 @@ async function searchCandidatesForPerson(params: {
   const queries = buildXSearchQueries(params.person, params.item);
   const contextTerms = extractContextTerms(params.item, params.person);
   const candidatesById = new Map<string, ScoredXProfileCandidate>();
+
+  for (const candidate of await loadStoredXProfileCandidates(params.db, {
+    person: params.person,
+    contextTerms,
+  })) {
+    candidatesById.set(candidate.id, candidate);
+  }
 
   if (params.tokens.userSearchAccessToken) {
     for (const query of queries) {
@@ -937,6 +1013,7 @@ export async function resolveXProfilesForItem(
       }
 
       const candidates = await searchCandidatesForPerson({
+        db,
         env,
         tokens,
         person,
@@ -1000,6 +1077,7 @@ export const socialResolutionInternals = {
   extractExplicitHandleCandidates,
   normalizeXUsername,
   resolveXAccessTokens,
+  scoreStoredXProfileCandidate,
   scoreInferredXProfileCandidate,
   scoreXProfileCandidate,
 };


### PR DESCRIPTION
## Summary
- Seed X profile resolution with stored candidate profiles before making fresh X API calls.
- Rescore stored candidates against the current item/person context so backfills can promote already-known profiles to linked.
- Add a regression case for promoting the stored `jake_k` profile when the profile description matches Verge/editor context.

## Why
The previous backfill updated enrichment rows, but existing X candidate rows kept their old confidence/evidence unless X returned the same profile again during that run. That left cases like Jake Kastrenakes stuck at the old 0.78 candidate score even after the context scoring fix.

## Validation
- `bun run --cwd apps/worker test:run src/people/social-resolution.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run format:check`
- `bun run lint`
- pre-push hook: format check, design-system check, repo typecheck, web tests, worker CI subset