### PR TITLE
Tech debt: support --no-* boolean flags in diagnostic arg parser

### DIFF
--- a/scripts/lib/observability.test.ts
+++ b/scripts/lib/observability.test.ts
@@ -160,13 +160,14 @@ describe('buildIncidentReport', () => {
 });
 
 describe('parseCommandArgs', () => {
-  it('parses equals assignments, repeated flags, and positional args', () => {
+  it('parses equals assignments, repeated flags, boolean negation, and positional args', () => {
     const parsed = parseCommandArgs([
       '--since=2h',
       '--provider',
       'youtube',
       '--provider=spotify',
       '--verbose',
+      '--no-color',
       '--',
       'incident-123',
     ]);
@@ -176,6 +177,7 @@ describe('parseCommandArgs', () => {
       since: '2h',
       provider: ['youtube', 'spotify'],
       verbose: true,
+      color: false,
     });
   });
 });

--- a/scripts/lib/observability.ts
+++ b/scripts/lib/observability.ts
@@ -688,6 +688,11 @@ export function parseCommandArgs(argv: string[]): Record<string, string | boolea
       continue;
     }
 
+    if (assignment.startsWith('no-') && assignment.length > 3) {
+      appendValue(assignment.slice(3), false);
+      continue;
+    }
+
     const key = assignment;
     const next = argv[index + 1];
 


### PR DESCRIPTION
## Summary
- add `--no-<flag>` handling to `parseCommandArgs` in observability utilities
- keep existing repeated/equals/positional argument behavior unchanged
- extend observability unit test coverage with a boolean-negation case

## Why
CLI boolean-negation flags are a common convention. Supporting them reduces ad-hoc parsing and improves maintainability for diagnostic scripts.

## Validation
- `bun run test:observability`
- `bun run typecheck --filter='*'`
- pre-commit hooks passed on commit (eslint/prettier/checks/typecheck/tests)
