### PR TITLE
[codex] Add customizable home screen settings

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -15,7 +15,14 @@ import {
   type NativeSyntheticEvent,
 } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
-import { HomeCollectionLayout, type ContentType as ApiContentType } from '@zine/shared';
+import {
+  HomeCollectionLayout,
+  HomeScreenBuiltInSection,
+  HomeScreenSectionKind,
+  type ContentType as ApiContentType,
+  type HomeScreenBuiltInSectionValue,
+  type HomeScreenLayoutSection,
+} from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
 import { ArticleIcon, PodcastIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
@@ -198,6 +205,7 @@ type HomeSectionItem =
       count: number;
       items: ItemCardData[];
     };
+type CustomHomeSectionItem = Extract<HomeSectionItem, { collectionId: string }>;
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -318,7 +326,7 @@ export default function HomeScreen() {
     }));
   }, [homeData?.byContentType.articles]);
 
-  const customCollectionSections = useMemo((): HomeSectionItem[] => {
+  const customCollectionSections = useMemo((): CustomHomeSectionItem[] => {
     return (homeData?.customCollections ?? [])
       .filter((section) => section.items.length > 0)
       .map((section) => {
@@ -400,68 +408,103 @@ export default function HomeScreen() {
   const showArticlesSection = contentTypeFilter === null || contentTypeFilter === 'article';
 
   const sections = useMemo((): HomeSectionItem[] => {
-    const items: HomeSectionItem[] = [];
+    const builtInSections: Partial<Record<HomeScreenBuiltInSectionValue, HomeSectionItem>> = {};
 
     if (filteredJumpBackInItems.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.JUMP_BACK_IN] = {
         key: 'jump-back-in',
         type: 'jump-back-in',
         title: 'Jump Back In',
         count: filteredJumpBackInItems.length,
         items: filteredJumpBackInItems,
-      });
+      };
     }
 
     if (filteredRecentlyBookmarked.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.RECENTLY_BOOKMARKED] = {
         key: 'recently-bookmarked',
         type: 'recently-bookmarked',
         title: 'Recently Bookmarked',
         count: filteredRecentlyBookmarked.length,
         items: filteredRecentlyBookmarked,
-      });
+      };
     }
 
     if (filteredInboxItems.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.INBOX] = {
         key: 'inbox',
         type: 'inbox',
         title: 'Inbox',
         count: filteredInboxItems.length,
         items: filteredInboxItems,
-      });
+      };
     }
 
-    items.push(...customCollectionSections);
-
     if (showPodcastsSection && podcasts.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.PODCASTS] = {
         key: 'podcasts',
         type: 'cover-rail',
         title: 'Podcasts',
         count: podcasts.length,
         items: podcasts.slice(0, HOME_PODCASTS_VISIBLE_LIMIT),
-      });
+      };
     }
 
     if (showArticlesSection && articles.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.ARTICLES] = {
         key: 'articles',
         type: 'stack-rail',
         title: 'Articles',
         count: articles.length,
         items: articles,
-      });
+      };
     }
 
     if (showVideosSection && videos.length > 0) {
-      items.push({
+      builtInSections[HomeScreenBuiltInSection.VIDEOS] = {
         key: 'videos',
         type: 'stack-rail',
         title: 'Videos',
         count: videos.length,
         items: videos,
-      });
+      };
+    }
+
+    const collectionSectionsById = new Map(
+      customCollectionSections.map((section) => [section.collectionId, section] as const)
+    );
+    const fallbackOrder: HomeScreenLayoutSection[] = [
+      {
+        kind: HomeScreenSectionKind.BUILT_IN,
+        builtInSection: HomeScreenBuiltInSection.JUMP_BACK_IN,
+      },
+      {
+        kind: HomeScreenSectionKind.BUILT_IN,
+        builtInSection: HomeScreenBuiltInSection.RECENTLY_BOOKMARKED,
+      },
+      { kind: HomeScreenSectionKind.BUILT_IN, builtInSection: HomeScreenBuiltInSection.INBOX },
+      ...customCollectionSections.map(
+        (section): HomeScreenLayoutSection => ({
+          kind: HomeScreenSectionKind.COLLECTION,
+          collectionId: section.collectionId,
+        })
+      ),
+      { kind: HomeScreenSectionKind.BUILT_IN, builtInSection: HomeScreenBuiltInSection.PODCASTS },
+      { kind: HomeScreenSectionKind.BUILT_IN, builtInSection: HomeScreenBuiltInSection.ARTICLES },
+      { kind: HomeScreenSectionKind.BUILT_IN, builtInSection: HomeScreenBuiltInSection.VIDEOS },
+    ];
+    const orderedSections = homeData?.sectionOrder ?? fallbackOrder;
+    const items: HomeSectionItem[] = [];
+
+    for (const section of orderedSections) {
+      if (section.kind === HomeScreenSectionKind.BUILT_IN) {
+        const builtInSection = builtInSections[section.builtInSection];
+        if (builtInSection) items.push(builtInSection);
+        continue;
+      }
+
+      const collectionSection = collectionSectionsById.get(section.collectionId);
+      if (collectionSection) items.push(collectionSection);
     }
 
     return items;
@@ -475,6 +518,7 @@ export default function HomeScreen() {
     showArticlesSection,
     showPodcastsSection,
     showVideosSection,
+    homeData?.sectionOrder,
     videos,
   ]);
 

--- a/apps/mobile/app/settings/_layout.tsx
+++ b/apps/mobile/app/settings/_layout.tsx
@@ -27,6 +27,12 @@ export default function SettingsLayout() {
         }}
       />
       <Stack.Screen
