### PR TITLE
[codex] Close article WebView on back gesture

### DIFF
--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -15,6 +15,7 @@
 
 import { Image } from 'expo-image';
 import * as Haptics from 'expo-haptics';
+import { usePreventRemove } from '@react-navigation/native';
 import { useRouter, type Href } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
@@ -129,6 +130,9 @@ export default function ItemDetailScreen() {
   const handleCloseArticleWebView = useCallback(() => {
     setArticleWebViewOpen(false);
   }, []);
+  usePreventRemove(articleWebViewOpen, () => {
+    setArticleWebViewOpen(false);
+  });
 
   useEffect(() => {
     setArticleWebViewOpen(false);


### PR DESCRIPTION
## Summary

- Intercepts navigation removal while the article WebView overlay is open.
- Converts iOS swipe-back on the WebView overlay into closing the overlay instead of popping the item detail route.
- Keeps normal back navigation behavior once the overlay is closed.

## Validation

- `bun run typecheck`
- `bun run --cwd apps/mobile lint`
- Pre-push hook: `prettier --check`, mobile design-system check, `turbo run typecheck`, `apps/web` tests, and worker tests excluding `user-do`/`scheduler`
