### PR TITLE
[codex] Rebuild web app mobile parity UX

### DIFF
--- a/apps/web/e2e/app.smoke.spec.ts
+++ b/apps/web/e2e/app.smoke.spec.ts
@@ -2,105 +2,80 @@ import { expect, test } from '@playwright/test';
 
 import { mockWebTrpc } from './trpc-mocks';
 
-test('loads the bookmarks desk, filters content, opens detail, and navigates to settings', async ({
-  page,
-}) => {
+test('loads the mobile-parity app routes and opens canonical detail', async ({ page }) => {
   await mockWebTrpc(page);
 
-  await page.goto('/bookmarks');
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/home$/);
+  await expect(page.getByRole('strong').filter({ hasText: 'Home' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Jump Back In' })).toBeVisible();
+  await expect(page.getByText('Design systems at scale').first()).toBeVisible();
 
-  await expect(page.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
-  await expect(page.getByText('Stable component APIs')).toBeVisible();
-  await expect(page.getByText('Design systems at scale')).toBeVisible();
-  await expect(page.getByText('Product taste and pacing')).toBeVisible();
+  await page.getByRole('link', { name: 'Inbox' }).first().click();
+  await expect(page).toHaveURL(/\/inbox$/);
+  await expect(page.getByRole('button', { name: 'Save' }).first()).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Archive' }).first()).toBeVisible();
 
-  await page.getByRole('button', { name: 'Videos' }).click();
-  await expect(page.getByText('Stable component APIs')).toHaveCount(0);
-  await expect(page.getByText('Design systems at scale')).toBeVisible();
-
-  await page.getByRole('button', { name: /Design systems at scale/ }).click();
-  await expect(page).toHaveURL(/\/bookmarks\/video-1\?contentType=video$/);
+  await page.getByRole('link', { name: 'Search' }).first().click();
+  await expect(page).toHaveURL(/\/search$/);
+  await page.getByLabel('Search your library').fill('design');
+  await expect(page.getByRole('heading', { name: 'Items' })).toBeVisible();
+  await page
+    .getByRole('link', { name: /Design systems at scale/ })
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/item\/video-1$/);
   await expect(page.getByRole('heading', { name: 'Design systems at scale' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Open in YouTube' })).toHaveAttribute(
     'href',
     'https://zine.example/watch/design-systems-at-scale'
   );
 
-  await page.getByRole('link', { name: 'Settings' }).click();
+  await page.getByRole('link', { name: 'Library' }).first().click();
+  await expect(page).toHaveURL(/\/library\/bookmarks$/);
+  await expect(page.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
+
+  await page.goto('/library/people');
+  await expect(page.getByText('Alice Example')).toBeVisible();
+
+  await page.goto('/library/sources');
+  await expect(page.getByText('Zine Editorial')).toBeVisible();
+  await expect(page.getByText('Interface Notes')).toBeVisible();
+
+  await page.goto('/library/collections');
+  await expect(page.getByText('Design systems')).toBeVisible();
+
+  await page.getByRole('link', { name: 'Settings' }).first().click();
   await expect(page).toHaveURL(/\/settings$/);
   await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Subscriptions' })).toBeVisible();
 });
 
-test('renders the empty state when no bookmarks exist', async ({ page }) => {
-  await mockWebTrpc(page, 'empty');
+test('preserves legacy bookmark redirects', async ({ page }) => {
+  await mockWebTrpc(page);
 
-  await page.goto('/bookmarks');
+  await page.goto('/bookmarks?contentType=video');
+  await expect(page).toHaveURL(/\/library\/bookmarks\?contentType=video$/);
 
-  await expect(
-    page.getByRole('heading', { name: /No bookmarks yet|Add your first bookmark/ })
-  ).toBeVisible({
-    timeout: 15_000,
-  });
-  await expect(
-    page.getByText(
-      /Save a few items first, then this desk becomes the main web surface for browsing them\.|Add a bookmark to start building your library\./
-    )
-  ).toBeVisible();
+  await page.goto('/bookmarks/video-1');
+  await expect(page).toHaveURL(/\/item\/video-1$/);
+  await expect(page.getByRole('heading', { name: 'Design systems at scale' })).toBeVisible();
 });
 
-test('uses a phone drill-in flow and keeps mobile chrome usable', async ({ page }) => {
+test('uses a phone drill-in flow and bottom app tabs', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await mockWebTrpc(page);
 
-  await page.goto('/bookmarks');
-
-  const listPane = page.locator('.new-page-column-card').first();
-
-  await expect(
-    page.getByText('Pick something from the list and its detail view will open here.')
-  ).toHaveCount(0);
-  await expect(listPane).toBeVisible();
-
-  const listPaneBorderRadius = await listPane.evaluate((element) => {
-    return window.getComputedStyle(element).borderRadius;
-  });
-  expect(listPaneBorderRadius).toBe('0px');
-
-  const listPaneRect = await listPane.evaluate((element) => {
-    const rect = element.getBoundingClientRect();
-    return {
-      x: rect.x,
-      y: rect.y,
-      height: rect.height,
-    };
-  });
-  expect(listPaneRect.x).toBeLessThanOrEqual(1);
-  expect(listPaneRect.y).toBeLessThanOrEqual(1);
-
-  const pageFitsViewport = await page.evaluate(() => {
-    return document.documentElement.scrollHeight <= window.innerHeight + 1;
-  });
-  expect(pageFitsViewport).toBe(true);
+  await page.goto('/library/bookmarks');
+  await expect(page.getByRole('navigation', { name: 'Tab bar' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Library' })).toHaveAttribute('aria-current', 'page');
+  await expect(page.locator('.new-page-sidebar')).toBeHidden();
 
   await page.getByRole('button', { name: /Design systems at scale/ }).click();
-
-  await expect(page).toHaveURL(/\/bookmarks\/video-1$/);
+  await expect(page).toHaveURL(/\/item\/video-1$/);
   await expect(page.getByRole('heading', { name: 'Design systems at scale' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Back to bookmarks list' })).toBeVisible();
   await expect(page.getByText('Stable component APIs')).toHaveCount(0);
-
-  const detailActionsLayout = await page
-    .locator('.new-page-bookmark-view__actions')
-    .evaluate((element) => {
-      const styles = window.getComputedStyle(element);
-      return {
-        flexDirection: styles.flexDirection,
-        alignItems: styles.alignItems,
-      };
-    });
-  expect(detailActionsLayout.flexDirection).toBe('row');
-  expect(detailActionsLayout.alignItems).toBe('center');
 
   const providerFab = await page.locator('.new-page-bookmark-view__fab').evaluate((element) => {
     const styles = window.getComputedStyle(element);
@@ -112,81 +87,31 @@ test('uses a phone drill-in flow and keeps mobile chrome usable', async ({ page 
   });
   expect(providerFab.width).toBe(providerFab.height);
   expect(parseFloat(providerFab.borderRadius)).toBeGreaterThanOrEqual(999);
-
-  const descriptionSection = await page
-    .locator('.new-page-bookmark-view__section')
-    .evaluate((element) => {
-      const styles = window.getComputedStyle(element);
-      return {
-        backgroundColor: styles.backgroundColor,
-        paddingLeft: styles.paddingLeft,
-        borderRadius: styles.borderRadius,
-      };
-    });
-  expect(descriptionSection.backgroundColor).toBe('rgb(26, 26, 26)');
-  expect(parseFloat(descriptionSection.paddingLeft)).toBeGreaterThanOrEqual(16);
-  expect(parseFloat(descriptionSection.borderRadius)).toBeGreaterThanOrEqual(16);
-
-  await page.getByRole('button', { name: 'Back to bookmarks list' }).click();
-
-  await expect(page).toHaveURL(/\/bookmarks$/);
-  await expect(page.getByText('Stable component APIs')).toBeVisible();
-  await page.getByRole('link', { name: 'Settings' }).click();
-
-  await expect(page).toHaveURL(/\/settings$/);
-  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Sources' })).toBeVisible();
-});
-
-test('shows a bottom tab bar on phone viewports and hides the sidebar', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
-  await mockWebTrpc(page);
-
-  await page.goto('/bookmarks');
-  await expect(page.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
-
-  const tabBar = page.getByRole('navigation', { name: 'Tab bar' });
-  await expect(tabBar).toBeVisible();
-
-  const sidebar = page.locator('.new-page-sidebar');
-  await expect(sidebar).toBeHidden();
-
-  const bookmarksTab = page.getByRole('link', { name: 'Bookmarks' }).locator('visible=true');
-  await expect(bookmarksTab).toHaveAttribute('aria-current', 'page');
-
-  await page.getByRole('link', { name: 'Settings' }).click();
-  await expect(page).toHaveURL(/\/settings$/);
 });
 
 test('renders post detail like the mobile app on phone viewports', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await mockWebTrpc(page);
 
-  await page.goto('/bookmarks');
-  await page.getByRole('button', { name: /Notes on interface pace/ }).click();
+  await page.goto('/item/post-1');
 
-  await expect(page).toHaveURL(/\/bookmarks\/post-1$/);
   await expect(page.locator('[aria-label="X post content"]')).toBeVisible();
   await expect(page.getByText('Notes on interface pace')).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Notes on interface pace' })).toHaveCount(0);
   await expect(page.locator('.new-page-bookmark-view__section')).toHaveCount(0);
   await expect(page.locator('.new-page-bookmark-view__hero')).toHaveCount(0);
-
-  const postRowDisplay = await page
-    .locator('.new-page-bookmark-view__post-row')
-    .evaluate((element) => {
-      return window.getComputedStyle(element).display;
-    });
-  expect(postRowDisplay).toBe('flex');
 });
 
-test('renders the error state when the bookmarks query fails', async ({ page }) => {
-  await mockWebTrpc(page, 'error');
+test('renders the empty home state when no data exists', async ({ page }) => {
+  await mockWebTrpc(page, 'empty');
 
-  await page.goto('/bookmarks');
+  await page.goto('/home');
 
-  await expect(page.getByRole('heading', { name: 'Could not load bookmarks' })).toBeVisible({
+  await expect(page.getByRole('heading', { name: 'Your home is ready when you are' })).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByText('Could not load bookmarks from the mock API.')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Connect sources' })).toHaveAttribute(
+    'href',
+    '/welcome'
+  );
 });

--- a/apps/web/e2e/trpc-mocks.ts
+++ b/apps/web/e2e/trpc-mocks.ts
@@ -100,6 +100,59 @@ const creators = {
   },
 } as const;
 
+const people = [
+  {
+    id: 'person-1',
+    displayName: 'Alice Example',
+    profileImageUrl: null,
+    profileImageSource: null,
+    xHandle: 'alice',
+    itemCount: 3,
+    latestSeenAt: '2025-02-20T09:00:00.000Z',
+    latestItemTitle: 'Design systems at scale',
+  },
+  {
+    id: 'person-2',
+    displayName: 'Bob Example',
+    profileImageUrl: null,
+    profileImageSource: null,
+    xHandle: null,
+    itemCount: 2,
+    latestSeenAt: '2025-02-19T09:00:00.000Z',
+    latestItemTitle: 'Product taste and pacing',
+  },
+];
+
+const collections = [
+  {
+    id: 'collection-1',
+    name: 'Design systems',
+    description: 'Interfaces worth revisiting',
+    rules: { contentTypes: [ContentType.ARTICLE, ContentType.VIDEO], isFinished: false },
+    sort: 'NEWEST_SAVED',
+    homeSection: { layout: 'STACK_RAIL', position: 1 },
+    createdAt: 1739890000000,
+    updatedAt: 1739890000000,
+  },
+];
+
+const inboxItems = [
+  {
+    ...libraryItems[0],
+    id: 'inbox-1',
+    state: 'INBOX',
+    title: 'A new article from the queue',
+    bookmarkedAt: null,
+  },
+  {
+    ...libraryItems[1],
+    id: 'inbox-2',
+    state: 'INBOX',
+    title: 'A new video from the queue',
+    bookmarkedAt: null,
+  },
+];
+
 type MockMode = 'default' | 'empty' | 'error';
 
 function unwrapInput(value: unknown): unknown {
@@ -184,6 +237,53 @@ export async function mockWebTrpc(page: Page, mode: MockMode = 'default') {
         return success({ items: filteredItems });
       }
 
+      if (procedure === 'items.home') {
+        if (mode === 'empty') {
+          return success({
+            recentBookmarks: [],
+            jumpBackIn: [],
+            byContentType: { videos: [], podcasts: [], articles: [] },
+            customCollections: [],
+            sectionOrder: [],
+          });
+        }
+
+        return success({
+          recentBookmarks: libraryItems,
+          jumpBackIn: [libraryItems[1], libraryItems[2]],
+          byContentType: {
+            videos: libraryItems.filter((item) => item.contentType === ContentType.VIDEO),
+            podcasts: libraryItems.filter((item) => item.contentType === ContentType.PODCAST),
+            articles: libraryItems.filter((item) => item.contentType === ContentType.ARTICLE),
+          },
+          customCollections: [
+            {
+              collectionId: 'collection-1',
+              title: 'Design systems',
+              layout: 'STACK_RAIL',
+              position: 1,
+              count: 2,
+              items: [libraryItems[0], libraryItems[1]],
+            },
+          ],
+          sectionOrder: [],
+        });
+      }
+
+      if (procedure === 'items.inbox') {
+        if (mode === 'empty') {
+          return success({ items: [], nextCursor: null });
+        }
+
+        const input =
+          (inputs[index] as { filter?: { contentType?: ContentType } } | undefined) ?? {};
+        const filteredItems = input.filter?.contentType
+          ? inboxItems.filter((item) => item.contentType === input.filter?.contentType)
+          : inboxItems;
+
+        return success({ items: filteredItems, nextCursor: null });
+      }
+
       if (procedure === 'items.get') {
         const input = (inputs[index] as { id?: string } | undefined) ?? {};
         const item = libraryItems.find((candidate) => candidate.id === input.id);
@@ -193,6 +293,153 @@ export async function mockWebTrpc(page: Page, mode: MockMode = 'default') {
       if (procedure === 'creators.get') {
         const input = (inputs[index] as { creatorId?: keyof typeof creators } | undefined) ?? {};
         return success(input.creatorId ? (creators[input.creatorId] ?? null) : null);
+      }
+
+      if (procedure === 'search.query') {
+        const input = (inputs[index] as { query?: string } | undefined) ?? {};
+        const query = input.query?.trim().toLowerCase() ?? '';
+        const matchedItems = query
+          ? libraryItems.filter((item) =>
+              [item.title, item.creator, item.publisher]
+                .filter(Boolean)
+                .join(' ')
+                .toLowerCase()
+                .includes(query)
+            )
+          : [];
+        const matchedPeople = query
+          ? people.filter((person) => person.displayName.toLowerCase().includes(query))
+          : [];
+        const creatorResults = query.includes('zine')
+          ? [
+              {
+                type: 'creator',
+                creatorId: 'creator-1',
+                name: 'Zine Editorial',
+                handle: 'zine-editorial',
+                imageUrl: null,
+                provider: Provider.YOUTUBE,
+                description: 'Hosted by Alice Example',
+                externalUrl: 'https://zine.example',
+                isSubscribed: true,
+                subscriptionId: 'subscription-1',
+                libraryItemCount: 2,
+                latestPublishedAt: '2025-02-18T09:45:00.000Z',
+              },
+            ]
+          : [];
+
+        return success({
+          query: input.query ?? '',
+          results: [
+            ...creatorResults,
+            ...matchedPeople.map((person) => ({
+              type: 'person',
+              personId: person.id,
+              displayName: person.displayName,
+              profileImageUrl: person.profileImageUrl,
+              itemCount: person.itemCount,
+              latestItemTitle: person.latestItemTitle,
+            })),
+            ...matchedItems.map((item) => ({ type: 'item', ...item })),
+          ],
+          sections: {
+            creators: creatorResults,
+            people: matchedPeople.map((person) => ({
+              type: 'person',
+              personId: person.id,
+              displayName: person.displayName,
+              profileImageUrl: person.profileImageUrl,
+              itemCount: person.itemCount,
+              latestItemTitle: person.latestItemTitle,
+            })),
+            items: matchedItems,
+          },
+          nextCursor: null,
+        });
+      }
+
+      if (procedure === 'people.list') {
+        return success({ people, nextCursor: null });
+      }
+
+      if (procedure === 'collections.list') {
+        return success({ collections });
+      }
+
+      if (procedure === 'subscriptions.list') {
+        return success({
+          items: [
+            {
+              id: 'subscription-1',
+              provider: Provider.YOUTUBE,
+              name: 'Zine Editorial',
+              status: 'ACTIVE',
+              imageUrl: null,
+            },
+            {
+              id: 'subscription-2',
+              provider: Provider.SPOTIFY,
+              name: 'Studio Dispatch',
+              status: 'ACTIVE',
+              imageUrl: null,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        });
+      }
+
+      if (procedure === 'subscriptions.newsletters.list') {
+        return success({
+          items: [
+            {
+              id: 'newsletter-1',
+              displayName: 'Interface Notes',
+              fromAddress: 'notes@example.com',
+              listId: 'interface-notes',
+              status: 'ACTIVE',
+              imageUrl: null,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        });
+      }
+
+      if (procedure === 'subscriptions.rss.list') {
+        return success({
+          items: [
+            {
+              id: 'rss-1',
+              title: 'Zine RSS',
+              feedUrl: 'https://zine.example/feed.xml',
+              siteUrl: 'https://zine.example',
+              status: 'ACTIVE',
+              imageUrl: null,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        });
+      }
+
+      if (procedure === 'subscriptions.xBookmarks.status') {
+        return success({
+          connected: true,
+          importedCount: 4,
+          connectionStatus: 'ACTIVE',
+        });
+      }
+
+      if (
+        procedure === 'items.bookmark' ||
+        procedure === 'items.archive' ||
+        procedure === 'items.unbookmark' ||
+        procedure === 'items.toggleFinished' ||
+        procedure === 'items.markOpened'
+      ) {
+        return success({ success: true });
       }
 
       return failure(`Unhandled mock procedure: ${procedure}`, procedure);

--- a/apps/web/playwright.storybook.config.ts
+++ b/apps/web/playwright.storybook.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   testDir: './e2e',
   testMatch: /storybook\.spec\.ts/,
   timeout: 30_000,
-  fullyParallel: true,
+  fullyParallel: false,
+  workers: 1,
   use: {
     baseURL: 'http://127.0.0.1:6007',
     headless: true,

--- a/apps/web/src/app.test.tsx
+++ b/apps/web/src/app.test.tsx
@@ -9,6 +9,12 @@ vi.mock('./auth-page', () => ({
 vi.mock('./bookmarks-page', () => ({
   BookmarksPage: () => <div>Bookmarks page</div>,
 }));
+vi.mock('./mobile-parity-pages', () => ({
+  HomePage: () => <div>Home page</div>,
+  InboxPage: () => <div>Inbox page</div>,
+  SearchPage: () => <div>Search page</div>,
+  LibraryPage: ({ object }: { object: string }) => <div>Library {object} page</div>,
+}));
 
 vi.mock('./oauth-callback-page', () => ({
   OAuthCallbackPage: () => <div>OAuth callback page</div>,
@@ -48,33 +54,63 @@ describe('App routes', () => {
     expect(screen.getByText('Auth page sign-up')).toBeVisible();
   });
 
-  test('redirects root and unknown routes to bookmarks', async () => {
+  test('redirects root and unknown routes to home', async () => {
     renderAppAt('/');
 
-    expect(await screen.findByText('Bookmarks page')).toBeVisible();
+    expect(await screen.findByText('Home page')).toBeVisible();
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/bookmarks');
+      expect(window.location.pathname).toBe('/home');
     });
 
     cleanup();
 
     renderAppAt('/definitely-not-here');
-    expect(await screen.findByText('Bookmarks page')).toBeVisible();
+    expect(await screen.findByText('Home page')).toBeVisible();
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/bookmarks');
+      expect(window.location.pathname).toBe('/home');
     });
   });
 
-  test('redirects legacy item URLs to bookmark detail routes', async () => {
-    renderAppAt('/item/bookmark-123');
+  test('redirects legacy bookmark URLs to canonical library and item routes', async () => {
+    renderAppAt('/bookmarks?contentType=video');
 
     expect(await screen.findByText('Bookmarks page')).toBeVisible();
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/bookmarks/bookmark-123');
+      expect(window.location.pathname).toBe('/library/bookmarks');
+      expect(window.location.search).toBe('?contentType=video');
+    });
+
+    cleanup();
+
+    renderAppAt('/bookmarks/bookmark-123');
+
+    expect(await screen.findByText('Bookmarks page')).toBeVisible();
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/item/bookmark-123');
     });
   });
 
-  test('renders protected callback and settings routes', async () => {
+  test('renders protected app routes', async () => {
+    renderAppAt('/home');
+    expect(await screen.findByText('Home page')).toBeVisible();
+
+    cleanup();
+
+    renderAppAt('/inbox');
+    expect(await screen.findByText('Inbox page')).toBeVisible();
+
+    cleanup();
+
+    renderAppAt('/search');
+    expect(await screen.findByText('Search page')).toBeVisible();
+
+    cleanup();
+
+    renderAppAt('/library/people');
+    expect(await screen.findByText('Library people page')).toBeVisible();
+
+    cleanup();
+
     renderAppAt('/oauth/callback');
     expect(await screen.findByText('OAuth callback page')).toBeVisible();
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,7 +1,8 @@
-import { BrowserRouter, Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 
 import { AuthPage } from './auth-page';
 import { BookmarksPage } from './bookmarks-page';
+import { HomePage, InboxPage, LibraryPage, SearchPage } from './mobile-parity-pages';
 import { OAuthCallbackPage } from './oauth-callback-page';
 import { PwaProvider } from './lib/pwa';
 import { ProtectedRoute } from './protected-route';
@@ -9,14 +10,15 @@ import { PwaSupport } from './pwa-support';
 import { SettingsPage } from './settings-page';
 import { WelcomePage } from './welcome-page';
 
-function LegacyItemRedirect() {
+function LegacyBookmarksRedirect({ detail = false }: { detail?: boolean }) {
   const { bookmarkId } = useParams<{ bookmarkId: string }>();
+  const location = useLocation();
 
-  if (!bookmarkId) {
-    return <Navigate to="/bookmarks" replace />;
+  if (detail) {
+    return <Navigate to={`/item/${bookmarkId ?? ''}${location.search}`} replace />;
   }
 
-  return <Navigate to={`/bookmarks/${bookmarkId}`} replace />;
+  return <Navigate to={`/library/bookmarks${location.search}`} replace />;
 }
 
 export default function App() {
@@ -35,7 +37,31 @@ export default function App() {
             }
           />
           <Route
-            path="/bookmarks"
+            path="/home"
+            element={
+              <ProtectedRoute>
+                <HomePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/inbox"
+            element={
+              <ProtectedRoute>
+                <InboxPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/search"
+            element={
+              <ProtectedRoute>
+                <SearchPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/library/bookmarks"
             element={
               <ProtectedRoute>
                 <BookmarksPage />
@@ -43,7 +69,31 @@ export default function App() {
             }
           />
           <Route
-            path="/bookmarks/:bookmarkId"
+            path="/library/people"
+            element={
+              <ProtectedRoute>
+                <LibraryPage object="people" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/library/sources"
+            element={
+              <ProtectedRoute>
+                <LibraryPage object="sources" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/library/collections"
+            element={
+              <ProtectedRoute>
+                <LibraryPage object="collections" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/item/:bookmarkId"
             element={
               <ProtectedRoute>
                 <BookmarksPage />
@@ -66,9 +116,10 @@ export default function App() {
               </ProtectedRoute>
             }
           />
-          <Route path="/item/:bookmarkId" element={<LegacyItemRedirect />} />
-          <Route path="/" element={<Navigate to="/bookmarks" replace />} />
-          <Route path="*" element={<Navigate to="/bookmarks" replace />} />
+          <Route path="/bookmarks" element={<LegacyBookmarksRedirect />} />
+          <Route path="/bookmarks/:bookmarkId" element={<LegacyBookmarksRedirect detail />} />
+          <Route path="/" element={<Navigate to="/home" replace />} />
+          <Route path="*" element={<Navigate to="/home" replace />} />
         </Routes>
         <PwaSupport />
       </PwaProvider>

--- a/apps/web/src/bookmarks-page.test.tsx
+++ b/apps/web/src/bookmarks-page.test.tsx
@@ -355,7 +355,7 @@ describe('BookmarksPage', () => {
     renderRoute(<BookmarksPage />, {
       route: '/bookmarks/missing-bookmark',
       path: '/bookmarks/:bookmarkId',
-      redirects: [{ path: '/bookmarks', element: <div>Bookmarks fallback</div> }],
+      redirects: [{ path: '/library/bookmarks', element: <div>Bookmarks fallback</div> }],
     });
 
     expect(await screen.findByText('Bookmarks fallback')).toBeVisible();
@@ -606,8 +606,19 @@ describe('BookmarksPage', () => {
         <LocationProbe />
       </>,
       {
-        route: '/bookmarks',
-        path: '/bookmarks/:bookmarkId?',
+        route: '/library/bookmarks',
+        path: '/library/bookmarks',
+        redirects: [
+          {
+            path: '/item/:bookmarkId',
+            element: (
+              <>
+                <BookmarksPage />
+                <LocationProbe />
+              </>
+            ),
+          },
+        ],
       }
     );
 
@@ -622,7 +633,7 @@ describe('BookmarksPage', () => {
     await user.click(screen.getByRole('button', { name: /Design systems at scale/ }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('location-path')).toHaveTextContent('/bookmarks/video-1');
+      expect(screen.getByTestId('location-path')).toHaveTextContent('/item/video-1');
     });
 
     expect(screen.getByRole('heading', { name: videoItem.title })).toBeVisible();
@@ -632,7 +643,7 @@ describe('BookmarksPage', () => {
     await user.click(screen.getByRole('button', { name: 'Back to bookmarks list' }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('location-path')).toHaveTextContent('/bookmarks');
+      expect(screen.getByTestId('location-path')).toHaveTextContent('/library/bookmarks');
     });
 
     expect(screen.getByText(articleItem.title)).toBeVisible();
@@ -650,8 +661,19 @@ describe('BookmarksPage', () => {
         <LocationProbe />
       </>,
       {
-        route: `/bookmarks/${videoItem.id}`,
-        path: '/bookmarks/:bookmarkId?',
+        route: `/item/${videoItem.id}`,
+        path: '/item/:bookmarkId',
+        redirects: [
+          {
+            path: '/library/bookmarks',
+            element: (
+              <>
+                <BookmarksPage />
+                <LocationProbe />
+              </>
+            ),
+          },
+        ],
       }
     );
 
@@ -664,7 +686,7 @@ describe('BookmarksPage', () => {
     await user.click(selectedBookmarkCard as HTMLElement);
 
     await waitFor(() => {
-      expect(screen.getByTestId('location-path')).toHaveTextContent('/bookmarks');
+      expect(screen.getByTestId('location-path')).toHaveTextContent('/library/bookmarks');
     });
 
     expect(selectedBookmarkCard).toHaveAttribute('aria-pressed', 'false');
@@ -676,18 +698,18 @@ describe('BookmarksPage', () => {
     setViewportWidth(390);
 
     const view = renderRoute(<BookmarksPage />, {
-      route: '/bookmarks',
-      path: '/bookmarks/:bookmarkId?',
+      route: '/library/bookmarks',
+      path: '/library/bookmarks',
     });
 
     const tabBar = screen.getByRole('navigation', { name: 'Tab bar' });
     expect(tabBar).toBeInTheDocument();
 
-    expect(screen.getByRole('link', { name: 'Bookmarks' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Library' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
 
-    const bookmarksTab = screen.getByRole('link', { name: 'Bookmarks' });
-    expect(bookmarksTab).toHaveAttribute('aria-current', 'page');
+    const libraryTab = screen.getByRole('link', { name: 'Library' });
+    expect(libraryTab).toHaveAttribute('aria-current', 'page');
     expect(document.documentElement).toHaveClass('mobile-bookmarks-scroll-lock');
     expect(document.body).toHaveClass('mobile-bookmarks-scroll-lock');
 

--- a/apps/web/src/bookmarks-page.tsx
+++ b/apps/web/src/bookmarks-page.tsx
@@ -1,12 +1,15 @@
 import {
   Bookmark,
-  BookmarkCheck,
   CircleCheck,
   CirclePlus,
   ChevronLeft,
   ChevronRight,
   Ellipsis,
+  Home,
+  Inbox,
+  Library,
   Plus,
+  Search,
   Settings,
   Share,
 } from 'lucide-react';
@@ -22,7 +25,14 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react';
-import { Link, NavLink, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import {
+  Link,
+  NavLink,
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 
 import { Colors, ContentColors, ProviderColors, getButtonMetrics } from '@zine/design-system';
 import { CollectionSort, ContentType, Provider } from '@zine/shared';
@@ -35,6 +45,7 @@ import { FilterChip } from './components/ui/filter-chip';
 import { AppWordmark } from './app-wordmark';
 import {
   formatDuration,
+  formatDisplayText,
   formatPlainText,
   isValidUrl,
   mapContentType,
@@ -188,7 +199,7 @@ function serializeBookmarkFilter(value: ContentType | undefined): string | null 
 
 function buildBookmarksLocation(bookmarkId: string | null | undefined, search: string) {
   return {
-    pathname: bookmarkId ? `/bookmarks/${bookmarkId}` : '/bookmarks',
+    pathname: bookmarkId ? `/item/${bookmarkId}` : '/library/bookmarks',
     search,
   };
 }
@@ -553,6 +564,7 @@ function BookmarkDetailSkeleton() {
 export function BookmarksPage() {
   const utils = trpc.useUtils();
   const navigate = useNavigate();
+  const currentLocation = useLocation();
   const { bookmarkId } = useParams<{ bookmarkId?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const [manualBookmarkOpen, setManualBookmarkOpen] = useState(false);
@@ -637,6 +649,7 @@ export function BookmarksPage() {
   ]);
 
   const displayBookmark = selectedBookmarkDetailQuery.data ?? selectedBookmark;
+  const displayBookmarkTitle = displayBookmark ? formatDisplayText(displayBookmark.title) : '';
   trpc.items.getEnrichment.useQuery(
     { id: selectedBookmarkId ?? '' },
     { enabled: Boolean(selectedBookmarkId) }
@@ -822,11 +835,7 @@ export function BookmarksPage() {
           <div className="new-page-sidebar__rail">
             <div className="new-page-sidebar__rail-top">
               <div className="new-page-sidebar__rail-header">
-                <Link
-                  to={buildBookmarksLocation(null, bookmarkSearchString)}
-                  className="new-page-sidebar__brand"
-                  aria-label="Go to bookmarks"
-                >
+                <Link to="/home" className="new-page-sidebar__brand" aria-label="Go to home">
                   <div className="new-page-sidebar__brand-icon">
                     <AppWordmark compact />
                   </div>
@@ -835,7 +844,7 @@ export function BookmarksPage() {
 
               <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
                 <NavLink
-                  to={buildBookmarksLocation(null, bookmarkSearchString)}
+                  to="/home"
                   end
                   className={({ isActive }) =>
                     cn(
@@ -843,11 +852,55 @@ export function BookmarksPage() {
                       isActive && 'new-page-sidebar__rail-btn--active'
                     )
                   }
-                  aria-label="Bookmarks"
-                  title="Bookmarks"
+                  aria-label="Home"
+                  title="Home"
                 >
-                  <BookmarkCheck size={18} strokeWidth={2.15} />
-                  <span>Bookmarks</span>
+                  <Home size={18} strokeWidth={2.15} />
+                  <span>Home</span>
+                </NavLink>
+                <NavLink
+                  to="/inbox"
+                  className={({ isActive }) =>
+                    cn(
+                      'new-page-sidebar__rail-btn',
+                      isActive && 'new-page-sidebar__rail-btn--active'
+                    )
+                  }
+                  aria-label="Inbox"
+                  title="Inbox"
+                >
+                  <Inbox size={18} strokeWidth={2.15} />
+                  <span>Inbox</span>
+                </NavLink>
+                <NavLink
+                  to="/search"
+                  className={({ isActive }) =>
+                    cn(
+                      'new-page-sidebar__rail-btn',
+                      isActive && 'new-page-sidebar__rail-btn--active'
+                    )
+                  }
+                  aria-label="Search"
+                  title="Search"
+                >
+                  <Search size={18} strokeWidth={2.15} />
+                  <span>Search</span>
+                </NavLink>
+                <NavLink
+                  to="/library/bookmarks"
+                  className={() =>
+                    cn(
+                      'new-page-sidebar__rail-btn',
+                      (currentLocation.pathname.startsWith('/library') ||
+                        currentLocation.pathname.startsWith('/item/')) &&
+                        'new-page-sidebar__rail-btn--active'
+                    )
+                  }
+                  aria-label="Library"
+                  title="Library"
+                >
+                  <Library size={18} strokeWidth={2.15} />
+                  <span>Library</span>
                 </NavLink>
               </nav>
             </div>
@@ -887,7 +940,7 @@ export function BookmarksPage() {
                       Bookmarks
                     </Link>
                     <ChevronRight size={14} strokeWidth={2.2} />
-                    <strong className="new-page-breadcrumb__title">{displayBookmark.title}</strong>
+                    <strong className="new-page-breadcrumb__title">{displayBookmarkTitle}</strong>
                   </>
                 ) : (
                   <strong>Bookmarks</strong>
@@ -1052,7 +1105,7 @@ export function BookmarksPage() {
                         <div className="bookmark-row__cover bookmark-row__cover--empty" />
                       )}
                       <div className="bookmark-row__info">
-                        <span className="bookmark-row__title">{item.title}</span>
+                        <span className="bookmark-row__title">{formatDisplayText(item.title)}</span>
                         <div className="bookmark-row__author">
                           {item.creatorImageUrl ? (
                             <img
@@ -1156,7 +1209,7 @@ export function BookmarksPage() {
                         ) : null}
 
                         {!isPhonePostView ? (
-                          <h2 className="new-page-bookmark-view__title">{displayBookmark.title}</h2>
+                          <h2 className="new-page-bookmark-view__title">{displayBookmarkTitle}</h2>
                         ) : null}
                       </div>
                       <div className="new-page-bookmark-view__creator-block">
@@ -1204,7 +1257,7 @@ export function BookmarksPage() {
                             size="icon"
                             className="new-page-bookmark-view__icon-action"
                             style={detailActionButtonStyle}
-                            aria-label={`Remove bookmark for ${displayBookmark.title}`}
+                            aria-label={`Remove bookmark for ${displayBookmarkTitle}`}
                             title="Remove bookmark"
                             disabled={!selectedBookmarkId || unbookmarkMutation.isPending}
                             onClick={() => {
@@ -1234,8 +1287,8 @@ export function BookmarksPage() {
                             style={detailActionButtonStyle}
                             aria-label={
                               selectedBookmarkIsFinished
-                                ? `Mark ${displayBookmark.title} as unfinished`
-                                : `Mark ${displayBookmark.title} as finished`
+                                ? `Mark ${displayBookmarkTitle} as unfinished`
+                                : `Mark ${displayBookmarkTitle} as finished`
                             }
                             title={selectedBookmarkIsFinished ? 'Mark unfinished' : 'Mark finished'}
                             disabled={!selectedBookmarkId || toggleFinishedMutation.isPending}
@@ -1255,7 +1308,7 @@ export function BookmarksPage() {
                             size="icon"
                             className="new-page-bookmark-view__icon-action"
                             style={detailActionButtonStyle}
-                            aria-label={`Manage tags for ${displayBookmark.title}`}
+                            aria-label={`Manage tags for ${displayBookmarkTitle}`}
                             title="Manage tags"
                             disabled={!selectedBookmarkId}
                             onClick={() => setBookmarkTagsOpen(true)}
@@ -1268,7 +1321,7 @@ export function BookmarksPage() {
                             size="icon"
                             className="new-page-bookmark-view__icon-action"
                             style={detailActionButtonStyle}
-                            aria-label={`Share ${displayBookmark.title}`}
+                            aria-label={`Share ${displayBookmarkTitle}`}
                             title="Share"
                             disabled={!selectedBookmarkSourceUrl}
                             onClick={async () => {
@@ -1282,7 +1335,7 @@ export function BookmarksPage() {
                               ) {
                                 try {
                                   await navigator.share({
-                                    title: displayBookmark.title,
+                                    title: displayBookmarkTitle,
                                     url: selectedBookmarkSourceUrl,
                                   });
                                   return;
@@ -1307,7 +1360,7 @@ export function BookmarksPage() {
                             size="icon"
                             className="new-page-bookmark-view__icon-action"
                             style={detailActionButtonStyle}
-                            aria-label={`More actions for ${displayBookmark.title}`}
+                            aria-label={`More actions for ${displayBookmarkTitle}`}
                             title="More actions"
                           >
                             <Ellipsis size={BOOKMARK_ACTION_ICON_SIZE} strokeWidth={2.15} />
@@ -1374,11 +1427,11 @@ export function BookmarksPage() {
                               </div>
 
                               <p className="new-page-bookmark-view__post-text">
-                                {displayBookmark.title}
+                                {displayBookmarkTitle}
                               </p>
 
                               {bookmarkPlainSummary &&
-                              bookmarkPlainSummary !== displayBookmark.title ? (
+                              bookmarkPlainSummary !== displayBookmarkTitle ? (
                                 <p className="new-page-bookmark-view__post-text new-page-bookmark-view__post-text--secondary">
                                   {bookmarkPlainSummary}
                                 </p>

--- a/apps/web/src/components/item-card.tsx
+++ b/apps/web/src/components/item-card.tsx
@@ -6,6 +6,7 @@ import type { ContentType, Provider } from '@zine/shared';
 
 import {
   formatDuration,
+  formatDisplayText,
   formatPlainText,
   formatRelativeDate,
   mapContentType,
@@ -152,32 +153,38 @@ export function ItemCardView({
   item,
   actionSlot,
   shape = 'row',
+  href,
 }: {
   item: ItemCardData;
   actionSlot?: ReactNode;
   shape?: ItemCardShape;
+  href?: string;
 }) {
   const sourceLabel = item.canonicalUrl
     ? new URL(item.canonicalUrl).hostname.replace(/^www\./, '')
     : 'original source';
-  const summary =
-    formatPlainText(item.summary) ?? item.creator ?? item.publisher ?? 'Untitled source';
+  const plainSummary = formatPlainText(item.summary);
+  const summary = plainSummary ?? item.creator ?? item.publisher ?? 'Untitled source';
+  const title = formatDisplayText(item.title);
   const creatorLabel = item.creator || item.publisher || 'Unknown creator';
-  const href = '/bookmarks';
+  const itemHref = href ?? `/item/${item.id}`;
   const inlineLengthLabel = getLengthLabel(item);
   const relativeLabel = getRelativeLabel(item);
+  const featureDescription =
+    plainSummary && plainSummary !== title && plainSummary !== creatorLabel
+      ? plainSummary
+      : sourceLabel;
 
   if (shape === 'feature') {
     return (
-      <Link to={href} className="group block">
-        <Surface className="overflow-hidden transition-transform duration-150 group-hover:-translate-y-0.5">
-          <div className="grid min-h-[104px] grid-cols-[92px_minmax(0,1fr)] sm:grid-cols-[104px_minmax(0,1fr)]">
-            <div className="bg-[var(--surface-raised)]">
+      <Link to={itemHref} className="group block h-full">
+        <Surface className="item-card-feature overflow-hidden transition-transform duration-150 group-hover:-translate-y-0.5">
+          <div className="item-card-feature__layout">
+            <div className="item-card-feature__media bg-[var(--surface-raised)]">
               <MediaThumb item={item} />
             </div>
-            <div className="flex min-w-0 flex-col justify-between p-4">
-              <div className="grid gap-2">
-                <ItemMetaRow item={item} />
+            <div className="flex min-w-0 flex-col justify-start gap-2 p-4">
+              <div className="grid min-w-0 gap-1.5">
                 <p
                   className="m-0 line-clamp-2 text-foreground"
                   style={{
@@ -185,20 +192,28 @@ export function ItemCardView({
                     letterSpacing: '-0.03em',
                   }}
                 >
-                  {item.title}
+                  {title}
                 </p>
+                <div
+                  className="flex min-w-0 items-center gap-2 text-[var(--text-subheader)]"
+                  style={typographyStyle(Typography.bodySmall)}
+                >
+                  <IdentityMark item={item} />
+                  <span className="truncate">{creatorLabel}</span>
+                  {inlineLengthLabel ? (
+                    <span className="shrink-0 text-[var(--text-tertiary)]">&bull;</span>
+                  ) : null}
+                  {inlineLengthLabel ? <span className="shrink-0">{inlineLengthLabel}</span> : null}
+                </div>
               </div>
-
-              <div
-                className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[var(--text-subheader)]"
-                style={typographyStyle(Typography.bodySmall)}
-              >
-                <span className="truncate">{creatorLabel}</span>
-                {inlineLengthLabel ? (
-                  <span className="text-[var(--text-tertiary)]">&bull;</span>
-                ) : null}
-                {inlineLengthLabel ? <span>{inlineLengthLabel}</span> : null}
-              </div>
+              {featureDescription ? (
+                <p
+                  className="m-0 line-clamp-2 text-[var(--text-subheader)]"
+                  style={typographyStyle(Typography.bodySmall)}
+                >
+                  {featureDescription}
+                </p>
+              ) : null}
             </div>
           </div>
         </Surface>
@@ -208,7 +223,7 @@ export function ItemCardView({
 
   if (shape === 'stack') {
     return (
-      <Link to={href} className="group block min-w-0 h-full">
+      <Link to={itemHref} className="group block min-w-0 h-full">
         <Surface className="flex h-full min-h-[272px] flex-col overflow-hidden transition-transform duration-150 group-hover:-translate-y-1">
           <div className="aspect-[1.1/0.86] bg-[var(--surface-raised)]">
             <MediaThumb item={item} />
@@ -223,7 +238,7 @@ export function ItemCardView({
                   letterSpacing: '-0.04em',
                 }}
               >
-                {item.title}
+                {title}
               </p>
               <p
                 className="m-0 line-clamp-2 text-[var(--text-subheader)]"
@@ -274,9 +289,9 @@ export function ItemCardView({
                   ...typographyStyle(Typography.titleMedium),
                   letterSpacing: '-0.03em',
                 }}
-                to={href}
+                to={itemHref}
               >
-                {item.title}
+                {title}
               </Link>
               <p
                 className="m-0 line-clamp-2 text-[var(--text-subheader)]"

--- a/apps/web/src/components/mobile-tab-bar.tsx
+++ b/apps/web/src/components/mobile-tab-bar.tsx
@@ -1,4 +1,4 @@
-import { BookmarkCheck, Settings } from 'lucide-react';
+import { BookmarkCheck, Home, Inbox, Search, Settings } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 
 import { cn } from '../components';
@@ -14,14 +14,44 @@ export function MobileTabBar() {
   return (
     <nav className="mobile-tab-bar" aria-label="Tab bar">
       <NavLink
-        to="/bookmarks"
+        to="/home"
         className={({ isActive }) =>
           cn('mobile-tab-bar__tab', isActive && 'mobile-tab-bar__tab--active')
         }
-        aria-label="Bookmarks"
+        aria-label="Home"
+      >
+        <Home size={20} strokeWidth={2} />
+        <span className="mobile-tab-bar__label">Home</span>
+      </NavLink>
+      <NavLink
+        to="/inbox"
+        className={({ isActive }) =>
+          cn('mobile-tab-bar__tab', isActive && 'mobile-tab-bar__tab--active')
+        }
+        aria-label="Inbox"
+      >
+        <Inbox size={20} strokeWidth={2} />
+        <span className="mobile-tab-bar__label">Inbox</span>
+      </NavLink>
+      <NavLink
+        to="/search"
+        className={({ isActive }) =>
+          cn('mobile-tab-bar__tab', isActive && 'mobile-tab-bar__tab--active')
+        }
+        aria-label="Search"
+      >
+        <Search size={20} strokeWidth={2} />
+        <span className="mobile-tab-bar__label">Search</span>
+      </NavLink>
+      <NavLink
+        to="/library/bookmarks"
+        className={({ isActive }) =>
+          cn('mobile-tab-bar__tab', isActive && 'mobile-tab-bar__tab--active')
+        }
+        aria-label="Library"
       >
         <BookmarkCheck size={20} strokeWidth={2} />
-        <span className="mobile-tab-bar__label">Bookmarks</span>
+        <span className="mobile-tab-bar__label">Library</span>
       </NavLink>
       <NavLink
         to="/settings"

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  formatDisplayText,
   formatDuration,
   formatEstimatedMinutes,
   formatPlainText,
@@ -15,6 +16,11 @@ describe('format utilities', () => {
         '<style>body{}</style><script>alert(1)</script><p>Hello&nbsp;<strong>world</strong> &amp; friends</p>'
       )
     ).toBe('Hello world & friends');
+  });
+
+  test('formats display text without leaking markup or entities', () => {
+    expect(formatDisplayText('Joy &amp; Curiosity #89')).toBe('Joy & Curiosity #89');
+    expect(formatDisplayText('<span></span>', 'Fallback')).toBe('Fallback');
   });
 
   test('formats durations across minute and hour boundaries', () => {

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -36,6 +36,10 @@ export function formatPlainText(value?: string | null) {
   return plainText.length > 0 ? plainText : null;
 }
 
+export function formatDisplayText(value?: string | null, fallback = 'Untitled') {
+  return formatPlainText(value) ?? fallback;
+}
+
 export function formatDuration(seconds?: number | null): string | undefined {
   return formatDurationTimestamp(seconds);
 }

--- a/apps/web/src/mobile-parity-pages.tsx
+++ b/apps/web/src/mobile-parity-pages.tsx
@@ -1,0 +1,901 @@
+import {
+  BookmarkCheck,
+  ChevronRight,
+  Folder,
+  Home,
+  Inbox,
+  Library,
+  Rss,
+  Search,
+  Settings,
+  UserRound,
+} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import { Link, NavLink, useLocation, useSearchParams } from 'react-router-dom';
+
+import { ContentType } from '@zine/shared';
+
+import { AppWordmark } from './app-wordmark';
+import { Badge, Button, EmptyState, Surface, cn } from './components';
+import { ItemCardView, type ItemCardData } from './components/item-card';
+import { MobileTabBar } from './components/mobile-tab-bar';
+import { FilterChip } from './components/ui/filter-chip';
+import { formatDisplayText, mapProvider } from './lib/format';
+import type { LibraryItem } from './lib/router-types';
+import { trpc } from './lib/trpc';
+
+type WebContentFilter = {
+  label: string;
+  value?: ContentType;
+  slug?: string;
+};
+
+const CONTENT_FILTERS: WebContentFilter[] = [
+  { label: 'All' },
+  { label: 'Articles', value: ContentType.ARTICLE, slug: 'article' },
+  { label: 'Podcasts', value: ContentType.PODCAST, slug: 'podcast' },
+  { label: 'Videos', value: ContentType.VIDEO, slug: 'video' },
+  { label: 'Posts', value: ContentType.POST, slug: 'post' },
+];
+
+const LIBRARY_OBJECTS = [
+  { label: 'Bookmarks', path: '/library/bookmarks', icon: BookmarkCheck },
+  { label: 'People', path: '/library/people', icon: UserRound },
+  { label: 'Sources', path: '/library/sources', icon: Rss },
+  { label: 'Collections', path: '/library/collections', icon: Folder },
+] as const;
+
+function parseContentFilter(value: string | null): ContentType | undefined {
+  return CONTENT_FILTERS.find((filter) => filter.slug === value)?.value;
+}
+
+function serializeContentFilter(value: ContentType | undefined): string | null {
+  return CONTENT_FILTERS.find((filter) => filter.value === value)?.slug ?? null;
+}
+
+function toItemCardData(
+  item: Partial<LibraryItem> & Pick<LibraryItem, 'id' | 'title'>
+): ItemCardData {
+  return {
+    id: item.id,
+    title: formatDisplayText(item.title),
+    creator: item.creator ?? item.publisher ?? 'Unknown creator',
+    creatorImageUrl: item.creatorImageUrl ?? null,
+    thumbnailUrl: item.thumbnailUrl ?? null,
+    contentType: item.contentType ?? ContentType.ARTICLE,
+    provider: item.provider ?? 'WEB',
+    duration: item.duration ?? null,
+    readingTimeMinutes: item.readingTimeMinutes ?? null,
+    publisher: item.publisher ?? null,
+    summary: item.summary ?? null,
+    canonicalUrl: item.canonicalUrl ?? null,
+    lastOpenedAt: item.lastOpenedAt ?? null,
+    bookmarkedAt: item.bookmarkedAt ?? null,
+    publishedAt: item.publishedAt ?? null,
+    ingestedAt: item.ingestedAt ?? null,
+  };
+}
+
+function useContentTypeSearchParam() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeFilter = parseContentFilter(searchParams.get('contentType'));
+
+  const setActiveFilter = useCallback(
+    (nextFilter: ContentType | undefined) => {
+      const next = new URLSearchParams(searchParams);
+      const serialized = serializeContentFilter(nextFilter);
+
+      if (serialized) {
+        next.set('contentType', serialized);
+      } else {
+        next.delete('contentType');
+      }
+
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  return { activeFilter, setActiveFilter };
+}
+
+function ContentFilterBar({
+  activeFilter,
+  onChange,
+}: {
+  activeFilter?: ContentType;
+  onChange: (filter: ContentType | undefined) => void;
+}) {
+  return (
+    <div className="web-page-chip-row" role="toolbar" aria-label="Content filters">
+      {CONTENT_FILTERS.map((filter) => (
+        <FilterChip
+          key={filter.label}
+          label={filter.label}
+          selected={activeFilter === filter.value}
+          tone={filter.value ?? 'default'}
+          size="small"
+          onClick={() => onChange(filter.value)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PrimaryNav() {
+  const location = useLocation();
+  const libraryActive =
+    location.pathname.startsWith('/library') || location.pathname.startsWith('/item/');
+
+  return (
+    <>
+      <div className="new-page-sidebar__rail-top">
+        <div className="new-page-sidebar__rail-header">
+          <Link to="/home" className="new-page-sidebar__brand" aria-label="Go to home">
+            <div className="new-page-sidebar__brand-icon">
+              <AppWordmark compact />
+            </div>
+          </Link>
+        </div>
+
+        <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
+          <NavLink
+            to="/home"
+            className={({ isActive }) =>
+              cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+            }
+            aria-label="Home"
+            title="Home"
+          >
+            <Home size={18} strokeWidth={2.15} />
+            <span>Home</span>
+          </NavLink>
+          <NavLink
+            to="/inbox"
+            className={({ isActive }) =>
+              cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+            }
+            aria-label="Inbox"
+            title="Inbox"
+          >
+            <Inbox size={18} strokeWidth={2.15} />
+            <span>Inbox</span>
+          </NavLink>
+          <NavLink
+            to="/search"
+            className={({ isActive }) =>
+              cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+            }
+            aria-label="Search"
+            title="Search"
+          >
+            <Search size={18} strokeWidth={2.15} />
+            <span>Search</span>
+          </NavLink>
+          <NavLink
+            to="/library/bookmarks"
+            className={cn(
+              'new-page-sidebar__rail-btn',
+              libraryActive && 'new-page-sidebar__rail-btn--active'
+            )}
+            aria-label="Library"
+            title="Library"
+          >
+            <Library size={18} strokeWidth={2.15} />
+            <span>Library</span>
+          </NavLink>
+        </nav>
+      </div>
+
+      <div className="new-page-sidebar__rail-footer">
+        <NavLink
+          to="/settings"
+          className={({ isActive }) =>
+            cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+          }
+          aria-label="Settings"
+          title="Settings"
+        >
+          <Settings size={18} strokeWidth={2.15} />
+          <span>Settings</span>
+        </NavLink>
+      </div>
+    </>
+  );
+}
+
+function WebPageFrame({
+  eyebrow,
+  title,
+  actions,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <main className="new-page-screen web-page-screen">
+      <div className="new-page-sidebar">
+        <div className="new-page-sidebar__rail">
+          <PrimaryNav />
+        </div>
+      </div>
+
+      <MobileTabBar />
+
+      <div className="new-page-inset web-page-inset">
+        <header className="new-page-inset__header web-page-header">
+          <nav className="new-page-breadcrumb" aria-label="Current page location">
+            <span>{eyebrow}</span>
+            <ChevronRight size={14} strokeWidth={2.2} />
+            <strong>{title}</strong>
+          </nav>
+          {actions ? <div className="new-page-inset__header-actions">{actions}</div> : null}
+        </header>
+        <div className="new-page-inset__body web-page-body">{children}</div>
+      </div>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="web-section">
+      <div className="web-section__header">
+        <h2>{title}</h2>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function InlineState({
+  title,
+  message,
+  action,
+}: {
+  title: string;
+  message: string;
+  action?: ReactNode;
+}) {
+  return <EmptyState title={title} message={message} action={action} />;
+}
+
+function ItemRail({
+  items,
+  shape = 'stack',
+}: {
+  items: ItemCardData[];
+  shape?: 'row' | 'stack' | 'feature';
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const railClassName = shape === 'feature' ? 'web-rail web-rail--feature' : 'web-rail';
+
+  return (
+    <div className={shape === 'row' ? 'web-list' : railClassName}>
+      {items.map((item) => (
+        <ItemCardView key={item.id} item={item} shape={shape} />
+      ))}
+    </div>
+  );
+}
+
+export function HomePage() {
+  const { activeFilter, setActiveFilter } = useContentTypeSearchParam();
+  const homeQuery = trpc.items.home.useQuery(
+    activeFilter ? { filter: { contentType: activeFilter } } : undefined
+  );
+  const inboxQuery = trpc.items.inbox.useQuery({
+    limit: 4,
+    filter: activeFilter ? { contentType: activeFilter } : {},
+  });
+
+  const homeData = homeQuery.data;
+  const jumpBackIn = useMemo(
+    () => (homeData?.jumpBackIn ?? []).map(toItemCardData),
+    [homeData?.jumpBackIn]
+  );
+  const recent = useMemo(
+    () => (homeData?.recentBookmarks ?? []).map(toItemCardData),
+    [homeData?.recentBookmarks]
+  );
+  const inboxItems = useMemo(
+    () => (inboxQuery.data?.items ?? []).map(toItemCardData),
+    [inboxQuery.data?.items]
+  );
+  const contentSections = [
+    { title: 'Podcasts', items: homeData?.byContentType.podcasts ?? [] },
+    { title: 'Articles', items: homeData?.byContentType.articles ?? [] },
+    { title: 'Videos', items: homeData?.byContentType.videos ?? [] },
+  ].map((section) => ({
+    ...section,
+    items: section.items.map(toItemCardData),
+  }));
+  const customCollections = (homeData?.customCollections ?? []).map((collection) => ({
+    ...collection,
+    items: collection.items.map(toItemCardData),
+  }));
+  const isEmpty =
+    !homeQuery.isLoading &&
+    !homeQuery.error &&
+    jumpBackIn.length === 0 &&
+    recent.length === 0 &&
+    inboxItems.length === 0 &&
+    contentSections.every((section) => section.items.length === 0) &&
+    customCollections.every((section) => section.items.length === 0);
+
+  return (
+    <WebPageFrame
+      eyebrow="Today"
+      title="Home"
+      actions={<ContentFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />}
+    >
+      <div className="web-page-scroll">
+        {homeQuery.error ? (
+          <InlineState
+            title="Could not load home"
+            message={homeQuery.error.message ?? 'Refresh and try again.'}
+          />
+        ) : homeQuery.isLoading ? (
+          <div className="web-skeleton-grid" aria-label="Loading home">
+            {Array.from({ length: 6 }, (_, index) => (
+              <div key={index} className="new-page-column-card__skeleton" />
+            ))}
+          </div>
+        ) : isEmpty ? (
+          <InlineState
+            title="Your home is ready when you are"
+            message="Save a few items or connect sources, then Zine will organize them here."
+            action={
+              <Button asChild>
+                <Link to="/welcome">Connect sources</Link>
+              </Button>
+            }
+          />
+        ) : (
+          <>
+            <Section title="Jump Back In">
+              <ItemRail items={jumpBackIn.slice(0, 6)} shape="feature" />
+            </Section>
+            <Section
+              title="Recently Bookmarked"
+              action={<Link to="/library/bookmarks">View all</Link>}
+            >
+              <ItemRail items={recent.slice(0, 8)} />
+            </Section>
+            <Section title="Inbox" action={<Link to="/inbox">Review inbox</Link>}>
+              <ItemRail items={inboxItems} shape="row" />
+            </Section>
+            {contentSections.map((section) =>
+              section.items.length > 0 ? (
+                <Section key={section.title} title={section.title}>
+                  <ItemRail items={section.items.slice(0, 8)} />
+                </Section>
+              ) : null
+            )}
+            {customCollections.map((section) =>
+              section.items.length > 0 ? (
+                <Section key={section.collectionId} title={section.title}>
+                  <ItemRail items={section.items.slice(0, 8)} />
+                </Section>
+              ) : null
+            )}
+          </>
+        )}
+      </div>
+    </WebPageFrame>
+  );
+}
+
+export function InboxPage() {
+  const utils = trpc.useUtils();
+  const { activeFilter, setActiveFilter } = useContentTypeSearchParam();
+  const [cursor, setCursor] = useState<string | undefined>();
+  const [items, setItems] = useState<LibraryItem[]>([]);
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const inboxQuery = trpc.items.inbox.useQuery({
+    limit: 20,
+    cursor,
+    filter: activeFilter ? { contentType: activeFilter } : {},
+  });
+  const bookmarkMutation = trpc.items.bookmark.useMutation({
+    onSuccess: () => {
+      void Promise.all([
+        utils.items.inbox.invalidate(),
+        utils.items.library.invalidate(),
+        utils.items.home.invalidate(),
+      ]);
+    },
+  });
+  const archiveMutation = trpc.items.archive.useMutation({
+    onSuccess: () => {
+      void utils.items.inbox.invalidate();
+    },
+  });
+
+  useEffect(() => {
+    setCursor(undefined);
+    setItems([]);
+    setDismissedIds(new Set());
+  }, [activeFilter]);
+
+  useEffect(() => {
+    if (!inboxQuery.data?.items) {
+      return;
+    }
+
+    setItems((current) => {
+      const next = cursor ? [...current] : [];
+      const seen = new Set(next.map((item) => item.id));
+      for (const item of inboxQuery.data.items) {
+        if (!seen.has(item.id)) {
+          next.push(item);
+        }
+      }
+      return next;
+    });
+  }, [cursor, inboxQuery.data?.items]);
+
+  const visibleItems = items.filter((item) => !dismissedIds.has(item.id));
+  const selectedFilterLabel = CONTENT_FILTERS.find(
+    (filter) => filter.value === activeFilter
+  )?.label;
+
+  const dismissWithMutation = (item: LibraryItem, action: 'bookmark' | 'archive') => {
+    setDismissedIds((current) => new Set(current).add(item.id));
+    const mutation = action === 'bookmark' ? bookmarkMutation : archiveMutation;
+    mutation.mutate(
+      { id: item.id },
+      {
+        onError: () => {
+          setDismissedIds((current) => {
+            const next = new Set(current);
+            next.delete(item.id);
+            return next;
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <WebPageFrame
+      eyebrow="Triage"
+      title="Inbox"
+      actions={<ContentFilterBar activeFilter={activeFilter} onChange={setActiveFilter} />}
+    >
+      <div className="web-page-scroll">
+        <Surface className="web-list-panel">
+          {inboxQuery.error && items.length === 0 ? (
+            <InlineState
+              title="Could not load inbox"
+              message={inboxQuery.error.message ?? 'Refresh and try again.'}
+            />
+          ) : inboxQuery.isLoading && items.length === 0 ? (
+            <div className="web-list">
+              {Array.from({ length: 6 }, (_, index) => (
+                <div key={index} className="new-page-column-card__skeleton" />
+              ))}
+            </div>
+          ) : visibleItems.length === 0 ? (
+            <InlineState
+              title={
+                selectedFilterLabel
+                  ? `No ${selectedFilterLabel.toLowerCase()}`
+                  : 'Your inbox is clear'
+              }
+              message={
+                selectedFilterLabel
+                  ? `New ${selectedFilterLabel.toLowerCase()} from your sources will appear here.`
+                  : 'Bookmark what you want to keep, archive the rest, and keep the queue light.'
+              }
+            />
+          ) : (
+            <div className="web-list">
+              {visibleItems.map((item) => (
+                <ItemCardView
+                  key={item.id}
+                  item={toItemCardData(item)}
+                  shape="row"
+                  actionSlot={
+                    <>
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => dismissWithMutation(item, 'bookmark')}
+                        disabled={bookmarkMutation.isPending}
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        tone="ghost"
+                        onClick={() => dismissWithMutation(item, 'archive')}
+                        disabled={archiveMutation.isPending}
+                      >
+                        Archive
+                      </Button>
+                    </>
+                  }
+                />
+              ))}
+              {inboxQuery.data?.nextCursor ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => setCursor(inboxQuery.data?.nextCursor ?? undefined)}
+                  disabled={inboxQuery.isLoading}
+                >
+                  Load more
+                </Button>
+              ) : null}
+            </div>
+          )}
+        </Surface>
+      </div>
+    </WebPageFrame>
+  );
+}
+
+function SearchEntityRow({
+  icon: Icon,
+  title,
+  subtitle,
+  to,
+}: {
+  icon: ComponentType<{ size?: number; strokeWidth?: number }>;
+  title: string;
+  subtitle: string;
+  to?: string;
+}) {
+  const content = (
+    <Surface className="web-entity-row">
+      <div className="web-entity-row__icon">
+        <Icon size={18} strokeWidth={2.1} />
+      </div>
+      <div className="web-entity-row__copy">
+        <strong>{title}</strong>
+        <span>{subtitle}</span>
+      </div>
+    </Surface>
+  );
+
+  return to ? <Link to={to}>{content}</Link> : content;
+}
+
+export function SearchPage() {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedQuery(query.trim()), 200);
+    return () => window.clearTimeout(timeout);
+  }, [query]);
+
+  const searchQuery = trpc.search.query.useQuery(
+    {
+      query: debouncedQuery || ' ',
+      creatorsLimit: 5,
+      peopleLimit: 5,
+      itemsLimit: 20,
+    },
+    { enabled: debouncedQuery.length > 0 }
+  );
+
+  const sections = searchQuery.data?.sections;
+  const creators = sections?.creators ?? [];
+  const people = sections?.people ?? [];
+  const items = sections?.items ?? [];
+  const hasQuery = debouncedQuery.length > 0;
+  const hasResults = creators.length > 0 || people.length > 0 || items.length > 0;
+
+  return (
+    <WebPageFrame eyebrow="Find" title="Search">
+      <div className="web-page-scroll">
+        <Surface className="web-search-panel">
+          <label className="web-search-box">
+            <Search size={18} strokeWidth={2} aria-hidden="true" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search your library"
+              aria-label="Search your library"
+            />
+          </label>
+        </Surface>
+
+        {!hasQuery ? null : searchQuery.error ? (
+          <InlineState
+            title="Could not search your library"
+            message={searchQuery.error.message ?? 'Try again in a moment.'}
+          />
+        ) : searchQuery.isLoading ? (
+          <div className="web-list">
+            {Array.from({ length: 5 }, (_, index) => (
+              <div key={index} className="new-page-column-card__skeleton" />
+            ))}
+          </div>
+        ) : !hasResults ? (
+          <InlineState title="No matches found" message="Try a different title or creator name." />
+        ) : (
+          <>
+            {creators.length > 0 ? (
+              <Section title="Creators">
+                <div className="web-list">
+                  {creators.map((creator) => (
+                    <SearchEntityRow
+                      key={creator.creatorId}
+                      icon={UserRound}
+                      title={creator.name}
+                      subtitle={[
+                        mapProvider(creator.provider),
+                        creator.isSubscribed ? 'Subscribed' : null,
+                        creator.libraryItemCount ? `${creator.libraryItemCount} saved` : null,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    />
+                  ))}
+                </div>
+              </Section>
+            ) : null}
+            {people.length > 0 ? (
+              <Section title="People">
+                <div className="web-list">
+                  {people.map((person) => (
+                    <SearchEntityRow
+                      key={person.personId}
+                      icon={UserRound}
+                      title={person.displayName}
+                      subtitle={`${person.itemCount} saved ${person.itemCount === 1 ? 'item' : 'items'}${
+                        person.latestItemTitle ? ` · ${person.latestItemTitle}` : ''
+                      }`}
+                    />
+                  ))}
+                </div>
+              </Section>
+            ) : null}
+            {items.length > 0 ? (
+              <Section title="Items">
+                <ItemRail items={items.map(toItemCardData)} shape="row" />
+              </Section>
+            ) : null}
+          </>
+        )}
+      </div>
+    </WebPageFrame>
+  );
+}
+
+function LibraryObjectTabs({ active }: { active: string }) {
+  return (
+    <div className="web-object-tabs" aria-label="Library sections">
+      {LIBRARY_OBJECTS.map((object) => {
+        const Icon = object.icon;
+        const isActive = active === object.label.toLowerCase();
+        return (
+          <Link
+            key={object.path}
+            to={object.path}
+            className={cn('web-object-tab', isActive && 'web-object-tab--active')}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <Icon size={17} strokeWidth={2.1} />
+            <span>{object.label}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function getCollectionRuleSummary(rules: {
+  contentTypes?: unknown[];
+  providers?: unknown[];
+  tagIds?: unknown[];
+  isFinished?: boolean;
+  search?: string;
+  minLengthMinutes?: number;
+  maxLengthMinutes?: number;
+}) {
+  const parts: string[] = [];
+  if (rules.contentTypes?.length) parts.push('content type');
+  if (rules.providers?.length) parts.push('source');
+  if (rules.tagIds?.length) parts.push('tag');
+  if (rules.isFinished !== undefined) parts.push(rules.isFinished ? 'finished' : 'unfinished');
+  if (rules.search) parts.push('search');
+  if (rules.minLengthMinutes !== undefined || rules.maxLengthMinutes !== undefined) {
+    parts.push('length');
+  }
+  return parts.length === 0 ? 'Manual collection' : `Saved filter: ${parts.join(', ')}`;
+}
+
+function LibrarySources() {
+  const subscriptionsQuery = trpc.subscriptions.list.useQuery({ limit: 100 });
+  const newslettersQuery = trpc.subscriptions.newsletters.list.useQuery({ limit: 100 });
+  const rssQuery = trpc.subscriptions.rss.list.useQuery({ limit: 100 });
+  const xBookmarksQuery = trpc.subscriptions.xBookmarks.status.useQuery(undefined, {
+    staleTime: 60 * 1000,
+  });
+  const rows = [
+    ...(subscriptionsQuery.data?.items ?? []).map((source) => ({
+      id: `subscription:${source.id}`,
+      title: source.name,
+      meta: `${mapProvider(source.provider)} subscription`,
+      status: source.status,
+      imageUrl: source.imageUrl ?? null,
+    })),
+    ...(newslettersQuery.data?.items ?? []).map((source) => ({
+      id: `newsletter:${source.id}`,
+      title: source.displayName,
+      meta: source.fromAddress ?? source.listId ?? 'Newsletter',
+      status: source.status,
+      imageUrl: source.imageUrl ?? null,
+    })),
+    ...(rssQuery.data?.items ?? [])
+      .filter((source) => source.status !== 'UNSUBSCRIBED')
+      .map((source) => ({
+        id: `rss:${source.id}`,
+        title: formatDisplayText(source.title),
+        meta: source.siteUrl ?? source.feedUrl,
+        status: source.status,
+        imageUrl: source.imageUrl ?? null,
+      })),
+  ];
+
+  if (xBookmarksQuery.data?.connected || xBookmarksQuery.data?.importedCount) {
+    rows.push({
+      id: 'x-bookmarks',
+      title: 'X Bookmarks',
+      meta: `${xBookmarksQuery.data.importedCount} imported`,
+      status: xBookmarksQuery.data.connected
+        ? 'ACTIVE'
+        : (xBookmarksQuery.data.connectionStatus ?? 'DISCONNECTED'),
+      imageUrl: null,
+    });
+  }
+
+  const isLoading =
+    subscriptionsQuery.isLoading || newslettersQuery.isLoading || rssQuery.isLoading;
+  const error = subscriptionsQuery.error ?? newslettersQuery.error ?? rssQuery.error;
+
+  if (error) {
+    return <InlineState title="Could not load sources" message={error.message} />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="web-list">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div key={index} className="new-page-column-card__skeleton" />
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <InlineState
+        title="No sources yet"
+        message="Connect YouTube, Spotify, newsletters, RSS, or X to start filling your inbox."
+        action={
+          <Button asChild>
+            <Link to="/welcome">Connect sources</Link>
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="web-object-grid">
+      {rows.map((source) => (
+        <Surface key={source.id} className="web-source-tile">
+          {source.imageUrl ? <img src={source.imageUrl} alt="" /> : <Rss size={20} />}
+          <div>
+            <strong>{formatDisplayText(source.title)}</strong>
+            <span>{source.meta}</span>
+          </div>
+          <Badge>{source.status.toLowerCase()}</Badge>
+        </Surface>
+      ))}
+    </div>
+  );
+}
+
+export function LibraryPage({ object }: { object: 'people' | 'sources' | 'collections' }) {
+  const collectionsQuery = trpc.collections.list.useQuery();
+  const peopleQuery = trpc.people.list.useQuery({ limit: 30, sort: 'count' });
+
+  return (
+    <WebPageFrame eyebrow="Library" title={object[0].toUpperCase() + object.slice(1)}>
+      <div className="web-page-scroll">
+        <LibraryObjectTabs active={object} />
+        {object === 'people' ? (
+          peopleQuery.error ? (
+            <InlineState title="Could not load people" message={peopleQuery.error.message} />
+          ) : peopleQuery.isLoading ? (
+            <div className="web-list">
+              {Array.from({ length: 6 }, (_, index) => (
+                <div key={index} className="new-page-column-card__skeleton" />
+              ))}
+            </div>
+          ) : (peopleQuery.data?.people ?? []).length === 0 ? (
+            <InlineState
+              title="No people yet"
+              message="People mentioned in saved work will appear here after enrichment runs."
+            />
+          ) : (
+            <div className="web-object-grid">
+              {(peopleQuery.data?.people ?? []).map((person) => (
+                <Surface key={person.id} className="web-person-tile">
+                  {person.profileImageUrl ? (
+                    <img src={person.profileImageUrl} alt="" />
+                  ) : (
+                    <div>{person.displayName.slice(0, 2).toUpperCase()}</div>
+                  )}
+                  <strong>{person.displayName}</strong>
+                  <span>
+                    {person.itemCount} saved {person.itemCount === 1 ? 'item' : 'items'}
+                  </span>
+                  {person.latestItemTitle ? <small>{person.latestItemTitle}</small> : null}
+                </Surface>
+              ))}
+            </div>
+          )
+        ) : object === 'sources' ? (
+          <LibrarySources />
+        ) : collectionsQuery.error ? (
+          <InlineState
+            title="Could not load collections"
+            message={collectionsQuery.error.message}
+          />
+        ) : collectionsQuery.isLoading ? (
+          <div className="web-list">
+            {Array.from({ length: 4 }, (_, index) => (
+              <div key={index} className="new-page-column-card__skeleton" />
+            ))}
+          </div>
+        ) : (collectionsQuery.data?.collections ?? []).length === 0 ? (
+          <InlineState
+            title="No collections yet"
+            message="Save a filtered bookmark view as a collection to pin a focused shelf."
+          />
+        ) : (
+          <div className="web-object-grid">
+            {(collectionsQuery.data?.collections ?? []).map((collection) => (
+              <Surface key={collection.id} className="web-collection-tile">
+                <Folder size={20} strokeWidth={2.1} />
+                <strong>{collection.name}</strong>
+                <span>{collection.description ?? getCollectionRuleSummary(collection.rules)}</span>
+                {collection.homeSection ? <Badge>on home</Badge> : null}
+              </Surface>
+            ))}
+          </div>
+        )}
+      </div>
+    </WebPageFrame>
+  );
+}

--- a/apps/web/src/settings-page.test.tsx
+++ b/apps/web/src/settings-page.test.tsx
@@ -70,13 +70,16 @@ describe('SettingsPage', () => {
     }));
   });
 
-  test('renders the bookmarks shell with a settings breadcrumb and a single card', () => {
+  test('renders the app shell with a settings breadcrumb and a single card', () => {
     const { container } = renderRoute(<SettingsPage />, {
       route: '/settings',
       path: '/settings',
     });
 
-    expect(screen.getByRole('link', { name: 'Bookmarks' })).toHaveAttribute('href', '/bookmarks');
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
+      'href',
+      '/library/bookmarks'
+    );
     expect(screen.getByRole('link', { name: 'Settings' })).toHaveClass(
       'new-page-sidebar__rail-btn--active'
     );

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -1,11 +1,14 @@
 import {
-  BookmarkCheck,
   ChevronRight,
+  Home,
+  Inbox,
+  Library,
   LogOut,
   Mail,
   Newspaper,
   Podcast,
   Rss,
+  Search,
   Settings,
   Sparkles,
   Video,
@@ -199,11 +202,7 @@ export function SettingsPage() {
         <div className="new-page-sidebar__rail">
           <div className="new-page-sidebar__rail-top">
             <div className="new-page-sidebar__rail-header">
-              <Link
-                to="/bookmarks"
-                className="new-page-sidebar__brand"
-                aria-label="Go to bookmarks"
-              >
+              <Link to="/home" className="new-page-sidebar__brand" aria-label="Go to home">
                 <div className="new-page-sidebar__brand-icon">
                   <AppWordmark compact />
                 </div>
@@ -212,16 +211,49 @@ export function SettingsPage() {
 
             <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
               <NavLink
-                to="/bookmarks"
+                to="/home"
                 end
                 className={({ isActive }) =>
                   cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
                 }
-                aria-label="Bookmarks"
-                title="Bookmarks"
+                aria-label="Home"
+                title="Home"
               >
-                <BookmarkCheck size={18} strokeWidth={2.15} />
-                <span>Bookmarks</span>
+                <Home size={18} strokeWidth={2.15} />
+                <span>Home</span>
+              </NavLink>
+              <NavLink
+                to="/inbox"
+                className={({ isActive }) =>
+                  cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+                }
+                aria-label="Inbox"
+                title="Inbox"
+              >
+                <Inbox size={18} strokeWidth={2.15} />
+                <span>Inbox</span>
+              </NavLink>
+              <NavLink
+                to="/search"
+                className={({ isActive }) =>
+                  cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+                }
+                aria-label="Search"
+                title="Search"
+              >
+                <Search size={18} strokeWidth={2.15} />
+                <span>Search</span>
+              </NavLink>
+              <NavLink
+                to="/library/bookmarks"
+                className={({ isActive }) =>
+                  cn('new-page-sidebar__rail-btn', isActive && 'new-page-sidebar__rail-btn--active')
+                }
+                aria-label="Library"
+                title="Library"
+              >
+                <Library size={18} strokeWidth={2.15} />
+                <span>Library</span>
               </NavLink>
             </nav>
           </div>

--- a/apps/web/src/storybook/layout-web-app-states.stories.tsx
+++ b/apps/web/src/storybook/layout-web-app-states.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
-  BookmarkCheck,
   ChevronRight,
+  Home,
+  Inbox,
+  Library,
   LogOut,
   Newspaper,
+  Search,
   Settings as SettingsIcon,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
@@ -51,12 +54,12 @@ function AuthStateReference() {
         <p className="eyebrow">Web channel</p>
         <h1>A single calm place for everything you bookmarked.</h1>
         <p>
-          The browser surface stays focused on saved items first: scan the shelf, open one in
-          context, and get back to the original source without losing your place.
+          The browser surface now mirrors the mobile rhythm: home, inbox, search, library, and
+          detail surfaces keep the same reading semantics across screen sizes.
         </p>
         <div className="auth-hero__grid">
-          <StatCard label="Surface" value="1" detail="Bookmarks only" />
-          <StatCard label="Route" value="/bookmarks" detail="The default signed-in landing page" />
+          <StatCard label="Tabs" value="4" detail="Home, Inbox, Search, Library" />
+          <StatCard label="Route" value="/home" detail="The signed-in landing page" />
         </div>
       </section>
       <section className="auth-panel">
@@ -65,7 +68,8 @@ function AuthStateReference() {
           <p style={accessibleEyebrowStyle}>Sign in</p>
           <h2>Continue where you left off.</h2>
           <p>
-            Clerk handles the browser auth step, then drops you directly onto the bookmarks desk.
+            Clerk handles the browser auth step, then drops you directly onto the mobile-parity web
+            shell.
           </p>
           <div className="button-row">
             <Button>Continue with Clerk</Button>
@@ -91,8 +95,21 @@ function BookmarkSelectionReference() {
               </div>
             </div>
             <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
+              <div className="new-page-sidebar__rail-btn">
+                <Home size={18} strokeWidth={2.15} />
+                <span>Home</span>
+              </div>
+              <div className="new-page-sidebar__rail-btn">
+                <Inbox size={18} strokeWidth={2.15} />
+                <span>Inbox</span>
+              </div>
+              <div className="new-page-sidebar__rail-btn">
+                <Search size={18} strokeWidth={2.15} />
+                <span>Search</span>
+              </div>
               <div className="new-page-sidebar__rail-btn new-page-sidebar__rail-btn--active">
-                <span>Bookmarks</span>
+                <Library size={18} strokeWidth={2.15} />
+                <span>Library</span>
               </div>
             </nav>
           </div>
@@ -224,7 +241,7 @@ function BookmarkEmptyReference() {
     <main className="new-page-screen">
       <EmptyState
         title="No bookmarks yet"
-        message="Save a few items first, then this desk becomes the main web surface for browsing them."
+        message="Save a few items first, then Home and Library become the main web surfaces for browsing them."
       />
     </main>
   );
@@ -237,11 +254,7 @@ function SettingsReference() {
         <div className="new-page-sidebar__rail">
           <div className="new-page-sidebar__rail-top">
             <div className="new-page-sidebar__rail-header">
-              <Link
-                to="/bookmarks"
-                className="new-page-sidebar__brand"
-                aria-label="Go to bookmarks"
-              >
+              <Link to="/home" className="new-page-sidebar__brand" aria-label="Go to home">
                 <div className="new-page-sidebar__brand-icon">
                   <AppWordmark compact />
                 </div>
@@ -249,9 +262,25 @@ function SettingsReference() {
             </div>
 
             <nav className="new-page-sidebar__rail-nav" aria-label="Primary">
-              <Link to="/bookmarks" className="new-page-sidebar__rail-btn" aria-label="Bookmarks">
-                <BookmarkCheck size={18} strokeWidth={2.15} />
-                <span>Bookmarks</span>
+              <Link to="/home" className="new-page-sidebar__rail-btn" aria-label="Home">
+                <Home size={18} strokeWidth={2.15} />
+                <span>Home</span>
+              </Link>
+              <Link to="/inbox" className="new-page-sidebar__rail-btn" aria-label="Inbox">
+                <Inbox size={18} strokeWidth={2.15} />
+                <span>Inbox</span>
+              </Link>
+              <Link to="/search" className="new-page-sidebar__rail-btn" aria-label="Search">
+                <Search size={18} strokeWidth={2.15} />
+                <span>Search</span>
+              </Link>
+              <Link
+                to="/library/bookmarks"
+                className="new-page-sidebar__rail-btn"
+                aria-label="Library"
+              >
+                <Library size={18} strokeWidth={2.15} />
+                <span>Library</span>
               </Link>
             </nav>
           </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -496,6 +496,276 @@ img {
   color: var(--text);
 }
 
+/* ── Mobile-parity web pages ── */
+
+.web-page-screen {
+  background: var(--background);
+}
+
+.web-page-inset {
+  grid-template-rows: 4.5rem minmax(0, 1fr);
+}
+
+.web-page-header {
+  padding-right: 1rem;
+}
+
+.web-page-body {
+  display: block;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.web-page-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+  overflow: auto;
+  padding: 0 1rem 1rem 0;
+  scrollbar-width: thin;
+}
+
+.web-page-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.375rem;
+}
+
+.web-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.web-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.web-section__header h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.web-section__header a {
+  color: var(--text-subheader);
+  font-size: 0.8125rem;
+}
+
+.web-rail {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(18rem, 22rem);
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+}
+
+.web-rail > * {
+  scroll-snap-align: start;
+}
+
+.web-rail--feature {
+  grid-auto-columns: minmax(32rem, 36rem);
+}
+
+.item-card-feature {
+  aspect-ratio: 3.5 / 1;
+  height: 100%;
+}
+
+.item-card-feature__layout {
+  display: grid;
+  grid-template-columns: calc((100% / 3.5) * (16 / 9)) minmax(0, 1fr);
+  height: 100%;
+}
+
+.item-card-feature__media {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.item-card-feature__media img {
+  transform: scale(1.06);
+}
+
+.web-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.web-list-panel,
+.web-search-panel {
+  padding: 0.75rem;
+}
+
+.web-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.web-search-box {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  min-height: 3rem;
+  padding-inline: 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface-subtle);
+  color: var(--text-subheader);
+}
+
+.web-search-box input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.web-search-box input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.web-entity-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem;
+}
+
+.web-entity-row__icon {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--text-subheader);
+}
+
+.web-entity-row__copy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.web-entity-row__copy strong,
+.web-person-tile strong,
+.web-collection-tile strong,
+.web-source-tile strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.9375rem;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.web-entity-row__copy span,
+.web-person-tile span,
+.web-person-tile small,
+.web-collection-tile span,
+.web-source-tile span {
+  overflow: hidden;
+  color: var(--text-subheader);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.web-object-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.625rem;
+}
+
+.web-object-tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.75rem;
+  padding-inline: 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface-subtle);
+  color: var(--text-subheader);
+  font-size: 0.875rem;
+  font-weight: 650;
+}
+
+.web-object-tab--active {
+  background: var(--surface-raised);
+  color: var(--text);
+}
+
+.web-object-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: 0.75rem;
+}
+
+.web-person-tile,
+.web-collection-tile,
+.web-source-tile {
+  display: grid;
+  align-content: start;
+  gap: 0.5rem;
+  min-height: 9rem;
+  padding: 1rem;
+}
+
+.web-person-tile img,
+.web-person-tile > div:first-child,
+.web-source-tile img,
+.web-source-tile > svg {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--text-subheader);
+  object-fit: cover;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.web-source-tile {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 5rem;
+}
+
+.web-source-tile > div {
+  display: grid;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.web-source-tile > :last-child {
+  justify-self: end;
+  max-width: 100%;
+}
+
 /* ── Mobile tab bar ── */
 
 .mobile-tab-bar {
@@ -504,7 +774,7 @@ img {
   left: 0.75rem;
   right: 0.75rem;
   z-index: 100;
-  display: flex;
+  display: none;
   align-items: stretch;
   justify-content: space-around;
   height: 3.5rem;
@@ -3768,6 +4038,69 @@ input:focus {
   }
 }
 
+@media (min-width: 701px) and (max-width: 1120px) {
+  .new-page-screen {
+    grid-template-columns: 4.75rem minmax(0, 1fr);
+    grid-template-rows: 4.5rem minmax(0, 1fr);
+    height: 100vh;
+  }
+
+  .new-page-sidebar {
+    grid-row: 1 / span 2;
+  }
+
+  .new-page-sidebar__rail {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-bottom: 1rem;
+  }
+
+  .new-page-sidebar__rail-top {
+    flex-direction: column;
+    align-items: center;
+    flex: 0 1 auto;
+  }
+
+  .new-page-sidebar__rail-header {
+    width: 100%;
+    min-height: 4.5rem;
+  }
+
+  .new-page-sidebar__brand {
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .new-page-sidebar__brand-icon {
+    width: 100%;
+  }
+
+  .new-page-sidebar__brand-icon .wordmark__mark {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .new-page-sidebar__rail-nav,
+  .new-page-sidebar__rail-footer {
+    width: 100%;
+  }
+
+  .new-page-sidebar__rail-nav {
+    flex-direction: column;
+  }
+
+  .new-page-sidebar__rail-footer {
+    margin-top: auto;
+  }
+
+  .new-page-inset {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    grid-template-rows: 4.5rem minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 700px) {
   .pwa-install-banner__actions {
     grid-template-columns: 1fr;
@@ -3784,6 +4117,7 @@ input:focus {
   }
 
   .new-page-screen {
+    grid-template-columns: 1fr;
     height: 100dvh;
     min-height: 100dvh;
     padding-bottom: 0;
@@ -3798,28 +4132,61 @@ input:focus {
     touch-action: pan-y;
   }
 
-  .new-page-sidebar__rail {
-    align-items: stretch;
-    gap: 0.75rem;
-    padding-bottom: 0;
+  .new-page-sidebar {
+    display: none;
   }
 
-  .new-page-sidebar__rail-top {
-    justify-content: space-between;
+  .mobile-tab-bar {
+    display: flex;
   }
 
-  .new-page-sidebar__rail-btn {
-    width: auto;
-    min-width: 3rem;
-    height: 3rem;
-    padding-inline: 0.85rem;
-    border-radius: 999px;
+  .web-page-screen {
+    grid-template-rows: minmax(0, 1fr);
   }
 
-  .new-page-sidebar__rail-btn span {
-    display: inline;
-    font-size: 0.82rem;
-    font-weight: 600;
+  .new-page-inset,
+  .web-page-inset {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .web-page-header {
+    align-content: start;
+    min-height: auto;
+  }
+
+  .web-page-body {
+    padding-bottom: calc(4.75rem + env(safe-area-inset-bottom, 0));
+  }
+
+  .web-page-scroll {
+    padding: 0 0.75rem 1rem;
+  }
+
+  .web-page-chip-row {
+    justify-content: flex-start;
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    width: 100%;
+    padding-bottom: 0.125rem;
+  }
+
+  .web-rail {
+    grid-auto-columns: minmax(16rem, 82vw);
+  }
+
+  .web-rail--feature {
+    grid-auto-columns: minmax(22rem, 90vw);
+  }
+
+  .web-skeleton-grid,
+  .web-object-tabs,
+  .web-object-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .web-object-tab {
+    justify-content: flex-start;
   }
 
   .new-page-inset__header,

--- a/apps/web/src/test/mocks/trpc.tsx
+++ b/apps/web/src/test/mocks/trpc.tsx
@@ -22,6 +22,22 @@ type ItemsLibraryInput = {
   };
 };
 
+type ItemsHomeInput =
+  | {
+      filter?: {
+        contentType?: ContentType;
+      };
+    }
+  | undefined;
+
+type ItemsInboxInput = {
+  limit: number;
+  cursor?: string;
+  filter: {
+    contentType?: ContentType;
+  };
+};
+
 type ItemsGetInput = {
   id: string;
 };
@@ -50,6 +66,11 @@ type DiscoverAvailableInput = {
 type NewslettersListInput = {
   status?: string;
   search?: string;
+  limit?: number;
+  cursor?: string;
+};
+
+type SubscriptionsListInput = {
   limit?: number;
   cursor?: string;
 };
@@ -84,6 +105,7 @@ const sessionState: SessionState = {
 
 export const invalidateSpies = {
   itemsGetInvalidate: vi.fn(async () => undefined),
+  itemsInboxInvalidate: vi.fn(async () => undefined),
   itemsLibraryInvalidate: vi.fn(async () => undefined),
   itemsHomeInvalidate: vi.fn(async () => undefined),
   itemsListTagsInvalidate: vi.fn(async () => undefined),
@@ -99,6 +121,8 @@ export const invalidateSpies = {
 
 export const mutationSpies = {
   toggleFinished: vi.fn(async (_input: unknown) => undefined),
+  bookmark: vi.fn(async (_input: unknown) => undefined),
+  archive: vi.fn(async (_input: unknown) => undefined),
   unbookmark: vi.fn(async (_input: unknown) => undefined),
   setTags: vi.fn(async (_input: unknown) => undefined),
   markOpened: vi.fn(async (_input: unknown) => undefined),
@@ -114,6 +138,18 @@ export const mutationSpies = {
 };
 
 export const hookSpies = {
+  itemsHomeUseQuery: vi.fn<(input?: ItemsHomeInput) => QueryResult<unknown>>((_input) =>
+    createQueryResult({
+      recentBookmarks: [],
+      jumpBackIn: [],
+      byContentType: { videos: [], podcasts: [], articles: [] },
+      customCollections: [],
+      sectionOrder: [],
+    })
+  ),
+  itemsInboxUseQuery: vi.fn<(input: ItemsInboxInput) => QueryResult<unknown>>((_input) =>
+    createQueryResult({ items: [], nextCursor: null })
+  ),
   itemsLibraryUseQuery: vi.fn<(input: ItemsLibraryInput) => QueryResult<unknown>>((_input) =>
     createQueryResult({})
   ),
@@ -156,6 +192,23 @@ export const hookSpies = {
   markOpenedUseMutation: vi.fn((options?: MutationOptions) =>
     createMutationResult(mutationSpies.markOpened, options)
   ),
+  bookmarkUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.bookmark, options)
+  ),
+  archiveUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.archive, options)
+  ),
+  searchQueryUseQuery: vi.fn<(input: unknown, options?: unknown) => QueryResult<unknown>>(
+    (_input) =>
+      createQueryResult({
+        results: [],
+        sections: { creators: [], people: [], items: [] },
+        nextCursor: null,
+      })
+  ),
+  peopleListUseQuery: vi.fn<(input: unknown) => QueryResult<unknown>>((_input) =>
+    createQueryResult({ people: [], nextCursor: null })
+  ),
   connectionsListUseQuery: vi.fn<() => QueryResult<unknown>>(() =>
     createQueryResult({
       YOUTUBE: null,
@@ -163,7 +216,7 @@ export const hookSpies = {
       GMAIL: null,
     })
   ),
-  subscriptionsListUseQuery: vi.fn<() => QueryResult<unknown>>(() =>
+  subscriptionsListUseQuery: vi.fn<(input?: SubscriptionsListInput) => QueryResult<unknown>>(() =>
     createQueryResult({ items: [], nextCursor: null, hasMore: false })
   ),
   discoverAvailableUseQuery: vi.fn<
@@ -233,6 +286,14 @@ export const hookSpies = {
   rssAddUseMutation: vi.fn((options?: MutationOptions) =>
     createMutationResult(mutationSpies.rssAdd, options)
   ),
+  xBookmarksStatusUseQuery: vi.fn<(_input?: unknown, options?: unknown) => QueryResult<unknown>>(
+    () =>
+      createQueryResult({
+        connected: false,
+        importedCount: 0,
+        connectionStatus: null,
+      })
+  ),
 };
 
 function createQueryResult<T>(data?: T, overrides: Partial<QueryResult<T>> = {}): QueryResult<T> {
@@ -290,6 +351,8 @@ export function resetTrpcMocks() {
   });
 
   mutationSpies.toggleFinished.mockResolvedValue(undefined);
+  mutationSpies.bookmark.mockResolvedValue(undefined);
+  mutationSpies.archive.mockResolvedValue(undefined);
   mutationSpies.unbookmark.mockResolvedValue(undefined);
   mutationSpies.setTags.mockResolvedValue(undefined);
   mutationSpies.markOpened.mockResolvedValue(undefined);
@@ -302,6 +365,22 @@ export function resetTrpcMocks() {
     id: 'collection-1',
     name: 'Smart collection',
   });
+
+  hookSpies.itemsHomeUseQuery.mockReset();
+  hookSpies.itemsHomeUseQuery.mockImplementation((_input) =>
+    createQueryResult({
+      recentBookmarks: [],
+      jumpBackIn: [],
+      byContentType: { videos: [], podcasts: [], articles: [] },
+      customCollections: [],
+      sectionOrder: [],
+    })
+  );
+
+  hookSpies.itemsInboxUseQuery.mockReset();
+  hookSpies.itemsInboxUseQuery.mockImplementation((_input) =>
+    createQueryResult({ items: [], nextCursor: null })
+  );
 
   hookSpies.itemsLibraryUseQuery.mockReset();
   hookSpies.itemsLibraryUseQuery.mockImplementation((_input) => createQueryResult());
@@ -359,6 +438,30 @@ export function resetTrpcMocks() {
   hookSpies.markOpenedUseMutation.mockReset();
   hookSpies.markOpenedUseMutation.mockImplementation((options?: MutationOptions) =>
     createMutationResult(mutationSpies.markOpened, options)
+  );
+
+  hookSpies.bookmarkUseMutation.mockReset();
+  hookSpies.bookmarkUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.bookmark, options)
+  );
+
+  hookSpies.archiveUseMutation.mockReset();
+  hookSpies.archiveUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.archive, options)
+  );
+
+  hookSpies.searchQueryUseQuery.mockReset();
+  hookSpies.searchQueryUseQuery.mockImplementation((_input) =>
+    createQueryResult({
+      results: [],
+      sections: { creators: [], people: [], items: [] },
+      nextCursor: null,
+    })
+  );
+
+  hookSpies.peopleListUseQuery.mockReset();
+  hookSpies.peopleListUseQuery.mockImplementation((_input) =>
+    createQueryResult({ people: [], nextCursor: null })
   );
 
   hookSpies.connectionsListUseQuery.mockReset();
@@ -453,6 +556,15 @@ export function resetTrpcMocks() {
   hookSpies.rssAddUseMutation.mockImplementation((options?: MutationOptions) =>
     createMutationResult(mutationSpies.rssAdd, options)
   );
+
+  hookSpies.xBookmarksStatusUseQuery.mockReset();
+  hookSpies.xBookmarksStatusUseQuery.mockImplementation(() =>
+    createQueryResult({
+      connected: false,
+      importedCount: 0,
+      connectionStatus: null,
+    })
+  );
 }
 
 export function setAuthAvailability(nextState: Partial<typeof authAvailability>) {
@@ -467,6 +579,7 @@ export const trpc = {
   useUtils: () => ({
     items: {
       get: { invalidate: invalidateSpies.itemsGetInvalidate },
+      inbox: { invalidate: invalidateSpies.itemsInboxInvalidate },
       library: { invalidate: invalidateSpies.itemsLibraryInvalidate },
       home: { invalidate: invalidateSpies.itemsHomeInvalidate },
       listTags: { invalidate: invalidateSpies.itemsListTagsInvalidate },
@@ -493,6 +606,12 @@ export const trpc = {
     },
   }),
   items: {
+    home: {
+      useQuery: (input?: ItemsHomeInput) => hookSpies.itemsHomeUseQuery(input),
+    },
+    inbox: {
+      useQuery: (input: ItemsInboxInput) => hookSpies.itemsInboxUseQuery(input),
+    },
     library: {
       useQuery: (input: ItemsLibraryInput) => hookSpies.itemsLibraryUseQuery(input),
     },
@@ -519,6 +638,12 @@ export const trpc = {
     markOpened: {
       useMutation: (options?: MutationOptions) => hookSpies.markOpenedUseMutation(options),
     },
+    bookmark: {
+      useMutation: (options?: MutationOptions) => hookSpies.bookmarkUseMutation(options),
+    },
+    archive: {
+      useMutation: (options?: MutationOptions) => hookSpies.archiveUseMutation(options),
+    },
   },
   collections: {
     list: {
@@ -538,6 +663,17 @@ export const trpc = {
         hookSpies.creatorsGetUseQuery(input, options),
     },
   },
+  search: {
+    query: {
+      useQuery: (input: unknown, options?: unknown) =>
+        hookSpies.searchQueryUseQuery(input, options),
+    },
+  },
+  people: {
+    list: {
+      useQuery: (input: unknown) => hookSpies.peopleListUseQuery(input),
+    },
+  },
   bookmarks: {
     preview: {
       useQuery: (input: BookmarkPreviewInput, options?: unknown) =>
@@ -554,7 +690,7 @@ export const trpc = {
       },
     },
     list: {
-      useQuery: () => hookSpies.subscriptionsListUseQuery(),
+      useQuery: (input?: SubscriptionsListInput) => hookSpies.subscriptionsListUseQuery(input),
     },
     add: {
       useMutation: (options?: MutationOptions) => hookSpies.subscriptionAddUseMutation(options),
@@ -595,6 +731,12 @@ export const trpc = {
       },
       add: {
         useMutation: (options?: MutationOptions) => hookSpies.rssAddUseMutation(options),
+      },
+    },
+    xBookmarks: {
+      status: {
+        useQuery: (input?: unknown, options?: unknown) =>
+          hookSpies.xBookmarksStatusUseQuery(input, options),
       },
     },
   },

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -129,11 +129,13 @@ type HomeItemView = Pick<
   | 'id'
   | 'title'
   | 'thumbnailUrl'
+  | 'canonicalUrl'
   | 'contentType'
   | 'provider'
   | 'creator'
   | 'creatorImageUrl'
   | 'publisher'
+  | 'summary'
   | 'duration'
   | 'readingTimeMinutes'
   | 'lastOpenedAt'
@@ -391,11 +393,13 @@ function toHomeItemViews(
       id: itemView.id,
       title: itemView.title,
       thumbnailUrl: itemView.thumbnailUrl,
+      canonicalUrl: itemView.canonicalUrl,
       contentType: itemView.contentType,
       provider: itemView.provider,
       creator: itemView.creator,
       creatorImageUrl: itemView.creatorImageUrl,
       publisher: itemView.publisher,
+      summary: itemView.summary,
       duration: itemView.duration,
       readingTimeMinutes: itemView.readingTimeMinutes,
       lastOpenedAt: itemView.lastOpenedAt,


### PR DESCRIPTION
## Summary

- Rebuilds the authenticated web app around mobile-parity routes: Home, Inbox, Search, Library object screens, canonical item detail, settings, and legacy redirects.
- Adds a responsive shell that uses a persistent left rail on desktop/tablet and bottom tabs on narrow mobile widths.
- Refactors Home and shared card surfaces, including the Jump Back In feature rail with fixed card/media ratios, creator avatar metadata, and summary descriptions.
- Extends the compact `items.home` response with `canonicalUrl` and `summary` so web cards can render useful descriptions without additional detail fetches.
- Updates web mocks, Storybook layout states, and smoke coverage for the new routes and responsive flows.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run test:web:storybook`
- `bun run test:web:e2e`
- Manual in-app browser verification on `http://localhost:8276/home` for the shell and Jump Back In card layout with production-shaped local data.

## Notes

- Existing repo warnings remain during validation: mobile lint warnings for duplicate imports/array type, Radix dialog warnings in web tests, and Vite chunk-size warnings during web/Storybook builds. None failed the gates.
