### PR TITLE
[codex] Fix home header filter spacing

### DIFF
--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -65,6 +65,9 @@ const HOME_PODCASTS_VISIBLE_LIMIT = 5;
 const HOME_TOP_THRESHOLD = 4;
 const NAVIGATION_PANE_WIDTH = 304;
 const NAVIGATION_PANE_ANIMATION_MS = 220;
+const HOME_HEADER_SETTINGS_BUTTON_SIZE = 36;
+const HOME_HEADER_SETTINGS_AREA_WIDTH = 44;
+const HOME_HEADER_FILTER_MIN_WIDTH = 180;
 
 type BuiltInHomeSectionKey =
   | 'jump-back-in'
@@ -207,7 +210,10 @@ export default function HomeScreen() {
   const [isNavigationPaneOpen, setNavigationPaneOpen] = useState(false);
   const featuredGridItemWidth = getFeaturedGridItemWidth(windowWidth - Spacing.md * 2, Spacing.md);
   const headerContentWidth = Math.max(windowWidth - Spacing.md * 2, 240);
-  const headerFilterWidth = Math.max(headerContentWidth - 38, 180);
+  const headerFilterWidth = Math.max(
+    headerContentWidth - HOME_HEADER_SETTINGS_AREA_WIDTH,
+    HOME_HEADER_FILTER_MIN_WIDTH
+  );
   const headerFadeEndColor =
     (colorScheme as string | null | undefined) === 'light'
       ? 'rgba(255, 255, 255, 0)'
@@ -1023,15 +1029,16 @@ const styles = StyleSheet.create({
     borderRadius: Radius.full,
   },
   settingsButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    width: HOME_HEADER_SETTINGS_BUTTON_SIZE,
+    height: HOME_HEADER_SETTINGS_BUTTON_SIZE,
+    borderRadius: HOME_HEADER_SETTINGS_BUTTON_SIZE / 2,
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 0,
     shadowOpacity: 0,
     elevation: 0,
+    zIndex: 2,
   },
   settingsAlertDot: {
     position: 'absolute',
@@ -1047,8 +1054,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   headerSettingsArea: {
-    width: 38,
-    height: 36,
+    width: HOME_HEADER_SETTINGS_AREA_WIDTH,
+    height: HOME_HEADER_SETTINGS_BUTTON_SIZE,
     position: 'relative',
     zIndex: 2,
   },
@@ -1056,13 +1063,12 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     bottom: 0,
-    left: 28,
-    width: 30,
+    left: HOME_HEADER_SETTINGS_BUTTON_SIZE,
+    width: HOME_HEADER_SETTINGS_AREA_WIDTH - HOME_HEADER_SETTINGS_BUTTON_SIZE,
     zIndex: 1,
   },
   headerFilterScroll: {
     flexGrow: 0,
-    marginLeft: Spacing.xs,
   },
   headerFilterContainer: {
     gap: Spacing.sm,

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -444,6 +444,35 @@ describe('HomeScreen', () => {
     );
   });
 
+  it('reserves header space so filter chips cannot cover the home settings button', () => {
+    let renderer: Renderer;
+    act(() => {
+      renderer = TestRenderer.create(<HomeScreen />);
+    });
+
+    const settingsButton = renderer!.root.findByProps({
+      accessibilityLabel: 'Open navigation menu',
+    });
+    const settingsAreaStyle = settingsButton.parent?.props.style;
+    const settingsButtonStyle = Array.isArray(settingsButton.props.style)
+      ? settingsButton.props.style
+      : [settingsButton.props.style];
+    const filterScroll = renderer!.root.find(
+      (node: TestNode) => node.type === 'scroll-view' && node.props.horizontal === true
+    );
+    const filterScrollStyle = Array.isArray(filterScroll.props.style)
+      ? filterScroll.props.style
+      : [filterScroll.props.style];
+
+    expect(settingsAreaStyle).toEqual(expect.objectContaining({ width: 44 }));
+    expect(settingsButtonStyle).toEqual(
+      expect.arrayContaining([expect.objectContaining({ width: 36 })])
+    );
+    expect(filterScrollStyle).toEqual(
+      expect.arrayContaining([expect.objectContaining({ width: 322 })])
+    );
+  });
+
   it('shows an alert dot on the settings button when an integration is disconnected', () => {
     mockSubscriptionsData = {
       items: [{ provider: 'YOUTUBE', status: 'DISCONNECTED' }],


### PR DESCRIPTION
## Summary

Fixes the Home screen header so the settings/navigation button has a protected layout area and the horizontal filter chips cannot overlap or clip it.

The root cause was that the filter rail was sized from an under-reserved settings area, with the fade and chip rail starting too close to the button. The header now uses explicit layout constants for the settings button, protected settings column, and filter rail minimum width. The protected area was tightened to keep the `All` chip visually close while still preventing overlap.

## Impact

- Settings icon remains fully visible in the upper-left Home header.
- Filter chips start closer to the settings icon without covering it.
- Adds regression coverage for the header spacing contract.

## Validation

- `bun run --cwd apps/mobile test -- home-screen.test.tsx`
- `bunx prettier --check 'apps/mobile/app/(tabs)/index/index.tsx' apps/mobile/lib/home-screen.test.tsx`\n- Pre-push hook passed:\n  - `bun run format:check`\n  - `bun run design-system:check`\n  - `bun run typecheck`\n  - `bun run test:web`\n  - worker test subset excluding `user-do.test.ts` and `scheduler.test.ts`\n- Manual Expo Go simulator verification with screenshot: `apps/mobile/tmp/home-settings-header-tight-reloaded.png`