### PR TITLE
[codex] Guard ambiguous X profile links

### DIFF
--- a/apps/worker/src/enrichment/prompt.test.ts
+++ b/apps/worker/src/enrichment/prompt.test.ts
@@ -67,6 +67,23 @@ describe('enrichment prompt helpers', () => {
     expect(userPayload.outputContract.entities[0]?.evidenceText).toContain('null');
   });
 
+  it('discourages first-name-only person entities', () => {
+    const messages = buildEnrichmentMessages(createPromptInput('Ben joins the show.'));
+    const userPayload = JSON.parse(String(messages[1].content)) as {
+      constraints: string[];
+      outputContract: {
+        entities: Array<{
+          name: string;
+        }>;
+      };
+    };
+    const constraints = userPayload.constraints.join(' ');
+
+    expect(constraints).toContain('full real names');
+    expect(constraints).toContain('first-name-only');
+    expect(userPayload.outputContract.entities[0]?.name).toContain('avoid first-name-only');
+  });
+
   it('includes the full top-level output contract in the prompt', () => {
     const messages = buildEnrichmentMessages(createPromptInput('A short item.'));
     const userPayload = JSON.parse(String(messages[1].content)) as {

--- a/apps/worker/src/enrichment/prompt.ts
+++ b/apps/worker/src/enrichment/prompt.ts
@@ -59,7 +59,7 @@ const OUTPUT_CONTRACT = {
   topics: [{ name: 'string', confidence: 'number from 0 to 1' }],
   entities: [
     {
-      name: 'string',
+      name: 'string, prefer full real names for people; avoid first-name-only people unless unambiguous',
       type: 'person | organization | product | technology | place | concept | other',
       relationship:
         'HOST | CO_HOST | OWNER | CREATOR | AUTHOR | GUEST | INTERVIEWER | INTERVIEWEE | PRIMARY_SUBJECT | MENTIONED',
@@ -115,6 +115,7 @@ export function buildEnrichmentMessages(input: EnrichmentPromptInput) {
       'Return one JSON object with exactly these top-level keys: summary, classification, topics, entities, suggestedTags, userContext, confidence.',
       'Do not return only an entity list, a wrapper object, markdown, commentary, or prose outside JSON.',
       'Every entity must include name, type, relationship, confidence, and evidenceText.',
+      'For human PERSON entities, prefer full real names. Do not emit first-name-only people unless the input clearly identifies that exact person; if only a first name is available, either omit it or assign confidence below 0.6.',
       'Prefer stable categories and short lowercase tag names.',
       'Do not invent facts not supported by the input.',
       'Use confidence below 0.6 when the input is thin or ambiguous.',

--- a/apps/worker/src/people/social-resolution.test.ts
+++ b/apps/worker/src/people/social-resolution.test.ts
@@ -191,11 +191,62 @@ describe('social profile resolution helpers', () => {
         profileUrl: 'https://x.com/jake_k',
         description: 'executive editor @verge / contact me: https://t.co/52CumWCN0M',
         verified: false,
+        evidenceJson: null,
       },
     });
 
     expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
     expect(scored.matchedTerms).toEqual(['executive', 'editor', 'verge']);
+  });
+
+  it('does not auto-link first-name-only people from search matches', () => {
+    const scored = socialResolutionInternals.scoreXProfileCandidate({
+      personName: 'Ben',
+      contextTerms: ['technology', 'podcast', 'writer', 'newsletter'],
+      candidate: {
+        id: 'x-ben',
+        name: 'Ben Thompson',
+        username: 'benthompson',
+        description: 'Technology writer, newsletter author, and podcast host.',
+        verified: true,
+        followersCount: 100000,
+      },
+    });
+
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+    expect(
+      socialResolutionInternals.canAutoLinkXProfileCandidate({
+        personName: 'Ben',
+        candidate: scored,
+      })
+    ).toBe(false);
+  });
+
+  it('allows first-name-only auto-linking when the handle is explicit in context', () => {
+    const scored = socialResolutionInternals.scoreInferredXProfileCandidate({
+      personName: 'Ben',
+      contextTerms: ['technology', 'podcast', 'writer'],
+      inferredHandle: {
+        username: 'benthompson',
+        confidence: 0.92,
+        source: 'CONTEXT_EXPLICIT',
+        reason: 'The handle appears in the content context.',
+      },
+      candidate: {
+        id: 'x-ben',
+        name: 'Ben Thompson',
+        username: 'benthompson',
+        description: 'Technology writer and podcast host.',
+      },
+    });
+
+    expect(scored.confidence).toBeGreaterThanOrEqual(0.82);
+    expect(
+      socialResolutionInternals.canAutoLinkXProfileCandidate({
+        personName: 'Ben',
+        candidate: scored,
+      })
+    ).toBe(true);
   });
 
   it('generates common validated lookup handles from names', () => {

--- a/apps/worker/src/people/social-resolution.ts
+++ b/apps/worker/src/people/social-resolution.ts
@@ -82,6 +82,7 @@ type StoredXProfileCandidate = Pick<
   | 'profileUrl'
   | 'description'
   | 'verified'
+  | 'evidenceJson'
 >;
 
 type XAccessTokens = {
@@ -404,6 +405,21 @@ function hasStrongNameMatch(personName: string, candidateName: string): boolean 
     candidateNameCompact.includes(personCompact) ||
     (personParts.length > 1 && personParts.every((part) => candidateNameCompact.includes(part)))
   );
+}
+
+export function isAmbiguousPersonNameForSocialResolution(personName: string): boolean {
+  return normalizedNameParts(personName).length < 2;
+}
+
+export function canAutoLinkXProfileCandidate(input: {
+  personName: string;
+  candidate: Pick<ScoredXProfileCandidate, 'inferredHandleSource'>;
+}): boolean {
+  if (!isAmbiguousPersonNameForSocialResolution(input.personName)) {
+    return true;
+  }
+
+  return input.candidate.inferredHandleSource === 'CONTEXT_EXPLICIT';
 }
 
 export function scoreInferredXProfileCandidate(input: {
@@ -751,7 +767,8 @@ export function scoreStoredXProfileCandidate(input: {
   contextTerms: string[];
   profile: StoredXProfileCandidate;
 }): ScoredXProfileCandidate {
-  return scoreXProfileCandidate({
+  const storedEvidence = parseStoredCandidateEvidence(input.profile.evidenceJson);
+  const scored = scoreXProfileCandidate({
     personName: input.personName,
     contextTerms: input.contextTerms,
     candidate: {
@@ -764,6 +781,40 @@ export function scoreStoredXProfileCandidate(input: {
       verified: input.profile.verified,
     },
   });
+
+  return {
+    ...scored,
+    ...storedEvidence,
+  };
+}
+
+function parseStoredCandidateEvidence(
+  evidenceJson: string | null
+): Pick<
+  ScoredXProfileCandidate,
+  'inferredHandleConfidence' | 'inferredHandleReason' | 'inferredHandleSource'
+> {
+  if (!evidenceJson) return {};
+
+  try {
+    const parsed = JSON.parse(evidenceJson) as Record<string, unknown>;
+    const source = parsed.inferredHandleSource;
+    if (source !== 'AI_INFERRED' && source !== 'CONTEXT_EXPLICIT' && source !== 'NAME_DERIVED') {
+      return {};
+    }
+
+    return {
+      inferredHandleSource: source,
+      inferredHandleConfidence:
+        typeof parsed.inferredHandleConfidence === 'number'
+          ? parsed.inferredHandleConfidence
+          : undefined,
+      inferredHandleReason:
+        typeof parsed.inferredHandleReason === 'string' ? parsed.inferredHandleReason : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 async function loadStoredXProfileCandidates(
@@ -782,6 +833,7 @@ async function loadStoredXProfileCandidates(
       profileUrl: personSocialProfiles.profileUrl,
       description: personSocialProfiles.description,
       verified: personSocialProfiles.verified,
+      evidenceJson: personSocialProfiles.evidenceJson,
     })
     .from(personSocialProfiles)
     .where(
@@ -851,11 +903,16 @@ async function searchCandidatesForPerson(params: {
     }
   }
 
-  const hasSearchAutoLinkCandidate = [...candidatesById.values()].some(
-    (candidate) => candidate.confidence >= AUTO_LINK_THRESHOLD
+  const hasAutoLinkCandidate = [...candidatesById.values()].some(
+    (candidate) =>
+      candidate.confidence >= AUTO_LINK_THRESHOLD &&
+      canAutoLinkXProfileCandidate({
+        personName: params.person.displayName,
+        candidate,
+      })
   );
 
-  if (!hasSearchAutoLinkCandidate && params.tokens.directLookupAccessToken) {
+  if (!hasAutoLinkCandidate && params.tokens.directLookupAccessToken) {
     const explicitHandles = extractExplicitHandleCandidates(params.item, params.person);
     const inferredHandles = await inferXHandleCandidates(params.env, params.person, params.item);
     const nameDerivedHandles = buildNameDerivedHandleCandidates(params.person);
@@ -1020,11 +1077,19 @@ export async function resolveXProfilesForItem(
         item: context.item,
       });
       const now = Date.now();
-      const best = candidates[0] ?? null;
+      const bestAutoLinkCandidate =
+        candidates.find(
+          (candidate) =>
+            candidate.confidence >= AUTO_LINK_THRESHOLD &&
+            canAutoLinkXProfileCandidate({
+              personName: person.displayName,
+              candidate,
+            })
+        ) ?? null;
 
       for (const candidate of candidates.slice(0, 3)) {
         const status =
-          candidate.id === best?.id && candidate.confidence >= AUTO_LINK_THRESHOLD
+          candidate.id === bestAutoLinkCandidate?.id && candidate.confidence >= AUTO_LINK_THRESHOLD
             ? 'LINKED'
             : 'CANDIDATE';
         await upsertCandidate(db, {
@@ -1045,7 +1110,7 @@ export async function resolveXProfilesForItem(
         });
       }
 
-      if (best && best.confidence >= AUTO_LINK_THRESHOLD) {
+      if (bestAutoLinkCandidate) {
         totals.linked += 1;
       }
       totals.candidates += candidates.length;
@@ -1073,8 +1138,10 @@ export async function resolveXProfilesForItem(
 export const socialResolutionInternals = {
   buildXSearchQueries,
   buildNameDerivedHandleCandidates,
+  canAutoLinkXProfileCandidate,
   extractContextTerms,
   extractExplicitHandleCandidates,
+  isAmbiguousPersonNameForSocialResolution,
   normalizeXUsername,
   resolveXAccessTokens,
   scoreStoredXProfileCandidate,


### PR DESCRIPTION
## Summary
- Prevent first-name-only people from being auto-linked to X profiles unless the content explicitly contains the handle.
- Keep ambiguous X matches as candidates so they can still be inspected or manually repaired later.
- Update the enrichment prompt/output contract to prefer full real names and keep first-name-only PERSON entities below the indexing threshold unless unambiguous.

## Why
A person extracted as only `Ben` can score highly against the wrong X account because first-name search is inherently ambiguous. The resolver now makes the final link decision conservative for one-token names while preserving explicit-handle linking.

## Validation
- `bun run --cwd apps/worker test:run src/people/social-resolution.test.ts src/enrichment/prompt.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run format:check`
- `bun run lint`
- pre-push hook: format check, design-system check, repo typecheck, web tests, worker CI subset