### PR TITLE
[codex] Add Substack FAB icon

### DIFF
--- a/apps/mobile/app/item/item-detail-helpers.tsx
+++ b/apps/mobile/app/item/item-detail-helpers.tsx
@@ -1,41 +1,62 @@
 import { FontAwesome5, Ionicons } from '@expo/vector-icons';
 import type { ReactNode } from 'react';
 import { Text } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
 
 // FAB Configuration by Provider
+
+const FAB_ICON_COLOR = '#FFFFFF';
 
 type FabConfig = {
   backgroundColor: string;
   providerIcon: ReactNode;
 };
 
+function SubstackIcon({ size = 22, color = FAB_ICON_COLOR }: { size?: number; color?: string }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 16 16" fill="none">
+      <Path
+        fill={color}
+        d="M15 3.604H1v1.891h14v-1.89ZM1 7.208V16l7-3.926L15 16V7.208zM15 0H1v1.89h14z"
+      />
+    </Svg>
+  );
+}
+
 export function getFabConfig(provider: string): FabConfig {
   switch (provider) {
     case 'SPOTIFY':
       return {
-        providerIcon: <FontAwesome5 name="spotify" size={22} color="#FFFFFF" />,
+        providerIcon: <FontAwesome5 name="spotify" size={22} color={FAB_ICON_COLOR} />,
         backgroundColor: '#1DB954',
       };
     case 'YOUTUBE':
       return {
-        providerIcon: <Ionicons name="logo-youtube" size={22} color="#FFFFFF" />,
+        providerIcon: <Ionicons name="logo-youtube" size={22} color={FAB_ICON_COLOR} />,
         backgroundColor: '#FF0000',
       };
     case 'GMAIL':
       return {
-        providerIcon: <Ionicons name="newspaper-outline" size={22} color="#FFFFFF" />,
+        providerIcon: <Ionicons name="newspaper-outline" size={22} color={FAB_ICON_COLOR} />,
         backgroundColor: '#1A73E8',
+      };
+    case 'SUBSTACK':
+      return {
+        providerIcon: <SubstackIcon />,
+        backgroundColor: '#FF6719',
       };
     case 'X':
     case 'TWITTER':
       return {
-        providerIcon: <Text style={{ color: '#FFFFFF', fontSize: 20, fontWeight: '800' }}>𝕏</Text>,
+        providerIcon: (
+          <Text style={{ color: FAB_ICON_COLOR, fontSize: 20, fontWeight: '800' }}>𝕏</Text>
+        ),
         backgroundColor: '#1A1A1A',
       };
     default:
-      // Web, Substack, and other providers
+      // Web and other providers
       return {
-        providerIcon: <Ionicons name="globe-outline" size={22} color="#FFFFFF" />,
+        providerIcon: <Ionicons name="globe-outline" size={22} color={FAB_ICON_COLOR} />,
         backgroundColor: '#1A1A1A',
       };
   }

--- a/apps/mobile/lib/item-detail-actions.test.tsx
+++ b/apps/mobile/lib/item-detail-actions.test.tsx
@@ -46,6 +46,13 @@ jest.mock('react-native-reanimated', () => ({
   },
 }));
 
+jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children?: React.ReactNode }) =>
+    React.createElement('Svg', props, children),
+  Path: (props: Record<string, unknown>) => React.createElement('Path', props),
+}));
+
 jest.mock('@expo/vector-icons', () => {
   const Icon = ({ name }: { name: string }) => React.createElement('Icon', { name });
 
@@ -54,6 +61,19 @@ jest.mock('@expo/vector-icons', () => {
     FontAwesome5: Icon,
   };
 });
+
+function styleHasBackgroundColor(style: unknown, backgroundColor: string): boolean {
+  if (Array.isArray(style)) {
+    return style.some((entry) => styleHasBackgroundColor(entry, backgroundColor));
+  }
+
+  return (
+    typeof style === 'object' &&
+    style !== null &&
+    'backgroundColor' in style &&
+    style.backgroundColor === backgroundColor
+  );
+}
 
 jest.mock('@/hooks/use-app-theme', () => ({
   useAppTheme: () => ({
@@ -111,5 +131,38 @@ describe('ItemDetailActions', () => {
     });
 
     expect(onOpenLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Substack links with the orange Substack FAB', () => {
+    let renderer: ReturnType<typeof create> | null = null;
+
+    act(() => {
+      renderer = create(
+        <ItemDetailActions
+          item={{ state: UserItemState.BOOKMARKED, provider: 'SUBSTACK' }}
+          colors={Colors.dark}
+          bookmarkActionIcon="bookmark-outline"
+          bookmarkActionColor={Colors.dark.text}
+          isBookmarkActionDisabled={false}
+          secondaryActionIcon="checkmark-circle-outline"
+          secondaryActionColor={Colors.dark.textSecondary}
+          isSecondaryActionDisabled={false}
+          onBookmarkToggle={jest.fn()}
+          onSecondaryAction={jest.fn()}
+          onManageTags={jest.fn()}
+          onShare={jest.fn()}
+          onOpenLink={jest.fn()}
+          useAnimatedContainer={false}
+        />
+      );
+    });
+
+    const fab = renderer!.root.findByProps({ accessibilityLabel: 'Open source link' });
+    const substackPath = renderer!.root.findByProps({
+      d: 'M15 3.604H1v1.891h14v-1.89ZM1 7.208V16l7-3.926L15 16V7.208zM15 0H1v1.89h14z',
+    });
+
+    expect(styleHasBackgroundColor(fab.props.style, '#FF6719')).toBe(true);
+    expect(substackPath.props.fill).toBe('#FFFFFF');
   });
 });


### PR DESCRIPTION
## Summary

Adds Substack-specific presentation for the mobile item-detail source FAB. Substack items now use an orange `#FF6719` button with a white Substack SVG mark instead of falling back to the generic web globe.

Also adds focused coverage for `ItemDetailActions` so the Substack FAB color and glyph stay pinned.

## Impact

Users opening Substack bookmarks or content details get the same provider-specific FAB treatment that Spotify and YouTube already have.

## Validation

- `bun run --cwd apps/mobile test item-detail-actions.test.tsx --runInBand`
- `bun run --cwd apps/mobile lint` (passes with existing unrelated warnings)
- Pre-push hook:
  - `bun run format:check`
  - `bun run design-system:check`
  - `bun run typecheck`
  - `bun run test:web`
  - `cd apps/worker && bun run test:run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'`
- Manual Expo Go verification with `https://open.substack.com/pub/thorstenball/p/joy-and-curiosity-89?r=1abvk&utm_medium=ios`: saved the link, opened the detail screen, confirmed the orange FAB with white Substack mark, and pressed it to open the source in Safari.