### PR TITLE
[codex] Match inbox filter chips to Home

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -20,14 +20,7 @@ import { ArticleIcon, InboxArrowIcon, PodcastIcon, PostIcon, VideoIcon } from '@
 import { type ItemCardData } from '@/components/item-card';
 import { LoadingState, ErrorState } from '@/components/list-states';
 import { SwipeableInboxItem, type EnterDirection } from '@/components/swipeable-inbox-item';
-import {
-  Colors,
-  Typography,
-  Spacing,
-  Radius,
-  ContentColors,
-  FilterChipPalette,
-} from '@/constants/theme';
+import { Colors, Typography, Spacing, Radius, ContentColors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useTabPrefetch } from '@/hooks/use-prefetch';
 import { useInfiniteInboxItems, useArchiveItem, useBookmarkItem } from '@/hooks/use-items-trpc';
@@ -61,8 +54,6 @@ const contentTypeFilters: {
   label: string;
   icon: ComponentType<{ size?: number; color?: string }>;
   dotColor: string;
-  selectedColor: string;
-  selectedSurfaceColor: string;
   contentType: ApiContentType;
 }[] = [
   {
@@ -70,8 +61,6 @@ const contentTypeFilters: {
     label: 'Articles',
     icon: ArticleIcon,
     dotColor: ContentColors.article,
-    selectedColor: FilterChipPalette.article.accent,
-    selectedSurfaceColor: FilterChipPalette.article.surface,
     contentType: ApiContentType.ARTICLE,
   },
   {
@@ -79,8 +68,6 @@ const contentTypeFilters: {
     label: 'Podcasts',
     icon: PodcastIcon,
     dotColor: ContentColors.podcast,
-    selectedColor: FilterChipPalette.podcast.accent,
-    selectedSurfaceColor: FilterChipPalette.podcast.surface,
     contentType: ApiContentType.PODCAST,
   },
   {
@@ -88,8 +75,6 @@ const contentTypeFilters: {
     label: 'Videos',
     icon: VideoIcon,
     dotColor: ContentColors.video,
-    selectedColor: FilterChipPalette.video.accent,
-    selectedSurfaceColor: FilterChipPalette.video.surface,
     contentType: ApiContentType.VIDEO,
   },
   {
@@ -97,8 +82,6 @@ const contentTypeFilters: {
     label: 'Posts',
     icon: PostIcon,
     dotColor: ContentColors.post,
-    selectedColor: FilterChipPalette.post.accent,
-    selectedSurfaceColor: FilterChipPalette.post.surface,
     contentType: ApiContentType.POST,
   },
 ];
@@ -386,8 +369,9 @@ export default function InboxScreen() {
                   onPress={() => handleContentTypeFilterPress(filter.id)}
                   icon={filter.icon}
                   dotColor={filter.dotColor}
-                  selectedColor={filter.selectedColor}
-                  selectedSurfaceColor={filter.selectedSurfaceColor}
+                  selectedColor={colors.warning}
+                  selectedSurfaceColor={colors.warning}
+                  selectedForegroundColor={colors.statusWarningForeground}
                 />
               ))}
             </ScrollView>


### PR DESCRIPTION
## Summary
- Update Inbox content-type filter chips to use the same selected yellow styling as the Home screen.
- Remove the per-content selected chip palette from the Inbox filter configuration.

## Impact
Selected Inbox chips now use the shared warning yellow surface/border and warning foreground, matching the Home screen visual treatment.

## Validation
- `bun run --cwd apps/mobile lint` (passed with existing warnings outside this change)
- `bun run typecheck`
- `bun run --cwd apps/mobile test -- filter-chip`
- Pre-push hook: `format:check`, mobile design-system check, `typecheck`, `test:web`, worker CI subset
