### PR TITLE
Tech debt: normalize diagnostic log level casing

### DIFF
--- a/scripts/lib/observability.test.ts
+++ b/scripts/lib/observability.test.ts
@@ -98,6 +98,19 @@ describe('summarizeDiagnosticRecords', () => {
     expect(summary.jobIds).toContain('job_123');
     expect(summary.providers[0]).toEqual({ value: 'YOUTUBE', count: 2 });
   });
+
+  it('normalizes level casing so incident detection is case-insensitive', () => {
+    const summary = summarizeDiagnosticRecords([
+      { level: 'ERROR' },
+      { level: 'error' },
+      { level: 'Warn' },
+    ]);
+
+    expect(summary.levels).toEqual([
+      { value: 'error', count: 2 },
+      { value: 'warn', count: 1 },
+    ]);
+  });
 });
 
 describe('buildIncidentReport', () => {

--- a/scripts/lib/observability.ts
+++ b/scripts/lib/observability.ts
@@ -222,6 +222,14 @@ function updateCount(counter: Record<string, number>, key: string | undefined): 
   counter[key] = (counter[key] ?? 0) + 1;
 }
 
+function normalizeLogLevel(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+
+  return value.trim().toLowerCase();
+}
+
 function sortCounts(counter: Record<string, number>): Array<{ value: string; count: number }> {
   return Object.entries(counter)
     .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
@@ -350,7 +358,7 @@ export function summarizeDiagnosticRecords(records: JsonRecord[]) {
   const jobIds = new Set<string>();
 
   for (const record of records) {
-    updateCount(levels, collectFieldValues(record, SUMMARY_FIELD_ALIASES.level)[0]);
+    updateCount(levels, normalizeLogLevel(collectFieldValues(record, SUMMARY_FIELD_ALIASES.level)[0]));
     updateCount(operations, collectFieldValues(record, SUMMARY_FIELD_ALIASES.operation)[0]);
     updateCount(providers, collectFieldValues(record, SUMMARY_FIELD_ALIASES.provider)[0]);
 


### PR DESCRIPTION
## Summary\n- normalize  level aggregation to lowercase\n- avoid case-sensitive misses when downstream incident logic checks for \n- add regression test proving mixed-case level aggregation\n\n## Validation\n- bun test v1.3.4 (5eb2145b)