### PR TITLE
[codex] Classify Substack newsletter articles

### DIFF
--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -1,5 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import * as WebBrowser from 'expo-web-browser';
+import { isSubstackArticleUrl } from '@zine/shared';
 import { useToast } from 'heroui-native';
 import { useCallback } from 'react';
 import { Linking, Share } from 'react-native';
@@ -39,7 +40,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
 
     try {
       const isArticle = item.contentType === ContentType.ARTICLE;
-      const isSubstack = item.provider === 'SUBSTACK';
+      const isSubstack = item.provider === 'SUBSTACK' || isSubstackArticleUrl(item.canonicalUrl);
       let didOpen = false;
 
       if (isArticle && !isSubstack) {

--- a/apps/mobile/app/subscriptions/[provider].tsx
+++ b/apps/mobile/app/subscriptions/[provider].tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Alert, FlatList, StyleSheet, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter, type Href } from 'expo-router';
+import { hasSubstackNewsletterIdentity } from '@zine/shared';
 import { Provider as ProviderEnum, type OAuthProvider } from '@zine/shared/types';
 
 import { ErrorState, LoadingState } from '@/components/list-states';
@@ -607,11 +608,7 @@ function getNewsletterImageUrl(feed: NewsletterFeed): string | null {
 }
 
 function isSubstackNewsletter(feed: NewsletterFeed): boolean {
-  return Boolean(
-    feed.fromAddress?.toLowerCase().endsWith('@substack.com') ||
-    feed.listId?.toLowerCase().includes('substack.com') ||
-    feed.unsubscribeUrl?.toLowerCase().includes('substack.com')
-  );
+  return hasSubstackNewsletterIdentity(feed);
 }
 
 function getNewsletterStatusLabel(feed: NewsletterFeed): string {

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -186,6 +186,27 @@ describe('useItemDetailActions', () => {
     expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
   });
 
+  it('opens substack article URLs with Linking even when provider is Gmail', async () => {
+    const item = {
+      ...baseItem,
+      provider: 'GMAIL',
+      canonicalUrl: 'https://lennysnewsletter.substack.com/p/getting-paid-to-vibe-code',
+      contentType: 'ARTICLE',
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(item));
+    mockMarkOpenedMutation.mutate.mockClear();
+
+    await act(async () => {
+      await result.current.handleOpenLink();
+    });
+
+    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: item.id });
+  });
+
   it('falls back to browser when substack can not be opened', async () => {
     mockCanOpenURL.mockResolvedValueOnce(false);
 

--- a/apps/worker/src/db/migrations/0017_reclassify_substack_newsletters.sql
+++ b/apps/worker/src/db/migrations/0017_reclassify_substack_newsletters.sql
@@ -1,0 +1,21 @@
+-- Reclassify Gmail-delivered Substack article items by content platform.
+-- Gmail newsletter feed/message tables still preserve the delivery source.
+UPDATE items
+SET
+  provider = 'SUBSTACK',
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE
+  provider = 'GMAIL'
+  AND (
+    lower(canonical_url) GLOB 'http://*.substack.com/p/*'
+    OR lower(canonical_url) GLOB 'https://*.substack.com/p/*'
+    OR lower(canonical_url) GLOB 'http://open.substack.com/pub/*/p/*'
+    OR lower(canonical_url) GLOB 'https://open.substack.com/pub/*/p/*'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM items AS existing_substack
+    WHERE
+      existing_substack.provider = 'SUBSTACK'
+      AND existing_substack.provider_id = items.provider_id
+  );

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779321600000,
       "tag": "0016_add_home_screen_sections",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780876800000,
+      "tag": "0017_reclassify_substack_newsletters",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/lib/link-parser.test.ts
+++ b/apps/worker/src/lib/link-parser.test.ts
@@ -264,6 +264,19 @@ describe('parseLink', () => {
 
         expect(result?.providerId).toBe('stratechery/the-great-analysis');
       });
+
+      it('normalizes open.substack.com article links', () => {
+        const result = parseLink(
+          'https://open.substack.com/pub/lennysnewsletter/p/getting-paid-to-vibe-code?utm_source=mail'
+        );
+
+        expect(result).toEqual({
+          provider: Provider.SUBSTACK,
+          contentType: ContentType.ARTICLE,
+          providerId: 'lennysnewsletter/getting-paid-to-vibe-code',
+          canonicalUrl: 'https://lennysnewsletter.substack.com/p/getting-paid-to-vibe-code',
+        });
+      });
     });
 
     describe('tracking parameter stripping', () => {

--- a/apps/worker/src/lib/link-parser.ts
+++ b/apps/worker/src/lib/link-parser.ts
@@ -5,7 +5,12 @@
  * Used by the Manual Link Saving feature to process user-submitted URLs.
  */
 
-import { ContentType, Provider } from '@zine/shared';
+import {
+  ContentType,
+  getSubstackArticleProviderId,
+  normalizeSubstackArticleUrl,
+  Provider,
+} from '@zine/shared';
 
 /**
  * Result of parsing a URL
@@ -173,30 +178,10 @@ function parseSpotify(url: URL): ParsedLink | null {
  * - *.substack.com/p/SLUG
  */
 function parseSubstack(url: URL): ParsedLink | null {
-  const hostname = url.hostname.toLowerCase();
+  const canonicalUrl = normalizeSubstackArticleUrl(url.toString());
+  const providerId = getSubstackArticleProviderId(canonicalUrl);
 
-  // Check for *.substack.com pattern
-  if (!hostname.endsWith('.substack.com') && hostname !== 'substack.com') {
-    return null;
-  }
-
-  // Parse /p/SLUG pattern
-  if (url.pathname.startsWith('/p/')) {
-    const slug = url.pathname.split('/p/')[1]?.split('/')[0]?.split('?')[0] ?? null;
-
-    if (!slug) {
-      return null;
-    }
-
-    // Extract publication name from subdomain
-    const publication = hostname.replace('.substack.com', '');
-
-    // Provider ID combines publication and slug for uniqueness
-    const providerId = `${publication}/${slug}`;
-
-    // Build canonical URL (strip tracking params)
-    const canonicalUrl = stripTrackingParams(url);
-
+  if (canonicalUrl && providerId) {
     return {
       provider: Provider.SUBSTACK,
       contentType: ContentType.ARTICLE,

--- a/apps/worker/src/newsletters/gmail.test.ts
+++ b/apps/worker/src/newsletters/gmail.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { Provider } from '@zine/shared';
 
 import {
+  classifyNewsletterIssue,
   computeNewsletterScore,
   isLikelyNewsletterFeedIdentity,
   normalizeUnsubscribeIdentityUrl,
@@ -214,6 +216,39 @@ describe('gmail newsletter detection', () => {
     });
 
     expect(bestUrl).toBe('https://lenny.substack.com/p/getting-paid-to-vibe-code');
+  });
+
+  it('classifies Substack newsletter issues as Substack items', () => {
+    const classification = classifyNewsletterIssue({
+      issueUrl:
+        'https://open.substack.com/pub/lennysnewsletter/p/getting-paid-to-vibe-code?utm_source=email',
+      gmailProviderId: 'google-sub:gmail-message-id',
+      listId: '<lennysnewsletter.substack.com>',
+      fromAddress: 'lenny@substack.com',
+      unsubscribeUrl: 'https://substack.com/unsubscribe?token=abc',
+    });
+
+    expect(classification).toEqual({
+      provider: Provider.SUBSTACK,
+      providerId: 'lennysnewsletter/getting-paid-to-vibe-code',
+      canonicalUrl: 'https://lennysnewsletter.substack.com/p/getting-paid-to-vibe-code',
+    });
+  });
+
+  it('keeps non-Substack newsletter issues as Gmail items', () => {
+    const classification = classifyNewsletterIssue({
+      issueUrl: 'https://newsletter.example.com/posts/42',
+      gmailProviderId: 'google-sub:gmail-message-id',
+      listId: '<newsletter.example.com>',
+      fromAddress: 'news@newsletter.example.com',
+      unsubscribeUrl: 'https://newsletter.example.com/unsubscribe',
+    });
+
+    expect(classification).toEqual({
+      provider: Provider.GMAIL,
+      providerId: 'google-sub:gmail-message-id',
+      canonicalUrl: 'https://newsletter.example.com/posts/42',
+    });
   });
 
   it('returns null when only non-content links are present', () => {

--- a/apps/worker/src/newsletters/gmail.ts
+++ b/apps/worker/src/newsletters/gmail.ts
@@ -1,6 +1,12 @@
 import { and, eq } from 'drizzle-orm';
 import { ulid } from 'ulid';
-import { ContentType, Provider } from '@zine/shared';
+import {
+  ContentType,
+  getSubstackArticleProviderId,
+  hasSubstackNewsletterIdentity,
+  normalizeSubstackArticleUrl,
+  Provider,
+} from '@zine/shared';
 import { parseHTML } from 'linkedom/worker';
 
 import { createDb, type Database } from '../db';
@@ -180,6 +186,12 @@ interface FeedSeedResult {
     | 'no_matching_message'
     | 'no_search_query';
 }
+
+export type NewsletterIssueClassification = {
+  provider: Provider;
+  providerId: string;
+  canonicalUrl: string;
+};
 
 export interface FeedBackfillResult {
   createdCount: number;
@@ -801,6 +813,8 @@ async function maybeUpgradeExistingNewsletterItem(params: {
     where: eq(items.id, params.itemId),
     columns: {
       id: true,
+      provider: true,
+      providerId: true,
       canonicalUrl: true,
       creatorId: true,
       thumbnailUrl: true,
@@ -854,6 +868,33 @@ async function maybeUpgradeExistingNewsletterItem(params: {
     }
   }
 
+  const itemUpdates: Partial<typeof items.$inferInsert> = {};
+  const substackCanonicalUrl = normalizeSubstackArticleUrl(canonicalUrl);
+  const substackProviderId = getSubstackArticleProviderId(substackCanonicalUrl);
+  if (
+    existingItem.provider === Provider.GMAIL &&
+    substackCanonicalUrl &&
+    substackProviderId &&
+    hasSubstackNewsletterIdentity({
+      canonicalUrl: substackCanonicalUrl,
+      listId: params.parsed.listId,
+      fromAddress: params.parsed.fromAddress,
+      unsubscribeUrl: params.parsed.unsubscribeUrl,
+    })
+  ) {
+    const existingSubstackItem = await params.db.query.items.findFirst({
+      where: and(eq(items.provider, Provider.SUBSTACK), eq(items.providerId, substackProviderId)),
+      columns: { id: true },
+    });
+
+    if (!existingSubstackItem || existingSubstackItem.id === existingItem.id) {
+      canonicalUrl = substackCanonicalUrl;
+      itemUpdates.provider = Provider.SUBSTACK;
+      itemUpdates.providerId = substackProviderId;
+      itemUpdates.canonicalUrl = substackCanonicalUrl;
+    }
+  }
+
   const newsletterAvatarUrl = buildNewsletterAvatarUrl({
     canonicalUrl,
     listId: params.parsed.listId,
@@ -862,7 +903,6 @@ async function maybeUpgradeExistingNewsletterItem(params: {
     creatorHandle: params.parsed.fromAddress,
   });
 
-  const itemUpdates: Partial<typeof items.$inferInsert> = {};
   if (shouldPersistCanonicalUpdate) {
     itemUpdates.canonicalUrl = canonicalUrl;
     itemUpdates.rawMetadata = rawMetadata;
@@ -1163,6 +1203,39 @@ export function shouldUpgradeNewsletterIssueUrl(currentUrl: string, nextUrl: str
   }
 
   return false;
+}
+
+export function classifyNewsletterIssue(params: {
+  issueUrl: string;
+  gmailProviderId: string;
+  listId: string | null;
+  fromAddress: string;
+  unsubscribeUrl: string | null;
+}): NewsletterIssueClassification {
+  const normalizedSubstackUrl = normalizeSubstackArticleUrl(params.issueUrl);
+  const substackProviderId = getSubstackArticleProviderId(normalizedSubstackUrl);
+  const isSubstackIssue =
+    Boolean(normalizedSubstackUrl && substackProviderId) &&
+    hasSubstackNewsletterIdentity({
+      canonicalUrl: normalizedSubstackUrl,
+      listId: params.listId,
+      fromAddress: params.fromAddress,
+      unsubscribeUrl: params.unsubscribeUrl,
+    });
+
+  if (isSubstackIssue && normalizedSubstackUrl && substackProviderId) {
+    return {
+      provider: Provider.SUBSTACK,
+      providerId: substackProviderId,
+      canonicalUrl: normalizedSubstackUrl,
+    };
+  }
+
+  return {
+    provider: Provider.GMAIL,
+    providerId: params.gmailProviderId,
+    canonicalUrl: params.issueUrl,
+  };
 }
 
 async function gmailGet<T>(accessToken: string, path: string): Promise<T> {
@@ -1572,7 +1645,14 @@ async function ingestNewsletterMessage(params: {
     accessToken: params.accessToken,
     parsed: params.parsed,
   });
-  const issueUrl = issueUrlResolution.url;
+  const issueClassification = classifyNewsletterIssue({
+    issueUrl: issueUrlResolution.url,
+    gmailProviderId: providerId,
+    listId: params.parsed.listId,
+    fromAddress: params.parsed.fromAddress,
+    unsubscribeUrl: params.parsed.unsubscribeUrl,
+  });
+  const issueUrl = issueClassification.canonicalUrl;
   const newsletterAvatarUrl = buildNewsletterAvatarUrl({
     canonicalUrl: issueUrl,
     listId: params.parsed.listId,
@@ -1600,8 +1680,8 @@ async function ingestNewsletterMessage(params: {
     .values({
       id: ulid(),
       contentType: ContentType.ARTICLE,
-      provider: Provider.GMAIL,
-      providerId,
+      provider: issueClassification.provider,
+      providerId: issueClassification.providerId,
       canonicalUrl: issueUrl,
       title: params.parsed.subject,
       thumbnailUrl: newsletterAvatarUrl,
@@ -1612,6 +1692,8 @@ async function ingestNewsletterMessage(params: {
       publishedAt: publishedAtIso,
       rawMetadata: JSON.stringify({
         messageId: params.parsed.messageId,
+        deliveryProvider: Provider.GMAIL,
+        deliveryProviderId: providerId,
         threadId: params.parsed.threadId,
         listId: params.parsed.listId,
         fromAddress: params.parsed.fromAddress,
@@ -1629,12 +1711,17 @@ async function ingestNewsletterMessage(params: {
     });
 
   const canonicalItem = await params.db.query.items.findFirst({
-    where: and(eq(items.provider, Provider.GMAIL), eq(items.providerId, providerId)),
+    where: and(
+      eq(items.provider, issueClassification.provider),
+      eq(items.providerId, issueClassification.providerId)
+    ),
     columns: { id: true },
   });
 
   if (!canonicalItem) {
-    throw new Error(`Failed to load created newsletter item for providerId=${providerId}`);
+    throw new Error(
+      `Failed to load created newsletter item for providerId=${issueClassification.providerId}`
+    );
   }
 
   await params.db

--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -14,7 +14,15 @@ import { z } from 'zod';
 import { ulid } from 'ulid';
 import { eq, and } from 'drizzle-orm';
 import { router, protectedProcedure } from '../trpc';
-import { ContentTypeSchema, ProviderSchema, UserItemState } from '@zine/shared';
+import {
+  ContentType,
+  ContentTypeSchema,
+  getSubstackArticleProviderId,
+  normalizeSubstackArticleUrl,
+  Provider,
+  ProviderSchema,
+  UserItemState,
+} from '@zine/shared';
 import { items, userItems, users, providerConnections } from '../../db/schema';
 import { fetchLinkPreview } from '../../lib/link-preview';
 import { getValidAccessToken, type TokenRefreshEnv } from '../../lib/token-refresh';
@@ -161,10 +169,17 @@ export const bookmarksRouter = router({
    */
   save: protectedProcedure.input(SaveInputSchema).mutation(async ({ input, ctx }) => {
     const now = new Date().toISOString();
+    const substackCanonicalUrl =
+      normalizeSubstackArticleUrl(input.canonicalUrl) ?? normalizeSubstackArticleUrl(input.url);
+    const substackProviderId = getSubstackArticleProviderId(substackCanonicalUrl);
+    const provider = substackProviderId ? Provider.SUBSTACK : input.provider;
+    const contentType = substackProviderId ? ContentType.ARTICLE : input.contentType;
+    const providerId = substackProviderId ?? input.providerId;
+    const canonicalUrl = substackCanonicalUrl ?? input.canonicalUrl;
 
     // 1. Find or create the canonical item
     const existingItem = await ctx.db.query.items.findFirst({
-      where: and(eq(items.provider, input.provider), eq(items.providerId, input.providerId)),
+      where: and(eq(items.provider, provider), eq(items.providerId, providerId)),
     });
 
     let itemId: string;
@@ -176,14 +191,14 @@ export const bookmarksRouter = router({
     if (input.rawMetadata) {
       try {
         const parsedMetadata = JSON.parse(input.rawMetadata);
-        const creatorParams = extractCreatorFromMetadata(input.provider, parsedMetadata);
+        const creatorParams = extractCreatorFromMetadata(provider, parsedMetadata);
 
         if (creatorParams) {
           const creator = await findOrCreateCreator(ctx, creatorParams);
           creatorId = creator.id;
           bookmarksLogger.debug('Creator extracted from metadata', {
             creatorId,
-            provider: input.provider,
+            provider,
             name: creatorParams.name,
           });
         }
@@ -194,9 +209,9 @@ export const bookmarksRouter = router({
 
     // Fallback: use creator name with synthetic ID
     if (!creatorId && input.creator) {
-      const syntheticId = generateSyntheticCreatorId(input.provider, input.creator);
+      const syntheticId = generateSyntheticCreatorId(provider, input.creator);
       const creator = await findOrCreateCreator(ctx, {
-        provider: input.provider,
+        provider,
         providerCreatorId: syntheticId,
         name: input.creator,
         imageUrl: input.creatorImageUrl ?? undefined,
@@ -204,7 +219,7 @@ export const bookmarksRouter = router({
       creatorId = creator.id;
       bookmarksLogger.debug('Creator created with synthetic ID', {
         creatorId,
-        provider: input.provider,
+        provider,
         name: input.creator,
         syntheticId,
       });
@@ -237,14 +252,14 @@ export const bookmarksRouter = router({
       let articleContentKey: string | null = null;
 
       // For WEB provider items with article content, extract and store the article
-      if (input.provider === 'WEB' && input.hasArticleContent === true) {
+      if (provider === Provider.WEB && input.hasArticleContent === true) {
         try {
           bookmarksLogger.debug('Extracting article content', {
-            url: input.canonicalUrl,
+            url: canonicalUrl,
             itemId,
           });
 
-          const articleData = await extractArticle(input.canonicalUrl);
+          const articleData = await extractArticle(canonicalUrl);
 
           if (articleData?.content && ctx.env.ARTICLE_CONTENT) {
             // Store article content in R2
@@ -275,7 +290,7 @@ export const bookmarksRouter = router({
           // Article storage is best-effort - log error but don't fail the save
           bookmarksLogger.error('Failed to extract/store article content', {
             error,
-            url: input.canonicalUrl,
+            url: canonicalUrl,
             itemId,
           });
         }
@@ -285,10 +300,10 @@ export const bookmarksRouter = router({
       // These deprecated fields are no longer written.
       await ctx.db.insert(items).values({
         id: itemId,
-        contentType: input.contentType,
-        provider: input.provider,
-        providerId: input.providerId,
-        canonicalUrl: input.canonicalUrl,
+        contentType,
+        provider,
+        providerId,
+        canonicalUrl,
         title: input.title,
         thumbnailUrl: input.thumbnailUrl,
         creatorId,

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -27,11 +27,13 @@ import {
   HomeScreenSectionKind,
   isJsonObject,
   type JsonObject,
-  type Provider,
+  Provider,
   type CollectionRules,
   UserItemState,
   ProviderSchema,
   ContentTypeSchema,
+  hasSubstackNewsletterIdentity,
+  isSubstackArticleUrl,
 } from '@zine/shared';
 import { normalizeTagKey, normalizeTagName } from '@zine/shared/tags';
 import {
@@ -260,6 +262,21 @@ function toItemView(
     item.provider === 'GMAIL'
       ? (normalizedCreatorImageUrl ?? newsletterAvatarUrl)
       : normalizedCreatorImageUrl;
+  const responseProvider =
+    item.provider === Provider.GMAIL &&
+    isSubstackArticleUrl(item.canonicalUrl) &&
+    hasSubstackNewsletterIdentity({
+      canonicalUrl: item.canonicalUrl,
+      listId: getStringMetadataField(metadata, 'listId'),
+      fromAddress:
+        getStringMetadataField(metadata, 'fromAddress') ??
+        getStringMetadataField(metadata, 'sender') ??
+        creator?.handle ??
+        null,
+      unsubscribeUrl: getStringMetadataField(metadata, 'unsubscribeUrl'),
+    })
+      ? Provider.SUBSTACK
+      : item.provider;
 
   return {
     id: userItem.id,
@@ -268,7 +285,7 @@ function toItemView(
     thumbnailUrl,
     canonicalUrl: normalizeCanonicalUrlForResponse(item.canonicalUrl),
     contentType: item.contentType as ContentType,
-    provider: item.provider as Provider,
+    provider: responseProvider as Provider,
     // Creator data from creators table (normalized)
     creator: creator?.name ?? 'Unknown Creator',
     creatorImageUrl,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,6 +30,10 @@
       "types": "./src/tags.ts",
       "import": "./src/tags.ts"
     },
+    "./substack": {
+      "types": "./src/substack.ts",
+      "import": "./src/substack.ts"
+    },
     "./telemetry": {
       "types": "./src/telemetry.ts",
       "import": "./src/telemetry.ts"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -51,6 +51,14 @@ export type { UIContentType, UIProvider } from './format';
 // Tag normalization helpers
 export { normalizeTagKey, normalizeTagName, sanitizeTagNames } from './tags';
 
+// Substack URL and newsletter identity helpers
+export {
+  getSubstackArticleProviderId,
+  hasSubstackNewsletterIdentity,
+  isSubstackArticleUrl,
+  normalizeSubstackArticleUrl,
+} from './substack';
+
 // Smart collection contracts
 export {
   CollectionItemMembership,

--- a/packages/shared/src/substack.ts
+++ b/packages/shared/src/substack.ts
@@ -1,0 +1,132 @@
+const TRACKING_PARAM_PREFIXES = ['utm_', 'mc_'];
+const TRACKING_PARAM_NAMES = new Set(['ref', 'ref_src', 'ref_url', 's', 'source']);
+
+function parseHttpUrl(rawUrl: string | null | undefined): URL | null {
+  const trimmed = rawUrl?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function stripTrackingParams(url: URL): string {
+  const cleanUrl = new URL(url.toString());
+
+  for (const key of Array.from(cleanUrl.searchParams.keys())) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (
+      TRACKING_PARAM_NAMES.has(normalizedKey) ||
+      TRACKING_PARAM_PREFIXES.some((prefix) => normalizedKey.startsWith(prefix))
+    ) {
+      cleanUrl.searchParams.delete(key);
+    }
+  }
+
+  cleanUrl.hash = '';
+  return cleanUrl.toString();
+}
+
+function normalizeHost(hostname: string): string {
+  return hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, '');
+}
+
+function directUrlFromOpenSubstack(url: URL): URL | null {
+  const hostname = normalizeHost(url.hostname);
+  if (hostname !== 'open.substack.com') {
+    return null;
+  }
+
+  const pathSegments = url.pathname.split('/').filter(Boolean);
+  if (pathSegments.length < 4 || pathSegments[0] !== 'pub' || pathSegments[2] !== 'p') {
+    return null;
+  }
+
+  const publication = pathSegments[1]?.trim().toLowerCase();
+  const slug = pathSegments[3];
+  if (!publication || !slug) {
+    return null;
+  }
+
+  return new URL(`https://${publication}.substack.com/p/${slug}`);
+}
+
+export function normalizeSubstackArticleUrl(rawUrl: string | null | undefined): string | null {
+  const parsedUrl = parseHttpUrl(rawUrl);
+  if (!parsedUrl) {
+    return null;
+  }
+
+  const url = directUrlFromOpenSubstack(parsedUrl) ?? parsedUrl;
+  const hostname = normalizeHost(url.hostname);
+  if (!hostname.endsWith('.substack.com')) {
+    return null;
+  }
+
+  const pathSegments = url.pathname.split('/').filter(Boolean);
+  if (pathSegments.length < 2 || pathSegments[0] !== 'p' || !pathSegments[1]) {
+    return null;
+  }
+
+  return stripTrackingParams(url);
+}
+
+export function isSubstackArticleUrl(rawUrl: string | null | undefined): boolean {
+  return normalizeSubstackArticleUrl(rawUrl) !== null;
+}
+
+export function getSubstackArticleProviderId(rawUrl: string | null | undefined): string | null {
+  const canonicalUrl = normalizeSubstackArticleUrl(rawUrl);
+  if (!canonicalUrl) {
+    return null;
+  }
+
+  const url = new URL(canonicalUrl);
+  const publication = normalizeHost(url.hostname).replace(/\.substack\.com$/, '');
+  const slug = url.pathname.split('/').filter(Boolean)[1];
+  if (!publication || !slug) {
+    return null;
+  }
+
+  return `${publication}/${slug}`;
+}
+
+function valueContainsSubstackDomain(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return Boolean(normalized && /(^|[<@\s./-])substack\.com([>\s/:-]|$)/i.test(normalized));
+}
+
+function hasSubstackHost(rawUrl: string | null | undefined): boolean {
+  const parsedUrl = parseHttpUrl(rawUrl);
+  if (!parsedUrl) {
+    return false;
+  }
+
+  const hostname = normalizeHost(parsedUrl.hostname);
+  return hostname === 'substack.com' || hostname.endsWith('.substack.com');
+}
+
+export function hasSubstackNewsletterIdentity(identity: {
+  canonicalUrl?: string | null;
+  listId?: string | null;
+  fromAddress?: string | null;
+  unsubscribeUrl?: string | null;
+}): boolean {
+  return (
+    isSubstackArticleUrl(identity.canonicalUrl) ||
+    valueContainsSubstackDomain(identity.listId) ||
+    valueContainsSubstackDomain(identity.fromAddress) ||
+    hasSubstackHost(identity.unsubscribeUrl)
+  );
+}

--- a/packages/shared/tsup.config.ts
+++ b/packages/shared/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/types/index.ts', 'src/schemas/index.ts', 'src/constants/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/types/index.ts',
+    'src/schemas/index.ts',
+    'src/constants/index.ts',
+    'src/substack.ts',
+  ],
   format: ['esm'],
   dts: true,
   clean: true,


### PR DESCRIPTION
## Summary
- add shared Substack URL/newsletter identity helpers
- classify Gmail-delivered and manually saved Substack articles as `SUBSTACK` while preserving Gmail delivery metadata
- route Substack article URLs through `Linking.openURL` so iOS universal links can open the Substack app
- add a conservative D1 migration for existing obvious Gmail-stored Substack article rows

## Root Cause
Gmail newsletter ingestion stored Substack issues as `GMAIL` items, and mobile only used `item.provider` to decide whether to bypass the in-app browser. Substack links delivered through Gmail therefore missed both Substack categorization and app-opening behavior.

## Validation
- `bun run format:check`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run --cwd apps/worker test:run src/lib/link-parser.test.ts src/newsletters/gmail.test.ts src/lib/link-preview.test.ts`
- `bun run --cwd apps/mobile test hooks/use-item-detail-actions.test.ts`
