### PR TITLE
[codex] Add home screen navigation drawer

### DIFF
--- a/apps/mobile/app/(tabs)/index/_layout.tsx
+++ b/apps/mobile/app/(tabs)/index/_layout.tsx
@@ -7,6 +7,7 @@ export default function HomeLayout() {
     <Stack screenOptions={lightweightHeaderStackScreenOptions}>
       <Stack.Screen name="index" options={{ title: 'Home' }} />
       <Stack.Screen name="collection/[id]" options={{ title: 'Collection', headerBackTitle: '' }} />
+      <Stack.Screen name="section/[section]" options={{ title: 'Section', headerBackTitle: '' }} />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -1,9 +1,12 @@
 import { Stack, useNavigation, useRouter, type Href } from 'expo-router';
+import { LinearGradient } from 'expo-linear-gradient';
 import { Surface } from 'heroui-native';
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType } from 'react';
 import {
   View,
   Text,
+  Animated,
+  Modal,
   ScrollView,
   StyleSheet,
   Pressable,
@@ -27,14 +30,7 @@ import {
 import { FilterChip } from '@/components/filter-chip';
 import { ArticleIcon, PodcastIcon, PostIcon, SettingsIcon, VideoIcon } from '@/components/icons';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
-import {
-  Colors,
-  Typography,
-  Spacing,
-  Radius,
-  ContentColors,
-  FilterChipPalette,
-} from '@/constants/theme';
+import { Colors, Typography, Spacing, Radius, ContentColors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import {
@@ -67,54 +63,49 @@ const HOME_RECENT_BOOKMARKS_VISIBLE_LIMIT = 6;
 const HOME_INBOX_VISIBLE_LIMIT = 4;
 const HOME_PODCASTS_VISIBLE_LIMIT = 5;
 const HOME_TOP_THRESHOLD = 4;
-const HOME_COLLAPSED_TITLE_THRESHOLD = 44;
+const NAVIGATION_PANE_WIDTH = 304;
+const NAVIGATION_PANE_ANIMATION_MS = 220;
 
-function getGreeting(): string {
-  const hour = new Date().getHours();
-  if (hour < 12) return 'Good morning';
-  if (hour < 17) return 'Good afternoon';
-  return 'Good evening';
-}
+type BuiltInHomeSectionKey =
+  | 'jump-back-in'
+  | 'recently-bookmarked'
+  | 'podcasts'
+  | 'articles'
+  | 'videos';
 
 const contentTypeFilters: {
-  id: UIContentType;
+  id: UIContentType | null;
   label: string;
-  icon: ComponentType<{ size?: number; color?: string }>;
-  dotColor: string;
-  selectedColor: string;
-  selectedSurfaceColor: string;
+  icon?: ComponentType<{ size?: number; color?: string }>;
+  dotColor?: string;
 }[] = [
+  {
+    id: null,
+    label: 'All',
+  },
   {
     id: 'article',
     label: 'Articles',
     icon: ArticleIcon,
     dotColor: ContentColors.article,
-    selectedColor: FilterChipPalette.article.accent,
-    selectedSurfaceColor: FilterChipPalette.article.surface,
   },
   {
     id: 'podcast',
     label: 'Podcasts',
     icon: PodcastIcon,
     dotColor: ContentColors.podcast,
-    selectedColor: FilterChipPalette.podcast.accent,
-    selectedSurfaceColor: FilterChipPalette.podcast.surface,
   },
   {
     id: 'video',
     label: 'Videos',
     icon: VideoIcon,
     dotColor: ContentColors.video,
-    selectedColor: FilterChipPalette.video.accent,
-    selectedSurfaceColor: FilterChipPalette.video.surface,
   },
   {
     id: 'post',
     label: 'Posts',
     icon: PostIcon,
     dotColor: ContentColors.post,
-    selectedColor: FilterChipPalette.post.accent,
-    selectedSurfaceColor: FilterChipPalette.post.surface,
   },
 ];
 
@@ -136,12 +127,10 @@ function mapHomeItemToCard(
 
 function SectionHeader({
   title,
-  count,
   colors,
   onPress,
 }: {
   title: string;
-  count?: number;
   colors: typeof Colors.dark;
   onPress?: () => void;
 }) {
@@ -149,9 +138,6 @@ function SectionHeader({
     <Pressable onPress={onPress} style={styles.sectionHeader} disabled={!onPress}>
       <View style={styles.sectionHeaderLeft}>
         <Text style={[styles.sectionTitle, { color: colors.text }]}>{title}</Text>
-        {count !== undefined && (
-          <Text style={[styles.sectionCount, { color: colors.textTertiary }]}>{count}</Text>
-        )}
       </View>
       {onPress && <ChevronRightIcon size={20} color={colors.textTertiary} />}
     </Pressable>
@@ -212,13 +198,20 @@ export default function HomeScreen() {
   const navigation = useNavigation() as HomeScreenNavigation;
   const listRef = useRef<FlatList<HomeSectionItem>>(null);
   const scrollOffsetYRef = useRef(0);
+  const navigationPaneProgress = useRef(new Animated.Value(0)).current;
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'dark'];
   const { width: windowWidth } = useWindowDimensions();
-  const greeting = useMemo(() => getGreeting(), []);
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
-  const [showCollapsedTitle, setShowCollapsedTitle] = useState(false);
+  const [isNavigationPaneMounted, setNavigationPaneMounted] = useState(false);
+  const [isNavigationPaneOpen, setNavigationPaneOpen] = useState(false);
   const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
+  const headerContentWidth = Math.max(windowWidth - Spacing.md * 2, 240);
+  const headerFilterWidth = Math.max(headerContentWidth - 38, 180);
+  const headerFadeEndColor =
+    (colorScheme as string | null | undefined) === 'light'
+      ? 'rgba(255, 255, 255, 0)'
+      : 'rgba(0, 0, 0, 0)';
   const apiContentTypeFilter = useMemo(
     () => (contentTypeFilter ? (contentTypeFilter.toUpperCase() as ApiContentType) : undefined),
     [contentTypeFilter]
@@ -364,21 +357,52 @@ export default function HomeScreen() {
     [router]
   );
 
-  const handleOpenSettings = useCallback(() => {
-    router.push('/settings');
-  }, [router]);
+  const handleOpenHomeSection = useCallback(
+    (section: BuiltInHomeSectionKey) => {
+      router.push({
+        pathname: '/(tabs)/section/[section]',
+        params: { section },
+      } as unknown as Href);
+    },
+    [router]
+  );
+
+  const handleOpenNavigationPane = useCallback(() => {
+    setNavigationPaneMounted(true);
+    setNavigationPaneOpen(true);
+  }, []);
+
+  const handleCloseNavigationPane = useCallback(() => {
+    setNavigationPaneOpen(false);
+  }, []);
+
+  const handleNavigationPaneRoute = useCallback(
+    (href: Href) => {
+      setNavigationPaneOpen(false);
+      router.push(href);
+    },
+    [router]
+  );
 
   const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const offsetY = event.nativeEvent.contentOffset.y;
-    scrollOffsetYRef.current = offsetY;
-
-    const shouldShowCollapsedTitle = offsetY > HOME_COLLAPSED_TITLE_THRESHOLD;
-    setShowCollapsedTitle((current) =>
-      current === shouldShowCollapsedTitle ? current : shouldShowCollapsedTitle
-    );
+    scrollOffsetYRef.current = event.nativeEvent.contentOffset.y;
   }, []);
 
   const isLoading = isInboxLoading || isHomeLoading;
+
+  useEffect(() => {
+    if (!isNavigationPaneMounted) return;
+
+    Animated.timing(navigationPaneProgress, {
+      toValue: isNavigationPaneOpen ? 1 : 0,
+      duration: NAVIGATION_PANE_ANIMATION_MS,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished && !isNavigationPaneOpen) {
+        setNavigationPaneMounted(false);
+      }
+    });
+  }, [isNavigationPaneMounted, isNavigationPaneOpen, navigationPaneProgress]);
 
   const filteredJumpBackInItems = useMemo(
     () => getVisibleFeaturedGridItems(jumpBackInItems, contentTypeFilter),
@@ -522,37 +546,79 @@ export default function HomeScreen() {
     videos,
   ]);
 
-  const listHeader = useMemo(
+  const headerContent = useMemo(
     () => (
-      <>
-        <View style={styles.header}>
-          <Text style={[styles.homeTitle, { color: colors.text }]}>Home</Text>
-          <Text style={[styles.greeting, { color: colors.textSubheader }]}>{greeting}</Text>
+      <View style={[styles.headerContent, { width: headerContentWidth }]}>
+        <View style={styles.headerSettingsArea}>
+          <Pressable
+            onPress={handleOpenNavigationPane}
+            style={[styles.settingsButton, { backgroundColor: colors.surfaceSubtle }]}
+            hitSlop={12}
+            accessibilityLabel={
+              hasSettingsAlert
+                ? 'Open navigation menu. Subscription integrations need attention'
+                : 'Open navigation menu'
+            }
+            accessibilityRole="button"
+          >
+            <SettingsIcon size={20} color={colors.text} />
+            {hasSettingsAlert ? (
+              <View
+                testID="home-settings-alert-dot"
+                pointerEvents="none"
+                style={[
+                  styles.settingsAlertDot,
+                  {
+                    backgroundColor: colors.warning,
+                    borderColor: colors.background,
+                  },
+                ]}
+              />
+            ) : null}
+          </Pressable>
+          <LinearGradient
+            pointerEvents="none"
+            colors={[colors.background, headerFadeEndColor]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.headerFilterFade}
+          />
         </View>
-
         <ScrollView
           horizontal
+          style={[styles.headerFilterScroll, { width: headerFilterWidth }]}
           showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.filterContainer}
+          contentContainerStyle={styles.headerFilterContainer}
         >
           {contentTypeFilters.map((filter) => (
             <FilterChip
-              key={filter.id}
+              key={filter.id ?? 'all'}
               label={filter.label}
               isSelected={contentTypeFilter === filter.id}
-              onPress={() =>
-                setContentTypeFilter((current) => (current === filter.id ? null : filter.id))
-              }
+              onPress={() => setContentTypeFilter(filter.id)}
               icon={filter.icon}
               dotColor={filter.dotColor}
-              selectedColor={filter.selectedColor}
-              selectedSurfaceColor={filter.selectedSurfaceColor}
+              selectedColor={colors.warning}
+              selectedSurfaceColor={colors.warning}
+              selectedForegroundColor={colors.statusWarningForeground}
             />
           ))}
         </ScrollView>
-      </>
+      </View>
     ),
-    [colors.text, colors.textSubheader, contentTypeFilter, greeting]
+    [
+      colors.background,
+      colors.surfaceSubtle,
+      colors.statusWarningForeground,
+      colors.text,
+      colors.warning,
+      contentTypeFilter,
+      handleOpenNavigationPane,
+      hasSettingsAlert,
+      headerContentWidth,
+      headerFadeEndColor,
+      headerFilterWidth,
+    ]
   );
 
   const renderSection = useCallback(
@@ -561,7 +627,11 @@ export default function HomeScreen() {
         case 'jump-back-in':
           return (
             <View>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                colors={colors}
+                onPress={() => handleOpenHomeSection('jump-back-in')}
+              />
               <View style={styles.jumpBackInGrid}>
                 {getFeaturedGridRows(item.items).map((row) => (
                   <View
@@ -573,7 +643,12 @@ export default function HomeScreen() {
                         key={sectionItem.id}
                         style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
                       >
-                        <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                        <ItemCard
+                          item={sectionItem}
+                          shape="row"
+                          rowStyle="featured"
+                          bordered={false}
+                        />
                       </View>
                     ))}
                   </View>
@@ -584,12 +659,16 @@ export default function HomeScreen() {
         case 'recently-bookmarked':
           return (
             <View>
-              <SectionHeader title={item.title} count={item.count} colors={colors} />
+              <SectionHeader
+                title={item.title}
+                colors={colors}
+                onPress={() => handleOpenHomeSection('recently-bookmarked')}
+              />
               <FlatList
                 horizontal
                 data={item.items}
                 renderItem={({ item: sectionItem, index }) => (
-                  <ItemCard item={sectionItem} shape="stack" index={index} />
+                  <ItemCard item={sectionItem} shape="stack" index={index} bordered={false} />
                 )}
                 keyExtractor={(sectionItem) => sectionItem.id}
                 showsHorizontalScrollIndicator={false}
@@ -602,7 +681,6 @@ export default function HomeScreen() {
             <View style={styles.section}>
               <SectionHeader
                 title={item.title}
-                count={item.count}
                 colors={colors}
                 onPress={() => router.push('/(tabs)/inbox')}
               />
@@ -610,7 +688,13 @@ export default function HomeScreen() {
                 style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
               >
                 {item.items.map((sectionItem, index) => (
-                  <ItemCard key={sectionItem.id} item={sectionItem} shape="row" index={index} />
+                  <ItemCard
+                    key={sectionItem.id}
+                    item={sectionItem}
+                    shape="row"
+                    index={index}
+                    bordered={false}
+                  />
                 ))}
               </View>
             </View>
@@ -621,19 +705,18 @@ export default function HomeScreen() {
             <View>
               <SectionHeader
                 title={item.title}
-                count={item.count}
                 colors={colors}
                 onPress={
                   item.type === 'custom-cover-rail'
                     ? () => handleOpenCollection(item.collectionId)
-                    : undefined
+                    : () => handleOpenHomeSection(item.key as BuiltInHomeSectionKey)
                 }
               />
               <FlatList
                 horizontal
                 data={item.items}
                 renderItem={({ item: sectionItem, index }) => (
-                  <ItemCard item={sectionItem} shape="cover" index={index} />
+                  <ItemCard item={sectionItem} shape="cover" index={index} bordered={false} />
                 )}
                 keyExtractor={(sectionItem) => sectionItem.id}
                 showsHorizontalScrollIndicator={false}
@@ -647,19 +730,18 @@ export default function HomeScreen() {
             <View>
               <SectionHeader
                 title={item.title}
-                count={item.count}
                 colors={colors}
                 onPress={
                   item.type === 'custom-stack-rail'
                     ? () => handleOpenCollection(item.collectionId)
-                    : undefined
+                    : () => handleOpenHomeSection(item.key as BuiltInHomeSectionKey)
                 }
               />
               <FlatList
                 horizontal
                 data={item.items}
                 renderItem={({ item: sectionItem, index }) => (
-                  <ItemCard item={sectionItem} shape="stack" index={index} />
+                  <ItemCard item={sectionItem} shape="stack" index={index} bordered={false} />
                 )}
                 keyExtractor={(sectionItem) => sectionItem.id}
                 showsHorizontalScrollIndicator={false}
@@ -672,7 +754,6 @@ export default function HomeScreen() {
             <View>
               <SectionHeader
                 title={item.title}
-                count={item.count}
                 colors={colors}
                 onPress={() => handleOpenCollection(item.collectionId)}
               />
@@ -687,7 +768,12 @@ export default function HomeScreen() {
                         key={sectionItem.id}
                         style={[styles.jumpBackInGridItem, { width: featuredGridItemWidth }]}
                       >
-                        <ItemCard item={sectionItem} shape="row" rowStyle="featured" />
+                        <ItemCard
+                          item={sectionItem}
+                          shape="row"
+                          rowStyle="featured"
+                          bordered={false}
+                        />
                       </View>
                     ))}
                   </View>
@@ -700,7 +786,6 @@ export default function HomeScreen() {
             <View style={styles.section}>
               <SectionHeader
                 title={item.title}
-                count={item.count}
                 colors={colors}
                 onPress={() => handleOpenCollection(item.collectionId)}
               />
@@ -708,14 +793,20 @@ export default function HomeScreen() {
                 style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
               >
                 {item.items.map((sectionItem, index) => (
-                  <ItemCard key={sectionItem.id} item={sectionItem} shape="row" index={index} />
+                  <ItemCard
+                    key={sectionItem.id}
+                    item={sectionItem}
+                    shape="row"
+                    index={index}
+                    bordered={false}
+                  />
                 ))}
               </View>
             </View>
           );
       }
     },
-    [colors, featuredGridItemWidth, handleOpenCollection, router]
+    [colors, featuredGridItemWidth, handleOpenCollection, handleOpenHomeSection, router]
   );
 
   useEffect(() => {
@@ -739,7 +830,7 @@ export default function HomeScreen() {
     <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
       <Stack.Screen
         options={{
-          title: showCollapsedTitle ? 'Home' : '',
+          title: '',
           headerLargeTitle: false,
           headerTransparent: false,
           headerShadowVisible: false,
@@ -750,33 +841,8 @@ export default function HomeScreen() {
           headerTitleStyle: {
             color: colors.text,
           },
-          headerRight: () => (
-            <Pressable
-              onPress={handleOpenSettings}
-              style={styles.settingsButton}
-              accessibilityLabel={
-                hasSettingsAlert
-                  ? 'Open settings. Subscription integrations need attention'
-                  : 'Open settings'
-              }
-              accessibilityRole="button"
-            >
-              <SettingsIcon size={20} color={colors.text} />
-              {hasSettingsAlert ? (
-                <View
-                  testID="home-settings-alert-dot"
-                  pointerEvents="none"
-                  style={[
-                    styles.settingsAlertDot,
-                    {
-                      backgroundColor: colors.warning,
-                      borderColor: colors.background,
-                    },
-                  ]}
-                />
-              ) : null}
-            </Pressable>
-          ),
+          headerTitleAlign: 'left',
+          headerTitle: () => headerContent,
         }}
       />
 
@@ -791,7 +857,6 @@ export default function HomeScreen() {
         onScroll={handleScroll}
         scrollEventThrottle={32}
         showsVerticalScrollIndicator={false}
-        ListHeaderComponent={listHeader}
         ListFooterComponent={<View style={styles.bottomSpacer} />}
         ListEmptyComponent={
           isLoading ? (
@@ -805,6 +870,85 @@ export default function HomeScreen() {
         updateCellsBatchingPeriod={16}
         windowSize={5}
       />
+      <Modal
+        visible={isNavigationPaneMounted}
+        transparent
+        animationType="none"
+        onRequestClose={handleCloseNavigationPane}
+      >
+        <View style={styles.navigationPaneRoot}>
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.navigationPaneScrim,
+              {
+                opacity: navigationPaneProgress.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [0, 1],
+                }),
+              },
+            ]}
+          />
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={handleCloseNavigationPane}
+            accessibilityLabel="Close navigation menu"
+            accessibilityRole="button"
+          />
+          <Animated.View
+            style={[
+              styles.navigationPane,
+              {
+                backgroundColor: colors.background,
+                transform: [
+                  {
+                    translateX: navigationPaneProgress.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [-NAVIGATION_PANE_WIDTH, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          >
+            <View style={styles.navigationPaneHeader}>
+              <Text style={[styles.navigationPaneTitle, { color: colors.text }]}>Zine</Text>
+            </View>
+
+            <View style={styles.navigationPaneRows}>
+              {[
+                { label: 'Edit Homescreen', href: '/settings/home-screen' as Href },
+                { label: 'Settings', href: '/settings' as Href, showAlertDot: hasSettingsAlert },
+                { label: 'Home', href: '/(tabs)' as Href, isActive: true },
+                { label: 'Inbox', href: '/(tabs)/inbox' as Href },
+                { label: 'Search', href: '/(tabs)/search' as Href },
+                { label: 'Library', href: '/(tabs)/library' as Href },
+              ].map((item) => (
+                <Pressable
+                  key={item.label}
+                  onPress={() => handleNavigationPaneRoute(item.href)}
+                  style={({ pressed }) => [
+                    styles.navigationPaneRow,
+                    item.isActive ? { backgroundColor: colors.surfaceSubtle } : null,
+                    pressed ? { opacity: 0.72 } : null,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open ${item.label}`}
+                >
+                  <Text style={[styles.navigationPaneRowLabel, { color: colors.text }]}>
+                    {item.label}
+                  </Text>
+                  {item.showAlertDot ? (
+                    <View
+                      style={[styles.navigationPaneAlertDot, { backgroundColor: colors.warning }]}
+                    />
+                  ) : null}
+                </Pressable>
+              ))}
+            </View>
+          </Animated.View>
+        </View>
+      </Modal>
     </Surface>
   );
 }
@@ -820,17 +964,50 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingBottom: 32,
   },
-  header: {
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.sm,
-    paddingBottom: Spacing.xl,
+  navigationPaneRoot: {
+    flex: 1,
   },
-  homeTitle: {
-    ...Typography.displayMedium,
+  navigationPaneScrim: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.48)',
+  },
+  navigationPane: {
+    width: NAVIGATION_PANE_WIDTH,
+    height: '100%',
+    paddingTop: 72,
+    paddingHorizontal: Spacing.lg,
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 0 },
+    shadowOpacity: 0.2,
+    shadowRadius: 16,
+    elevation: 12,
+  },
+  navigationPaneHeader: {
+    marginBottom: Spacing.xl,
+  },
+  navigationPaneTitle: {
+    ...Typography.titleLarge,
     marginBottom: Spacing.xs,
   },
-  greeting: {
-    ...Typography.labelMedium,
+  navigationPaneRows: {
+    gap: Spacing.xs,
+  },
+  navigationPaneRow: {
+    minHeight: 48,
+    borderRadius: Radius.lg,
+    paddingHorizontal: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  navigationPaneRowLabel: {
+    ...Typography.bodyMedium,
+    fontWeight: '600',
+  },
+  navigationPaneAlertDot: {
+    width: 8,
+    height: 8,
+    borderRadius: Radius.full,
   },
   settingsButton: {
     width: 36,
@@ -839,7 +1016,9 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'transparent',
+    borderWidth: 0,
+    shadowOpacity: 0,
+    elevation: 0,
   },
   settingsAlertDot: {
     position: 'absolute',
@@ -850,10 +1029,32 @@ const styles = StyleSheet.create({
     borderRadius: Radius.full,
     borderWidth: 2,
   },
-  filterContainer: {
-    paddingHorizontal: Spacing.md,
+  headerContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  headerSettingsArea: {
+    width: 38,
+    height: 36,
+    position: 'relative',
+    zIndex: 2,
+  },
+  headerFilterFade: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 28,
+    width: 30,
+    zIndex: 1,
+  },
+  headerFilterScroll: {
+    flexGrow: 0,
+    marginLeft: Spacing.xs,
+  },
+  headerFilterContainer: {
     gap: Spacing.sm,
-    marginBottom: Spacing.lg,
+    paddingLeft: Spacing.sm,
+    paddingRight: Spacing.sm,
   },
   section: {
     marginBottom: Spacing.xl,
@@ -872,9 +1073,6 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     ...Typography.titleLarge,
-  },
-  sectionCount: {
-    ...Typography.bodySmall,
   },
   horizontalList: {
     paddingHorizontal: Spacing.md,

--- a/apps/mobile/app/(tabs)/index/section/[section].tsx
+++ b/apps/mobile/app/(tabs)/index/section/[section].tsx
@@ -1,0 +1,190 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { Surface } from 'heroui-native';
+import { useCallback, useMemo, useRef } from 'react';
+import { FlatList, StyleSheet, Text, View, type ListRenderItemInfo } from 'react-native';
+
+import { ItemCard, type ItemCardData } from '@/components/item-card';
+import { EmptyState, ErrorState, InvalidParamState, LoadingState } from '@/components/list-states';
+import { Colors, Spacing, Typography } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useHomeData } from '@/hooks/use-items-trpc';
+import {
+  mapContentType,
+  mapProvider,
+  type UIContentType,
+  type UIProvider,
+} from '@/lib/content-utils';
+import {
+  createLightweightHeaderScreenOptions,
+  useCollapsedHeaderTitle,
+} from '@/lib/native-large-title-header';
+
+type HomeSectionKey = 'jump-back-in' | 'recently-bookmarked' | 'podcasts' | 'articles' | 'videos';
+type HomeData = NonNullable<ReturnType<typeof useHomeData>['data']>;
+type HomeItem = HomeData['recentBookmarks'][number];
+
+const SECTION_TITLES: Record<HomeSectionKey, string> = {
+  'jump-back-in': 'Jump Back In',
+  'recently-bookmarked': 'Recently Bookmarked',
+  podcasts: 'Podcasts',
+  articles: 'Articles',
+  videos: 'Videos',
+};
+
+const VALID_SECTION_KEYS = Object.keys(SECTION_TITLES) as HomeSectionKey[];
+
+function parseSectionKey(value: string | string[] | undefined): HomeSectionKey | null {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+
+  return VALID_SECTION_KEYS.includes(rawValue as HomeSectionKey)
+    ? (rawValue as HomeSectionKey)
+    : null;
+}
+
+function mapHomeItemToCard(item: HomeItem, contentType?: UIContentType): ItemCardData {
+  return {
+    id: item.id,
+    title: item.title,
+    creator: item.publisher ?? item.creator,
+    creatorImageUrl: item.creatorImageUrl ?? null,
+    thumbnailUrl: item.thumbnailUrl ?? null,
+    contentType: contentType ?? (mapContentType(item.contentType) as UIContentType),
+    provider: mapProvider(item.provider) as UIProvider,
+    duration: item.duration ?? null,
+    readingTimeMinutes: item.readingTimeMinutes ?? null,
+  };
+}
+
+function getSectionItems(
+  homeData: HomeData | undefined,
+  sectionKey: HomeSectionKey
+): ItemCardData[] {
+  if (!homeData) {
+    return [];
+  }
+
+  switch (sectionKey) {
+    case 'jump-back-in':
+      return homeData.jumpBackIn.map((item) => mapHomeItemToCard(item));
+    case 'recently-bookmarked':
+      return homeData.recentBookmarks.map((item) => mapHomeItemToCard(item));
+    case 'podcasts':
+      return homeData.byContentType.podcasts.map((item) => mapHomeItemToCard(item, 'podcast'));
+    case 'articles':
+      return homeData.byContentType.articles.map((item) => mapHomeItemToCard(item, 'article'));
+    case 'videos':
+      return homeData.byContentType.videos.map((item) => mapHomeItemToCard(item, 'video'));
+  }
+}
+
+export default function HomeSectionScreen() {
+  const params = useLocalSearchParams<{ section?: string }>();
+  const sectionKey = parseSectionKey(params.section);
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme ?? 'light'];
+  const listRef = useRef<FlatList<ItemCardData>>(null);
+  const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
+  const { data: homeData, isLoading, error, refetch } = useHomeData();
+
+  const sectionTitle = sectionKey ? SECTION_TITLES[sectionKey] : 'Section';
+  const sectionItems = useMemo(
+    () => (sectionKey ? getSectionItems(homeData, sectionKey) : []),
+    [homeData, sectionKey]
+  );
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
+      <ItemCard item={item} shape="row" index={index} bordered={false} />
+    ),
+    []
+  );
+
+  if (!sectionKey) {
+    return (
+      <Surface
+        style={[styles.container, { backgroundColor: colors.background }]}
+        collapsable={false}
+      >
+        <Stack.Screen
+          options={createLightweightHeaderScreenOptions({
+            backgroundColor: colors.background,
+            tintColor: colors.text,
+            screenTitle: 'Section',
+            showScreenTitle: true,
+          })}
+        />
+        <InvalidParamState message="The home section link is missing or invalid." />
+      </Surface>
+    );
+  }
+
+  const listEmptyComponent = isLoading ? (
+    <LoadingState message={`Loading ${sectionTitle.toLowerCase()}...`} />
+  ) : error ? (
+    <ErrorState message={error.message} onRetry={() => void refetch()} />
+  ) : (
+    <EmptyState
+      title={`No ${sectionTitle.toLowerCase()} yet`}
+      message="Items will appear here as your library grows."
+    />
+  );
+
+  return (
+    <Surface style={[styles.container, { backgroundColor: colors.background }]} collapsable={false}>
+      <Stack.Screen
+        options={createLightweightHeaderScreenOptions({
+          backgroundColor: colors.background,
+          tintColor: colors.text,
+          screenTitle: sectionTitle,
+          showScreenTitle: isLoading || Boolean(error) || showCollapsedTitle,
+        })}
+      />
+
+      <FlatList
+        ref={listRef}
+        data={isLoading || error ? [] : sectionItems}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={32}
+        ListHeaderComponent={
+          <View style={styles.listHeader}>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>{sectionTitle}</Text>
+          </View>
+        }
+        ListEmptyComponent={listEmptyComponent}
+        ListFooterComponent={<View style={styles.listFooter} />}
+      />
+    </Surface>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    flex: 1,
+  },
+  listContent: {
+    flexGrow: 1,
+    paddingBottom: Spacing['3xl'],
+  },
+  listHeader: {
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.md,
+  },
+  headerTitle: {
+    ...Typography.displayMedium,
+    paddingHorizontal: Spacing.md,
+  },
+  listFooter: {
+    minHeight: Spacing['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/apps/mobile/app/settings/home-screen.tsx
+++ b/apps/mobile/app/settings/home-screen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { ActivityIndicator, Alert, Pressable, StyleSheet, Switch, View } from 'react-native';
-import { Stack } from 'expo-router';
+import { Stack, useNavigation, useRouter } from 'expo-router';
 import { useToast } from 'heroui-native';
 import {
   NestableDraggableFlatList,
@@ -180,6 +180,8 @@ function AddCollectionRow({
 }
 
 export default function HomeScreenSettingsScreen() {
+  const navigation = useNavigation();
+  const router = useRouter();
   const { toast } = useToast();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
@@ -316,6 +318,23 @@ export default function HomeScreenSettingsScreen() {
   const headerRight = () => (
     <HeaderButton label="Save" disabled={!canSave} onPress={handleSave} colors={colors} />
   );
+  const headerLeft = () => (
+    <Pressable
+      accessibilityLabel="Go back"
+      onPress={() => {
+        if (navigation.canGoBack()) {
+          router.back();
+          return;
+        }
+
+        router.replace('/(tabs)');
+      }}
+      hitSlop={8}
+      style={styles.headerBack}
+    >
+      <Ionicons name="chevron-back" size={28} color={colors.text} />
+    </Pressable>
+  );
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -325,6 +344,7 @@ export default function HomeScreenSettingsScreen() {
           tintColor: colors.text,
           screenTitle: 'Home Screen',
           showScreenTitle: showCollapsedTitle,
+          headerLeft,
           headerRight,
         })}
       />
@@ -533,5 +553,8 @@ const styles = StyleSheet.create({
   headerButtonText: {
     fontSize: 16,
     fontWeight: '600',
+  },
+  headerBack: {
+    marginLeft: -Spacing.xs,
   },
 });

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -41,6 +41,9 @@ export interface FilterChipProps {
   /** Optional selected surface color for type-associated selection states */
   selectedSurfaceColor?: string;
 
+  /** Optional selected foreground color for filled selection states */
+  selectedForegroundColor?: string;
+
   /** Size variant */
   size?: 'small' | 'medium';
 }
@@ -75,6 +78,7 @@ export function FilterChip({
   dotColor,
   selectedColor,
   selectedSurfaceColor,
+  selectedForegroundColor,
   size = 'medium',
 }: FilterChipProps) {
   const { colors, motion } = useAppTheme();
@@ -85,9 +89,10 @@ export function FilterChip({
   const chipBorderColor = isSelected
     ? (selectedColor ?? colors.borderDefault)
     : colors.borderSubtle;
-  const selectedForegroundColor = hasTintedSelection ? selectedColor : colors.textPrimary;
+  const resolvedSelectedForegroundColor =
+    selectedForegroundColor ?? (hasTintedSelection ? selectedColor : colors.textPrimary);
   const unselectedForegroundColor = colors.textSubheader;
-  const iconColor = isSelected ? selectedForegroundColor : unselectedForegroundColor;
+  const iconColor = isSelected ? resolvedSelectedForegroundColor : unselectedForegroundColor;
 
   const sizeStyles = size === 'small' ? styles.chipSmall : styles.chipMedium;
   const textStyles = size === 'small' ? styles.textSmall : styles.textMedium;
@@ -119,7 +124,7 @@ export function FilterChip({
         tone={isSelected ? 'primary' : 'subheader'}
         style={[
           textStyles,
-          { color: isSelected ? selectedForegroundColor : unselectedForegroundColor },
+          { color: isSelected ? resolvedSelectedForegroundColor : unselectedForegroundColor },
         ]}
       >
         {label}

--- a/apps/mobile/components/item-card.tsx
+++ b/apps/mobile/components/item-card.tsx
@@ -71,6 +71,9 @@ export interface ItemCardProps {
   /** Optional list index for parent list ordering */
   index?: number;
 
+  /** Whether the card should render an outer border when its visual treatment supports one */
+  bordered?: boolean;
+
   /** Custom press handler (default: navigate to detail) */
   onPress?: () => void;
 }
@@ -94,6 +97,7 @@ function areItemCardPropsEqual(previous: ItemCardProps, next: ItemCardProps): bo
     previous.shape === next.shape &&
     previous.rowStyle === next.rowStyle &&
     previous.index === next.index &&
+    previous.bordered === next.bordered &&
     previous.onPress === next.onPress &&
     areItemCardItemsEqual(previous.item, next.item)
   );
@@ -104,6 +108,7 @@ function ItemCardComponent({
   shape = 'row',
   rowStyle = 'compact',
   index: _index,
+  bordered = true,
   onPress,
 }: ItemCardProps) {
   const router = useRouter();
@@ -293,7 +298,11 @@ function ItemCardComponent({
         style={({ pressed }) => [
           styles.rowFeaturedCard,
           styles.rowFeaturedWrapper,
-          { backgroundColor: colors.surfaceElevated, borderColor: colors.borderDefault },
+          {
+            backgroundColor: colors.surfaceElevated,
+            borderColor: bordered ? colors.borderDefault : 'transparent',
+            borderWidth: bordered ? 1 : 0,
+          },
           pressed && { opacity: motion.opacity.pressed },
         ]}
       >

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -5,6 +5,14 @@ const expoConfig = require('eslint-config-expo/flat');
 module.exports = defineConfig([
   expoConfig,
   {
+    settings: {
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+          paths: ['../../node_modules'],
+        },
+      },
+    },
     ignores: ['dist/*', '.rnstorybook/storybook.requires.ts', 'uniwind-types.d.ts'],
   },
 ]);

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -99,6 +99,15 @@ function findButtonByText(renderer: Renderer, text: string) {
   );
 }
 
+function findSectionHeaderButton(renderer: Renderer, text: string) {
+  return renderer.root.find(
+    (node: TestNode) =>
+      node.type === 'button' &&
+      !node.props.accessibilityLabel &&
+      getTextContent(node).includes(text)
+  );
+}
+
 function findFilterChip(renderer: Renderer, label: string) {
   return renderer.root.find(
     (node: TestNode) =>
@@ -128,6 +137,21 @@ function pressHomeTab() {
   tabPressListener();
 }
 
+function createFeedItem(id: string, contentType = 'ARTICLE'): MockFeedItem {
+  return {
+    id,
+    title: id,
+    creator: 'Creator',
+    publisher: 'Publisher',
+    creatorImageUrl: null,
+    thumbnailUrl: null,
+    contentType,
+    provider: 'RSS',
+    duration: null,
+    readingTimeMinutes: null,
+  };
+}
+
 jest.mock('expo-router', () => ({
   useRouter: () => ({
     push: mockPush,
@@ -139,9 +163,16 @@ jest.mock('expo-router', () => ({
     }: {
       options?: {
         headerRight?: () => React.ReactNode;
+        headerTitle?: () => React.ReactNode;
       };
-    }) => React.createElement(React.Fragment, null, options?.headerRight?.()),
+    }) =>
+      React.createElement(React.Fragment, null, options?.headerTitle?.(), options?.headerRight?.()),
   },
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('div', props, children),
 }));
 
 jest.mock('react-native', () => ({
@@ -167,6 +198,8 @@ jest.mock('react-native', () => ({
   ),
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
+    absoluteFill: { position: 'absolute' },
+    absoluteFillObject: { position: 'absolute' },
   },
   Pressable: ({
     children,
@@ -221,6 +254,20 @@ jest.mock('react-native', () => ({
     }
   ),
   ActivityIndicator: () => React.createElement('span', null, 'loading'),
+  Animated: {
+    Value: class {
+      interpolate() {
+        return 0;
+      }
+    },
+    View: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement('div', props, children),
+    timing: () => ({
+      start: (callback?: (result: { finished: boolean }) => void) => callback?.({ finished: true }),
+    }),
+  },
+  Modal: ({ children, visible }: { children?: React.ReactNode; visible?: boolean }) =>
+    visible ? React.createElement('modal', null, children) : null,
   useWindowDimensions: () => ({ width: 390, height: 844, scale: 1, fontScale: 1 }),
 }));
 
@@ -343,7 +390,7 @@ describe('HomeScreen', () => {
     expect(getTextContent(renderer!.root)).not.toContain('Weekly recap card');
   });
 
-  it('keeps settings navigation on the Home screen', () => {
+  it('opens settings from the Home navigation pane', () => {
     let renderer: Renderer;
     act(() => {
       renderer = TestRenderer.create(<HomeScreen />);
@@ -353,19 +400,48 @@ describe('HomeScreen', () => {
       findButtonByText(renderer!, 'Settings icon').props.onPress();
     });
 
+    act(() => {
+      renderer!.root.findByProps({ accessibilityLabel: 'Open Settings' }).props.onPress();
+    });
+
     expect(mockPush).toHaveBeenCalledWith('/settings');
   });
 
-  it('keeps the home settings button background transparent without custom press feedback', () => {
+  it('opens the Home screen editor from the top navigation pane row', () => {
     let renderer: Renderer;
     act(() => {
       renderer = TestRenderer.create(<HomeScreen />);
     });
 
-    const settingsButton = renderer!.root.findByProps({ accessibilityLabel: 'Open settings' });
+    act(() => {
+      findButtonByText(renderer!, 'Settings icon').props.onPress();
+    });
 
-    expect(settingsButton.props.style).toEqual(
-      expect.objectContaining({ backgroundColor: 'transparent' })
+    act(() => {
+      renderer!.root.findByProps({ accessibilityLabel: 'Open Edit Homescreen' }).props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/settings/home-screen');
+  });
+
+  it('keeps the home settings button flat with a subtle circular background', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    const settingsButton = renderer!.root.findByProps({
+      accessibilityLabel: 'Open navigation menu',
+    });
+    const styleObjects = Array.isArray(settingsButton.props.style)
+      ? settingsButton.props.style
+      : [settingsButton.props.style];
+
+    expect(styleObjects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ borderWidth: 0, shadowOpacity: 0, elevation: 0 }),
+        expect.objectContaining({ backgroundColor: expect.any(String) }),
+      ])
     );
   });
 
@@ -534,6 +610,63 @@ describe('HomeScreen', () => {
       pathname: '/(tabs)/collection/[id]',
       params: { id: 'collection-1' },
     });
+  });
+
+  it('opens built-in home section list views from their headers', () => {
+    mockUseHomeData.mockReturnValue({
+      data: {
+        jumpBackIn: [createFeedItem('jump-1')],
+        recentBookmarks: [createFeedItem('bookmark-1')],
+        byContentType: {
+          podcasts: [createFeedItem('podcast-1', 'PODCAST')],
+          videos: [createFeedItem('video-1', 'VIDEO')],
+          articles: [createFeedItem('article-1', 'ARTICLE')],
+        },
+        customCollections: [],
+      },
+      isLoading: false,
+    });
+    mockUseInfiniteInboxItems.mockReturnValue({
+      data: {
+        pages: [
+          {
+            items: [createFeedItem('inbox-1')],
+            nextCursor: null,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    const builtInRoutes = [
+      ['Jump Back In', 'jump-back-in'],
+      ['Recently Bookmarked', 'recently-bookmarked'],
+      ['Podcasts', 'podcasts'],
+      ['Articles', 'articles'],
+      ['Videos', 'videos'],
+    ] as const;
+
+    builtInRoutes.forEach(([label, section]) => {
+      act(() => {
+        findSectionHeaderButton(renderer!, label).props.onPress();
+      });
+
+      expect(mockPush).toHaveBeenLastCalledWith({
+        pathname: '/(tabs)/section/[section]',
+        params: { section },
+      });
+    });
+
+    act(() => {
+      findSectionHeaderButton(renderer!, 'Inbox').props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenLastCalledWith('/(tabs)/inbox');
   });
 
   it('restores the home section visual caps without changing the expanded fetch size', () => {


### PR DESCRIPTION
## Summary

- Reworks the Home header to host the settings/menu button and filter chips, with the selected chip filled in Zine orange and `All` as the default filter.
- Adds a left slideout navigation pane with `Edit Homescreen` at the top, plus Settings, Home, Inbox, Search, and Library links.
- Makes every Home section header navigable: built-in sections open a dedicated section list, Inbox opens the Inbox tab, and custom sections continue opening their collection list.
- Removes visible card borders on Home cards and adds a back chevron to the Home Screen editor.
- Adds a mobile ESLint resolver path so the merged draggable home-screen editor dependency resolves reliably.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Pre-push hook passed during `git push -u origin codex/home-screen-navigation`

## Notes

`bun run lint` still reports existing warnings in `apps/mobile/app/(tabs)/index/collection/[id].tsx` and `apps/mobile/components/insights/weekly-recap-card.test.tsx`; there are no lint errors.
