### PR TITLE
[codex] Preserve mobile content filters in drill-ins

### DIFF
--- a/apps/mobile/app/(tabs)/inbox/index.tsx
+++ b/apps/mobile/app/(tabs)/inbox/index.tsx
@@ -1,4 +1,4 @@
-import { Stack, useNavigation } from 'expo-router';
+import { Stack, useLocalSearchParams, useNavigation } from 'expo-router';
 import { Surface, useToast } from 'heroui-native';
 import type { ComponentType } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -90,6 +90,19 @@ const contentTypeFilters: {
   },
 ];
 
+const LOCKABLE_CONTENT_TYPE_FILTERS = contentTypeFilters.filter(
+  (filter): filter is (typeof contentTypeFilters)[number] & { id: UIContentType } =>
+    filter.id !== null
+);
+
+function parseLockedContentTypeFilter(value: string | string[] | undefined): UIContentType | null {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+
+  return LOCKABLE_CONTENT_TYPE_FILTERS.some((filter) => filter.id === rawValue)
+    ? (rawValue as UIContentType)
+    : null;
+}
+
 function InboxEmptyState({
   colors,
   selectedFilterLabel,
@@ -122,16 +135,20 @@ function InboxEmptyState({
 
 export default function InboxScreen() {
   const navigation = useNavigation();
+  const params = useLocalSearchParams<{ contentType?: string | string[] }>();
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const { toast } = useToast();
   const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
   const [contentTypeFilter, setContentTypeFilter] = useState<UIContentType | null>(null);
+  const lockedContentTypeFilter = parseLockedContentTypeFilter(params.contentType);
+  const activeContentTypeFilter = lockedContentTypeFilter ?? contentTypeFilter;
+  const isContentTypeFilterLocked = lockedContentTypeFilter !== null;
 
   useTabPrefetch('inbox');
 
-  const apiContentTypeFilter = contentTypeFilter
-    ? contentTypeFilters.find((filter) => filter.id === contentTypeFilter)?.contentType
+  const apiContentTypeFilter = activeContentTypeFilter
+    ? contentTypeFilters.find((filter) => filter.id === activeContentTypeFilter)?.contentType
     : undefined;
 
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -144,8 +161,8 @@ export default function InboxScreen() {
   const [pendingDismissedItemIds, setPendingDismissedItemIds] = useState<Set<string>>(new Set());
   const listRef = useRef<Animated.FlatList<ItemCardData>>(null);
   const scrollOffsetYRef = useRef(0);
-  const selectedContentTypeFilter = contentTypeFilter
-    ? contentTypeFilters.find((filter) => filter.id === contentTypeFilter)
+  const selectedContentTypeFilter = activeContentTypeFilter
+    ? contentTypeFilters.find((filter) => filter.id === activeContentTypeFilter)
     : undefined;
 
   const archiveMutation = useArchiveItem();
@@ -317,14 +334,14 @@ export default function InboxScreen() {
 
       const isAtTop = scrollOffsetYRef.current <= INBOX_TOP_THRESHOLD;
 
-      if (contentTypeFilter !== null && isAtTop) {
+      if (!isContentTypeFilterLocked && contentTypeFilter !== null && isAtTop) {
         setContentTypeFilter(null);
         return;
       }
 
       listRef.current?.scrollToOffset({ offset: 0, animated: true });
     });
-  }, [contentTypeFilter, navigation]);
+  }, [contentTypeFilter, isContentTypeFilterLocked, navigation]);
 
   const listEmptyComponent = isLoading ? (
     <LoadingState />
@@ -365,12 +382,16 @@ export default function InboxScreen() {
               showsHorizontalScrollIndicator={false}
               contentContainerStyle={styles.filterContainer}
             >
-              {contentTypeFilters.map((filter) => (
+              {(isContentTypeFilterLocked && selectedContentTypeFilter
+                ? [selectedContentTypeFilter]
+                : contentTypeFilters
+              ).map((filter) => (
                 <FilterChip
                   key={filter.id ?? 'all'}
                   label={filter.label}
-                  isSelected={contentTypeFilter === filter.id}
+                  isSelected={activeContentTypeFilter === filter.id}
                   onPress={() => handleContentTypeFilterPress(filter.id)}
+                  disabled={isContentTypeFilterLocked}
                   icon={filter.icon}
                   dotColor={filter.dotColor}
                   selectedColor={colors.warning}

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -359,13 +359,30 @@ export default function HomeScreen() {
 
   const handleOpenHomeSection = useCallback(
     (section: BuiltInHomeSectionKey) => {
+      const params: { section: BuiltInHomeSectionKey; contentType?: UIContentType } = { section };
+      if (contentTypeFilter) {
+        params.contentType = contentTypeFilter;
+      }
+
       router.push({
         pathname: '/(tabs)/section/[section]',
-        params: { section },
+        params,
       } as unknown as Href);
     },
-    [router]
+    [contentTypeFilter, router]
   );
+
+  const handleOpenInbox = useCallback(() => {
+    if (!contentTypeFilter) {
+      router.push('/(tabs)/inbox');
+      return;
+    }
+
+    router.push({
+      pathname: '/(tabs)/inbox',
+      params: { contentType: contentTypeFilter },
+    } as unknown as Href);
+  }, [contentTypeFilter, router]);
 
   const handleOpenNavigationPane = useCallback(() => {
     setNavigationPaneMounted(true);
@@ -679,11 +696,7 @@ export default function HomeScreen() {
         case 'inbox':
           return (
             <View style={styles.section}>
-              <SectionHeader
-                title={item.title}
-                colors={colors}
-                onPress={() => router.push('/(tabs)/inbox')}
-              />
+              <SectionHeader title={item.title} colors={colors} onPress={handleOpenInbox} />
               <View
                 style={[styles.inboxContainer, { backgroundColor: colors.backgroundSecondary }]}
               >
@@ -806,7 +819,7 @@ export default function HomeScreen() {
           );
       }
     },
-    [colors, featuredGridItemWidth, handleOpenCollection, handleOpenHomeSection, router]
+    [colors, featuredGridItemWidth, handleOpenCollection, handleOpenHomeSection, handleOpenInbox]
   );
 
   useEffect(() => {

--- a/apps/mobile/app/(tabs)/index/section/[section].tsx
+++ b/apps/mobile/app/(tabs)/index/section/[section].tsx
@@ -1,11 +1,22 @@
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { Surface } from 'heroui-native';
+import type { ComponentType } from 'react';
 import { useCallback, useMemo, useRef } from 'react';
-import { FlatList, StyleSheet, Text, View, type ListRenderItemInfo } from 'react-native';
+import {
+  FlatList,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type ListRenderItemInfo,
+} from 'react-native';
+import { ContentType as ApiContentType } from '@zine/shared';
 
+import { FilterChip } from '@/components/filter-chip';
+import { ArticleIcon, PodcastIcon, PostIcon, VideoIcon } from '@/components/icons';
 import { ItemCard, type ItemCardData } from '@/components/item-card';
 import { EmptyState, ErrorState, InvalidParamState, LoadingState } from '@/components/list-states';
-import { Colors, Spacing, Typography } from '@/constants/theme';
+import { Colors, ContentColors, Spacing, Typography } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useHomeData } from '@/hooks/use-items-trpc';
 import {
@@ -32,12 +43,56 @@ const SECTION_TITLES: Record<HomeSectionKey, string> = {
 };
 
 const VALID_SECTION_KEYS = Object.keys(SECTION_TITLES) as HomeSectionKey[];
+const contentTypeFilters: {
+  id: UIContentType;
+  label: string;
+  icon?: ComponentType<{ size?: number; color?: string }>;
+  dotColor?: string;
+  contentType: ApiContentType;
+}[] = [
+  {
+    id: 'article',
+    label: 'Articles',
+    icon: ArticleIcon,
+    dotColor: ContentColors.article,
+    contentType: ApiContentType.ARTICLE,
+  },
+  {
+    id: 'podcast',
+    label: 'Podcasts',
+    icon: PodcastIcon,
+    dotColor: ContentColors.podcast,
+    contentType: ApiContentType.PODCAST,
+  },
+  {
+    id: 'video',
+    label: 'Videos',
+    icon: VideoIcon,
+    dotColor: ContentColors.video,
+    contentType: ApiContentType.VIDEO,
+  },
+  {
+    id: 'post',
+    label: 'Posts',
+    icon: PostIcon,
+    dotColor: ContentColors.post,
+    contentType: ApiContentType.POST,
+  },
+];
 
 function parseSectionKey(value: string | string[] | undefined): HomeSectionKey | null {
   const rawValue = Array.isArray(value) ? value[0] : value;
 
   return VALID_SECTION_KEYS.includes(rawValue as HomeSectionKey)
     ? (rawValue as HomeSectionKey)
+    : null;
+}
+
+function parseContentTypeFilter(value: string | string[] | undefined): UIContentType | null {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+
+  return contentTypeFilters.some((filter) => filter.id === rawValue)
+    ? (rawValue as UIContentType)
     : null;
 }
 
@@ -78,19 +133,35 @@ function getSectionItems(
 }
 
 export default function HomeSectionScreen() {
-  const params = useLocalSearchParams<{ section?: string }>();
+  const params = useLocalSearchParams<{ section?: string; contentType?: string | string[] }>();
   const sectionKey = parseSectionKey(params.section);
+  const contentTypeFilter = parseContentTypeFilter(params.contentType);
+  const selectedContentTypeFilter = contentTypeFilter
+    ? contentTypeFilters.find((filter) => filter.id === contentTypeFilter)
+    : undefined;
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const listRef = useRef<FlatList<ItemCardData>>(null);
   const { handleScroll, showCollapsedTitle } = useCollapsedHeaderTitle();
-  const { data: homeData, isLoading, error, refetch } = useHomeData();
+  const {
+    data: homeData,
+    isLoading,
+    error,
+    refetch,
+  } = useHomeData(
+    selectedContentTypeFilter
+      ? { filter: { contentType: selectedContentTypeFilter.contentType } }
+      : undefined
+  );
 
   const sectionTitle = sectionKey ? SECTION_TITLES[sectionKey] : 'Section';
-  const sectionItems = useMemo(
-    () => (sectionKey ? getSectionItems(homeData, sectionKey) : []),
-    [homeData, sectionKey]
-  );
+  const sectionItems = useMemo(() => {
+    const items = sectionKey ? getSectionItems(homeData, sectionKey) : [];
+
+    return contentTypeFilter
+      ? items.filter((item) => item.contentType === contentTypeFilter)
+      : items;
+  }, [contentTypeFilter, homeData, sectionKey]);
 
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<ItemCardData>) => (
@@ -154,6 +225,25 @@ export default function HomeSectionScreen() {
         ListHeaderComponent={
           <View style={styles.listHeader}>
             <Text style={[styles.headerTitle, { color: colors.text }]}>{sectionTitle}</Text>
+            {selectedContentTypeFilter ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filterContainer}
+              >
+                <FilterChip
+                  label={selectedContentTypeFilter.label}
+                  isSelected
+                  onPress={() => {}}
+                  disabled
+                  icon={selectedContentTypeFilter.icon}
+                  dotColor={selectedContentTypeFilter.dotColor}
+                  selectedColor={colors.warning}
+                  selectedSurfaceColor={colors.warning}
+                  selectedForegroundColor={colors.statusWarningForeground}
+                />
+              </ScrollView>
+            ) : null}
           </View>
         }
         ListEmptyComponent={listEmptyComponent}
@@ -181,6 +271,11 @@ const styles = StyleSheet.create({
   headerTitle: {
     ...Typography.displayMedium,
     paddingHorizontal: Spacing.md,
+  },
+  filterContainer: {
+    paddingHorizontal: Spacing.md,
+    paddingTop: Spacing.md,
+    gap: Spacing.sm,
   },
   listFooter: {
     minHeight: Spacing['3xl'],

--- a/apps/mobile/components/filter-chip.test.tsx
+++ b/apps/mobile/components/filter-chip.test.tsx
@@ -85,4 +85,27 @@ describe('FilterChip', () => {
     expect(mockSelectionAsync).toHaveBeenCalledTimes(1);
     expect(onPress).toHaveBeenCalledTimes(1);
   });
+
+  it('does not trigger haptics or onPress when disabled', () => {
+    const onPress = jest.fn();
+    let renderer: ReturnType<typeof TestRenderer.create>;
+
+    act(() => {
+      renderer = TestRenderer.create(
+        React.createElement(FilterChip, {
+          label: 'Articles',
+          isSelected: true,
+          onPress,
+          disabled: true,
+        })
+      );
+    });
+
+    act(() => {
+      renderer.root.findByType('button').props.onPress();
+    });
+
+    expect(mockSelectionAsync).not.toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+  });
 });

--- a/apps/mobile/components/filter-chip.tsx
+++ b/apps/mobile/components/filter-chip.tsx
@@ -29,6 +29,9 @@ export interface FilterChipProps {
   /** Handler called when chip is pressed */
   onPress: () => void;
 
+  /** Whether the chip should render as static/non-interactive */
+  disabled?: boolean;
+
   /** Optional leading icon component */
   icon?: ComponentType<FilterChipIconProps>;
 
@@ -74,6 +77,7 @@ export function FilterChip({
   label,
   isSelected,
   onPress,
+  disabled = false,
   icon: Icon,
   dotColor,
   selectedColor,
@@ -98,6 +102,8 @@ export function FilterChip({
   const textStyles = size === 'small' ? styles.textSmall : styles.textMedium;
   const iconSize = size === 'small' ? 12 : 14;
   const handlePress = () => {
+    if (disabled) return;
+
     void Haptics.selectionAsync();
     onPress();
   };
@@ -105,6 +111,8 @@ export function FilterChip({
   return (
     <Pressable
       onPress={handlePress}
+      disabled={disabled}
+      accessibilityState={disabled ? { disabled: true } : undefined}
       style={({ pressed }) => [
         styles.chip,
         sizeStyles,
@@ -112,7 +120,7 @@ export function FilterChip({
           backgroundColor: chipBackgroundColor,
           borderColor: chipBorderColor,
         },
-        pressed && { opacity: motion.opacity.pressed },
+        pressed && !disabled && { opacity: motion.opacity.pressed },
       ]}
     >
       {Icon ? <Icon size={iconSize} color={iconColor} /> : null}

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -668,6 +668,60 @@ describe('HomeScreen', () => {
     expect(mockPush).toHaveBeenLastCalledWith('/(tabs)/inbox');
   });
 
+  it('passes the active content type filter when opening Home list views', () => {
+    mockUseHomeData.mockReturnValue({
+      data: {
+        jumpBackIn: [createFeedItem('jump-1')],
+        recentBookmarks: [createFeedItem('bookmark-1')],
+        byContentType: {
+          podcasts: [],
+          videos: [],
+          articles: [createFeedItem('article-1', 'ARTICLE')],
+        },
+        customCollections: [],
+      },
+      isLoading: false,
+    });
+    mockUseInfiniteInboxItems.mockReturnValue({
+      data: {
+        pages: [
+          {
+            items: [createFeedItem('inbox-1')],
+            nextCursor: null,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    act(() => {
+      findFilterChip(renderer!, 'Articles').props.onPress();
+    });
+
+    act(() => {
+      findSectionHeaderButton(renderer!, 'Recently Bookmarked').props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '/(tabs)/section/[section]',
+      params: { section: 'recently-bookmarked', contentType: 'article' },
+    });
+
+    act(() => {
+      findSectionHeaderButton(renderer!, 'Inbox').props.onPress();
+    });
+
+    expect(mockPush).toHaveBeenLastCalledWith({
+      pathname: '/(tabs)/inbox',
+      params: { contentType: 'article' },
+    });
+  });
+
   it('restores the home section visual caps without changing the expanded fetch size', () => {
     mockUseHomeData.mockReturnValue({
       data: {


### PR DESCRIPTION
## Summary

- Preserve the selected Home content-type filter when opening Inbox and built-in Home section list views.
- Render a single selected static chip on filtered drill-in pages so the filter cannot be changed or deselected there.
- Keep the normal editable Inbox filter row when Inbox is opened without a Home filter.

## Why

Home section previews were filtered, but drilling into Inbox or section list views dropped that filter and showed mixed content. Passing the selected content type through the route keeps the list view consistent with the preview the user tapped.

## Validation

- `bun run --cwd apps/mobile test --runTestsByPath lib/home-screen.test.tsx components/filter-chip.test.tsx`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run --cwd apps/mobile lint`
- Manual Expo Go simulator verification with screenshot at `apps/mobile/tmp/zine-inbox-article-filter.png`
- Pre-push hook: `format:check`, `design-system:check`, `typecheck`, `test:web`, worker test subset
