### PR TITLE
[codex] Fix item detail actions

### DIFF
--- a/.codex/skills/zine-mobile-preview-deploy/SKILL.md
+++ b/.codex/skills/zine-mobile-preview-deploy/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: zine-mobile-preview-deploy
+description: Use when the user asks to push, deploy, install, or send the Zine mobile app to their phone or device. Treat these requests as iOS preview deployments by default, and use the mobile deploy script unless the user explicitly asks for a different build type or target.
+metadata:
+  short-description: Deploy Zine mobile preview to phone
+---
+
+# Zine Mobile Preview Deploy
+
+When the user asks to "push it to my phone", "deploy it to my phone", "install it on my phone", or similar, assume they mean the iOS preview build for `apps/mobile`.
+
+Default workflow:
+
+1. Work from the requested source snapshot. If they say to pull latest/main first, update to `origin/main` before building. In a linked worktree, use detached `origin/main` if the local `main` branch is already checked out elsewhere.
+2. From `apps/mobile`, run:
+
+   ```bash
+   bun run deploy:ios:preview
+   ```
+
+3. Let the script handle the EAS preview build, IPA download, device discovery, and `devicectl` install.
+4. Do not run production, TestFlight, or ad hoc EAS commands unless the user explicitly asks for that.
+5. If the script appears quiet, check EAS status with:
+
+   ```bash
+   eas build:list --platform ios --limit 3 --non-interactive
+   ```
+
+   Keep the existing deploy process attached instead of starting duplicate builds when a current build is in progress.
+
+Expected output after success includes `App installed` with bundle ID `app.zine.mobile`.

--- a/.codex/skills/zine-mobile-preview-deploy/agents/openai.yaml
+++ b/.codex/skills/zine-mobile-preview-deploy/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: 'Zine Mobile Preview Deploy'
+  short_description: 'Deploy the Zine iOS preview build to a phone'
+  default_prompt: 'Use $zine-mobile-preview-deploy to build and install the Zine mobile preview app on my phone.'
+
+policy:
+  allow_implicit_invocation: true

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -129,6 +129,18 @@ bun run design-system:check
 
 Expo Go provides a pre-built native runtime that loads JavaScript bundles over the network. This is sufficient for testing UI, navigation, and most app functionality.
 
