### PR TITLE
Centralize worker cursor encoding helpers

### DIFF
--- a/apps/worker/src/lib/pagination.test.ts
+++ b/apps/worker/src/lib/pagination.test.ts
@@ -4,11 +4,31 @@ import {
   MAX_PAGE_SIZE,
   buildPaginatedQuery,
   decodeCursor,
+  decodeCursorPayload,
   encodeCursor,
+  encodeCursorPayload,
   processPaginatedResults,
 } from './pagination';
 
 describe('pagination utilities', () => {
+  describe('generic cursor payload encoding and decoding', () => {
+    it('round-trips non-standard cursor payloads', () => {
+      const payload = {
+        offset: 40,
+        priority: 1,
+        sortValue: '120',
+        id: 'user_item_123',
+      };
+
+      expect(decodeCursorPayload(encodeCursorPayload(payload))).toEqual(payload);
+    });
+
+    it('returns null for malformed generic cursor payloads', () => {
+      expect(decodeCursorPayload('not-base64')).toBeNull();
+      expect(decodeCursorPayload('')).toBeNull();
+    });
+  });
+
   describe('cursor encoding and decoding', () => {
     it('round-trips a valid cursor', () => {
       const original = {

--- a/apps/worker/src/lib/pagination.ts
+++ b/apps/worker/src/lib/pagination.ts
@@ -46,6 +46,32 @@ export const DEFAULT_PAGE_SIZE = 20;
 export const MAX_PAGE_SIZE = 100;
 
 /**
+ * Encode a JSON-serializable cursor payload to a base64url string.
+ */
+export function encodeCursorPayload(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Decode a base64url JSON cursor payload.
+ */
+export function decodeCursorPayload(cursorString: string): unknown | null {
+  try {
+    // Restore base64 from base64url
+    let base64 = cursorString.replace(/-/g, '+').replace(/_/g, '/');
+    // Add padding if needed
+    while (base64.length % 4) {
+      base64 += '=';
+    }
+
+    return JSON.parse(atob(base64));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Encode a pagination cursor to a base64url string
  *
  * @param cursor - The cursor object to encode
@@ -61,9 +87,7 @@ export const MAX_PAGE_SIZE = 100;
  * ```
  */
 export function encodeCursor(cursor: PaginationCursor): string {
-  const json = JSON.stringify(cursor);
-  // Use base64url encoding (URL-safe, no padding)
-  return btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return encodeCursorPayload(cursor);
 }
 
 /**
@@ -79,42 +103,32 @@ export function encodeCursor(cursor: PaginationCursor): string {
  * ```
  */
 export function decodeCursor(cursorString: string): PaginationCursor | null {
-  try {
-    // Restore base64 from base64url
-    let base64 = cursorString.replace(/-/g, '+').replace(/_/g, '/');
-    // Add padding if needed
-    while (base64.length % 4) {
-      base64 += '=';
+  const parsed = decodeCursorPayload(cursorString);
+
+  // Validate the cursor structure
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'sortValue' in parsed &&
+    'id' in parsed &&
+    typeof parsed.sortValue === 'string' &&
+    typeof parsed.id === 'string'
+  ) {
+    const sortValue = parsed.sortValue.trim();
+    const id = parsed.id.trim();
+
+    // Reject empty values and non-date sort values to avoid malformed cursors.
+    if (!sortValue || !id || Number.isNaN(Date.parse(sortValue))) {
+      return null;
     }
 
-    const json = atob(base64);
-    const parsed = JSON.parse(json);
-
-    // Validate the cursor structure
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      typeof parsed.sortValue === 'string' &&
-      typeof parsed.id === 'string'
-    ) {
-      const sortValue = parsed.sortValue.trim();
-      const id = parsed.id.trim();
-
-      // Reject empty values and non-date sort values to avoid malformed cursors.
-      if (!sortValue || !id || Number.isNaN(Date.parse(sortValue))) {
-        return null;
-      }
-
-      return {
-        sortValue,
-        id,
-      };
-    }
-
-    return null;
-  } catch {
-    return null;
+    return {
+      sortValue,
+      id,
+    };
   }
+
+  return null;
 }
 
 /**

--- a/apps/worker/src/trpc/routers/collections.ts
+++ b/apps/worker/src/trpc/routers/collections.ts
@@ -27,7 +27,12 @@ import {
   userItems,
   userItemTags,
 } from '../../db/schema';
-import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import {
+  decodeCursorPayload,
+  encodeCursorPayload,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from '../../lib/pagination';
 import { toItemViewsWithTags } from './items';
 import type { Database } from '../../db';
 import {
@@ -79,31 +84,24 @@ function isAscendingSort(sort: z.infer<typeof CollectionSortSchema>): boolean {
 }
 
 function encodeCollectionItemsCursor(cursor: CollectionItemsCursor): string {
-  return btoa(JSON.stringify(cursor)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return encodeCursorPayload(cursor);
 }
 
 function decodeCollectionItemsCursor(cursorString: string): CollectionItemsCursor | null {
-  try {
-    let base64 = cursorString.replace(/-/g, '+').replace(/_/g, '/');
-    while (base64.length % 4) {
-      base64 += '=';
-    }
-
-    const parsed = JSON.parse(atob(base64));
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      typeof parsed.sortValue === 'string' &&
-      typeof parsed.id === 'string'
-    ) {
-      return {
-        priority: typeof parsed.priority === 'number' ? parsed.priority : 0,
-        sortValue: parsed.sortValue,
-        id: parsed.id,
-      };
-    }
-  } catch {
-    return null;
+  const parsed = decodeCursorPayload(cursorString);
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'sortValue' in parsed &&
+    'id' in parsed &&
+    typeof parsed.sortValue === 'string' &&
+    typeof parsed.id === 'string'
+  ) {
+    return {
+      priority: 'priority' in parsed && typeof parsed.priority === 'number' ? parsed.priority : 0,
+      sortValue: parsed.sortValue,
+      id: parsed.id,
+    };
   }
 
   return null;

--- a/apps/worker/src/trpc/routers/people.ts
+++ b/apps/worker/src/trpc/routers/people.ts
@@ -5,7 +5,14 @@ import { UserItemState } from '@zine/shared';
 
 import type { Database } from '../../db';
 import { creators, items, userItems, userPeople, userPersonMentions } from '../../db/schema';
-import { decodeCursor, encodeCursor, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../lib/pagination';
+import {
+  decodeCursor,
+  decodeCursorPayload,
+  encodeCursor,
+  encodeCursorPayload,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from '../../lib/pagination';
 import { router, protectedProcedure } from '../trpc';
 import { toItemViewsWithTags } from './items';
 import { normalizePersonDisplayName } from '../../people/service';
@@ -31,30 +38,24 @@ type PeopleOffsetCursor = {
 };
 
 function encodeOffsetCursor(offset: number): string {
-  return btoa(JSON.stringify({ offset }))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  return encodeCursorPayload({ offset });
 }
 
 function decodeOffsetCursor(value: string | undefined): PeopleOffsetCursor | null {
   if (!value) return null;
-  try {
-    let base64 = value.replace(/-/g, '+').replace(/_/g, '/');
-    while (base64.length % 4) base64 += '=';
-    const parsed = JSON.parse(atob(base64));
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      typeof parsed.offset === 'number' &&
-      Number.isInteger(parsed.offset) &&
-      parsed.offset >= 0
-    ) {
-      return { offset: parsed.offset };
-    }
-  } catch {
-    return null;
+
+  const parsed = decodeCursorPayload(value);
+  if (
+    parsed &&
+    typeof parsed === 'object' &&
+    'offset' in parsed &&
+    typeof parsed.offset === 'number' &&
+    Number.isInteger(parsed.offset) &&
+    parsed.offset >= 0
+  ) {
+    return { offset: parsed.offset };
   }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- centralize base64url cursor payload encode/decode in worker pagination utilities
- reuse shared helpers in people and collections routers instead of duplicating logic
- add tests for generic cursor payload round-trip and malformed payload handling

## Validation
- bun run --cwd apps/worker test:run src/lib/pagination.test.ts
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/worker test:run