### PR TITLE
[codex] Fix collection sheet bottom safe area

### DIFF
--- a/apps/mobile/lib/item-collections-bottom-sheet.ios.tsx
+++ b/apps/mobile/lib/item-collections-bottom-sheet.ios.tsx
@@ -40,7 +40,7 @@ export function ItemCollectionsBottomSheet({
     () => [
       frame({ maxWidth: Infinity, maxHeight: Infinity, alignment: 'topLeading' }),
       background(backgroundColor),
-      ignoreSafeArea({ regions: 'container', edges: 'bottom' }),
+      ignoreSafeArea({ regions: 'all', edges: 'bottom' }),
       presentationDetents([initialDetent, 'large'], {
         selection: selectedDetent,
         onSelectionChange: setSelectedDetent,
@@ -62,7 +62,12 @@ export function ItemCollectionsBottomSheet({
           style={[styles.backdropPressTarget, { height, width }]}
         />
       ) : null}
-      <Host colorScheme="dark" pointerEvents="box-none" style={[styles.host, { width }]}>
+      <Host
+        colorScheme="dark"
+        ignoreSafeArea="all"
+        pointerEvents="box-none"
+        style={[styles.host, { height, width }]}
+      >
         <BottomSheet
           isPresented={visible}
           onIsPresentedChange={(isPresented) => {


### PR DESCRIPTION
## Summary
- Make the iOS Expo UI bottom sheet host ignore the full safe area and use the full viewport size.
- Extend the sheet background through the bottom safe area so underlying item content does not show beneath the sheet footer on device.

## Verification
- `bun run format:check`
- `bun run --cwd apps/mobile lint` (passes with existing warnings)
- `bun run typecheck`
- `bunx expo export -p ios --clear`
- pre-push hook: format, mobile design-system check, typecheck, web tests, worker CI subset
