### PR TITLE
[codex] Harden mobile preview deploy env

### DIFF
--- a/.codex/skills/zine-mobile-preview-deploy/SKILL.md
+++ b/.codex/skills/zine-mobile-preview-deploy/SKILL.md
@@ -18,7 +18,12 @@ Default workflow:
    bun run deploy:ios:preview
    ```
 
-3. Let the script handle the EAS preview build, IPA download, device discovery, and `devicectl` install.
+3. Let the script handle preview env resolution, required env validation, the local EAS preview build, device discovery, and `devicectl` install.
+   - The script reads `apps/mobile/.env.preview` from the current worktree when present.
+   - In Codex or other linked worktrees that do not have `.env.preview`, it falls back to the `main` worktree's `apps/mobile/.env.preview`.
+   - To override explicitly, set `ZINE_MOBILE_PREVIEW_ENV_FILE=/absolute/path/to/.env.preview`.
+   - Do not copy secrets by hand; if required preview env values are missing, fix the env source and rerun the script.
+   - To validate env resolution without building, run `./scripts/build-and-install-ios.sh --check-env` from `apps/mobile`.
 4. Do not run production, TestFlight, or ad hoc EAS commands unless the user explicitly asks for that.
 5. If the script appears quiet, check EAS status with:
 

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -139,7 +139,7 @@ Use the deploy wrapper from `apps/mobile`:
 bun run deploy:ios:preview
 ```
 
-The script creates the EAS preview build, downloads the IPA, discovers the connected iOS device, and installs it with `devicectl`. Do not substitute production, TestFlight, or raw EAS commands unless requested.
+The script resolves and validates the preview env, creates a local EAS preview build, discovers the connected iOS device, and installs it with `devicectl`. It uses the current worktree's `apps/mobile/.env.preview` when present, falls back to the `main` worktree's `apps/mobile/.env.preview`, and supports `ZINE_MOBILE_PREVIEW_ENV_FILE=/absolute/path/to/.env.preview` for an explicit override. Do not substitute production, TestFlight, or raw EAS commands unless requested.
 
 ### Running the App
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint && bun run design-system:check",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "build:ios:preview": "env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- env EXPO_PUBLIC_API_URL=https://api.myzine.app eas build --platform ios --profile preview --local --output ./build/preview.ipa --non-interactive",
+    "build:ios:preview": "./scripts/build-and-install-ios.sh --build-only",
     "deploy:ios:production": "eas build --platform ios --profile production --auto-submit --non-interactive",
     "deploy:ios:testflight:local": "./scripts/deploy-testflight-local.sh",
     "deploy:ios:preview": "./scripts/build-and-install-ios.sh"

