### PR TITLE
[codex] Make mobile web views full screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,12 @@
 - This bypass is the preferred path for `agent-browser` screenshots and UI checks on localhost because it exercises protected routes without needing an interactive Clerk login flow.
 - If `/bookmarks` or other protected pages load but show empty state unexpectedly, do not assume auth is broken; first follow **Empty Local Data Recovery** below to verify the worktree D1 file actually contains the expected local data for `dev-user-001`.
 
+### Mobile Auth Verification
+
+- Always start mobile verification with `bun run dev:worktree`.
+- If Expo Go lands on Clerk sign-in, use `ZINE_TEST_EMAIL` and `ZINE_TEST_PASSWORD` from `apps/mobile/.env.local`; do not print their values.
+- If credential login is blocked and the task is not auth-related, use the local Clerk-disabled bypass and call that out.
+
 ### Empty Local Data Recovery
 
 - Symptom: Expo Go loads, but Home/Inbox/Library are empty even though local test data should exist.

--- a/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
+++ b/apps/mobile/app/item/detail/hooks/useItemDetailActions.ts
@@ -54,7 +54,7 @@ export function useItemDetailActions(item?: ItemDetailItem | null) {
       if (isArticle && !isSubstack) {
         await WebBrowser.openBrowserAsync(item.canonicalUrl, {
           enableBarCollapsing: true,
-          presentationStyle: WebBrowser.WebBrowserPresentationStyle.AUTOMATIC,
+          presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
         });
         didOpen = true;
       } else if (isWebUrl(item.canonicalUrl)) {

--- a/apps/mobile/components/external-link.tsx
+++ b/apps/mobile/components/external-link.tsx
@@ -36,7 +36,7 @@ export function ExternalLink({ href, onPress, platformOverride, onOpenExternal, 
           } else {
             await openBrowserAsync(href, {
               enableBarCollapsing: true,
-              presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
+              presentationStyle: WebBrowserPresentationStyle.FULL_SCREEN,
             });
           }
         }

--- a/apps/mobile/hooks/use-item-detail-actions.test.ts
+++ b/apps/mobile/hooks/use-item-detail-actions.test.ts
@@ -147,7 +147,7 @@ describe('useItemDetailActions', () => {
     expect(mockOpenURL).not.toHaveBeenCalled();
     expect(mockOpenBrowserAsync).toHaveBeenCalledWith(item.canonicalUrl, {
       enableBarCollapsing: true,
-      presentationStyle: 'AUTOMATIC',
+      presentationStyle: 'FULL_SCREEN',
     });
     expect(mockMarkOpenedMutation.mutate).toHaveBeenCalledWith({ id: item.id });
   });
@@ -304,7 +304,7 @@ describe('useItemDetailActions', () => {
     expect(logger.error).toHaveBeenCalledWith('Failed to open URL', { error });
     expect(mockOpenBrowserAsync).toHaveBeenCalledWith(baseItem.canonicalUrl, {
       enableBarCollapsing: true,
-      presentationStyle: 'AUTOMATIC',
+      presentationStyle: 'FULL_SCREEN',
     });
     expect(mockShowError).toHaveBeenCalledWith(
       mockToastManager,


### PR DESCRIPTION
## Summary

- Present mobile in-app web browser views full screen instead of the default pull-down modal style.
- Update item detail action tests to expect the full-screen presentation style.
- Add a short AGENTS note documenting the mobile auth verification process with local test credentials.

## Why

Article source links were opening in a sheet-style browser presentation, which made the web view feel modal and easy to dismiss accidentally. Full-screen presentation better matches the requested reading flow.

## Validation

- `bun run --cwd apps/mobile test --runTestsByPath hooks/use-item-detail-actions.test.ts`
- Manual iOS Simulator verification via `bun run dev:worktree`, opening Armin Ronacher's article source link and capturing `apps/mobile/tmp/armin-source-link-webview.png`
- Pre-push hook: format check, design-system check, typecheck, web tests, worker tests