+### Real Device Preview Deploys
+
+When the user asks to push, deploy, install, or send the app to their phone or device, assume they mean the iOS preview build unless they explicitly say otherwise.
+
+Use the deploy wrapper from `apps/mobile`:
+
+```bash
+bun run deploy:ios:preview
+```
+
+The script creates the EAS preview build, downloads the IPA, discovers the connected iOS device, and installs it with `devicectl`. Do not substitute production, TestFlight, or raw EAS commands unless requested.
+
 ### Running the App
 
 ```bash

--- a/apps/mobile/app/item/[id].tsx
+++ b/apps/mobile/app/item/[id].tsx
@@ -129,6 +129,15 @@ export default function ItemDetailScreen() {
     return <ItemDetailNotFoundState colors={colors} />;
   }
 
+  const collectionsSheet = (
+    <ItemCollectionsSheet
+      item={item}
+      colors={colors}
+      visible={collectionsSheetOpen}
+      onClose={handleCloseCollectionsSheet}
+    />
+  );
+
   if (viewState.isXPost) {
     return (
       <>
@@ -159,12 +168,7 @@ export default function ItemDetailScreen() {
           otherUnfinishedBookmarks={otherUnfinishedBookmarks}
           onOtherBookmarkPress={(bookmarkId) => router.push(`/item/${bookmarkId}` as Href)}
         />
-        <ItemCollectionsSheet
-          item={item}
-          colors={colors}
-          visible={collectionsSheetOpen}
-          onClose={handleCloseCollectionsSheet}
-        />
+        {collectionsSheet}
       </>
     );
   }
@@ -181,6 +185,7 @@ export default function ItemDetailScreen() {
         onScroll={handleScroll}
         screenTitle={item.title}
         showCollapsedTitle={showCollapsedTitle}
+        overlay={collectionsSheet}
         headerImage={
           <Image
             source={{ uri: item.thumbnailUrl! }}
@@ -220,12 +225,6 @@ export default function ItemDetailScreen() {
           onContentLayout={handleContentLayout}
           onTitleLayout={handleTitleLayout}
         />
-        <ItemCollectionsSheet
-          item={item}
-          colors={colors}
-          visible={collectionsSheetOpen}
-          onClose={handleCloseCollectionsSheet}
-        />
       </ItemDetailParallaxLayout>
     );
   }
@@ -238,6 +237,7 @@ export default function ItemDetailScreen() {
       onScroll={handleScroll}
       screenTitle={item.title}
       showCollapsedTitle={showCollapsedTitle}
+      overlay={collectionsSheet}
     >
       <ItemDetailContent
         item={item}
@@ -267,12 +267,6 @@ export default function ItemDetailScreen() {
         useAnimatedDescription={false}
         onContentLayout={handleContentLayout}
         onTitleLayout={handleTitleLayout}
-      />
-      <ItemCollectionsSheet
-        item={item}
-        colors={colors}
-        visible={collectionsSheetOpen}
-        onClose={handleCloseCollectionsSheet}
       />
     </ItemDetailScrollLayout>
   );

--- a/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailActions.tsx
@@ -1,8 +1,9 @@
 import type { Ionicons } from '@expo/vector-icons';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
+import { IconButton } from '@/components/primitives';
 import { UserItemState } from '@/hooks/use-items-trpc';
 
 import { getFabConfig } from '../../item-detail-helpers';
@@ -77,12 +78,16 @@ export function ItemDetailActions({
         <IconActionButton icon="share-outline" color={colors.textSecondary} onPress={onShare} />
         <IconActionButton icon="ellipsis-horizontal" color={colors.textSecondary} />
       </View>
-      <Pressable
+      <IconButton
         onPress={onOpenLink}
+        size="lg"
+        variant="solid"
+        colors={colors}
+        accessibilityLabel="Open source link"
         style={[styles.fabButton, { backgroundColor: fabConfig.backgroundColor }]}
       >
         {fabConfig.providerIcon}
-      </Pressable>
+      </IconButton>
     </Container>
   );
 }

--- a/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
+++ b/apps/mobile/app/item/detail/components/ItemDetailLayouts.tsx
@@ -57,7 +57,11 @@ export function ItemDetailParallaxLayout({
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
       />
-      {overlay}
+      {overlay ? (
+        <View pointerEvents="box-none" style={styles.overlayContainer}>
+          {overlay}
+        </View>
+      ) : null}
     </View>
   );
 }
@@ -93,7 +97,11 @@ export function ItemDetailScrollLayout({
         screenTitle={screenTitle}
         showCollapsedTitle={showCollapsedTitle}
       />
-      {overlay}
+      {overlay ? (
+        <View pointerEvents="box-none" style={styles.overlayContainer}>
+          {overlay}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -19,6 +19,15 @@ import { showError } from '@/lib/toast-utils';
 
 import type { ItemDetailItem } from '../types';
 
+function isWebUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function useItemDetailActions(item?: ItemDetailItem | null) {
   const { toast } = useToast();
   const bookmarkMutation = useBookmarkItem();
@@ -36,9 +45,8 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
   const handleOpenLink = useCallback(async () => {
     if (!item?.canonicalUrl) return;
 
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-
     try {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       const isArticle = item.contentType === ContentType.ARTICLE;
       const isSubstack = item.provider === 'SUBSTACK' || isSubstackArticleUrl(item.canonicalUrl);
       let didOpen = false;
@@ -46,19 +54,16 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
       if (isArticle && !isSubstack) {
         await WebBrowser.openBrowserAsync(item.canonicalUrl, {
           enableBarCollapsing: true,
-          presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+          presentationStyle: WebBrowser.WebBrowserPresentationStyle.AUTOMATIC,
         });
+        didOpen = true;
+      } else if (isWebUrl(item.canonicalUrl)) {
+        await Linking.openURL(item.canonicalUrl);
         didOpen = true;
       } else {
         const supported = await Linking.canOpenURL(item.canonicalUrl);
         if (supported) {
           await Linking.openURL(item.canonicalUrl);
-          didOpen = true;
-        } else if (isSubstack) {
-          await WebBrowser.openBrowserAsync(item.canonicalUrl, {
-            enableBarCollapsing: true,
-            presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
-          });
           didOpen = true;
         }
       }
@@ -68,8 +73,9 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
       }
     } catch (err) {
       logger.error('Failed to open URL', { error: err });
+      showError(toast, err, 'Failed to open link', 'itemDetail.openLink');
     }
-  }, [handleMarkLinkOpened, item]);
+  }, [handleMarkLinkOpened, item, toast]);
 
   const handleShare = useCallback(async () => {
     if (!item) return;

--- a/apps/mobile/app/item/item-detail-styles.ts
+++ b/apps/mobile/app/item/item-detail-styles.ts
@@ -9,6 +9,10 @@ export const styles = StyleSheet.create({
   animatedContainer: {
     flex: 1,
   },
+  overlayContainer: {
+    ...StyleSheet.absoluteFill,
+    zIndex: 200,
+  },
   safeArea: {
     flex: 1,
   },

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -36,6 +36,7 @@ jest.mock('expo-web-browser', () => ({
   ) => mockOpenBrowserAsync(...args),
   WebBrowserPresentationStyle: {
     FULL_SCREEN: 'FULL_SCREEN',
+    AUTOMATIC: 'AUTOMATIC',
   },
 }));
 
@@ -142,9 +143,11 @@ describe('useItemDetailActions', () => {
       await result.current.handleOpenLink();
     });
 
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
+    expect(mockOpenURL).not.toHaveBeenCalled();
     expect(mockOpenBrowserAsync).toHaveBeenCalledWith(item.canonicalUrl, {
       enableBarCollapsing: true,
-      presentationStyle: 'FULL_SCREEN',
+      presentationStyle: 'AUTOMATIC',
     });
     expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: item.id });
   });
@@ -153,6 +156,25 @@ describe('useItemDetailActions', () => {
     const item = {
       ...baseItem,
       contentType: 'VIDEO',
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(item));
+    mockMarkOpenedMutation.mutate.mockClear();
+
+    await act(async () => {
+      await result.current.handleOpenLink();
+    });
+
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
+    expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+  });
+
+  it('checks support before opening non-web external links', async () => {
+    const item = {
+      ...baseItem,
+      canonicalUrl: 'spotify:show:show-123',
+      contentType: 'PODCAST',
       state: UserItemState.BOOKMARKED,
     } as unknown as ItemDetailItem;
     const { result } = renderHook(() => useItemDetailActions(item));
@@ -181,9 +203,30 @@ describe('useItemDetailActions', () => {
       await result.current.handleOpenLink();
     });
 
-    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
     expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
     expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+  });
+
+  it('opens provider-classified substack articles on custom domains with Linking', async () => {
+    const item = {
+      ...baseItem,
+      provider: 'SUBSTACK',
+      canonicalUrl: 'https://blog.pragmaticengineer.com/ideas-slow-down-to-speed-up/',
+      contentType: 'ARTICLE',
+      state: UserItemState.BOOKMARKED,
+    } as unknown as ItemDetailItem;
+    const { result } = renderHook(() => useItemDetailActions(item));
+    mockMarkOpenedMutation.mutate.mockClear();
+
+    await act(async () => {
+      await result.current.handleOpenLink();
+    });
+
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
+    expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+    expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: item.id });
   });
 
   it('opens substack article URLs with Linking even when provider is Gmail', async () => {
@@ -201,18 +244,20 @@ describe('useItemDetailActions', () => {
       await result.current.handleOpenLink();
     });
 
-    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
     expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
     expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
     expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: item.id });
   });
 
-  it('falls back to browser when substack can not be opened', async () => {
-    mockCanOpenURL.mockResolvedValueOnce(false);
+  it('shows feedback when a web URL can not be opened', async () => {
+    const error = new Error('no handler');
+    mockOpenURL.mockRejectedValueOnce(error);
 
     const item = {
       ...baseItem,
       provider: 'SUBSTACK',
+      canonicalUrl: 'https://blog.pragmaticengineer.com/ideas-slow-down-to-speed-up/',
       contentType: 'ARTICLE',
       state: UserItemState.BOOKMARKED,
     } as unknown as ItemDetailItem;
@@ -223,12 +268,17 @@ describe('useItemDetailActions', () => {
       await result.current.handleOpenLink();
     });
 
-    expect(mockCanOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
-    expect(mockOpenURL).not.toHaveBeenCalled();
-    expect(mockOpenBrowserAsync).toHaveBeenCalledWith(item.canonicalUrl, {
-      enableBarCollapsing: true,
-      presentationStyle: 'FULL_SCREEN',
-    });
+    expect(mockCanOpenURL).not.toHaveBeenCalled();
+    expect(mockOpenURL).toHaveBeenCalledWith(item.canonicalUrl);
+    expect(mockOpenBrowserAsync).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith('Failed to open URL', { error });
+    expect(mockShowError).toHaveBeenCalledWith(
+      mockToastManager,
+      error,
+      'Failed to open link',
+      'itemDetail.openLink'
+    );
+    expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
   });
 
   it('does not mark opened after a successful open when the item is not bookmarked', async () => {
@@ -252,7 +302,16 @@ describe('useItemDetailActions', () => {
     });
 
     expect(logger.error).toHaveBeenCalledWith('Failed to open URL', { error });
-    expect(mockOpenBrowserAsync).toHaveBeenCalled();
+    expect(mockOpenBrowserAsync).toHaveBeenCalledWith(baseItem.canonicalUrl, {
+      enableBarCollapsing: true,
+      presentationStyle: 'AUTOMATIC',
+    });
+    expect(mockShowError).toHaveBeenCalledWith(
+      mockToastManager,
+      error,
+      'Failed to open link',
+      'itemDetail.openLink'
+    );
     expect(mockMarkOpenedMutation.mutate).not.toHaveBeenCalled();
   });
 
@@ -260,7 +319,8 @@ describe('useItemDetailActions', () => {
     mockCanOpenURL.mockResolvedValueOnce(false);
     const item = {
       ...baseItem,
-      contentType: 'VIDEO',
+      canonicalUrl: 'spotify:show:show-123',
+      contentType: 'PODCAST',
     } as unknown as ItemDetailItem;
     const { result } = renderHook(() => useItemDetailActions(item));
     mockMarkOpenedMutation.mutate.mockClear();

--- a/apps/mobile/lib/item-collections-bottom-sheet.ios.tsx
+++ b/apps/mobile/lib/item-collections-bottom-sheet.ios.tsx
@@ -1,18 +1,6 @@
-import { BottomSheet, Group, Host, RNHostView } from '@expo/ui/swift-ui';
-import {
-  background,
-  frame,
-  ignoreSafeArea,
-  presentationBackground,
-  presentationBackgroundInteraction,
-  presentationDetents,
-  presentationDragIndicator,
-  type PresentationDetent,
-} from '@expo/ui/swift-ui/modifiers';
-import { Fragment, useEffect, useMemo, useState, type ReactElement } from 'react';
-import { Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
-
-const initialDetent: PresentationDetent = { fraction: 0.75 };
+import BottomSheet, { BottomSheetView } from '@expo/ui/community/bottom-sheet';
+import { type ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
 
 type ItemCollectionsBottomSheetProps = {
   visible: boolean;
@@ -27,78 +15,21 @@ export function ItemCollectionsBottomSheet({
   backgroundColor,
   children,
 }: ItemCollectionsBottomSheetProps) {
-  const { height, width } = useWindowDimensions();
-  const [selectedDetent, setSelectedDetent] = useState<PresentationDetent>(initialDetent);
-
-  useEffect(() => {
-    if (visible) {
-      setSelectedDetent(initialDetent);
-    }
-  }, [visible]);
-
-  const modifiers = useMemo(
-    () => [
-      frame({ maxWidth: Infinity, maxHeight: Infinity, alignment: 'topLeading' }),
-      background(backgroundColor),
-      ignoreSafeArea({ regions: 'all', edges: 'bottom' }),
-      presentationDetents([initialDetent, 'large'], {
-        selection: selectedDetent,
-        onSelectionChange: setSelectedDetent,
-      }),
-      presentationDragIndicator('visible'),
-      presentationBackground(backgroundColor),
-      presentationBackgroundInteraction({ type: 'enabledUpThrough', detent: initialDetent }),
-    ],
-    [backgroundColor, selectedDetent]
-  );
-
   return (
-    <Fragment>
-      {visible ? (
-        <Pressable
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-          onPress={onClose}
-          style={[styles.backdropPressTarget, { height, width }]}
-        />
-      ) : null}
-      <Host
-        colorScheme="dark"
-        ignoreSafeArea="all"
-        pointerEvents="box-none"
-        style={[styles.host, { height, width }]}
-      >
-        <BottomSheet
-          isPresented={visible}
-          onIsPresentedChange={(isPresented) => {
-            if (!isPresented) {
-              onClose();
-            }
-          }}
-          fitToContents={false}
-        >
-          <Group modifiers={modifiers}>
-            <RNHostView>
-              <View style={[styles.content, { backgroundColor }]}>{children}</View>
-            </RNHostView>
-          </Group>
-        </BottomSheet>
-      </Host>
-    </Fragment>
+    <BottomSheet
+      index={visible ? 0 : -1}
+      onClose={onClose}
+      snapPoints={['75%', '100%']}
+      enablePanDownToClose
+      enableDynamicSizing={false}
+      backgroundStyle={{ backgroundColor }}
+    >
+      <BottomSheetView style={[styles.content, { backgroundColor }]}>{children}</BottomSheetView>
+    </BottomSheet>
   );
 }
 
 const styles = StyleSheet.create({
-  backdropPressTarget: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    zIndex: 1,
-  },
-  host: {
-    position: 'absolute',
-    zIndex: 2,
-  },
   content: {
     flex: 1,
   },

--- a/apps/mobile/lib/item-detail-actions.test.tsx
+++ b/apps/mobile/lib/item-detail-actions.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import { Colors } from '@/constants/theme';
+import { UserItemState } from '@/hooks/use-items-trpc';
+
+import { ItemDetailActions } from '@/app/item/detail/components/ItemDetailActions';
+
+jest.mock('react-native', () => ({
+  View: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('View', props, children),
+  Pressable: ({
+    children,
+    style,
+    ...props
+  }: {
+    children?: React.ReactNode | ((state: { pressed: boolean }) => React.ReactNode);
+    style?: unknown;
+  }) =>
+    React.createElement(
+      'Pressable',
+      {
+        ...props,
+        style: typeof style === 'function' ? style({ pressed: false }) : style,
+      },
+      typeof children === 'function' ? children({ pressed: false }) : children
+    ),
+  StyleSheet: {
+    create: (styles: unknown) => styles,
+    flatten: (style: unknown) => style,
+    absoluteFill: {},
+  },
+  Text: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('Text', props, children),
+  Platform: {
+    OS: 'ios',
+    select: (values: Record<string, unknown>) => values.ios ?? values.default,
+  },
+}));
+
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    View: ({ children, ...props }: { children?: React.ReactNode }) =>
+      React.createElement('AnimatedView', props, children),
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  const Icon = ({ name }: { name: string }) => React.createElement('Icon', { name });
+
+  return {
+    Ionicons: Icon,
+    FontAwesome5: Icon,
+  };
+});
+
+jest.mock('@/hooks/use-app-theme', () => ({
+  useAppTheme: () => ({
+    colorScheme: 'dark',
+    colors: {
+      accent: '#0a84ff',
+      borderDefault: '#333333',
+      borderSubtle: '#222222',
+      statusError: '#ff453a',
+      statusErrorSurface: '#3a1010',
+      surfaceRaised: '#1f1f1f',
+    },
+    fonts: {},
+    motion: {},
+  }),
+}));
+
+jest.mock('@/hooks/use-items-trpc', () => ({
+  UserItemState: {
+    BOOKMARKED: 'BOOKMARKED',
+    INBOX: 'INBOX',
+  },
+}));
+
+describe('ItemDetailActions', () => {
+  it('wires the provider FAB to the open-link action', () => {
+    const onOpenLink = jest.fn();
+    let renderer: ReturnType<typeof create> | null = null;
+
+    act(() => {
+      renderer = create(
+        <ItemDetailActions
+          item={{ state: UserItemState.BOOKMARKED, provider: 'SPOTIFY' }}
+          colors={Colors.dark}
+          bookmarkActionIcon="bookmark-outline"
+          bookmarkActionColor={Colors.dark.text}
+          isBookmarkActionDisabled={false}
+          secondaryActionIcon="checkmark-circle-outline"
+          secondaryActionColor={Colors.dark.textSecondary}
+          isSecondaryActionDisabled={false}
+          onBookmarkToggle={jest.fn()}
+          onSecondaryAction={jest.fn()}
+          onManageTags={jest.fn()}
+          onShare={jest.fn()}
+          onOpenLink={onOpenLink}
+          useAnimatedContainer={false}
+        />
+      );
+    });
+
+    const fab = renderer!.root.findByProps({ accessibilityLabel: 'Open source link' });
+
+    act(() => {
+      fab.props.onPress();
+    });
+
+    expect(onOpenLink).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the hand-rolled iOS collection sheet wrapper with Expo UI's community bottom sheet wrapper so the sheet is closed with `index={-1}` instead of leaving a native host mounted over the detail page.
- Mount the collection sheet through the item detail overlay layer and wrap the source FAB with the shared `IconButton` so page actions receive taps reliably.
- Keep article links opening in the native in-app browser, route Substack/provider web links through `Linking`, and show toast feedback when opening fails.
- Add a local Codex skill/docs entry for the iOS preview deploy workflow requested earlier.

## Root Cause

The previous SwiftUI `Host` for the collection bottom sheet could remain mounted in the screen interaction layer while the sheet was not visible. That native host intercepted touches on the item detail page, so the action row and provider FAB appeared dead.

## Validation

- Manually verified in the iOS Simulator: collection plus opens the sheet, source FAB opens the native in-app browser, and share opens the iOS share sheet.
- Deployed the preview build to the paired iPhone with `bun run deploy:ios:preview`; user confirmed the build looks good.
- `bun run --cwd apps/mobile lint`
- `bun run --cwd apps/mobile test lib/item-detail-actions.test.tsx hooks/use-item-detail-actions.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run test`
- `bun run build`
- Pre-push hook passed: format check, mobile design-system check, typecheck, web tests, worker CI subset.