--- a/apps/mobile/scripts/build-and-install-ios.sh
+++ b/apps/mobile/scripts/build-and-install-ios.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -7,28 +7,147 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-BUILD_OUTPUT="./build/preview.ipa"
-MAX_BUILD_ATTEMPTS=3
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(git -C "$MOBILE_DIR" rev-parse --show-toplevel)"
+
+BUILD_OUTPUT="$MOBILE_DIR/build/preview.ipa"
+MAX_BUILD_ATTEMPTS="${MAX_BUILD_ATTEMPTS:-1}"
+BUILD_ONLY=0
+CHECK_ENV_ONLY=0
+
+REQUIRED_PREVIEW_ENV_KEYS=(
+    "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY"
+    "EXPO_PUBLIC_SPOTIFY_CLIENT_ID"
+    "EXPO_PUBLIC_YOUTUBE_CLIENT_ID"
+    "EXPO_PUBLIC_X_CLIENT_ID"
+    "EXPO_PUBLIC_API_URL"
+)
+
+for arg in "$@"; do
+    case "$arg" in
+        --build-only)
+            BUILD_ONLY=1
+            ;;
+        --check-env)
+            CHECK_ENV_ONLY=1
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown argument '$arg'${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+find_main_worktree() {
+    git -C "$REPO_ROOT" worktree list --porcelain | awk '
+        /^worktree / { worktree = substr($0, 10) }
+        /^branch refs\/heads\/main$/ { print worktree; exit }
+    '
+}
+
+resolve_preview_env_file() {
+    if [ -n "${ZINE_MOBILE_PREVIEW_ENV_FILE:-}" ]; then
+        printf '%s\n' "$ZINE_MOBILE_PREVIEW_ENV_FILE"
+        return
+    fi
+
+    if [ -f "$MOBILE_DIR/.env.preview" ]; then
+        printf '%s\n' "$MOBILE_DIR/.env.preview"
+        return
+    fi
+
+    local main_worktree
+    main_worktree="$(find_main_worktree)"
+    if [ -n "$main_worktree" ] && [ -f "$main_worktree/apps/mobile/.env.preview" ]; then
+        printf '%s\n' "$main_worktree/apps/mobile/.env.preview"
+    fi
+
+    return 0
+}
+
+validate_preview_env_file() {
+    local env_file="$1"
+    local missing=()
+
+    if [ -z "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo -e "${RED}Error: Missing preview env file.${NC}"
+        echo -e "${YELLOW}Set ZINE_MOBILE_PREVIEW_ENV_FILE or create apps/mobile/.env.preview in this worktree or the main worktree.${NC}"
+        exit 1
+    fi
+
+    for key in "${REQUIRED_PREVIEW_ENV_KEYS[@]}"; do
+        local value
+        value="$(
+            grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$env_file" 2>/dev/null | \
+                tail -n 1 | \
+                sed -E 's/^[[:space:]]*(export[[:space:]]+)?[^=]+=//'
+        )"
+        if [ -z "$value" ]; then
+            missing+=("$key")
+        fi
+    done
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+        echo -e "${RED}Error: Preview env file is missing required keys:${NC}"
+        printf '   - %s\n' "${missing[@]}"
+        echo -e "${YELLOW}Preview builds embed these public values, so the build is blocked before EAS starts.${NC}"
+        exit 1
+    fi
+}
+
+find_available_device_uuid() {
+    local devices_output
+    devices_output="$(xcrun devicectl list devices 2>&1 || true)"
+
+    local device_uuid
+    device_uuid="$(
+        printf '%s\n' "$devices_output" | awk '
+            {
+                for (i = 1; i <= NF; i++) {
+                    if ($i ~ /^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$/ && $(i + 1) == "available") {
+                        print $i
+                        exit
+                    }
+                }
+            }
+        '
+    )"
+
+    if [ -z "$device_uuid" ]; then
+        echo "$devices_output"
+        echo -e "${RED}Error: No available iOS device found. Please connect/unlock your device and trust this computer.${NC}"
+        echo -e "${YELLOW}Tip: The device must show as 'available' in xcrun devicectl list devices.${NC}"
+        exit 1
+    fi
+
+    printf '%s\n' "$device_uuid"
+}
 
 echo -e "${YELLOW}=== iOS Preview Build & Install ===${NC}"
 
-# Step 1: Build and download the IPA from EAS
+PREVIEW_ENV_FILE="$(resolve_preview_env_file)"
+validate_preview_env_file "$PREVIEW_ENV_FILE"
+
+echo -e "${GREEN}Using preview env: $PREVIEW_ENV_FILE${NC}"
+
+if [ "$CHECK_ENV_ONLY" -eq 1 ]; then
+    exit 0
+fi
+
+# Step 1: Build the IPA locally
 echo -e "\n${GREEN}[1/3] Building iOS preview...${NC}"
 
 BUILD_SUCCESS=0
 for attempt in $(seq 1 "$MAX_BUILD_ATTEMPTS"); do
     echo -e "${YELLOW}Build attempt ${attempt}/${MAX_BUILD_ATTEMPTS}${NC}"
 