+        name="home-screen"
+        options={{
+          title: 'Home Screen',
+        }}
+      />
+      <Stack.Screen
         name="account"
         options={{
           title: 'Account',

--- a/apps/mobile/app/settings/home-screen.tsx
+++ b/apps/mobile/app/settings/home-screen.tsx
@@ -1,0 +1,537 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Switch, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { useToast } from 'heroui-native';
+import {
+  NestableDraggableFlatList,
+  NestableScrollContainer,
+  ScaleDecorator,
+  type RenderItemParams,
+} from 'react-native-draggable-flatlist';
+import { HomeScreenSectionKind, type HomeScreenSettingsSectionInput } from '@zine/shared';
+
+import { Text } from '@/components/primitives/text';
+import { Colors, Radius, Spacing, Typography, type ThemeColors } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import {
+  useHomeScreenSettings,
+  useResetHomeScreenSettings,
+  useUpdateHomeScreenSettings,
+} from '@/hooks/use-items-trpc';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+import { showError, showSuccess } from '@/lib/toast-utils';
+
+type HomeScreenSettingsData = NonNullable<ReturnType<typeof useHomeScreenSettings>['data']>;
+type VisibleSection = HomeScreenSettingsData['visibleSections'][number];
+type BuiltInSection = Extract<VisibleSection, { kind: typeof HomeScreenSectionKind.BUILT_IN }>;
+type HiddenBuiltInSection = BuiltInSection;
+type AddableCollection = HomeScreenSettingsData['addableCollections'][number];
+
+function sectionKey(section: VisibleSection | HiddenBuiltInSection): string {
+  return section.kind === HomeScreenSectionKind.BUILT_IN
+    ? `built-in-${section.builtInSection}`
+    : `collection-${section.collectionId}`;
+}
+
+function toInputSection(
+  section: VisibleSection | HiddenBuiltInSection,
+  enabled: boolean
+): HomeScreenSettingsSectionInput {
+  if (section.kind === HomeScreenSectionKind.BUILT_IN) {
+    return {
+      kind: HomeScreenSectionKind.BUILT_IN,
+      builtInSection: section.builtInSection,
+      enabled,
+    };
+  }
+
+  return {
+    kind: HomeScreenSectionKind.COLLECTION,
+    collectionId: section.collectionId,
+    enabled: true,
+  };
+}
+
+function HeaderButton({
+  label,
+  disabled,
+  onPress,
+  colors,
+}: {
+  label: string;
+  disabled?: boolean;
+  onPress: () => void;
+  colors: ThemeColors;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      disabled={disabled}
+      onPress={onPress}
+      hitSlop={8}
+      style={({ pressed }) => [
+        styles.headerButton,
+        {
+          opacity: disabled ? 0.35 : pressed ? 0.7 : 1,
+        },
+      ]}
+    >
+      <Text style={[styles.headerButtonText, { color: colors.buttonPrimary }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function SectionRow({
+  section,
+  colors,
+  onToggle,
+  drag,
+  isActive = false,
+}: {
+  section: VisibleSection | HiddenBuiltInSection;
+  colors: ThemeColors;
+  onToggle: () => void;
+  drag?: () => void;
+  isActive?: boolean;
+}) {
+  return (
+    <View
+      style={[
+        styles.row,
+        {
+          backgroundColor: isActive ? colors.cardHover : colors.card,
+          borderBottomColor: colors.border,
+        },
+      ]}
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Drag ${section.title}`}
+        disabled={!drag}
+        onLongPress={drag}
+        delayLongPress={120}
+        hitSlop={8}
+        style={({ pressed }) => [
+          styles.dragHandle,
+          { opacity: drag ? (pressed || isActive ? 0.8 : 1) : 0.35 },
+        ]}
+      >
+        <Ionicons name="reorder-three-outline" size={24} color={colors.textTertiary} />
+      </Pressable>
+      <View style={styles.rowText}>
+        <View style={styles.titleLine}>
+          <Text style={[styles.rowTitle, { color: colors.text }]} numberOfLines={1}>
+            {section.title}
+          </Text>
+          {section.kind === HomeScreenSectionKind.COLLECTION ? (
+            <Text style={[styles.badge, { color: colors.textSubheader }]}>Collection</Text>
+          ) : null}
+        </View>
+        <Text style={[styles.rowSubtitle, { color: colors.textSubheader }]} numberOfLines={1}>
+          {section.subtitle}
+        </Text>
+      </View>
+      <Switch value={section.enabled} onValueChange={onToggle} />
+    </View>
+  );
+}
+
+function AddCollectionRow({
+  collection,
+  colors,
+  onPress,
+}: {
+  collection: AddableCollection;
+  colors: ThemeColors;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Add ${collection.name} to Home`}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        { borderBottomColor: colors.border, opacity: pressed ? 0.7 : 1 },
+      ]}
+    >
+      <View style={[styles.addIcon, { backgroundColor: colors.backgroundTertiary }]}>
+        <Ionicons name="add" size={18} color={colors.buttonPrimary} />
+      </View>
+      <View style={styles.rowText}>
+        <Text style={[styles.rowTitle, { color: colors.text }]} numberOfLines={1}>
+          {collection.name}
+        </Text>
+        {collection.description ? (
+          <Text style={[styles.rowSubtitle, { color: colors.textSubheader }]} numberOfLines={1}>
+            {collection.description}
+          </Text>
+        ) : (
+          <Text style={[styles.rowSubtitle, { color: colors.textSubheader }]}>Collection</Text>
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+export default function HomeScreenSettingsScreen() {
+  const { toast } = useToast();
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
+  const settingsQuery = useHomeScreenSettings();
+  const updateMutation = useUpdateHomeScreenSettings();
+  const resetMutation = useResetHomeScreenSettings();
+  const [visibleSections, setVisibleSections] = useState<VisibleSection[]>([]);
+  const [hiddenBuiltInSections, setHiddenBuiltInSections] = useState<HiddenBuiltInSection[]>([]);
+  const [addableCollections, setAddableCollections] = useState<AddableCollection[]>([]);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    if (!settingsQuery.data || isDirty) return;
+    setVisibleSections(settingsQuery.data.visibleSections);
+    setHiddenBuiltInSections(
+      settingsQuery.data.hiddenBuiltInSections.filter(
+        (section): section is BuiltInSection => section.kind === HomeScreenSectionKind.BUILT_IN
+      )
+    );
+    setAddableCollections(settingsQuery.data.addableCollections);
+  }, [isDirty, settingsQuery.data]);
+
+  const isSaving = updateMutation.isPending || resetMutation.isPending;
+  const canSave = isDirty && !isSaving && visibleSections.length > 0;
+
+  const inputSections = useMemo((): HomeScreenSettingsSectionInput[] => {
+    return [
+      ...visibleSections.map((section) => toInputSection(section, true)),
+      ...hiddenBuiltInSections.map((section) => toInputSection(section, false)),
+    ];
+  }, [hiddenBuiltInSections, visibleSections]);
+
+  const markDirty = useCallback(() => setIsDirty(true), []);
+
+  const hideVisibleSection = useCallback(
+    (section: VisibleSection) => {
+      if (visibleSections.length <= 1) {
+        Alert.alert('Keep one section visible', 'Home needs at least one visible section.');
+        return;
+      }
+
+      setVisibleSections((current) =>
+        current.filter((item) => sectionKey(item) !== sectionKey(section))
+      );
+
+      if (section.kind === HomeScreenSectionKind.BUILT_IN) {
+        setHiddenBuiltInSections((current) => [...current, { ...section, enabled: false }]);
+      } else {
+        setAddableCollections((current) =>
+          [
+            ...current,
+            { id: section.collectionId, name: section.title, description: section.subtitle },
+          ].sort((a, b) => a.name.localeCompare(b.name))
+        );
+      }
+      markDirty();
+    },
+    [markDirty, visibleSections.length]
+  );
+
+  const showHiddenBuiltInSection = (section: HiddenBuiltInSection) => {
+    setHiddenBuiltInSections((current) =>
+      current.filter((item) => item.builtInSection !== section.builtInSection)
+    );
+    setVisibleSections((current) => [...current, { ...section, enabled: true }]);
+    markDirty();
+  };
+
+  const addCollection = (collection: AddableCollection) => {
+    setAddableCollections((current) => current.filter((item) => item.id !== collection.id));
+    setVisibleSections((current) => [
+      ...current,
+      {
+        kind: HomeScreenSectionKind.COLLECTION,
+        collectionId: collection.id,
+        title: collection.name,
+        subtitle: collection.description,
+        enabled: true,
+        position: current.length + 1,
+      },
+    ]);
+    markDirty();
+  };
+
+  const renderVisibleSection = useCallback(
+    ({ item, drag, isActive }: RenderItemParams<VisibleSection>) => (
+      <ScaleDecorator activeScale={1.02}>
+        <SectionRow
+          section={item}
+          colors={colors}
+          drag={drag}
+          isActive={isActive}
+          onToggle={() => hideVisibleSection(item)}
+        />
+      </ScaleDecorator>
+    ),
+    [colors, hideVisibleSection]
+  );
+
+  const handleSave = async () => {
+    try {
+      await updateMutation.mutateAsync({ sections: inputSections });
+      setIsDirty(false);
+      showSuccess(toast, 'Home screen updated', 'settings.homeScreen.save');
+    } catch (error) {
+      showError(toast, error, 'Failed to save Home screen', 'settings.homeScreen.save');
+    }
+  };
+
+  const handleReset = () => {
+    Alert.alert(
+      'Reset Home Screen?',
+      'This restores the default Home sections and removes collections from Home.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Reset',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await resetMutation.mutateAsync();
+              setIsDirty(false);
+              showSuccess(toast, 'Home screen reset', 'settings.homeScreen.reset');
+            } catch (error) {
+              showError(toast, error, 'Failed to reset Home screen', 'settings.homeScreen.reset');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const headerRight = () => (
+    <HeaderButton label="Save" disabled={!canSave} onPress={handleSave} colors={colors} />
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: 'Home Screen',
+          showScreenTitle: showCollapsedTitle,
+          headerRight,
+        })}
+      />
+      <NestableScrollContainer
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        contentInsetAdjustmentBehavior="automatic"
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.screenHeader}>
+          <Text style={[styles.screenTitle, { color: colors.text }]}>Home Screen</Text>
+          <Text style={[styles.screenSubtitle, { color: colors.textSubheader }]}>
+            Choose which sections appear on Home and arrange the visible order.
+          </Text>
+        </View>
+
+        {settingsQuery.isLoading ? (
+          <View style={styles.loadingState}>
+            <ActivityIndicator color={colors.text} />
+          </View>
+        ) : (
+          <>
+            <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>
+              VISIBLE ON HOME
+            </Text>
+            <View style={[styles.section, { backgroundColor: colors.card }]}>
+              <NestableDraggableFlatList
+                data={visibleSections}
+                keyExtractor={sectionKey}
+                renderItem={renderVisibleSection}
+                onDragEnd={({ data }) => {
+                  setVisibleSections(data);
+                  markDirty();
+                }}
+                activationDistance={8}
+                autoscrollThreshold={80}
+                autoscrollSpeed={160}
+                containerStyle={styles.visibleList}
+              />
+            </View>
+
+            <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>
+              HIDDEN SECTIONS
+            </Text>
+            <View style={[styles.section, { backgroundColor: colors.card }]}>
+              {hiddenBuiltInSections.length === 0 ? (
+                <Text style={[styles.emptyRow, { color: colors.textSubheader }]}>
+                  No built-in sections are hidden.
+                </Text>
+              ) : (
+                hiddenBuiltInSections.map((section) => (
+                  <SectionRow
+                    key={sectionKey(section)}
+                    section={section}
+                    colors={colors}
+                    onToggle={() => showHiddenBuiltInSection(section)}
+                  />
+                ))
+              )}
+            </View>
+
+            <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>
+              ADD COLLECTIONS
+            </Text>
+            <View style={[styles.section, { backgroundColor: colors.card }]}>
+              {addableCollections.length === 0 ? (
+                <Text style={[styles.emptyRow, { color: colors.textSubheader }]}>
+                  All collections are already on Home.
+                </Text>
+              ) : (
+                addableCollections.map((collection) => (
+                  <AddCollectionRow
+                    key={collection.id}
+                    collection={collection}
+                    colors={colors}
+                    onPress={() => addCollection(collection)}
+                  />
+                ))
+              )}
+            </View>
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Reset Home Screen"
+              disabled={isSaving}
+              onPress={handleReset}
+              style={({ pressed }) => [
+                styles.resetButton,
+                { backgroundColor: colors.card, opacity: pressed ? 0.7 : 1 },
+              ]}
+            >
+              <Text style={[styles.resetText, { color: colors.error }]}>Reset Home Screen</Text>
+            </Pressable>
+          </>
+        )}
+      </NestableScrollContainer>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+  },
+  screenHeader: {
+    marginBottom: Spacing.sm,
+  },
+  screenTitle: {
+    ...Typography.displayMedium,
+  },
+  screenSubtitle: {
+    ...Typography.bodyMedium,
+    marginTop: Spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginTop: Spacing.xl,
+    marginBottom: Spacing.sm,
+    marginLeft: Spacing.sm,
+  },
+  section: {
+    borderRadius: Radius.lg,
+    overflow: 'hidden',
+  },
+  row: {
+    minHeight: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  titleLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  rowTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    flexShrink: 1,
+  },
+  rowSubtitle: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  badge: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  dragHandle: {
+    width: 30,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  visibleList: {
+    flexGrow: 0,
+  },
+  addIcon: {
+    width: 30,
+    height: 30,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyRow: {
+    padding: Spacing.md,
+    fontSize: 14,
+  },
+  loadingState: {
+    padding: Spacing['2xl'],
+    alignItems: 'center',
+  },
+  resetButton: {
+    marginTop: Spacing.xl,
+    borderRadius: Radius.lg,
+    padding: Spacing.md,
+    alignItems: 'center',
+  },
+  resetText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  headerButton: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xs,
+  },
+  headerButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/app/settings/index.tsx
+++ b/apps/mobile/app/settings/index.tsx
@@ -246,6 +246,12 @@ function SettingsScreenContent({
             rightText="→"
             onPress={() => router.push('/settings/collections' as Href)}
           />
+          <SettingsRow
+            title="Home Screen"
+            subtitle="Choose and arrange sections"
+            rightText="→"
+            onPress={() => router.push('/settings/home-screen' as Href)}
+          />
         </View>
 
         <Text style={[styles.sectionTitle, { color: colors.textSubheader }]}>INSIGHTS</Text>

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -581,6 +581,38 @@ export function useSetCollectionHomeSection() {
       utils.collections.list.invalidate();
       utils.collections.get.invalidate();
       utils.items.home.invalidate();
+      utils.homeSettings.get.invalidate();
+    },
+  });
+}
+
+export function useHomeScreenSettings() {
+  return trpc.homeSettings.get.useQuery(undefined, {
+    refetchOnMount: 'always',
+    staleTime: 0,
+  });
+}
+
+export function useUpdateHomeScreenSettings() {
+  const utils = trpc.useUtils();
+
+  return trpc.homeSettings.update.useMutation({
+    onSuccess: () => {
+      utils.homeSettings.get.invalidate();
+      utils.items.home.invalidate();
+      utils.collections.list.invalidate();
+    },
+  });
+}
+
+export function useResetHomeScreenSettings() {
+  const utils = trpc.useUtils();
+
+  return trpc.homeSettings.reset.useMutation({
+    onSuccess: () => {
+      utils.homeSettings.get.invalidate();
+      utils.items.home.invalidate();
+      utils.collections.list.invalidate();
     },
   });
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -61,6 +61,7 @@
     "react-dom": "19.2.4",
     "react-native": "0.83.2",
     "react-native-context-menu-view": "^1.21.0",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/apps/worker/src/db/migrations/0016_add_home_screen_sections.sql
+++ b/apps/worker/src/db/migrations/0016_add_home_screen_sections.sql
@@ -1,0 +1,23 @@
+-- Created: 2026-05-21
+-- Add unified configurable mobile Home screen sections
+
+CREATE TABLE IF NOT EXISTS `home_screen_sections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL REFERENCES `users`(`id`),
+  `section_type` text NOT NULL,
+  `built_in_section` text,
+  `collection_id` text REFERENCES `collections`(`id`),
+  `enabled` integer NOT NULL DEFAULT 1,
+  `position` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `home_screen_sections_user_builtin_idx`
+  ON `home_screen_sections` (`user_id`, `built_in_section`);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `home_screen_sections_user_collection_idx`
+  ON `home_screen_sections` (`user_id`, `collection_id`);
+
+CREATE INDEX IF NOT EXISTS `home_screen_sections_user_position_idx`
+  ON `home_screen_sections` (`user_id`, `position`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1779235200000,
       "tag": "0015_add_person_social_profiles",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1779321600000,
+      "tag": "0016_add_home_screen_sections",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -263,6 +263,31 @@ export const homeCollectionSections = sqliteTable(
   ]
 );
 
+// Home screen sections
+// Stores the user's ordered built-in and custom collection Home screen layout.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const homeScreenSections = sqliteTable(
+  'home_screen_sections',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    sectionType: text('section_type').notNull(),
+    builtInSection: text('built_in_section'),
+    collectionId: text('collection_id').references(() => collections.id),
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+    position: integer('position').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('home_screen_sections_user_builtin_idx').on(table.userId, table.builtInSection),
+    uniqueIndex('home_screen_sections_user_collection_idx').on(table.userId, table.collectionId),
+    index('home_screen_sections_user_position_idx').on(table.userId, table.position),
+  ]
+);
+
 // Item Enrichments
 // Canonical AI-generated enrichment for a content item and content hash.
 // Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.

--- a/apps/worker/src/home-screen/layout.ts
+++ b/apps/worker/src/home-screen/layout.ts
@@ -1,0 +1,438 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { ulid } from 'ulid';
+import {
+  HOME_SCREEN_COLLECTION_INSERT_AFTER,
+  HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS,
+  HomeCollectionLayout,
+  HomeScreenBuiltInSectionSchema,
+  HomeScreenSectionKind,
+  getHomeScreenBuiltInSectionSubtitle,
+  getHomeScreenBuiltInSectionTitle,
+  type HomeScreenBuiltInSectionValue,
+  type HomeScreenLayoutSection,
+  type HomeScreenSettingsSectionInput,
+} from '@zine/shared';
+import type { Database } from '../db';
+import { collections, homeCollectionSections, homeScreenSections } from '../db/schema';
+
+export type HomeScreenEditableSection =
+  | {
+      kind: typeof HomeScreenSectionKind.BUILT_IN;
+      builtInSection: HomeScreenBuiltInSectionValue;
+      title: string;
+      subtitle: string;
+      enabled: boolean;
+      position: number;
+    }
+  | {
+      kind: typeof HomeScreenSectionKind.COLLECTION;
+      collectionId: string;
+      title: string;
+      subtitle: string | null;
+      enabled: true;
+      position: number;
+    };
+
+export type AddableHomeCollection = {
+  id: string;
+  name: string;
+  description: string | null;
+};
+
+type PersistedHomeScreenRow = {
+  sectionType: string;
+  builtInSection: string | null;
+  collectionId: string | null;
+  enabled: boolean;
+  position: number;
+};
+
+type LegacyHomeCollectionRow = {
+  collectionId: string;
+  title: string;
+  subtitle: string | null;
+  position: number;
+};
+
+function buildDefaultLayout(
+  legacyCollections: LegacyHomeCollectionRow[]
+): HomeScreenLayoutSection[] {
+  const sections: HomeScreenLayoutSection[] = [];
+
+  for (const builtInSection of HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS) {
+    sections.push({ kind: HomeScreenSectionKind.BUILT_IN, builtInSection });
+
+    if (builtInSection === HOME_SCREEN_COLLECTION_INSERT_AFTER) {
+      sections.push(
+        ...legacyCollections.map(
+          (collection): HomeScreenLayoutSection => ({
+            kind: HomeScreenSectionKind.COLLECTION,
+            collectionId: collection.collectionId,
+          })
+        )
+      );
+    }
+  }
+
+  return sections;
+}
+
+function parseBuiltInSection(value: string | null): HomeScreenBuiltInSectionValue | null {
+  const parsed = HomeScreenBuiltInSectionSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function normalizePersistedLayout(rows: PersistedHomeScreenRow[]): HomeScreenLayoutSection[] {
+  const sections: HomeScreenLayoutSection[] = [];
+  const seenBuiltIns = new Set<HomeScreenBuiltInSectionValue>();
+
+  for (const row of rows) {
+    if (row.sectionType === HomeScreenSectionKind.BUILT_IN) {
+      const builtInSection = parseBuiltInSection(row.builtInSection);
+      if (!builtInSection || seenBuiltIns.has(builtInSection)) continue;
+      seenBuiltIns.add(builtInSection);
+      if (!row.enabled) continue;
+      sections.push({ kind: HomeScreenSectionKind.BUILT_IN, builtInSection });
+      continue;
+    }
+
+    if (row.sectionType === HomeScreenSectionKind.COLLECTION && row.collectionId) {
+      sections.push({ kind: HomeScreenSectionKind.COLLECTION, collectionId: row.collectionId });
+    }
+  }
+
+  for (const builtInSection of HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS) {
+    if (!seenBuiltIns.has(builtInSection)) {
+      sections.push({ kind: HomeScreenSectionKind.BUILT_IN, builtInSection });
+    }
+  }
+
+  return sections;
+}
+
+export async function getHomeScreenLayoutSections(
+  db: Database,
+  userId: string
+): Promise<HomeScreenLayoutSection[]> {
+  const persistedRows = await db
+    .select({
+      sectionType: homeScreenSections.sectionType,
+      builtInSection: homeScreenSections.builtInSection,
+      collectionId: homeScreenSections.collectionId,
+      enabled: homeScreenSections.enabled,
+      position: homeScreenSections.position,
+    })
+    .from(homeScreenSections)
+    .where(eq(homeScreenSections.userId, userId))
+    .orderBy(asc(homeScreenSections.position), asc(homeScreenSections.createdAt));
+
+  if (persistedRows.length > 0) {
+    return normalizePersistedLayout(persistedRows);
+  }
+
+  const legacyCollections = await db
+    .select({
+      collectionId: collections.id,
+      title: collections.name,
+      subtitle: collections.description,
+      position: homeCollectionSections.position,
+    })
+    .from(homeCollectionSections)
+    .innerJoin(collections, eq(homeCollectionSections.collectionId, collections.id))
+    .where(and(eq(homeCollectionSections.userId, userId), eq(collections.userId, userId)))
+    .orderBy(asc(homeCollectionSections.position), asc(homeCollectionSections.createdAt));
+
+  return buildDefaultLayout(legacyCollections);
+}
+
+export async function getHomeScreenSettings(db: Database, userId: string) {
+  const [persistedRows, legacyCollections, userCollections] = await Promise.all([
+    db
+      .select({
+        sectionType: homeScreenSections.sectionType,
+        builtInSection: homeScreenSections.builtInSection,
+        collectionId: homeScreenSections.collectionId,
+        enabled: homeScreenSections.enabled,
+        position: homeScreenSections.position,
+      })
+      .from(homeScreenSections)
+      .where(eq(homeScreenSections.userId, userId))
+      .orderBy(asc(homeScreenSections.position), asc(homeScreenSections.createdAt)),
+    db
+      .select({
+        collectionId: collections.id,
+        title: collections.name,
+        subtitle: collections.description,
+        position: homeCollectionSections.position,
+      })
+      .from(homeCollectionSections)
+      .innerJoin(collections, eq(homeCollectionSections.collectionId, collections.id))
+      .where(and(eq(homeCollectionSections.userId, userId), eq(collections.userId, userId)))
+      .orderBy(asc(homeCollectionSections.position), asc(homeCollectionSections.createdAt)),
+    db
+      .select({
+        id: collections.id,
+        name: collections.name,
+        description: collections.description,
+      })
+      .from(collections)
+      .where(eq(collections.userId, userId))
+      .orderBy(asc(collections.name), asc(collections.createdAt)),
+  ]);
+
+  const collectionById = new Map(
+    userCollections.map((collection) => [collection.id, collection] as const)
+  );
+  const visibleSections: HomeScreenEditableSection[] = [];
+  const hiddenBuiltInSections: HomeScreenEditableSection[] = [];
+  const selectedCollectionIds = new Set<string>();
+
+  if (persistedRows.length === 0) {
+    let position = 1;
+    for (const section of buildDefaultLayout(legacyCollections)) {
+      if (section.kind === HomeScreenSectionKind.BUILT_IN) {
+        visibleSections.push({
+          kind: HomeScreenSectionKind.BUILT_IN,
+          builtInSection: section.builtInSection,
+          title: getHomeScreenBuiltInSectionTitle(section.builtInSection),
+          subtitle: getHomeScreenBuiltInSectionSubtitle(section.builtInSection),
+          enabled: true,
+          position: position++,
+        });
+      } else {
+        const collection = collectionById.get(section.collectionId);
+        if (!collection) continue;
+        selectedCollectionIds.add(collection.id);
+        visibleSections.push({
+          kind: HomeScreenSectionKind.COLLECTION,
+          collectionId: collection.id,
+          title: collection.name,
+          subtitle: collection.description,
+          enabled: true,
+          position: position++,
+        });
+      }
+    }
+  } else {
+    const seenBuiltIns = new Set<HomeScreenBuiltInSectionValue>();
+    for (const row of persistedRows) {
+      if (row.sectionType === HomeScreenSectionKind.BUILT_IN) {
+        const builtInSection = parseBuiltInSection(row.builtInSection);
+        if (!builtInSection || seenBuiltIns.has(builtInSection)) continue;
+        seenBuiltIns.add(builtInSection);
+        const section: HomeScreenEditableSection = {
+          kind: HomeScreenSectionKind.BUILT_IN,
+          builtInSection,
+          title: getHomeScreenBuiltInSectionTitle(builtInSection),
+          subtitle: getHomeScreenBuiltInSectionSubtitle(builtInSection),
+          enabled: row.enabled,
+          position: row.position,
+        };
+        if (row.enabled) {
+          visibleSections.push(section);
+        } else {
+          hiddenBuiltInSections.push(section);
+        }
+        continue;
+      }
+
+      if (row.sectionType === HomeScreenSectionKind.COLLECTION && row.collectionId && row.enabled) {
+        const collection = collectionById.get(row.collectionId);
+        if (!collection) continue;
+        selectedCollectionIds.add(collection.id);
+        visibleSections.push({
+          kind: HomeScreenSectionKind.COLLECTION,
+          collectionId: collection.id,
+          title: collection.name,
+          subtitle: collection.description,
+          enabled: true,
+          position: row.position,
+        });
+      }
+    }
+
+    for (const builtInSection of HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS) {
+      if (!seenBuiltIns.has(builtInSection)) {
+        visibleSections.push({
+          kind: HomeScreenSectionKind.BUILT_IN,
+          builtInSection,
+          title: getHomeScreenBuiltInSectionTitle(builtInSection),
+          subtitle: getHomeScreenBuiltInSectionSubtitle(builtInSection),
+          enabled: true,
+          position: Number.MAX_SAFE_INTEGER,
+        });
+      }
+    }
+  }
+
+  return {
+    visibleSections: visibleSections.sort((a, b) => a.position - b.position),
+    hiddenBuiltInSections: hiddenBuiltInSections.sort((a, b) => a.position - b.position),
+    addableCollections: userCollections
+      .filter((collection) => !selectedCollectionIds.has(collection.id))
+      .map(
+        (collection): AddableHomeCollection => ({
+          id: collection.id,
+          name: collection.name,
+          description: collection.description,
+        })
+      ),
+  };
+}
+
+export async function replaceHomeScreenSettings(
+  db: Database,
+  userId: string,
+  inputSections: HomeScreenSettingsSectionInput[]
+) {
+  const now = Date.now();
+  const collectionIds = inputSections
+    .filter((section) => section.kind === HomeScreenSectionKind.COLLECTION)
+    .map((section) => section.collectionId);
+  const uniqueCollectionIds = [...new Set(collectionIds)];
+  const ownedCollections =
+    uniqueCollectionIds.length === 0
+      ? []
+      : await db
+          .select({ id: collections.id })
+          .from(collections)
+          .where(and(eq(collections.userId, userId), inArray(collections.id, uniqueCollectionIds)));
+  const ownedCollectionIds = new Set(ownedCollections.map((collection) => collection.id));
+
+  if (ownedCollectionIds.size !== uniqueCollectionIds.length) {
+    throw new Error('One or more collections are unavailable.');
+  }
+
+  const previousHomeCollections = await db
+    .select({
+      collectionId: homeCollectionSections.collectionId,
+      layout: homeCollectionSections.layout,
+    })
+    .from(homeCollectionSections)
+    .where(eq(homeCollectionSections.userId, userId));
+  const previousLayoutByCollectionId = new Map(
+    previousHomeCollections.map((section) => [section.collectionId, section.layout] as const)
+  );
+
+  await db.delete(homeScreenSections).where(eq(homeScreenSections.userId, userId));
+  await db.delete(homeCollectionSections).where(eq(homeCollectionSections.userId, userId));
+
+  const rows = inputSections.map((section, index) => ({
+    id: ulid(),
+    userId,
+    sectionType: section.kind,
+    builtInSection: section.kind === HomeScreenSectionKind.BUILT_IN ? section.builtInSection : null,
+    collectionId: section.kind === HomeScreenSectionKind.COLLECTION ? section.collectionId : null,
+    enabled: section.enabled,
+    position: index + 1,
+    createdAt: now,
+    updatedAt: now,
+  }));
+
+  if (rows.length > 0) {
+    await db.insert(homeScreenSections).values(rows);
+  }
+
+  const visibleCollections = inputSections.filter(
+    (section) => section.kind === HomeScreenSectionKind.COLLECTION && section.enabled
+  );
+
+  if (visibleCollections.length > 0) {
+    await db.insert(homeCollectionSections).values(
+      visibleCollections.map((section, index) => ({
+        id: ulid(),
+        userId,
+        collectionId: section.collectionId,
+        position: index + 1,
+        layout:
+          previousLayoutByCollectionId.get(section.collectionId) ?? HomeCollectionLayout.STACK_RAIL,
+        createdAt: now,
+        updatedAt: now,
+      }))
+    );
+  }
+}
+
+export async function resetHomeScreenSettings(db: Database, userId: string) {
+  await db.delete(homeScreenSections).where(eq(homeScreenSections.userId, userId));
+  await db.delete(homeCollectionSections).where(eq(homeCollectionSections.userId, userId));
+}
+
+export async function addCollectionToHomeScreenIfMissing(
+  db: Database,
+  userId: string,
+  collectionId: string
+) {
+  const allRows = await db
+    .select({ id: homeScreenSections.id })
+    .from(homeScreenSections)
+    .where(eq(homeScreenSections.userId, userId));
+
+  if (allRows.length === 0) {
+    const layout = await getHomeScreenLayoutSections(db, userId);
+    const now = Date.now();
+    await db.insert(homeScreenSections).values(
+      layout.map((section, index) => ({
+        id: ulid(),
+        userId,
+        sectionType: section.kind,
+        builtInSection:
+          section.kind === HomeScreenSectionKind.BUILT_IN ? section.builtInSection : null,
+        collectionId:
+          section.kind === HomeScreenSectionKind.COLLECTION ? section.collectionId : null,
+        enabled: true,
+        position: index + 1,
+        createdAt: now,
+        updatedAt: now,
+      }))
+    );
+    return;
+  }
+
+  const existingRows = await db
+    .select({ id: homeScreenSections.id })
+    .from(homeScreenSections)
+    .where(
+      and(eq(homeScreenSections.userId, userId), eq(homeScreenSections.collectionId, collectionId))
+    )
+    .limit(1);
+
+  if (existingRows[0]) return;
+
+  const nextPositionRows = await db
+    .select({
+      nextPosition: homeScreenSections.position,
+    })
+    .from(homeScreenSections)
+    .where(eq(homeScreenSections.userId, userId))
+    .orderBy(asc(homeScreenSections.position));
+  const position =
+    nextPositionRows.length === 0
+      ? HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS.length + 1
+      : Math.max(...nextPositionRows.map((row) => row.nextPosition)) + 1;
+  const now = Date.now();
+
+  await db.insert(homeScreenSections).values({
+    id: ulid(),
+    userId,
+    sectionType: HomeScreenSectionKind.COLLECTION,
+    builtInSection: null,
+    collectionId,
+    enabled: true,
+    position,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+export async function removeCollectionFromHomeScreen(
+  db: Database,
+  userId: string,
+  collectionId: string
+) {
+  await db
+    .delete(homeScreenSections)
+    .where(
+      and(eq(homeScreenSections.userId, userId), eq(homeScreenSections.collectionId, collectionId))
+    );
+}

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -13,6 +13,7 @@ import { insightsRouter } from './routers/insights';
 import { searchRouter } from './routers/search';
 import { peopleRouter } from './routers/people';
 import { collectionsRouter } from './routers/collections';
+import { homeSettingsRouter } from './routers/home-settings';
 
 /**
  * Root tRPC router
@@ -70,6 +71,7 @@ export const appRouter = router({
   creators: creatorsRouter,
   people: peopleRouter,
   collections: collectionsRouter,
+  homeSettings: homeSettingsRouter,
   search: searchRouter,
   insights: insightsRouter,
 });

--- a/apps/worker/src/trpc/routers/collections.ts
+++ b/apps/worker/src/trpc/routers/collections.ts
@@ -21,6 +21,7 @@ import {
   collections,
   creators,
   homeCollectionSections,
+  homeScreenSections,
   items,
   tags,
   userItems,
@@ -29,6 +30,10 @@ import {
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { toItemViewsWithTags } from './items';
 import type { Database } from '../../db';
+import {
+  addCollectionToHomeScreenIfMissing,
+  removeCollectionFromHomeScreen,
+} from '../../home-screen/layout';
 
 function parseRules(rulesJson: string): CollectionRules {
   try {
@@ -442,6 +447,7 @@ export const collectionsRouter = router({
       await ctx.db
         .delete(homeCollectionSections)
         .where(eq(homeCollectionSections.collectionId, input.id));
+      await ctx.db.delete(homeScreenSections).where(eq(homeScreenSections.collectionId, input.id));
       await ctx.db
         .delete(collections)
         .where(and(eq(collections.id, input.id), eq(collections.userId, ctx.userId)));
@@ -464,6 +470,7 @@ export const collectionsRouter = router({
         await ctx.db
           .delete(homeCollectionSections)
           .where(eq(homeCollectionSections.collectionId, input.id));
+        await removeCollectionFromHomeScreen(ctx.db, ctx.userId, input.id);
         return { success: true as const };
       }
 
@@ -479,6 +486,7 @@ export const collectionsRouter = router({
           .update(homeCollectionSections)
           .set({ layout: input.layout, updatedAt: now })
           .where(eq(homeCollectionSections.id, existingRows[0].id));
+        await addCollectionToHomeScreenIfMissing(ctx.db, ctx.userId, input.id);
         return { success: true as const };
       }
 
@@ -499,6 +507,7 @@ export const collectionsRouter = router({
         createdAt: now,
         updatedAt: now,
       });
+      await addCollectionToHomeScreenIfMissing(ctx.db, ctx.userId, input.id);
 
       return { success: true as const };
     }),

--- a/apps/worker/src/trpc/routers/home-settings.ts
+++ b/apps/worker/src/trpc/routers/home-settings.ts
@@ -1,0 +1,93 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import {
+  HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS,
+  HomeScreenSectionKind,
+  HomeScreenSettingsSectionInputSchema,
+} from '@zine/shared';
+import {
+  getHomeScreenSettings,
+  replaceHomeScreenSettings,
+  resetHomeScreenSettings,
+} from '../../home-screen/layout';
+import { protectedProcedure, router } from '../trpc';
+
+const UpdateHomeScreenSettingsInput = z
+  .object({
+    sections: z.array(HomeScreenSettingsSectionInputSchema).min(1).max(100),
+  })
+  .superRefine((input, ctx) => {
+    const builtIns = new Set<string>();
+    const collections = new Set<string>();
+    let enabledCount = 0;
+
+    for (const [index, section] of input.sections.entries()) {
+      if (section.enabled) enabledCount += 1;
+
+      if (section.kind === HomeScreenSectionKind.BUILT_IN) {
+        if (builtIns.has(section.builtInSection)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Built-in sections cannot be duplicated',
+            path: ['sections', index, 'builtInSection'],
+          });
+        }
+        builtIns.add(section.builtInSection);
+        continue;
+      }
+
+      if (collections.has(section.collectionId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Collections cannot be duplicated',
+          path: ['sections', index, 'collectionId'],
+        });
+      }
+      collections.add(section.collectionId);
+    }
+
+    for (const builtInSection of HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS) {
+      if (!builtIns.has(builtInSection)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'All built-in sections must be included',
+          path: ['sections'],
+        });
+        break;
+      }
+    }
+
+    if (enabledCount === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one Home section must be visible',
+        path: ['sections'],
+      });
+    }
+  });
+
+export const homeSettingsRouter = router({
+  get: protectedProcedure.query(async ({ ctx }) => getHomeScreenSettings(ctx.db, ctx.userId)),
+
+  update: protectedProcedure
+    .input(UpdateHomeScreenSettingsInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await replaceHomeScreenSettings(ctx.db, ctx.userId, input.sections);
+        return { success: true as const };
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === 'One or more collections are unavailable.'
+        ) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: error.message });
+        }
+        throw error;
+      }
+    }),
+
+  reset: protectedProcedure.mutation(async ({ ctx }) => {
+    await resetHomeScreenSettings(ctx.db, ctx.userId);
+    return { success: true as const };
+  }),
+});

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -24,6 +24,7 @@ import {
   CollectionSort,
   CollectionSortSchema,
   HomeCollectionLayoutSchema,
+  HomeScreenSectionKind,
   isJsonObject,
   type JsonObject,
   type Provider,
@@ -48,6 +49,7 @@ import {
   userPeople,
   userPersonMentions,
 } from '../../db/schema';
+import { getHomeScreenLayoutSections } from '../../home-screen/layout';
 import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
 import { getArticleContent } from '../../lib/article-storage';
 import type { Database } from '../../db';
@@ -791,9 +793,10 @@ export const itemsRouter = router({
       .innerJoin(collections, eq(homeCollectionSections.collectionId, collections.id))
       .where(and(eq(homeCollectionSections.userId, ctx.userId), eq(collections.userId, ctx.userId)))
       .orderBy(asc(homeCollectionSections.position), asc(homeCollectionSections.createdAt));
+    const homeLayoutSectionsQuery = getHomeScreenLayoutSections(ctx.db, ctx.userId);
 
     // Execute all queries in parallel
-    const [recentBookmarks, jumpBackIn, videos, podcasts, articles, homeSections] =
+    const [recentBookmarks, jumpBackIn, videos, podcasts, articles, homeSections, sectionOrder] =
       await Promise.all([
         recentBookmarksQuery,
         jumpBackInQuery,
@@ -801,6 +804,7 @@ export const itemsRouter = router({
         podcastsQuery,
         articlesQuery,
         homeSectionsQuery,
+        homeLayoutSectionsQuery,
       ]);
 
     const customCollections = await Promise.all(
@@ -878,6 +882,15 @@ export const itemsRouter = router({
         articles: articlesViews,
       },
       customCollections,
+      sectionOrder: sectionOrder.filter(
+        (section) =>
+          section.kind === HomeScreenSectionKind.BUILT_IN ||
+          customCollections.some(
+            (collection) =>
+              section.kind === HomeScreenSectionKind.COLLECTION &&
+              collection.collectionId === section.collectionId
+          )
+      ),
     };
   }),
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "react-dom": "19.2.4",
         "react-native": "0.83.2",
         "react-native-context-menu-view": "^1.21.0",
+        "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.30.0",
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -444,7 +445,7 @@
 
     "@babel/preset-react": ["@babel/preset-react@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-transform-react-display-name": "^7.28.0", "@babel/plugin-transform-react-jsx": "^7.27.1", "@babel/plugin-transform-react-jsx-development": "^7.27.1", "@babel/plugin-transform-react-pure-annotations": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ=="],
 
-    "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
 
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
@@ -1142,7 +1143,7 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
-    "@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.90.22", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.91.19" }, "peerDependencies": { "@tanstack/react-query": "^5.90.20", "react": "^18 || ^19" } }, "sha512-BrD3Y/SsrSIDl+t/gpYvjvGHXd7m7oF+GIqktKE8LmTgt7bS1lYHd/CLkVxMPixTU53gHHVFfPNGmY7Hv4L/7g=="],
+    "@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.99.0", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.99.0" }, "peerDependencies": { "@tanstack/react-query": "^5.99.0", "react": "^18 || ^19" } }, "sha512-A3TTaaYZOy6dFUNJj3r10rwmUBWaXqc2N71a7jzpFXilYAYWLKJf9ivT5n5bhXsJnSkdvv1RLifUg/GdvDGaDw=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -2688,6 +2689,8 @@
 
     "react-native-context-menu-view": ["react-native-context-menu-view@1.21.0", "", { "peerDependencies": { "react": "^16.8.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": ">=0.60.0-rc.0 <1.0.x" } }, "sha512-GVQckdDxKyM4BYqWqiApnfzzk56vLEMWiVLsvs95mPhJJYvzRXx+Ev3T6DVEasWCZxk6PbgtcZaWi9jnXGdhCQ=="],
 
+    "react-native-draggable-flatlist": ["react-native-draggable-flatlist@4.0.3", "", { "dependencies": { "@babel/preset-typescript": "^7.17.12" }, "peerDependencies": { "react-native": ">=0.64.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=2.8.0" } }, "sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw=="],
+
     "react-native-gesture-handler": ["react-native-gesture-handler@2.30.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.2.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q=="],
@@ -3486,6 +3489,8 @@
 
     "@tanstack/query-sync-storage-persister/@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" } }, "sha512-FzXoxqGYa+ozGNGBIPHJT06rJD4geiHGbVXNS8K7cwN34te64LXlO5Ep+roQYvZjXJFNrLa4W48DIYITpMxzuA=="],
 
+    "@tanstack/react-query-persist-client/@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" } }, "sha512-FzXoxqGYa+ozGNGBIPHJT06rJD4geiHGbVXNS8K7cwN34te64LXlO5Ep+roQYvZjXJFNrLa4W48DIYITpMxzuA=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -3516,8 +3521,6 @@
 
     "@wallet-standard/errors/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
-    "@zine/web/@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.99.0", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.99.0" }, "peerDependencies": { "@tanstack/react-query": "^5.99.0", "react": "^18 || ^19" } }, "sha512-A3TTaaYZOy6dFUNJj3r10rwmUBWaXqc2N71a7jzpFXilYAYWLKJf9ivT5n5bhXsJnSkdvv1RLifUg/GdvDGaDw=="],
-
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3527,8 +3530,6 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "babel-plugin-syntax-hermes-parser/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
-
-    "babel-preset-expo/@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
 
     "babel-preset-expo/babel-plugin-syntax-hermes-parser": ["babel-plugin-syntax-hermes-parser@0.32.1", "", { "dependencies": { "hermes-parser": "0.32.1" } }, "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ=="],
 
@@ -3785,6 +3786,8 @@
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
 
     "react-native-web/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
+
+    "react-native-worklets/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
     "react-native-worklets/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -4108,6 +4111,8 @@
 
     "@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
 
+    "@tanstack/react-query-persist-client/@tanstack/query-persist-client-core/@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
+
     "@testing-library/dom/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -4129,8 +4134,6 @@
     "@vitest/mocker/@vitest/spy/tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
     "@vitest/mocker/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
-
-    "@zine/web/@tanstack/react-query-persist-client/@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.99.0", "", { "dependencies": { "@tanstack/query-core": "5.99.0" } }, "sha512-FzXoxqGYa+ozGNGBIPHJT06rJD4geiHGbVXNS8K7cwN34te64LXlO5Ep+roQYvZjXJFNrLa4W48DIYITpMxzuA=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -4581,8 +4584,6 @@
     "@vitest/mocker/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
     "@vitest/mocker/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
-
-    "@zine/web/@tanstack/react-query-persist-client/@tanstack/query-persist-client-core/@tanstack/query-core": ["@tanstack/query-core@5.99.0", "", {}, "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/packages/shared/src/home-screen.ts
+++ b/packages/shared/src/home-screen.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+
+export const HomeScreenSectionKind = {
+  BUILT_IN: 'BUILT_IN',
+  COLLECTION: 'COLLECTION',
+} as const;
+
+export type HomeScreenSectionKindValue =
+  (typeof HomeScreenSectionKind)[keyof typeof HomeScreenSectionKind];
+
+export const HomeScreenBuiltInSection = {
+  JUMP_BACK_IN: 'JUMP_BACK_IN',
+  RECENTLY_BOOKMARKED: 'RECENTLY_BOOKMARKED',
+  INBOX: 'INBOX',
+  PODCASTS: 'PODCASTS',
+  ARTICLES: 'ARTICLES',
+  VIDEOS: 'VIDEOS',
+} as const;
+
+export type HomeScreenBuiltInSectionValue =
+  (typeof HomeScreenBuiltInSection)[keyof typeof HomeScreenBuiltInSection];
+
+export const HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS: HomeScreenBuiltInSectionValue[] = [
+  HomeScreenBuiltInSection.JUMP_BACK_IN,
+  HomeScreenBuiltInSection.RECENTLY_BOOKMARKED,
+  HomeScreenBuiltInSection.INBOX,
+  HomeScreenBuiltInSection.PODCASTS,
+  HomeScreenBuiltInSection.ARTICLES,
+  HomeScreenBuiltInSection.VIDEOS,
+];
+
+export const HOME_SCREEN_COLLECTION_INSERT_AFTER = HomeScreenBuiltInSection.INBOX;
+
+export const HomeScreenBuiltInSectionSchema = z.nativeEnum(HomeScreenBuiltInSection);
+export const HomeScreenSectionKindSchema = z.nativeEnum(HomeScreenSectionKind);
+
+export const HomeScreenLayoutSectionSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal(HomeScreenSectionKind.BUILT_IN),
+    builtInSection: HomeScreenBuiltInSectionSchema,
+  }),
+  z.object({
+    kind: z.literal(HomeScreenSectionKind.COLLECTION),
+    collectionId: z.string().min(1),
+  }),
+]);
+
+export type HomeScreenLayoutSection = z.infer<typeof HomeScreenLayoutSectionSchema>;
+
+export const HomeScreenSettingsSectionInputSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal(HomeScreenSectionKind.BUILT_IN),
+    builtInSection: HomeScreenBuiltInSectionSchema,
+    enabled: z.boolean(),
+  }),
+  z.object({
+    kind: z.literal(HomeScreenSectionKind.COLLECTION),
+    collectionId: z.string().min(1),
+    enabled: z.literal(true).default(true),
+  }),
+]);
+
+export type HomeScreenSettingsSectionInput = z.infer<typeof HomeScreenSettingsSectionInputSchema>;
+
+export function getHomeScreenBuiltInSectionTitle(section: HomeScreenBuiltInSectionValue): string {
+  switch (section) {
+    case HomeScreenBuiltInSection.JUMP_BACK_IN:
+      return 'Jump Back In';
+    case HomeScreenBuiltInSection.RECENTLY_BOOKMARKED:
+      return 'Recently Bookmarked';
+    case HomeScreenBuiltInSection.INBOX:
+      return 'Inbox';
+    case HomeScreenBuiltInSection.PODCASTS:
+      return 'Podcasts';
+    case HomeScreenBuiltInSection.ARTICLES:
+      return 'Articles';
+    case HomeScreenBuiltInSection.VIDEOS:
+      return 'Videos';
+  }
+}
+
+export function getHomeScreenBuiltInSectionSubtitle(
+  section: HomeScreenBuiltInSectionValue
+): string {
+  switch (section) {
+    case HomeScreenBuiltInSection.JUMP_BACK_IN:
+      return 'Items you opened recently';
+    case HomeScreenBuiltInSection.RECENTLY_BOOKMARKED:
+      return 'Your latest saves';
+    case HomeScreenBuiltInSection.INBOX:
+      return 'Fresh items waiting for review';
+    case HomeScreenBuiltInSection.PODCASTS:
+      return 'Saved audio episodes';
+    case HomeScreenBuiltInSection.ARTICLES:
+      return 'Saved reads';
+    case HomeScreenBuiltInSection.VIDEOS:
+      return 'Saved videos';
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -70,6 +70,26 @@ export type {
   HomeCollectionLayoutValue,
 } from './collections';
 
+// Home screen customization contracts
+export {
+  HOME_SCREEN_COLLECTION_INSERT_AFTER,
+  HOME_SCREEN_DEFAULT_BUILT_IN_SECTIONS,
+  HomeScreenBuiltInSection,
+  HomeScreenBuiltInSectionSchema,
+  HomeScreenLayoutSectionSchema,
+  HomeScreenSectionKind,
+  HomeScreenSectionKindSchema,
+  HomeScreenSettingsSectionInputSchema,
+  getHomeScreenBuiltInSectionSubtitle,
+  getHomeScreenBuiltInSectionTitle,
+} from './home-screen';
+export type {
+  HomeScreenBuiltInSectionValue,
+  HomeScreenLayoutSection,
+  HomeScreenSectionKindValue,
+  HomeScreenSettingsSectionInput,
+} from './home-screen';
+
 // Schemas (Zod validation for tRPC input)
 export { ContentTypeSchema, ProviderSchema, SubscriptionStatusSchema } from './schemas';
 


### PR DESCRIPTION
## Summary

Adds backend-persisted Home screen customization for the mobile app.

- Adds shared Home screen section contracts and a `home_screen_sections` D1 table.
- Adds `homeSettings.get`, `homeSettings.update`, and `homeSettings.reset` tRPC routes.
- Updates `items.home` to return persisted section order for Home rendering.
- Adds Settings -> Home Screen with Visible on Home, Hidden Sections, and Add Collections groups.
- Adds drag-and-drop ordering for visible sections using `react-native-draggable-flatlist`.

## Impact

Users can hide built-in Home sections, add collections to Home, reorder visible sections, reset the layout, and persist the configuration in the backend.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run typecheck`
- Pre-push hook: `format:check`, `design-system:check`, `typecheck`, `apps/web test`, worker CI test subset

Notes: mobile lint still reports existing warnings in unrelated files; tests emit existing React Test Renderer/Radix warnings, but all commands completed successfully.