### PR TITLE
[codex] Redesign mobile library page

### DIFF
--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef, type ComponentType }
 
 import * as Haptics from 'expo-haptics';
 import { Surface } from 'heroui-native';
-import { Stack, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
+import { Stack, useNavigation, useRouter, type Href } from 'expo-router';
 import {
   ActivityIndicator,
   View,
@@ -10,7 +10,6 @@ import {
   ScrollView,
   StyleSheet,
   Pressable,
-  TextInput,
   FlatList,
   type ListRenderItemInfo,
 } from 'react-native';
@@ -18,55 +17,71 @@ import Svg, { Path } from 'react-native-svg';
 import { ContentType as ApiContentType } from '@zine/shared';
 
 import { FilterChip } from '@/components/filter-chip';
-import {
-  ArticleIcon,
-  CheckOutlineIcon,
-  PodcastIcon,
-  PostIcon,
-  VideoIcon,
-} from '@/components/icons';
+import { ArticleIcon, PodcastIcon, PostIcon, VideoIcon } from '@/components/icons';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { LoadingState, ErrorState, EmptyState } from '@/components/list-states';
-import { PersonResultRow, type PersonResultRowData } from '@/components/person-result-row';
-import {
-  Colors,
-  Typography,
-  Spacing,
-  Radius,
-  ContentColors,
-  FilterChipPalette,
-} from '@/constants/theme';
+import { type PersonResultRowData } from '@/components/person-result-row';
+import { SourceSubscriptionRow } from '@/components/subscriptions/source-ui';
+import { Colors, Typography, Spacing, Radius, ContentColors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
-import { useInfiniteLibraryItems } from '@/hooks/use-items-trpc';
+import { useCollections, useInfiniteLibraryItems } from '@/hooks/use-items-trpc';
 import { usePeople } from '@/hooks/use-people';
+import { useSubscriptions as useSubscriptionsQuery } from '@/hooks/use-subscriptions-query';
 import {
   mapContentType,
   mapProvider,
   type UIContentType,
   type UIProvider,
 } from '@/lib/content-utils';
+import { getSubscriptionSourceConfig, type SubscriptionSource } from '@/lib/subscription-sources';
 import {
   createLightweightHeaderScreenOptions,
   useCollapsedHeaderTitle,
 } from '@/lib/native-large-title-header';
-
-function SearchIcon({ size = 20, color = '#94A3B8' }: { size?: number; color?: string }) {
-  return (
-    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
-      <Path
-        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </Svg>
-  );
-}
+import { trpc } from '@/lib/trpc';
 
 function PlusIcon({ size = 24, color = '#FFFFFF' }: { size?: number; color?: string }) {
   return (
     <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
       <Path d="M12 5v14M5 12h14" strokeLinecap="round" strokeLinejoin="round" />
+    </Svg>
+  );
+}
+
+function PeopleIcon({ size = 22, color = '#FFFFFF' }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
+      <Path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2" strokeLinecap="round" />
+      <Path d="M9 11a4 4 0 100-8 4 4 0 000 8z" strokeLinecap="round" />
+      <Path d="M22 21v-2a4 4 0 00-3-3.87" strokeLinecap="round" />
+      <Path d="M16 3.13a4 4 0 010 7.75" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function SourcesIcon({ size = 22, color = '#FFFFFF' }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
+      <Path d="M4 11a9 9 0 019 9" strokeLinecap="round" />
+      <Path d="M4 4a16 16 0 0116 16" strokeLinecap="round" />
+      <Path d="M5 20h.01" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function BookmarksIcon({ size = 22, color = '#FFFFFF' }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
+      <Path d="M19 21l-7-4-7 4V5a2 2 0 012-2h10a2 2 0 012 2z" strokeLinecap="round" />
+    </Svg>
+  );
+}
+
+function CollectionsIcon({ size = 22, color = '#FFFFFF' }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={2}>
+      <Path d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
     </Svg>
   );
 }
@@ -79,8 +94,6 @@ const filterOptions: {
   label: string;
   color: string | undefined;
   icon?: ComponentType<{ size?: number; color?: string }>;
-  selectedColor?: string;
-  selectedSurfaceColor?: string;
   contentType: ApiContentType | null;
 }[] = [
   { id: 'all', label: 'All', color: undefined, contentType: null },
@@ -89,8 +102,6 @@ const filterOptions: {
     label: 'Articles',
     color: ContentColors.article,
     icon: ArticleIcon,
-    selectedColor: FilterChipPalette.article.accent,
-    selectedSurfaceColor: FilterChipPalette.article.surface,
     contentType: ApiContentType.ARTICLE,
   },
   {
@@ -98,8 +109,6 @@ const filterOptions: {
     label: 'Podcasts',
     color: ContentColors.podcast,
     icon: PodcastIcon,
-    selectedColor: FilterChipPalette.podcast.accent,
-    selectedSurfaceColor: FilterChipPalette.podcast.surface,
     contentType: ApiContentType.PODCAST,
   },
   {
@@ -107,8 +116,6 @@ const filterOptions: {
     label: 'Videos',
     color: ContentColors.video,
     icon: VideoIcon,
-    selectedColor: FilterChipPalette.video.accent,
-    selectedSurfaceColor: FilterChipPalette.video.surface,
     contentType: ApiContentType.VIDEO,
   },
   {
@@ -116,10 +123,19 @@ const filterOptions: {
     label: 'Posts',
     color: ContentColors.post,
     icon: PostIcon,
-    selectedColor: FilterChipPalette.post.accent,
-    selectedSurfaceColor: FilterChipPalette.post.surface,
     contentType: ApiContentType.POST,
   },
+];
+
+const subscriptionSourceOptions: {
+  id: SubscriptionSource;
+  label: string;
+}[] = [
+  { id: 'YOUTUBE', label: 'YouTube' },
+  { id: 'SPOTIFY', label: 'Spotify' },
+  { id: 'GMAIL', label: 'Newsletters' },
+  { id: 'X', label: 'X' },
+  { id: 'RSS', label: 'RSS' },
 ];
 
 type LibraryTabNavigation = {
@@ -132,63 +148,293 @@ type LibraryScreenNavigation = {
   isFocused: () => boolean;
 };
 
-type LibraryMode = 'items' | 'people';
+type LibraryObject = 'people' | 'sources' | 'bookmarks' | 'collections';
 
 type LibraryRow =
   | { type: 'item'; item: ItemCardData }
-  | { type: 'person'; person: PersonResultRowData };
+  | { type: 'person'; person: PersonResultRowData }
+  | {
+      type: 'source';
+      source: {
+        id: string;
+        name: string;
+        sourceKey: SubscriptionSource;
+        sourceLabel: string;
+        status: string;
+        imageUrl: string | null;
+        detail: string;
+      };
+    }
+  | {
+      type: 'collection';
+      collection: {
+        id: string;
+        name: string;
+        description: string | null;
+        ruleSummary: string;
+      };
+    };
+
+type LibraryColors = (typeof Colors)['dark'];
+
+type LibraryObjectTileModel = {
+  id: LibraryObject;
+  title: string;
+  icon: ComponentType<{ size?: number; color?: string }>;
+};
+
+type CollectionRuleSummaryInput = {
+  contentTypes?: unknown[];
+  providers?: unknown[];
+  tagIds?: unknown[];
+  isFinished?: boolean;
+  search?: string;
+  minLengthMinutes?: number;
+  maxLengthMinutes?: number;
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function getLibraryObjectTitle(activeObject: LibraryObject): string {
+  switch (activeObject) {
+    case 'people':
+      return 'People with saved work';
+    case 'sources':
+      return 'Subscriptions';
+    case 'collections':
+      return 'Collections';
+    case 'bookmarks':
+    default:
+      return 'Saved bookmarks';
+  }
+}
+
+function getCollectionRuleSummary(rules: CollectionRuleSummaryInput): string {
+  const parts: string[] = [];
+
+  if (rules.contentTypes?.length) parts.push('content type');
+  if (rules.providers?.length) parts.push('source');
+  if (rules.tagIds?.length) parts.push('tag');
+  if (rules.isFinished !== undefined) parts.push(rules.isFinished ? 'finished' : 'unfinished');
+  if (rules.search) parts.push('search');
+  if (rules.minLengthMinutes !== undefined || rules.maxLengthMinutes !== undefined) {
+    parts.push('length');
+  }
+
+  if (parts.length === 0) {
+    return 'Manual collection';
+  }
+
+  return `Saved filter: ${parts.join(', ')}`;
+}
+
+function getSourceStatusLabel(status: string): string {
+  if (status === 'ACTIVE') return 'Fresh';
+  if (status === 'PAUSED') return 'Paused';
+  if (status === 'ERROR') return 'Error';
+  if (status === 'DISCONNECTED') return 'Connect';
+  if (status === 'EXPIRED' || status === 'REVOKED') return 'Fix';
+  return status.toLowerCase();
+}
+
+function getProgressWidth(index: number, itemCount: number): `${number}%` {
+  const base = Math.min(84, Math.max(32, itemCount * 6));
+  return `${Math.max(28, base - index * 10)}%`;
+}
+
+function getSubscriptionSourceTitle(source: SubscriptionSource): string {
+  return getSubscriptionSourceConfig(source).name;
+}
+
+function LibraryObjectTile({
+  tile,
+  isSelected,
+  colors,
+  onPress,
+}: {
+  tile: LibraryObjectTileModel;
+  isSelected: boolean;
+  colors: LibraryColors;
+  onPress: () => void;
+}) {
+  const Icon = tile.icon;
+  const foregroundColor = isSelected ? colors.statusWarning : colors.textSubheader;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: isSelected }}
+      accessibilityLabel={`Show ${tile.title}`}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.objectTile,
+        {
+          backgroundColor: isSelected ? colors.statusWarningSurface : colors.backgroundSecondary,
+          borderColor: isSelected ? colors.statusWarning : colors.border,
+        },
+        pressed && styles.pressed,
+      ]}
+    >
+      <View style={styles.objectTileTitleRow}>
+        <Icon size={18} color={foregroundColor} />
+        <Text style={[styles.objectTileTitle, { color: colors.text }]}>{tile.title}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+function LibraryPersonRow({
+  person,
+  index,
+  colors,
+}: {
+  person: PersonResultRowData;
+  index: number;
+  colors: LibraryColors;
+}) {
+  const router = useRouter();
+  const initials = useMemo(() => getInitials(person.displayName), [person.displayName]);
+  const progressColor =
+    index % 3 === 0
+      ? colors.statusInfo
+      : index % 3 === 1
+        ? colors.statusWarning
+        : colors.statusSuccess;
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${person.displayName}, ${person.itemCount} saved items`}
+      onPress={() => router.push(`/person/${person.id}?source=library` as Href)}
+      style={({ pressed }) => [
+        styles.hubRow,
+        { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
+        pressed && styles.pressed,
+      ]}
+    >
+      <View style={[styles.avatar, { backgroundColor: colors.surfaceRaised }]}>
+        <Text style={[styles.avatarText, { color: colors.text }]}>{initials}</Text>
+      </View>
+      <View style={styles.hubRowContent}>
+        <Text style={[styles.hubRowTitle, { color: colors.text }]} numberOfLines={1}>
+          {person.displayName}
+        </Text>
+        <Text style={[styles.hubRowSubtitle, { color: colors.textSubheader }]} numberOfLines={1}>
+          {person.itemCount} saved {person.itemCount === 1 ? 'item' : 'items'}
+          {person.latestItemTitle ? ` - ${person.latestItemTitle}` : ''}
+        </Text>
+        <View style={[styles.progressTrack, { backgroundColor: colors.surfaceRaised }]}>
+          <View
+            style={[
+              styles.progressFill,
+              { backgroundColor: progressColor, width: getProgressWidth(index, person.itemCount) },
+            ]}
+          />
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+function LibrarySourceRow({
+  source,
+  colors,
+  onPress,
+}: {
+  source: Extract<LibraryRow, { type: 'source' }>['source'];
+  colors: LibraryColors;
+  onPress: () => void;
+}) {
+  const statusLabel = getSourceStatusLabel(source.status);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${source.name}, ${statusLabel}`}
+      onPress={onPress}
+      style={({ pressed }) => [styles.sourceSubscriptionPressable, pressed && styles.pressed]}
+    >
+      <SourceSubscriptionRow
+        source={source.sourceKey}
+        variant="card"
+        title={source.name}
+        subtitle={source.detail}
+        meta={source.sourceLabel}
+        imageUrl={source.imageUrl}
+        toggleChecked
+        toggleCheckedColor={colors.statusWarning}
+        onToggle={onPress}
+      />
+    </Pressable>
+  );
+}
+
+function LibraryCollectionRow({
+  collection,
+  colors,
+  onPress,
+}: {
+  collection: Extract<LibraryRow, { type: 'collection' }>['collection'];
+  colors: LibraryColors;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${collection.name}`}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.hubRow,
+        { backgroundColor: colors.backgroundSecondary, borderColor: colors.border },
+        pressed && styles.pressed,
+      ]}
+    >
+      <View style={[styles.collectionIcon, { backgroundColor: colors.surfaceRaised }]}>
+        <CollectionsIcon size={24} color={colors.textSubheader} />
+      </View>
+      <View style={styles.hubRowContent}>
+        <Text style={[styles.hubRowTitle, { color: colors.text }]} numberOfLines={1}>
+          {collection.name}
+        </Text>
+        <Text style={[styles.hubRowSubtitle, { color: colors.textSubheader }]} numberOfLines={1}>
+          {collection.description || collection.ruleSummary}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
 
 export default function LibraryScreen() {
   const router = useRouter();
   const navigation = useNavigation() as LibraryScreenNavigation;
   const listScrollRef = useRef<FlatList<LibraryRow>>(null);
-  const params = useLocalSearchParams<{ contentType?: string }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const { handleScroll, scrollOffsetYRef, showCollapsedTitle } = useCollapsedHeaderTitle();
 
   useTabPrefetch('library');
 
-  const contentTypeParam = useMemo(() => {
-    const rawContentType = Array.isArray(params.contentType)
-      ? params.contentType[0]
-      : params.contentType;
-    if (typeof rawContentType !== 'string' || rawContentType.length === 0) {
-      return undefined;
+  const [contentTypeFilter, setContentTypeFilter] = useState<ApiContentType | null>(null);
+  const [activeObject, setActiveObject] = useState<LibraryObject>('bookmarks');
+  const [subscriptionSourceFilter, setSubscriptionSourceFilter] =
+    useState<SubscriptionSource>('YOUTUBE');
+
+  const handleSelectObject = useCallback((object: LibraryObject) => {
+    setActiveObject(object);
+    if (object === 'bookmarks') {
+      setContentTypeFilter(null);
     }
-
-    return rawContentType.toLowerCase();
-  }, [params.contentType]);
-
-  const preselectedContentType = useMemo(() => {
-    if (!contentTypeParam) {
-      return undefined;
+    if (object === 'sources') {
+      setSubscriptionSourceFilter('YOUTUBE');
     }
-
-    const matchedOption = filterOptions.find((option) => option.id === contentTypeParam);
-    return matchedOption ? matchedOption.contentType : undefined;
-  }, [contentTypeParam]);
-
-  const [contentTypeFilter, setContentTypeFilter] = useState<ApiContentType | null>(
-    () => preselectedContentType ?? null
-  );
-  const [libraryMode, setLibraryMode] = useState<LibraryMode>('items');
-  const [showCompletedOnly, setShowCompletedOnly] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
-
-  useEffect(() => {
-    if (preselectedContentType !== undefined) {
-      setContentTypeFilter(preselectedContentType);
-    }
-  }, [preselectedContentType]);
-
-  useEffect(() => {
-    const handle = setTimeout(() => {
-      setDebouncedSearchQuery(searchQuery.trim());
-    }, 200);
-    return () => clearTimeout(handle);
-  }, [searchQuery]);
+  }, []);
 
   const handleAddBookmark = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -198,15 +444,13 @@ export default function LibraryScreen() {
   const filter = useMemo(
     () => ({
       contentType: contentTypeFilter ?? undefined,
-      ...(showCompletedOnly ? { isFinished: true } : {}),
     }),
-    [contentTypeFilter, showCompletedOnly]
+    [contentTypeFilter]
   );
 
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteLibraryItems({
       filter,
-      search: debouncedSearchQuery || undefined,
       limit: LIBRARY_PAGE_SIZE,
     });
   const {
@@ -217,9 +461,21 @@ export default function LibraryScreen() {
     hasNextPage: hasNextPeoplePage,
     isFetchingNextPage: isFetchingNextPeoplePage,
   } = usePeople({
-    query: debouncedSearchQuery || undefined,
     limit: LIBRARY_PAGE_SIZE,
     sort: 'count',
+  });
+  const collectionsQuery = useCollections();
+  const subscriptionsQuery = useSubscriptionsQuery();
+  const newslettersQuery = trpc.subscriptions.newsletters.list.useQuery(
+    { limit: 100 },
+    { staleTime: 60 * 1000 }
+  );
+  const rssFeedsQuery = trpc.subscriptions.rss.list.useQuery(
+    { limit: 100 },
+    { staleTime: 60 * 1000 }
+  );
+  const xBookmarksStatusQuery = trpc.subscriptions.xBookmarks.status.useQuery(undefined, {
+    staleTime: 60 * 1000,
   });
 
   const libraryItems: ItemCardData[] = useMemo(
@@ -251,21 +507,115 @@ export default function LibraryScreen() {
       })),
     [peopleData?.pages]
   );
-  const rows: LibraryRow[] = useMemo(
+  const collections = useMemo(
     () =>
-      libraryMode === 'people'
-        ? people.map((person) => ({ type: 'person' as const, person }))
-        : libraryItems.map((item) => ({ type: 'item' as const, item })),
-    [libraryItems, libraryMode, people]
+      (collectionsQuery.data?.collections ?? []).map((collection) => ({
+        id: collection.id,
+        name: collection.name,
+        description: collection.description,
+        ruleSummary: getCollectionRuleSummary(collection.rules),
+      })),
+    [collectionsQuery.data?.collections]
   );
+  const subscriptionRows = useMemo(() => {
+    const rows: Extract<LibraryRow, { type: 'source' }>['source'][] = [];
+
+    for (const subscription of subscriptionsQuery.data?.items ?? []) {
+      const sourceKey = subscription.provider;
+      const sourceLabel = getSubscriptionSourceTitle(sourceKey);
+      rows.push({
+        id: `subscription:${subscription.id}`,
+        name: subscription.name,
+        sourceKey,
+        sourceLabel,
+        status: subscription.status,
+        imageUrl: subscription.imageUrl,
+        detail: `${sourceLabel} subscription`,
+      });
+    }
+
+    for (const newsletter of newslettersQuery.data?.items ?? []) {
+      rows.push({
+        id: `newsletter:${newsletter.id}`,
+        name: newsletter.displayName,
+        sourceKey: 'GMAIL',
+        sourceLabel: getSubscriptionSourceTitle('GMAIL'),
+        status: newsletter.status,
+        imageUrl: newsletter.imageUrl,
+        detail: newsletter.fromAddress ?? newsletter.listId ?? 'Newsletter',
+      });
+    }
+
+    for (const feed of rssFeedsQuery.data?.items ?? []) {
+      if (feed.status === 'UNSUBSCRIBED') {
+        continue;
+      }
+
+      rows.push({
+        id: `rss:${feed.id}`,
+        name: feed.title,
+        sourceKey: 'RSS',
+        sourceLabel: getSubscriptionSourceTitle('RSS'),
+        status: feed.status,
+        imageUrl: feed.imageUrl,
+        detail: feed.siteUrl ?? feed.feedUrl,
+      });
+    }
+
+    const xStatus = xBookmarksStatusQuery.data;
+    if (xStatus?.connected || xStatus?.importedCount) {
+      rows.push({
+        id: 'x-bookmarks',
+        name: 'X Bookmarks',
+        sourceKey: 'X',
+        sourceLabel: getSubscriptionSourceTitle('X'),
+        status: xStatus.connected ? 'ACTIVE' : (xStatus.connectionStatus ?? 'DISCONNECTED'),
+        imageUrl: null,
+        detail: `${xStatus.importedCount} imported ${
+          xStatus.importedCount === 1 ? 'bookmark' : 'bookmarks'
+        }`,
+      });
+    }
+
+    return rows;
+  }, [
+    newslettersQuery.data?.items,
+    rssFeedsQuery.data?.items,
+    subscriptionsQuery.data?.items,
+    xBookmarksStatusQuery.data,
+  ]);
+  const sourceRows: Extract<LibraryRow, { type: 'source' }>[] = useMemo(() => {
+    return subscriptionRows
+      .filter((row) => row.sourceKey === subscriptionSourceFilter)
+      .map((source) => ({ type: 'source' as const, source }));
+  }, [subscriptionRows, subscriptionSourceFilter]);
+  const rows: LibraryRow[] = useMemo(() => {
+    if (activeObject === 'people') {
+      return people.map((person) => ({ type: 'person' as const, person }));
+    }
+
+    if (activeObject === 'sources') {
+      return sourceRows;
+    }
+
+    if (activeObject === 'collections') {
+      return collections.map((collection) => ({ type: 'collection' as const, collection }));
+    }
+
+    return libraryItems.map((item) => ({ type: 'item' as const, item }));
+  }, [activeObject, collections, libraryItems, people, sourceRows]);
 
   const handleEndReached = useCallback(() => {
-    if (libraryMode === 'people') {
+    if (activeObject === 'people') {
       if (!hasNextPeoplePage || isFetchingNextPeoplePage) {
         return;
       }
 
       void fetchNextPeoplePage();
+      return;
+    }
+
+    if (activeObject !== 'bookmarks') {
       return;
     }
 
@@ -280,23 +630,85 @@ export default function LibraryScreen() {
     hasNextPeoplePage,
     isFetchingNextPage,
     isFetchingNextPeoplePage,
-    libraryMode,
+    activeObject,
   ]);
 
-  const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<LibraryRow>) =>
-      item.type === 'person' ? (
-        <PersonResultRow person={item.person} source="library" />
-      ) : (
-        <ItemCard item={item.item} shape="row" index={index} />
-      ),
-    []
+  const handleOpenCollection = useCallback(
+    (collectionId: string) => {
+      router.push({
+        pathname: '/(tabs)/collection/[id]',
+        params: { id: collectionId },
+      } as unknown as Href);
+    },
+    [router]
   );
 
-  const isActiveLoading = libraryMode === 'people' ? peopleLoading : isLoading;
-  const activeError = libraryMode === 'people' ? peopleError : error;
+  const handleOpenSource = useCallback(
+    (source: SubscriptionSource) => {
+      router.push(getSubscriptionSourceConfig(source).route);
+    },
+    [router]
+  );
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<LibraryRow>) => {
+      if (item.type === 'person') {
+        return <LibraryPersonRow person={item.person} index={index} colors={colors} />;
+      }
+
+      if (item.type === 'source') {
+        return (
+          <LibrarySourceRow
+            source={item.source}
+            colors={colors}
+            onPress={() => handleOpenSource(item.source.sourceKey)}
+          />
+        );
+      }
+
+      if (item.type === 'collection') {
+        return (
+          <LibraryCollectionRow
+            collection={item.collection}
+            colors={colors}
+            onPress={() => handleOpenCollection(item.collection.id)}
+          />
+        );
+      }
+
+      return <ItemCard item={item.item} shape="row" index={index} />;
+    },
+    [colors, handleOpenCollection, handleOpenSource]
+  );
+
+  const isActiveLoading =
+    activeObject === 'people'
+      ? peopleLoading
+      : activeObject === 'sources'
+        ? subscriptionsQuery.isLoading ||
+          newslettersQuery.isLoading ||
+          rssFeedsQuery.isLoading ||
+          xBookmarksStatusQuery.isLoading
+        : activeObject === 'collections'
+          ? collectionsQuery.isLoading
+          : isLoading;
+  const activeError =
+    activeObject === 'people'
+      ? peopleError
+      : activeObject === 'sources'
+        ? (subscriptionsQuery.error ??
+          newslettersQuery.error ??
+          rssFeedsQuery.error ??
+          xBookmarksStatusQuery.error)
+        : activeObject === 'collections'
+          ? collectionsQuery.error
+          : error;
   const isActiveFetchingNextPage =
-    libraryMode === 'people' ? isFetchingNextPeoplePage : isFetchingNextPage;
+    activeObject === 'people'
+      ? isFetchingNextPeoplePage
+      : activeObject === 'bookmarks'
+        ? isFetchingNextPage
+        : false;
 
   useEffect(() => {
     const tabNavigation = navigation.getParent?.() ?? navigation;
@@ -306,15 +718,42 @@ export default function LibraryScreen() {
 
       const isAtTop = scrollOffsetYRef.current <= LIBRARY_TOP_THRESHOLD;
 
-      if (isAtTop && (showCompletedOnly || contentTypeFilter !== null)) {
-        setShowCompletedOnly(false);
+      if (isAtTop && (contentTypeFilter !== null || activeObject !== 'bookmarks')) {
         setContentTypeFilter(null);
+        setActiveObject('bookmarks');
         return;
       }
 
       listScrollRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
-  }, [contentTypeFilter, navigation, scrollOffsetYRef, showCompletedOnly]);
+  }, [activeObject, contentTypeFilter, navigation, scrollOffsetYRef]);
+
+  const activeObjectTitle = getLibraryObjectTitle(activeObject);
+  const objectTiles = useMemo(
+    () => [
+      {
+        id: 'bookmarks' as const,
+        title: 'Bookmarks',
+        icon: BookmarksIcon,
+      },
+      {
+        id: 'collections' as const,
+        title: 'Collections',
+        icon: CollectionsIcon,
+      },
+      {
+        id: 'sources' as const,
+        title: 'Subscriptions',
+        icon: SourcesIcon,
+      },
+      {
+        id: 'people' as const,
+        title: 'People',
+        icon: PeopleIcon,
+      },
+    ],
+    []
+  );
 
   const listEmptyComponent = isActiveLoading ? (
     <LoadingState />
@@ -323,20 +762,22 @@ export default function LibraryScreen() {
   ) : (
     <EmptyState
       title={
-        searchQuery.trim()
-          ? 'No matches found'
-          : libraryMode === 'people'
-            ? 'No people yet'
-            : 'No bookmarked items'
+        activeObject === 'people'
+          ? 'No people yet'
+          : activeObject === 'sources'
+            ? `No ${getSubscriptionSourceConfig(subscriptionSourceFilter).subscriptionNoun}s yet`
+            : activeObject === 'collections'
+              ? 'No collections yet'
+              : 'No bookmarked items'
       }
       message={
-        searchQuery.trim()
-          ? libraryMode === 'people'
-            ? 'Try a different person name.'
-            : 'Try a different title or creator name.'
-          : libraryMode === 'people'
-            ? 'People appear here after your saved items are enriched.'
-            : 'Bookmark content from your inbox to save it here for later.'
+        activeObject === 'people'
+          ? 'People appear here after your saved items are enriched.'
+          : activeObject === 'sources'
+            ? 'Connect sources to keep new work flowing into Zine.'
+            : activeObject === 'collections'
+              ? 'Create collections from Settings or from a saved item.'
+              : 'Bookmark content from your inbox to save it here for later.'
       }
     />
   );
@@ -365,9 +806,12 @@ export default function LibraryScreen() {
       <FlatList
         ref={listScrollRef}
         data={isActiveLoading || activeError ? [] : rows}
-        keyExtractor={(item) =>
-          item.type === 'person' ? `person:${item.person.id}` : item.item.id
-        }
+        keyExtractor={(item) => {
+          if (item.type === 'person') return `person:${item.person.id}`;
+          if (item.type === 'source') return `source:${item.source.id}`;
+          if (item.type === 'collection') return `collection:${item.collection.id}`;
+          return item.item.id;
+        }}
         renderItem={renderItem}
         style={styles.listContainer}
         contentContainerStyle={styles.listContent}
@@ -381,76 +825,33 @@ export default function LibraryScreen() {
           <View style={styles.listHeader}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>Library</Text>
 
-            <View
-              style={[
-                styles.modeSwitcher,
-                {
-                  backgroundColor: colors.backgroundSecondary,
-                  borderColor: colors.border,
-                },
-              ]}
-            >
-              {(['items', 'people'] as const).map((mode) => {
-                const isSelected = libraryMode === mode;
-                return (
-                  <Pressable
-                    key={mode}
-                    accessibilityRole="button"
-                    accessibilityState={{ selected: isSelected }}
-                    onPress={() => setLibraryMode(mode)}
-                    style={[
-                      styles.modeButton,
-                      isSelected && { backgroundColor: colors.surfaceRaised },
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        styles.modeButtonText,
-                        { color: isSelected ? colors.text : colors.textTertiary },
-                      ]}
-                    >
-                      {mode === 'items' ? 'Items' : 'People'}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </View>
-
-            <View style={styles.searchContainer}>
-              <View
-                style={[
-                  styles.searchBar,
-                  {
-                    backgroundColor: colors.backgroundSecondary,
-                    borderColor: colors.border,
-                  },
-                ]}
-              >
-                <SearchIcon size={18} color={colors.textTertiary} />
-                <TextInput
-                  placeholder="Search your library..."
-                  placeholderTextColor={colors.textTertiary}
-                  style={[styles.searchInput, { color: colors.text }]}
-                  value={searchQuery}
-                  onChangeText={setSearchQuery}
+            <View style={styles.objectGrid}>
+              {objectTiles.map((tile) => (
+                <LibraryObjectTile
+                  key={tile.id}
+                  tile={tile}
+                  isSelected={activeObject === tile.id}
+                  colors={colors}
+                  onPress={() => handleSelectObject(tile.id)}
                 />
-              </View>
+              ))}
             </View>
 
-            {libraryMode === 'items' ? (
+            <View style={styles.sectionHeader}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>{activeObjectTitle}</Text>
+              {activeObject === 'sources' ? (
+                <Pressable onPress={() => router.push('/subscriptions')} hitSlop={8}>
+                  <Text style={[styles.sectionAction, { color: colors.textTertiary }]}>Manage</Text>
+                </Pressable>
+              ) : null}
+            </View>
+
+            {activeObject === 'bookmarks' ? (
               <ScrollView
                 horizontal
                 showsHorizontalScrollIndicator={false}
                 contentContainerStyle={styles.filterContainer}
               >
-                <FilterChip
-                  label="Completed"
-                  isSelected={showCompletedOnly}
-                  onPress={() => setShowCompletedOnly((prev) => !prev)}
-                  icon={CheckOutlineIcon}
-                  selectedColor={FilterChipPalette.completed.accent}
-                  selectedSurfaceColor={FilterChipPalette.completed.surface}
-                />
                 {filterOptions.map((option) => (
                   <FilterChip
                     key={option.id}
@@ -463,8 +864,27 @@ export default function LibraryScreen() {
                     }
                     icon={option.icon}
                     dotColor={option.color}
-                    selectedColor={option.selectedColor}
-                    selectedSurfaceColor={option.selectedSurfaceColor}
+                    selectedColor={colors.statusWarningForeground}
+                    selectedSurfaceColor={colors.statusWarning}
+                  />
+                ))}
+              </ScrollView>
+            ) : null}
+
+            {activeObject === 'sources' ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filterContainer}
+              >
+                {subscriptionSourceOptions.map((option) => (
+                  <FilterChip
+                    key={option.id}
+                    label={option.label}
+                    isSelected={subscriptionSourceFilter === option.id}
+                    onPress={() => setSubscriptionSourceFilter(option.id)}
+                    selectedColor={colors.statusWarningForeground}
+                    selectedSurfaceColor={colors.statusWarning}
                   />
                 ))}
               </ScrollView>
@@ -504,42 +924,42 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: 'transparent',
   },
-  searchContainer: {
+  objectGrid: {
     paddingHorizontal: Spacing.md,
-    marginBottom: Spacing.md,
-  },
-  modeSwitcher: {
     flexDirection: 'row',
-    marginHorizontal: Spacing.md,
-    marginBottom: Spacing.md,
-    padding: Spacing.xs,
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginBottom: Spacing.lg,
+  },
+  objectTile: {
+    flexBasis: '48%',
+    flexGrow: 1,
+    minHeight: 72,
     borderRadius: Radius.lg,
     borderWidth: 1,
-    gap: Spacing.xs,
-  },
-  modeButton: {
-    flex: 1,
-    minHeight: 36,
-    alignItems: 'center',
+    padding: Spacing.md,
     justifyContent: 'center',
-    borderRadius: Radius.md,
   },
-  modeButtonText: {
-    ...Typography.labelMedium,
-  },
-  searchBar: {
+  objectTileTitleRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    borderRadius: Radius.lg,
-    borderWidth: 1,
     gap: Spacing.sm,
   },
-  searchInput: {
-    flex: 1,
-    ...Typography.bodyMedium,
-    paddingVertical: 0,
+  objectTileTitle: {
+    ...Typography.titleMedium,
+  },
+  sectionHeader: {
+    paddingHorizontal: Spacing.md,
+    marginBottom: Spacing.md,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sectionTitle: {
+    ...Typography.titleLarge,
+  },
+  sectionAction: {
+    ...Typography.bodySmall,
   },
   filterContainer: {
     paddingHorizontal: Spacing.md,
@@ -552,6 +972,62 @@ const styles = StyleSheet.create({
   listContent: {
     flexGrow: 1,
     paddingBottom: Spacing['3xl'],
+  },
+  hubRow: {
+    minHeight: 88,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    marginHorizontal: Spacing.md,
+    marginBottom: Spacing.sm,
+    padding: Spacing.md,
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+  },
+  hubRowContent: {
+    flex: 1,
+    minWidth: 0,
+  },
+  hubRowTitle: {
+    ...Typography.titleMedium,
+  },
+  hubRowSubtitle: {
+    ...Typography.bodyMedium,
+    marginTop: Spacing.xs,
+  },
+  sourceSubscriptionPressable: {
+    marginHorizontal: Spacing.md,
+    marginBottom: Spacing.sm,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  collectionIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: Radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    ...Typography.titleMedium,
+  },
+  progressTrack: {
+    height: 6,
+    borderRadius: Radius.full,
+    overflow: 'hidden',
+    marginTop: Spacing.sm,
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: Radius.full,
+  },
+  pressed: {
+    opacity: 0.72,
   },
   listFooter: {
     minHeight: Spacing['3xl'],

--- a/apps/mobile/components/subscriptions/source-ui.tsx
+++ b/apps/mobile/components/subscriptions/source-ui.tsx
@@ -1,7 +1,7 @@
 import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import { useCallback, useRef } from 'react';
 import { View, Image, Pressable, StyleSheet, TextInput } from 'react-native';
-import { Rss } from 'lucide-react-native';
+import { Check, Rss } from 'lucide-react-native';
 import * as Haptics from 'expo-haptics';
 import ReanimatedSwipeable, {
   type SwipeableMethods,
@@ -18,7 +18,6 @@ import Animated, {
 
 import { Badge, Button, IconButton, Surface, Text } from '@/components/primitives';
 import {
-  CheckIcon,
   CheckOutlineIcon,
   ChevronRightIcon,
   PlusIcon,
@@ -266,14 +265,17 @@ function RemoveActionPanel({ progress, translation, releaseLocked }: SwipeAction
 
 function SubscriptionToggle({
   checked,
+  checkedColor,
   disabled = false,
   onPress,
 }: {
   checked: boolean;
+  checkedColor?: string;
   disabled?: boolean;
   onPress: () => void;
 }) {
   const { colors } = useAppTheme();
+  const activeColor = checkedColor ?? colors.statusSuccess;
 
   return (
     <IconButton
@@ -288,7 +290,9 @@ function SubscriptionToggle({
       style={styles.subscriptionToggle}
     >
       {checked ? (
-        <CheckIcon size={ACTION_ICON_SIZE} color={colors.statusSuccess} />
+        <View style={[styles.subscriptionToggleCheckedIcon, { backgroundColor: activeColor }]}>
+          <Check size={17} color={colors.overlayForeground} strokeWidth={3} />
+        </View>
       ) : (
         <CheckOutlineIcon size={ACTION_ICON_SIZE} color={colors.textTertiary} />
       )}
@@ -527,6 +531,7 @@ export function SourceSubscriptionRow({
   imageUrl,
   statusLabel,
   toggleChecked,
+  toggleCheckedColor,
   onToggle,
   toggleDisabled = false,
   primaryActionLabel,
@@ -550,6 +555,7 @@ export function SourceSubscriptionRow({
   imageUrl?: string | null;
   statusLabel?: string | null;
   toggleChecked?: boolean;
+  toggleCheckedColor?: string;
   onToggle?: (() => void) | null;
   toggleDisabled?: boolean;
   primaryActionLabel?: string | null;
@@ -641,7 +647,12 @@ export function SourceSubscriptionRow({
         </View>
       ) : null}
       {typeof toggleChecked === 'boolean' && onToggle ? (
-        <SubscriptionToggle checked={toggleChecked} disabled={toggleDisabled} onPress={onToggle} />
+        <SubscriptionToggle
+          checked={toggleChecked}
+          checkedColor={toggleCheckedColor}
+          disabled={toggleDisabled}
+          onPress={onToggle}
+        />
       ) : null}
       {variant === 'flat' ? (
         <View style={[styles.flatRowSeparator, { backgroundColor: colors.borderDefault }]} />
@@ -898,6 +909,13 @@ const styles = StyleSheet.create({
   },
   subscriptionToggle: {
     flexShrink: 0,
+  },
+  subscriptionToggleCheckedIcon: {
+    width: 28,
+    height: 28,
+    borderRadius: Radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   rowActions: {
     alignItems: 'flex-end',

--- a/apps/mobile/lib/library-screen.test.tsx
+++ b/apps/mobile/lib/library-screen.test.tsx
@@ -37,6 +37,12 @@ function findLibraryList(renderer: Renderer) {
   return renderer.root.find((node: TestNode) => node.type === 'flat-list');
 }
 
+function findObjectTile(renderer: Renderer, label: string) {
+  return renderer.root.find(
+    (node: TestNode) => node.type === 'button' && node.props.accessibilityLabel === `Show ${label}`
+  );
+}
+
 function pressLibraryTab() {
   if (!tabPressListener) {
     throw new Error('Expected library tab press listener to be registered');
@@ -186,8 +192,8 @@ jest.mock('@/components/filter-chip', () => ({
 
 jest.mock('@/components/icons', () => ({
   ArticleIcon: () => null,
-  CheckOutlineIcon: () => null,
   HeadphonesIcon: () => null,
+  PodcastIcon: () => null,
   PostIcon: () => null,
   VideoIcon: () => null,
 }));
@@ -200,6 +206,10 @@ jest.mock('@/components/list-states', () => ({
   LoadingState: () => React.createElement('div', null, 'loading'),
   ErrorState: ({ message }: { message: string }) => React.createElement('div', null, message),
   EmptyState: ({ title }: { title: string }) => React.createElement('div', null, title),
+}));
+
+jest.mock('@/components/subscriptions/source-ui', () => ({
+  SourceSubscriptionRow: ({ title }: { title: string }) => React.createElement('div', null, title),
 }));
 
 jest.mock('@/hooks/use-color-scheme', () => ({
@@ -240,8 +250,117 @@ jest.mock('@/hooks/use-items-trpc', () => ({
     hasNextPage: false,
     isFetchingNextPage: false,
   }),
+  useCollections: () => ({
+    data: {
+      collections: [
+        {
+          id: 'collection-1',
+          name: 'Example collection',
+          description: null,
+          rules: {},
+          sort: 'NEWEST_SAVED',
+          homeSection: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
   mapContentType: (value: string) => value.toLowerCase(),
   mapProvider: (value: string) => value,
+}));
+
+jest.mock('@/hooks/use-subscriptions-query', () => ({
+  useSubscriptions: () => ({
+    data: {
+      items: [
+        {
+          id: 'subscription-1',
+          provider: 'YOUTUBE',
+          providerChannelId: 'channel-1',
+          name: 'Example channel',
+          imageUrl: null,
+          status: 'ACTIVE',
+          createdAt: 1,
+          lastItemAt: null,
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('@/lib/trpc', () => ({
+  trpc: {
+    subscriptions: {
+      newsletters: {
+        list: {
+          useQuery: () => ({
+            data: {
+              items: [
+                {
+                  id: 'newsletter-1',
+                  displayName: 'Example newsletter',
+                  fromAddress: 'newsletter@example.com',
+                  listId: null,
+                  imageUrl: null,
+                  status: 'ACTIVE',
+                },
+              ],
+              nextCursor: null,
+              hasMore: false,
+            },
+            isLoading: false,
+            error: null,
+          }),
+        },
+      },
+      rss: {
+        list: {
+          useQuery: () => ({
+            data: {
+              items: [
+                {
+                  id: 'rss-1',
+                  title: 'Example RSS',
+                  feedUrl: 'https://example.com/feed.xml',
+                  siteUrl: 'https://example.com',
+                  imageUrl: null,
+                  status: 'ACTIVE',
+                },
+              ],
+              nextCursor: null,
+              hasMore: false,
+            },
+            isLoading: false,
+            error: null,
+          }),
+        },
+      },
+      xBookmarks: {
+        status: {
+          useQuery: () => ({
+            data: {
+              connected: true,
+              connectionStatus: 'ACTIVE',
+              importedCount: 12,
+              sync: {
+                status: 'SUCCESS',
+                dailySyncEnabled: true,
+              },
+            },
+            isLoading: false,
+            error: null,
+          }),
+        },
+      },
+    },
+  },
 }));
 
 jest.mock('@/hooks/use-people', () => ({
@@ -306,28 +425,35 @@ describe('LibraryScreen', () => {
       pressLibraryTab();
     });
 
+    expect(findObjectTile(renderer!, 'Bookmarks').props.accessibilityState.selected).toBe(true);
+    expect(findFilterChip(renderer!, 'All').props['data-selected']).toBe(true);
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
     expect(mockScrollToOffset).not.toHaveBeenCalled();
   });
 
-  it('clears the completed filter when the library tab is reselected at the top', () => {
+  it('resets bookmark filters to all when bookmarks is selected', () => {
     let renderer: Renderer;
     act(() => {
       renderer = TestRenderer.create(<LibraryScreen />);
     });
 
     act(() => {
-      findFilterChip(renderer!, 'Completed').props.onPress();
+      findFilterChip(renderer!, 'Articles').props.onPress();
     });
 
-    expect(findFilterChip(renderer!, 'Completed').props['data-selected']).toBe(true);
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
 
     act(() => {
-      pressLibraryTab();
+      findObjectTile(renderer!, 'People').props.onPress();
     });
 
-    expect(findFilterChip(renderer!, 'Completed').props['data-selected']).toBe(false);
-    expect(mockScrollToOffset).not.toHaveBeenCalled();
+    act(() => {
+      findObjectTile(renderer!, 'Bookmarks').props.onPress();
+    });
+
+    expect(findObjectTile(renderer!, 'Bookmarks').props.accessibilityState.selected).toBe(true);
+    expect(findFilterChip(renderer!, 'All').props['data-selected']).toBe(true);
+    expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
   });
 
   it('scrolls to the top without clearing the active filter when the library tab is reselected mid-scroll', () => {
@@ -355,6 +481,7 @@ describe('LibraryScreen', () => {
     });
 
     expect(mockScrollToOffset).toHaveBeenCalledWith({ offset: 0, animated: true });
+    expect(findObjectTile(renderer!, 'Bookmarks').props.accessibilityState.selected).toBe(true);
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(true);
   });
 
@@ -374,6 +501,8 @@ describe('LibraryScreen', () => {
       pressLibraryTab();
     });
 
+    expect(findObjectTile(renderer!, 'Bookmarks').props.accessibilityState.selected).toBe(true);
+    expect(findFilterChip(renderer!, 'All').props['data-selected']).toBe(true);
     expect(findFilterChip(renderer!, 'Articles').props['data-selected']).toBe(false);
     expect(mockScrollToOffset).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Redesign the mobile Library page around Bookmarks, Collections, Subscriptions, and People sections.
- Add source-specific subscription filters and render subscription rows with the settings subscription row treatment.
- Apply Zine orange selection styling to tiles, filter chips, and Library subscription toggles.

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Pre-push hook passed: format check, mobile design-system check, typecheck, web tests, worker CI subset

## Notes
- `bun run lint` still reports existing unrelated mobile warnings in `apps/mobile/app/(tabs)/index/collection/[id].tsx` and `apps/mobile/components/insights/weekly-recap-card.test.tsx`.