-    BUILD_JSON=$(env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e .env.preview -- env EXPO_PUBLIC_API_URL=https://api.myzine.app eas build --platform ios --profile preview --non-interactive --wait --json 2>/dev/null || true)
+    rm -f "$BUILD_OUTPUT"
+    mkdir -p "$(dirname "$BUILD_OUTPUT")"
 
-    BUILD_URL=$(echo "$BUILD_JSON" | jq -r 'if type == "array" then .[0].artifacts.buildUrl // .[0].artifacts.applicationArchiveUrl // .[0].artifacts.url else .artifacts.buildUrl // .artifacts.applicationArchiveUrl // .artifacts.url end // empty')
-
-    if [ -n "$BUILD_URL" ]; then
-        mkdir -p "$(dirname "$BUILD_OUTPUT")"
-        if curl -fL "$BUILD_URL" -o "$BUILD_OUTPUT"; then
-            BUILD_SUCCESS=1
-            break
-        fi
+    if env -u EXPO_PUBLIC_STORYBOOK_ENABLED EXPO_NO_DOTENV=1 dotenv -e "$PREVIEW_ENV_FILE" -- env EXPO_PUBLIC_API_URL=https://api.myzine.app eas build --platform ios --profile preview --local --output "$BUILD_OUTPUT" --non-interactive; then
+        BUILD_SUCCESS=1
+        break
     fi
 
     if [ "$attempt" -lt "$MAX_BUILD_ATTEMPTS" ]; then
@@ -49,35 +168,14 @@ fi
 
 echo -e "${GREEN}Build complete: $BUILD_OUTPUT${NC}"
 
+if [ "$BUILD_ONLY" -eq 1 ]; then
+    exit 0
+fi
+
 # Step 2: Find connected device
 echo -e "\n${GREEN}[2/3] Finding connected iOS device...${NC}"
 
-# Get device info as JSON and parse it
-DEVICE_INFO=$(xcrun devicectl list devices --json-output /dev/stdout 2>/dev/null | grep -v "^{" | head -1 || true)
-
-if [ -z "$DEVICE_INFO" ]; then
-    # Fallback: try to get device list and parse
-    DEVICES_OUTPUT=$(xcrun devicectl list devices 2>&1)
-    echo "$DEVICES_OUTPUT"
-    
-    # Extract UUID from output (looking for connected devices)
-    DEVICE_UUID=$(echo "$DEVICES_OUTPUT" | grep -E "^\s+[A-F0-9-]{36}" | head -1 | awk '{print $1}')
-    
-    if [ -z "$DEVICE_UUID" ]; then
-        echo -e "${RED}Error: No iOS device found. Please connect your device and trust this computer.${NC}"
-        echo -e "${YELLOW}Tip: Make sure your device is unlocked and you've tapped 'Trust' on the device.${NC}"
-        exit 1
-    fi
-fi
-
-# Try to get device UUID using simpler parsing
-DEVICE_UUID=$(xcrun devicectl list devices 2>&1 | grep -oE "[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}" | head -1)
-
-if [ -z "$DEVICE_UUID" ]; then
-    echo -e "${RED}Error: Could not find device UUID. Please check device connection.${NC}"
-    xcrun devicectl list devices
-    exit 1
-fi
+DEVICE_UUID="$(find_available_device_uuid)"
 
 echo -e "${GREEN}Found device: $DEVICE_UUID${NC}"
 


### PR DESCRIPTION
## Summary

- resolve preview env for mobile preview builds from the current worktree or the main worktree
- validate required `EXPO_PUBLIC_*` preview values before EAS starts
- make `build:ios:preview` use the same guarded script path with `--build-only`
- document the worktree preview deploy behavior and `ZINE_MOBILE_PREVIEW_ENV_FILE` override

## Why

Preview builds from Codex worktrees could silently build without `apps/mobile/.env.preview`, producing IPAs missing provider client IDs. This keeps preview env in one canonical place while still allowing branch/worktree code to be built and deployed.

## Validation

- `bash -n apps/mobile/scripts/build-and-install-ios.sh`
- `./scripts/build-and-install-ios.sh --check-env` from `apps/mobile` in the Codex worktree
- `ZINE_MOBILE_PREVIEW_ENV_FILE=/tmp/zine-missing-preview.env ./scripts/build-and-install-ios.sh --check-env` fails before EAS as expected
- `bun run format:check`
- `bun prettier --check apps/mobile/package.json apps/mobile/AGENTS.md .codex/skills/zine-mobile-preview-deploy/SKILL.md`
- `git diff --check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- pre-push hook: format, mobile design-system check, typecheck, web tests, worker CI subset
