### PR TITLE
[codex] Sort inbox by ingested time

### DIFF
--- a/apps/worker/src/trpc/routers/items.test.ts
+++ b/apps/worker/src/trpc/routers/items.test.ts
@@ -127,6 +127,8 @@ function createMockItemsCaller(options: {
         items = items.filter((item) => item.contentType === input.filter!.contentType);
       }
 
+      items.sort((a, b) => b.ingestedAt.localeCompare(a.ingestedAt) || b.id.localeCompare(a.id));
+
       const limit = input?.limit ?? 20;
       const hasMore = items.length > limit;
       const pageItems = hasMore ? items.slice(0, limit) : items;
@@ -514,6 +516,32 @@ describe('Items Router', () => {
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].contentType).toBe(ContentType.VIDEO);
+    });
+
+    it('should sort by most recently ingested instead of published date', async () => {
+      const olderReleaseAddedRecently = createMockItemView({
+        id: 'ui-added-recently',
+        title: 'Older release added recently',
+        publishedAt: '2024-01-01T00:00:00Z',
+        ingestedAt: '2024-12-03T00:00:00Z',
+      });
+      const newerReleaseAddedEarlier = createMockItemView({
+        id: 'ui-added-earlier',
+        title: 'Newer release added earlier',
+        publishedAt: '2024-12-01T00:00:00Z',
+        ingestedAt: '2024-12-01T00:00:00Z',
+      });
+
+      const caller = createMockItemsCaller({
+        userId: TEST_USER_ID,
+        inboxItems: [newerReleaseAddedEarlier, olderReleaseAddedRecently],
+      });
+      const result = await caller.inbox();
+
+      expect(result.items.map((item) => item.id)).toEqual([
+        'ui-added-recently',
+        'ui-added-earlier',
+      ]);
     });
   });
 

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -536,8 +536,7 @@ export const itemsRouter = router({
   /**
    * Get items in the triage queue (INBOX state).
    * Supports filtering by provider and content type.
-   * Uses cursor-based pagination sorted by publishedAt DESC (most recent first).
-   * Falls back to ingestedAt for items without a publishedAt date.
+   * Uses cursor-based pagination sorted by ingestedAt DESC (most recently added first).
    */
   inbox: protectedProcedure.input(PaginationSchema.optional()).query(async ({ input, ctx }) => {
     const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
@@ -550,15 +549,12 @@ export const itemsRouter = router({
       eq(userItems.isFinished, false),
     ];
 
-    // Use COALESCE to handle NULL publishedAt - falls back to ingestedAt
-    const sortField = sql`COALESCE(${items.publishedAt}, ${userItems.ingestedAt})`;
-
-    // Apply cursor-based pagination (fetch items published before cursor)
+    // Apply cursor-based pagination (fetch items ingested before cursor)
     if (cursor) {
       conditions.push(
         or(
-          sql`${sortField} < ${cursor.sortValue}`,
-          and(sql`${sortField} = ${cursor.sortValue}`, lt(userItems.id, cursor.id))
+          lt(userItems.ingestedAt, cursor.sortValue),
+          and(eq(userItems.ingestedAt, cursor.sortValue), lt(userItems.id, cursor.id))
         )!
       );
     }
@@ -578,7 +574,7 @@ export const itemsRouter = router({
       .innerJoin(items, eq(userItems.itemId, items.id))
       .leftJoin(creators, eq(items.creatorId, creators.id))
       .where(and(...conditions))
-      .orderBy(sql`${sortField} DESC`, desc(userItems.id))
+      .orderBy(desc(userItems.ingestedAt), desc(userItems.id))
       .limit(limit + 1); // Fetch one extra to check for more
 
     // Check if there are more results
@@ -593,7 +589,7 @@ export const itemsRouter = router({
     if (hasMore && pageResults.length > 0) {
       const lastResult = pageResults[pageResults.length - 1];
       nextCursor = encodeCursor({
-        sortValue: lastResult.items.publishedAt ?? lastResult.user_items.ingestedAt,
+        sortValue: lastResult.user_items.ingestedAt,
         id: lastResult.user_items.id,
       });
     }


### PR DESCRIPTION
## Summary

Sort the inbox by when an item was added to the user's inbox instead of when the content was originally published.

## Why

The inbox is a triage queue, so ordering by user_items.ingested_at better reflects what most recently arrived for the user. The previous query used items.published_at first and only fell back to ingested_at when the publication date was missing, which could push newly added older releases below older inbox entries.

## Changes

- Update items.inbox ordering and cursor pagination to use userItems.ingestedAt DESC with userItems.id as the tie-breaker.
- Add a regression test for an older release that was added more recently than a newer release.

## Validation

- bun run --cwd apps/worker test:run src/trpc/routers/items.test.ts
- bun run --cwd apps/worker typecheck
- Pre-push hook: format:check, design-system:check, repo typecheck, test:web, worker test subset excluding user-do and scheduler