### PR TITLE
Mobile: make FilterChip haptics failure-safe

### DIFF
--- a/apps/mobile/components/filter-chip.test.tsx
+++ b/apps/mobile/components/filter-chip.test.tsx
@@ -85,4 +85,30 @@ describe('FilterChip', () => {
     expect(mockSelectionAsync).toHaveBeenCalledTimes(1);
     expect(onPress).toHaveBeenCalledTimes(1);
   });
+
+  it('still calls onPress if haptics fails', async () => {
+    const onPress = jest.fn();
+    const rejection = new Error('haptics unavailable');
+    mockSelectionAsync.mockRejectedValueOnce(rejection);
+
+    let renderer: ReturnType<typeof TestRenderer.create>;
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(FilterChip, {
+          label: 'Podcasts',
+          isSelected: true,
+          onPress,
+        })
+      );
+    });
+
+    act(() => {
+      renderer.root.findByType('button').props.onPress();
+    });
+
+    await Promise.resolve();
+
+    expect(mockSelectionAsync).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -98,7 +98,9 @@ export function FilterChip({
   const textStyles = size === 'small' ? styles.textSmall : styles.textMedium;
   const iconSize = size === 'small' ? 12 : 14;
   const handlePress = () => {
-    void Haptics.selectionAsync();
+    void Haptics.selectionAsync().catch(() => {
+      // Best-effort haptic feedback should never block chip interaction.
+    });
     onPress();
   };
 


### PR DESCRIPTION
Summary:\n- make FilterChip haptic selection feedback best-effort by catching selectionAsync failures\n- ensure chip presses still trigger onPress even when haptics are unavailable\n- add regression coverage in filter-chip.test.tsx for haptics rejection path\n\nValidation:\n- bun run --cwd apps/mobile test components/filter-chip.test.tsx\n- bunx eslint apps/mobile/components/filter-chip.tsx apps/mobile/components/filter-chip.test.tsx