### PR TITLE
[codex] add bookmark personal access tokens

### DIFF
--- a/apps/web/src/settings-page.test.tsx
+++ b/apps/web/src/settings-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -7,7 +7,14 @@ import { renderRoute } from './test/render-router';
 vi.mock('./lib/trpc', () => import('./test/mocks/trpc'));
 
 import { SettingsPage } from './settings-page';
-import { hookSpies, resetTrpcMocks, setAuthAvailability, setSessionState } from './test/mocks/trpc';
+import {
+  hookSpies,
+  invalidateSpies,
+  mutationSpies,
+  resetTrpcMocks,
+  setAuthAvailability,
+  setSessionState,
+} from './test/mocks/trpc';
 
 describe('SettingsPage', () => {
   beforeEach(() => {
@@ -176,6 +183,113 @@ describe('SettingsPage', () => {
       await user.click(within(nav).getByRole('button', { name: 'Sign out' }));
 
       expect(signOut).toHaveBeenCalledWith({ redirectUrl: '/sign-in' });
+    });
+
+    test('shows API tokens in settings', () => {
+      hookSpies.apiTokensListUseQuery.mockImplementation(() => ({
+        data: {
+          tokens: [
+            {
+              id: 'token-1',
+              name: 'Codex on MacBook',
+              tokenPrefix: 'zine_pat_abcd1234',
+              scopes: ['bookmarks:read', 'bookmarks:write'],
+              createdAt: Date.UTC(2026, 5, 1),
+              lastUsedAt: Date.UTC(2026, 5, 2),
+              expiresAt: null,
+              revokedAt: null,
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      }));
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      expect(screen.getByRole('heading', { name: 'API tokens' })).toBeVisible();
+      expect(screen.getByText('Codex on MacBook')).toBeVisible();
+      expect(screen.getByText('zine_pat_abcd1234...')).toBeVisible();
+      expect(screen.getByText('bookmarks:read, bookmarks:write')).toBeVisible();
+    });
+
+    test('creates an API token and shows the raw token once', async () => {
+      const user = userEvent.setup();
+      const writeText = vi.fn(async () => undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+
+      mutationSpies.apiTokensCreate.mockResolvedValue({
+        token: {
+          id: 'token-2',
+          name: 'Codex on MacBook',
+          tokenPrefix: 'zine_pat_created',
+          scopes: ['bookmarks:read', 'bookmarks:write'],
+          createdAt: Date.now(),
+          lastUsedAt: null,
+          expiresAt: null,
+          revokedAt: null,
+        },
+        rawToken: 'zine_pat_created_raw_token',
+      });
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      await user.type(screen.getByLabelText('Name'), 'Codex on MacBook');
+      await user.click(screen.getByRole('button', { name: 'Create token' }));
+
+      expect(await screen.findByText('zine_pat_created_raw_token')).toBeVisible();
+      expect(mutationSpies.apiTokensCreate).toHaveBeenCalledWith({
+        name: 'Codex on MacBook',
+        scopes: ['bookmarks:read', 'bookmarks:write'],
+      });
+      expect(invalidateSpies.apiTokensListInvalidate).toHaveBeenCalled();
+
+      await user.click(screen.getByRole('button', { name: 'Copy' }));
+      expect(writeText).toHaveBeenCalledWith('zine_pat_created_raw_token');
+      expect(screen.getByRole('button', { name: 'Copied' })).toBeVisible();
+    });
+
+    test('revokes an API token', async () => {
+      const user = userEvent.setup();
+      hookSpies.apiTokensListUseQuery.mockImplementation(() => ({
+        data: {
+          tokens: [
+            {
+              id: 'token-1',
+              name: 'Codex on MacBook',
+              tokenPrefix: 'zine_pat_abcd1234',
+              scopes: ['bookmarks:read'],
+              createdAt: Date.UTC(2026, 5, 1),
+              lastUsedAt: null,
+              expiresAt: null,
+              revokedAt: null,
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      }));
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Revoke Codex on MacBook' }));
+
+      await waitFor(() => {
+        expect(mutationSpies.apiTokensRevoke).toHaveBeenCalledWith({ id: 'token-1' });
+      });
+      expect(invalidateSpies.apiTokensListInvalidate).toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronRight,
+  Copy,
   Home,
   Inbox,
   Library,
@@ -11,9 +12,11 @@ import {
   Search,
   Settings,
   Sparkles,
+  Trash2,
   Video,
   type LucideIcon,
 } from 'lucide-react';
+import { useMemo, useState, type FormEvent } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 
 import { AppWordmark } from './app-wordmark';
@@ -191,6 +194,171 @@ function InstallAppSection({
   );
 }
 
+type ApiTokenScope = 'bookmarks:read' | 'bookmarks:write';
+
+function formatTimestamp(value: number | null | undefined): string {
+  if (!value) {
+    return 'Never';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function ApiTokensSection() {
+  const utils = trpc.useUtils();
+  const tokensQuery = trpc.apiTokens.list.useQuery();
+  const [name, setName] = useState('');
+  const [readEnabled, setReadEnabled] = useState(true);
+  const [writeEnabled, setWriteEnabled] = useState(true);
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const selectedScopes = useMemo(() => {
+    const scopes: ApiTokenScope[] = [];
+    if (readEnabled) scopes.push('bookmarks:read');
+    if (writeEnabled) scopes.push('bookmarks:write');
+    return scopes;
+  }, [readEnabled, writeEnabled]);
+
+  const createToken = trpc.apiTokens.create.useMutation({
+    onSuccess: (result) => {
+      setCreatedToken(result.rawToken);
+      setCopied(false);
+      setName('');
+      void utils.apiTokens.list.invalidate();
+    },
+  });
+
+  const revokeToken = trpc.apiTokens.revoke.useMutation({
+    onSuccess: () => {
+      void utils.apiTokens.list.invalidate();
+    },
+  });
+
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (selectedScopes.length === 0) {
+      return;
+    }
+
+    await createToken.mutateAsync({
+      name: name.trim(),
+      scopes: selectedScopes,
+    });
+  };
+
+  const handleCopy = async () => {
+    if (!createdToken || !navigator.clipboard) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(createdToken);
+    setCopied(true);
+  };
+
+  const tokens = tokensQuery.data?.tokens ?? [];
+
+  return (
+    <div className="settings-page__section api-tokens-section">
+      <div className="group-panel__header">
+        <div>
+          <h2 className="settings-page__section-title">API tokens</h2>
+        </div>
+      </div>
+
+      {createdToken ? (
+        <div className="api-token-reveal" role="status">
+          <code>{createdToken}</code>
+          <Button type="button" tone="ghost" onClick={handleCopy}>
+            <Copy size={16} aria-hidden="true" />
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+      ) : null}
+
+      <form className="api-token-form" onSubmit={(event) => void handleCreate(event)}>
+        <label className="api-token-form__field">
+          <span>Name</span>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Codex on MacBook"
+            maxLength={80}
+            required
+          />
+        </label>
+
+        <div className="api-token-form__scopes" aria-label="Token scopes">
+          <label>
+            <input
+              type="checkbox"
+              checked={readEnabled}
+              onChange={(event) => setReadEnabled(event.target.checked)}
+            />
+            Read bookmarks
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={writeEnabled}
+              onChange={(event) => setWriteEnabled(event.target.checked)}
+            />
+            Add bookmarks
+          </label>
+        </div>
+
+        <Button
+          type="submit"
+          disabled={
+            createToken.isPending || name.trim().length === 0 || selectedScopes.length === 0
+          }
+        >
+          Create token
+        </Button>
+      </form>
+
+      <div className="api-token-list">
+        {tokens.length === 0 ? (
+          <p className="api-token-list__empty">No tokens yet.</p>
+        ) : (
+          tokens.map((token) => (
+            <div key={token.id} className="api-token-row">
+              <div>
+                <strong>{token.name}</strong>
+                <span>{token.tokenPrefix}...</span>
+              </div>
+              <div className="api-token-row__meta">
+                <span>{token.scopes.join(', ')}</span>
+                <span>Created {formatTimestamp(token.createdAt)}</span>
+                <span>Last used {formatTimestamp(token.lastUsedAt)}</span>
+              </div>
+              {token.revokedAt ? (
+                <Badge tone="danger">revoked</Badge>
+              ) : (
+                <Button
+                  type="button"
+                  tone="danger"
+                  variant="ghost"
+                  onClick={() => revokeToken.mutate({ id: token.id })}
+                  disabled={revokeToken.isPending}
+                  aria-label={`Revoke ${token.name}`}
+                >
+                  <Trash2 size={16} aria-hidden="true" />
+                  Revoke
+                </Button>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function SettingsPage() {
   const { mode } = useAuthAvailability();
   const { signOut } = useAppSession();
@@ -314,6 +482,7 @@ export function SettingsPage() {
 
               <div className="settings-page__content">
                 <SourcesSection />
+                <ApiTokensSection />
                 <InstallAppSection
                   installAvailability={installAvailability}
                   promptInstall={promptInstall}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1170,6 +1170,127 @@ img {
   color: var(--text-dim);
 }
 
+.api-tokens-section {
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.api-token-reveal {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface-subtle);
+}
+
+.api-token-reveal code {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 0.8125rem;
+}
+
+.api-token-form {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto auto;
+  align-items: end;
+  gap: 0.75rem;
+}
+
+.api-token-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.api-token-form__field input {
+  min-height: 2.5rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+}
+
+.api-token-form__scopes {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 2.5rem;
+}
+
+.api-token-form__scopes label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+
+.api-token-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.api-token-list__empty {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+
+.api-token-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) minmax(14rem, 1.4fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--surface-subtle);
+}
+
+.api-token-row strong,
+.api-token-row span {
+  display: block;
+}
+
+.api-token-row strong {
+  color: var(--text);
+  font-size: 0.875rem;
+}
+
+.api-token-row span,
+.api-token-row__meta {
+  color: var(--text-dim);
+  font-size: 0.75rem;
+}
+
+.api-token-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.75rem;
+}
+
+@media (max-width: 760px) {
+  .api-token-form,
+  .api-token-row {
+    grid-template-columns: 1fr;
+  }
+
+  .api-token-reveal {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 /* ── Bookmark row (flat) ── */
 
 .bookmark-row {

--- a/apps/web/src/test/mocks/trpc.tsx
+++ b/apps/web/src/test/mocks/trpc.tsx
@@ -59,6 +59,28 @@ type BookmarkPreviewInput = {
   url: string;
 };
 
+type ApiTokenScope = 'bookmarks:read' | 'bookmarks:write';
+
+type ApiTokenSummary = {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  scopes: ApiTokenScope[];
+  createdAt: number;
+  lastUsedAt: number | null;
+  expiresAt: number | null;
+  revokedAt: number | null;
+};
+
+type ApiTokensCreateInput = {
+  name: string;
+  scopes: ApiTokenScope[];
+};
+
+type ApiTokensRevokeInput = {
+  id: string;
+};
+
 type DiscoverAvailableInput = {
   provider: string;
 };
@@ -117,6 +139,7 @@ export const invalidateSpies = {
   rssListInvalidate: vi.fn(async () => undefined),
   rssStatsInvalidate: vi.fn(async () => undefined),
   collectionsListInvalidate: vi.fn(async () => undefined),
+  apiTokensListInvalidate: vi.fn(async () => undefined),
 };
 
 export const mutationSpies = {
@@ -135,6 +158,20 @@ export const mutationSpies = {
     id: 'collection-1',
     name: 'Smart collection',
   })),
+  apiTokensCreate: vi.fn(async (_input: ApiTokensCreateInput) => ({
+    token: {
+      id: 'token-2',
+      name: 'Codex on MacBook',
+      tokenPrefix: 'zine_pat_created',
+      scopes: ['bookmarks:read', 'bookmarks:write'] as ApiTokenScope[],
+      createdAt: Date.now(),
+      lastUsedAt: null,
+      expiresAt: null,
+      revokedAt: null,
+    },
+    rawToken: 'zine_pat_created_raw_token',
+  })),
+  apiTokensRevoke: vi.fn(async (_input: ApiTokensRevokeInput) => ({ success: true })),
 };
 
 export const hookSpies = {
@@ -173,6 +210,15 @@ export const hookSpies = {
   >((_input) => createQueryResult({ items: [] })),
   collectionsCreateUseMutation: vi.fn((options?: MutationOptions) =>
     createMutationResult(mutationSpies.collectionsCreate, options)
+  ),
+  apiTokensListUseQuery: vi.fn<() => QueryResult<{ tokens: ApiTokenSummary[] }>>(() =>
+    createQueryResult({ tokens: [] })
+  ),
+  apiTokensCreateUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.apiTokensCreate, options)
+  ),
+  apiTokensRevokeUseMutation: vi.fn((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.apiTokensRevoke, options)
   ),
   bookmarksPreviewUseQuery: vi.fn<
     (input: BookmarkPreviewInput, options?: unknown) => QueryResult<unknown>
@@ -365,6 +411,20 @@ export function resetTrpcMocks() {
     id: 'collection-1',
     name: 'Smart collection',
   });
+  mutationSpies.apiTokensCreate.mockResolvedValue({
+    token: {
+      id: 'token-2',
+      name: 'Codex on MacBook',
+      tokenPrefix: 'zine_pat_created',
+      scopes: ['bookmarks:read', 'bookmarks:write'],
+      createdAt: Date.now(),
+      lastUsedAt: null,
+      expiresAt: null,
+      revokedAt: null,
+    },
+    rawToken: 'zine_pat_created_raw_token',
+  });
+  mutationSpies.apiTokensRevoke.mockResolvedValue({ success: true });
 
   hookSpies.itemsHomeUseQuery.mockReset();
   hookSpies.itemsHomeUseQuery.mockImplementation((_input) =>
@@ -410,6 +470,19 @@ export function resetTrpcMocks() {
   hookSpies.collectionsCreateUseMutation.mockReset();
   hookSpies.collectionsCreateUseMutation.mockImplementation((options?: MutationOptions) =>
     createMutationResult(mutationSpies.collectionsCreate, options)
+  );
+
+  hookSpies.apiTokensListUseQuery.mockReset();
+  hookSpies.apiTokensListUseQuery.mockImplementation(() => createQueryResult({ tokens: [] }));
+
+  hookSpies.apiTokensCreateUseMutation.mockReset();
+  hookSpies.apiTokensCreateUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.apiTokensCreate, options)
+  );
+
+  hookSpies.apiTokensRevokeUseMutation.mockReset();
+  hookSpies.apiTokensRevokeUseMutation.mockImplementation((options?: MutationOptions) =>
+    createMutationResult(mutationSpies.apiTokensRevoke, options)
   );
 
   hookSpies.bookmarksPreviewUseQuery.mockReset();
@@ -587,6 +660,9 @@ export const trpc = {
     collections: {
       list: { invalidate: invalidateSpies.collectionsListInvalidate },
     },
+    apiTokens: {
+      list: { invalidate: invalidateSpies.apiTokensListInvalidate },
+    },
     subscriptions: {
       connections: {
         list: { invalidate: invalidateSpies.subscriptionsConnectionsInvalidate },
@@ -655,6 +731,17 @@ export const trpc = {
     },
     create: {
       useMutation: (options?: MutationOptions) => hookSpies.collectionsCreateUseMutation(options),
+    },
+  },
+  apiTokens: {
+    list: {
+      useQuery: () => hookSpies.apiTokensListUseQuery(),
+    },
+    create: {
+      useMutation: (options?: MutationOptions) => hookSpies.apiTokensCreateUseMutation(options),
+    },
+    revoke: {
+      useMutation: (options?: MutationOptions) => hookSpies.apiTokensRevokeUseMutation(options),
     },
   },
   creators: {

--- a/apps/worker/src/db/migrations/0018_add_api_tokens.sql
+++ b/apps/worker/src/db/migrations/0018_add_api_tokens.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `api_tokens` (
+  `id` text PRIMARY KEY NOT NULL,
+  `user_id` text NOT NULL,
+  `name` text NOT NULL,
+  `token_hash` text NOT NULL,
+  `token_prefix` text NOT NULL,
+  `scopes_json` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `last_used_at` integer,
+  `expires_at` integer,
+  `revoked_at` integer,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `api_tokens_token_hash_idx` ON `api_tokens` (`token_hash`);
+CREATE INDEX IF NOT EXISTS `api_tokens_user_created_idx` ON `api_tokens` (`user_id`, `created_at`);
+CREATE INDEX IF NOT EXISTS `api_tokens_user_revoked_idx` ON `api_tokens` (`user_id`, `revoked_at`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780876800000,
       "tag": "0017_reclassify_substack_newsletters",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0018_add_api_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -11,6 +11,32 @@ export const users = sqliteTable('users', {
   updatedAt: text('updated_at').notNull(), // ISO8601 (legacy)
 });
 
+// Personal access tokens
+// Stores only token hashes. Raw tokens are shown once at creation time.
+// Uses Unix ms INTEGER timestamps (new standard). See docs/zine-tech-stack.md.
+export const apiTokens = sqliteTable(
+  'api_tokens',
+  {
+    id: text('id').primaryKey(), // ULID
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id),
+    name: text('name').notNull(),
+    tokenHash: text('token_hash').notNull(),
+    tokenPrefix: text('token_prefix').notNull(),
+    scopesJson: text('scopes_json').notNull(),
+    createdAt: integer('created_at').notNull(),
+    lastUsedAt: integer('last_used_at'),
+    expiresAt: integer('expires_at'),
+    revokedAt: integer('revoked_at'),
+  },
+  (table) => [
+    uniqueIndex('api_tokens_token_hash_idx').on(table.tokenHash),
+    index('api_tokens_user_created_idx').on(table.userId, table.createdAt),
+    index('api_tokens_user_revoked_idx').on(table.userId, table.revokedAt),
+  ]
+);
+
 // Items (Canonical Content)
 // NOTE: Legacy table using ISO8601 TEXT timestamps. New tables should use Unix ms INTEGER.
 // See docs/zine-tech-stack.md for timestamp standard.

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -28,6 +28,7 @@ import { resolveCorsOrigin } from './lib/cors';
 import { createWorkerRequestTelemetry, getWorkerRelease } from './lib/telemetry';
 import { authMiddleware } from './middleware/auth';
 import authRoutes from './routes/auth';
+import apiV1Routes from './routes/api-v1';
 import { appRouter } from './trpc/router';
 import { createContext } from './trpc/context';
 import { getDependencyHealth, getQueueHealth } from './diagnostics/health';
@@ -164,6 +165,7 @@ app.get('/health/queues', async (c) => {
 
 // Mount auth routes first (webhook endpoint handles its own auth via Svix)
 app.route('/api/auth', authRoutes);
+app.route('/api/v1', apiV1Routes);
 
 app.post('/admin/enrichment/backfill', async (c) => {
   const configuredSecret = c.env.ENRICHMENT_BACKFILL_SECRET;

--- a/apps/worker/src/lib/api-tokens.ts
+++ b/apps/worker/src/lib/api-tokens.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+import type { apiTokens } from '../db/schema';
+
+export const API_TOKEN_PREFIX = 'zine_pat_';
+
+export const ApiTokenScopeSchema = z.enum(['bookmarks:read', 'bookmarks:write']);
+export const ApiTokenScopesSchema = z
+  .array(ApiTokenScopeSchema)
+  .min(1)
+  .max(2)
+  .refine((scopes) => new Set(scopes).size === scopes.length, {
+    message: 'Scopes must be unique',
+  });
+
+export type ApiTokenScope = z.infer<typeof ApiTokenScopeSchema>;
+export type ApiTokenRecord = typeof apiTokens.$inferSelect;
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function bufferToHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function generateApiToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return `${API_TOKEN_PREFIX}${toBase64Url(bytes)}`;
+}
+
+export function getApiTokenPrefix(token: string): string {
+  return token.slice(0, API_TOKEN_PREFIX.length + 8);
+}
+
+export async function hashApiToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return bufferToHex(digest);
+}
+
+export function parseApiTokenScopes(scopesJson: string): ApiTokenScope[] {
+  const parsed = JSON.parse(scopesJson) as unknown;
+  return ApiTokenScopesSchema.parse(parsed);
+}
+
+export function hasApiTokenScope(token: ApiTokenRecord, scope: ApiTokenScope): boolean {
+  try {
+    return parseApiTokenScopes(token.scopesJson).includes(scope);
+  } catch {
+    return false;
+  }
+}
+
+export function isApiTokenActive(token: ApiTokenRecord, now = Date.now()): boolean {
+  return token.revokedAt === null && (token.expiresAt === null || token.expiresAt > now);
+}
+
+export function toApiTokenSummary(token: ApiTokenRecord) {
+  return {
+    id: token.id,
+    name: token.name,
+    tokenPrefix: token.tokenPrefix,
+    scopes: parseApiTokenScopes(token.scopesJson),
+    createdAt: token.createdAt,
+    lastUsedAt: token.lastUsedAt,
+    expiresAt: token.expiresAt,
+    revokedAt: token.revokedAt,
+  };
+}

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment miniflare
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { ContentType, Provider } from '@zine/shared';
+import type { Env } from '../types';
+
+const { mockCreateDb, mockCreateContext, mockCreateCaller, mockLibrary, mockPreview, mockSave } =
+  vi.hoisted(() => ({
+    mockCreateDb: vi.fn(),
+    mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
+      userId: c.get('userId'),
+    })),
+    mockCreateCaller: vi.fn(),
+    mockLibrary: vi.fn(),
+    mockPreview: vi.fn(),
+    mockSave: vi.fn(),
+  }));
+
+vi.mock('../db', () => ({
+  createDb: mockCreateDb,
+}));
+
+vi.mock('../trpc/context', () => ({
+  createContext: mockCreateContext,
+}));
+
+vi.mock('../trpc/router', () => ({
+  appRouter: {
+    createCaller: mockCreateCaller,
+  },
+}));
+
+import apiV1Routes from './api-v1';
+
+type JsonBody = Record<string, unknown>;
+
+const READ_WRITE_TOKEN = 'zine_pat_read_write_token';
+const READ_ONLY_TOKEN = 'zine_pat_read_only_token';
+
+function createTokenRecord(scopes: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'token_1',
+    userId: 'user_123',
+    name: 'Codex',
+    tokenHash: 'hash',
+    tokenPrefix: 'zine_pat_read',
+    scopesJson: JSON.stringify(scopes),
+    createdAt: Date.now(),
+    lastUsedAt: null,
+    expiresAt: null,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function createTestApp() {
+  const app = new Hono<Env>();
+
+  app.use('*', async (c, next) => {
+    c.set('requestId', 'test-request-id');
+    c.set('traceId', 'test-trace-id');
+    await next();
+  });
+
+  app.route('/api/v1', apiV1Routes);
+  return app;
+}
+
+function createMockEnv(): Env['Bindings'] {
+  return {
+    DB: {} as D1Database,
+    WEBHOOK_IDEMPOTENCY: {} as KVNamespace,
+    OAUTH_STATE_KV: {} as KVNamespace,
+    ARTICLE_CONTENT: {} as R2Bucket,
+    SPOTIFY_CACHE: {} as KVNamespace,
+    CREATOR_CONTENT_CACHE: {} as KVNamespace,
+    ENVIRONMENT: 'test',
+  } as Env['Bindings'];
+}
+
+function mockDbToken(token: ReturnType<typeof createTokenRecord> | null) {
+  const tokenUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const tokenUpdateSet = vi.fn().mockReturnValue({ where: tokenUpdateWhere });
+  mockCreateDb.mockReturnValue({
+    query: {
+      apiTokens: {
+        findFirst: vi.fn(async () => token),
+      },
+    },
+    update: vi.fn().mockReturnValue({ set: tokenUpdateSet }),
+  });
+}
+
+describe('apiV1Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbToken(createTokenRecord(['bookmarks:read', 'bookmarks:write']));
+    mockCreateCaller.mockReturnValue({
+      items: {
+        library: mockLibrary,
+      },
+      bookmarks: {
+        preview: mockPreview,
+        save: mockSave,
+      },
+    });
+  });
+
+  it('serves an OpenAPI document without PAT auth', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(new Request('http://localhost/api/v1/openapi.json'), {});
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as JsonBody;
+    expect(body.openapi).toBe('3.1.0');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks');
+  });
+
+  it('returns 401 for missing and invalid tokens', async () => {
+    const app = createTestApp();
+
+    const missing = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks'),
+      createMockEnv()
+    );
+
+    mockDbToken(null);
+    const invalid = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(missing.status).toBe(401);
+    expect(invalid.status).toBe(401);
+  });
+
+  it('returns 401 for revoked tokens', async () => {
+    mockDbToken(
+      createTokenRecord(['bookmarks:read', 'bookmarks:write'], {
+        revokedAt: Date.now(),
+      })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the token is missing the required scope', async () => {
+    mockDbToken(createTokenRecord(['bookmarks:read']));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_ONLY_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ url: 'https://example.com/article' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockPreview).not.toHaveBeenCalled();
+  });
+
+  it('lists bookmarks for the token owner', async () => {
+    mockLibrary.mockResolvedValue({
+      items: [{ id: 'ui_1', title: 'Recent bookmark' }],
+      nextCursor: 'next-cursor',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks?limit=20&cursor=abc&search=recent', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateCaller).toHaveBeenCalledWith({ userId: 'user_123' });
+    expect(mockLibrary).toHaveBeenCalledWith({
+      limit: 20,
+      cursor: 'abc',
+      search: 'recent',
+      filter: {
+        isFinished: undefined,
+      },
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      items: [{ title: 'Recent bookmark' }],
+      nextCursor: 'next-cursor',
+    });
+  });
+
+  it('previews and saves a bookmark URL for tokens with write scope', async () => {
+    mockPreview.mockResolvedValue({
+      provider: Provider.WEB,
+      contentType: ContentType.ARTICLE,
+      providerId: 'https://example.com/article',
+      title: 'Article title',
+      creator: 'Example',
+      thumbnailUrl: null,
+      duration: null,
+      canonicalUrl: 'https://example.com/article',
+      source: 'opengraph',
+      description: 'Article summary',
+    });
+    mockSave.mockResolvedValue({
+      itemId: 'item_1',
+      userItemId: 'ui_1',
+      status: 'created',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ url: 'https://example.com/article' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPreview).toHaveBeenCalledWith({ url: 'https://example.com/article' });
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://example.com/article',
+        title: 'Article title',
+      })
+    );
+    expect((await res.json()) as JsonBody).toMatchObject({
+      bookmark: {
+        status: 'created',
+      },
+      item: {
+        title: 'Article title',
+      },
+    });
+  });
+});

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1,0 +1,288 @@
+import { Hono } from 'hono';
+import type { MiddlewareHandler } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { Env } from '../types';
+import { createDb } from '../db';
+import { apiTokens } from '../db/schema';
+import { appRouter } from '../trpc/router';
+import { createContext } from '../trpc/context';
+import {
+  type ApiTokenScope,
+  API_TOKEN_PREFIX,
+  hashApiToken,
+  hasApiTokenScope,
+  isApiTokenActive,
+} from '../lib/api-tokens';
+
+const DEFAULT_BOOKMARKS_LIMIT = 10;
+const MAX_BOOKMARKS_LIMIT = 50;
+
+const SaveBookmarkBodySchema = z.object({
+  url: z.string().url('Invalid URL format'),
+});
+
+function extractBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+  return token.startsWith(API_TOKEN_PREFIX) ? token : null;
+}
+
+function parseLimit(value: string | undefined): number {
+  if (!value) {
+    return DEFAULT_BOOKMARKS_LIMIT;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_BOOKMARKS_LIMIT;
+  }
+
+  return Math.min(MAX_BOOKMARKS_LIMIT, Math.max(1, parsed));
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === 'true') {
+    return true;
+  }
+
+  if (value === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+
+function openApiSpec() {
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'Zine API',
+      version: '1.0.0',
+      description: 'REST API for personal access token access to Zine bookmarks.',
+    },
+    servers: [{ url: 'https://api.myzine.app' }],
+    security: [{ bearerAuth: [] }],
+    paths: {
+      '/api/v1/bookmarks': {
+        get: {
+          operationId: 'listBookmarks',
+          summary: 'List bookmarks',
+          parameters: [
+            {
+              name: 'limit',
+              in: 'query',
+              schema: {
+                type: 'integer',
+                minimum: 1,
+                maximum: MAX_BOOKMARKS_LIMIT,
+                default: DEFAULT_BOOKMARKS_LIMIT,
+              },
+            },
+            { name: 'cursor', in: 'query', schema: { type: 'string' } },
+            { name: 'search', in: 'query', schema: { type: 'string' } },
+            {
+              name: 'isFinished',
+              in: 'query',
+              schema: { type: 'boolean', default: false },
+            },
+          ],
+          responses: {
+            '200': { description: 'Bookmarks' },
+            '401': { description: 'Missing or invalid personal access token' },
+            '403': { description: 'Token is missing bookmarks:read scope' },
+          },
+        },
+        post: {
+          operationId: 'saveBookmark',
+          summary: 'Save a URL as a bookmark',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['url'],
+                  properties: {
+                    url: { type: 'string', format: 'uri' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': { description: 'Bookmark saved or already present' },
+            '400': { description: 'Invalid request body' },
+            '401': { description: 'Missing or invalid personal access token' },
+            '403': { description: 'Token is missing bookmarks:write scope' },
+            '422': { description: 'URL could not be previewed or saved' },
+          },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+        },
+      },
+    },
+  };
+}
+
+function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
+  const middleware: MiddlewareHandler<Env> = async (c, next) => {
+    const requestId = c.get('requestId');
+    const traceId = c.get('traceId');
+    const rawToken = extractBearerToken(c.req.header('Authorization'));
+
+    if (!rawToken) {
+      return c.json(
+        {
+          error: 'Unauthorized',
+          code: 'UNAUTHORIZED',
+          requestId,
+          traceId,
+        },
+        401
+      );
+    }
+
+    const tokenHash = await hashApiToken(rawToken);
+    const db = createDb(c.env.DB);
+    const token = await db.query.apiTokens.findFirst({
+      where: eq(apiTokens.tokenHash, tokenHash),
+    });
+
+    if (!token || !isApiTokenActive(token)) {
+      return c.json(
+        {
+          error: 'Unauthorized',
+          code: 'UNAUTHORIZED',
+          requestId,
+          traceId,
+        },
+        401
+      );
+    }
+
+    if (!hasApiTokenScope(token, requiredScope)) {
+      return c.json(
+        {
+          error: 'Forbidden',
+          code: 'FORBIDDEN',
+          requestId,
+          traceId,
+        },
+        403
+      );
+    }
+
+    await db
+      .update(apiTokens)
+      .set({ lastUsedAt: Date.now() })
+      .where(and(eq(apiTokens.id, token.id), eq(apiTokens.userId, token.userId)));
+
+    c.set('userId', token.userId);
+    await next();
+  };
+
+  return middleware;
+}
+
+const apiV1Routes = new Hono<Env>();
+
+apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec()));
+
+apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+  const search = c.req.query('search')?.trim();
+  const isFinished = parseBoolean(c.req.query('isFinished'));
+
+  const result = await caller.items.library({
+    limit: parseLimit(c.req.query('limit')),
+    cursor: cursor && cursor.length > 0 ? cursor : undefined,
+    search: search && search.length > 0 ? search : undefined,
+    filter: {
+      isFinished,
+    },
+  });
+
+  return c.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = SaveBookmarkBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  const preview = await caller.bookmarks.preview({ url: parsedBody.data.url });
+
+  if (!preview) {
+    return c.json(
+      {
+        error: 'URL could not be previewed',
+        code: 'UNSUPPORTED_URL',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      422
+    );
+  }
+
+  const bookmark = await caller.bookmarks.save({
+    ...preview,
+    url: parsedBody.data.url,
+  });
+
+  return c.json({
+    bookmark,
+    item: {
+      provider: preview.provider,
+      contentType: preview.contentType,
+      providerId: preview.providerId,
+      title: preview.title,
+      creator: preview.creator,
+      creatorImageUrl: preview.creatorImageUrl ?? null,
+      thumbnailUrl: preview.thumbnailUrl,
+      duration: preview.duration,
+      canonicalUrl: preview.canonicalUrl,
+      description: preview.description ?? null,
+      siteName: preview.siteName ?? null,
+      wordCount: preview.wordCount ?? null,
+      readingTimeMinutes: preview.readingTimeMinutes ?? null,
+      publishedAt: preview.publishedAt ?? null,
+    },
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+export default apiV1Routes;

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -14,6 +14,7 @@ import { searchRouter } from './routers/search';
 import { peopleRouter } from './routers/people';
 import { collectionsRouter } from './routers/collections';
 import { homeSettingsRouter } from './routers/home-settings';
+import { apiTokensRouter } from './routers/api-tokens';
 
 /**
  * Root tRPC router
@@ -72,6 +73,7 @@ export const appRouter = router({
   people: peopleRouter,
   collections: collectionsRouter,
   homeSettings: homeSettingsRouter,
+  apiTokens: apiTokensRouter,
   search: searchRouter,
   insights: insightsRouter,
 });

--- a/apps/worker/src/trpc/routers/api-tokens.test.ts
+++ b/apps/worker/src/trpc/routers/api-tokens.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment miniflare
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { apiTokensRouter } from './api-tokens';
+import type { TRPCContext } from '../context';
+
+function createTokenRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'token_1',
+    userId: 'user_123',
+    name: 'Codex on MacBook',
+    tokenHash: 'secret-hash',
+    tokenPrefix: 'zine_pat_abcd1234',
+    scopesJson: JSON.stringify(['bookmarks:read', 'bookmarks:write']),
+    createdAt: 1_800_000_000_000,
+    lastUsedAt: null,
+    expiresAt: null,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function createContext(db: unknown): TRPCContext {
+  return {
+    userId: 'user_123',
+    db,
+    env: {} as TRPCContext['env'],
+    requestId: 'request-id',
+    traceId: 'trace-id',
+    clientRequestId: undefined,
+    environment: 'test',
+    release: {},
+  } as TRPCContext;
+}
+
+describe('apiTokensRouter', () => {
+  it('lists token summaries without raw tokens or hashes', async () => {
+    const token = createTokenRecord();
+    const orderBy = vi.fn().mockResolvedValue([token]);
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const caller = apiTokensRouter.createCaller(createContext({ select }));
+
+    const result = await caller.list();
+
+    expect(result.tokens).toEqual([
+      {
+        id: 'token_1',
+        name: 'Codex on MacBook',
+        tokenPrefix: 'zine_pat_abcd1234',
+        scopes: ['bookmarks:read', 'bookmarks:write'],
+        createdAt: 1_800_000_000_000,
+        lastUsedAt: null,
+        expiresAt: null,
+        revokedAt: null,
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('secret-hash');
+  });
+
+  it('creates a token, stores only a hash, and returns the raw token once', async () => {
+    const insertedTokens: Record<string, unknown>[] = [];
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const insert = vi
+      .fn()
+      .mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({ onConflictDoNothing }),
+      })
+      .mockReturnValueOnce({
+        values: vi.fn(async (values: Record<string, unknown>) => {
+          insertedTokens.push(values);
+        }),
+      });
+
+    const findFirst = vi.fn(async () =>
+      createTokenRecord({
+        id: insertedTokens[0]?.id,
+        name: insertedTokens[0]?.name,
+        tokenHash: insertedTokens[0]?.tokenHash,
+        tokenPrefix: insertedTokens[0]?.tokenPrefix,
+        scopesJson: insertedTokens[0]?.scopesJson,
+        createdAt: insertedTokens[0]?.createdAt,
+      })
+    );
+    const caller = apiTokensRouter.createCaller(
+      createContext({
+        insert,
+        query: { apiTokens: { findFirst } },
+      })
+    );
+
+    const result = await caller.create({
+      name: 'Codex on MacBook',
+      scopes: ['bookmarks:read', 'bookmarks:write'],
+    });
+
+    expect(result.rawToken).toMatch(/^zine_pat_/);
+    const storedToken = insertedTokens[0];
+    if (!storedToken) {
+      throw new Error('Expected token insert values to be captured');
+    }
+    expect(storedToken.tokenHash).toEqual(expect.any(String));
+    expect(storedToken.tokenHash).not.toBe(result.rawToken);
+    expect(storedToken.tokenPrefix).toBe(result.rawToken.slice(0, 'zine_pat_'.length + 8));
+    expect(result.token).not.toHaveProperty('tokenHash');
+  });
+
+  it('revokes an owned active token', async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: 'token_1' }]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    const update = vi.fn().mockReturnValue({ set });
+    const caller = apiTokensRouter.createCaller(createContext({ update }));
+
+    await expect(caller.revoke({ id: 'token_1' })).resolves.toEqual({ success: true });
+    expect(set).toHaveBeenCalledWith({ revokedAt: expect.any(Number) });
+  });
+
+  it('rejects revoke for missing tokens', async () => {
+    const returning = vi.fn().mockResolvedValue([]);
+    const where = vi.fn().mockReturnValue({ returning });
+    const set = vi.fn().mockReturnValue({ where });
+    const update = vi.fn().mockReturnValue({ set });
+    const caller = apiTokensRouter.createCaller(createContext({ update }));
+
+    await expect(caller.revoke({ id: 'missing' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});

--- a/apps/worker/src/trpc/routers/api-tokens.ts
+++ b/apps/worker/src/trpc/routers/api-tokens.ts
@@ -1,0 +1,102 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import { ulid } from 'ulid';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { router, protectedProcedure } from '../trpc';
+import { apiTokens, users } from '../../db/schema';
+import {
+  ApiTokenScopesSchema,
+  generateApiToken,
+  getApiTokenPrefix,
+  hashApiToken,
+  toApiTokenSummary,
+} from '../../lib/api-tokens';
+
+const CreateApiTokenInputSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  scopes: ApiTokenScopesSchema,
+});
+
+const RevokeApiTokenInputSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const apiTokensRouter = router({
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const tokens = await ctx.db
+      .select()
+      .from(apiTokens)
+      .where(eq(apiTokens.userId, ctx.userId))
+      .orderBy(desc(apiTokens.createdAt), desc(apiTokens.id));
+
+    return {
+      tokens: tokens.map(toApiTokenSummary),
+    };
+  }),
+
+  create: protectedProcedure.input(CreateApiTokenInputSchema).mutation(async ({ ctx, input }) => {
+    const now = Date.now();
+    const rawToken = generateApiToken();
+    const tokenHash = await hashApiToken(rawToken);
+    const tokenId = ulid();
+
+    await ctx.db
+      .insert(users)
+      .values({
+        id: ctx.userId,
+        email: null,
+        createdAt: new Date(now).toISOString(),
+        updatedAt: new Date(now).toISOString(),
+      })
+      .onConflictDoNothing();
+
+    await ctx.db.insert(apiTokens).values({
+      id: tokenId,
+      userId: ctx.userId,
+      name: input.name,
+      tokenHash,
+      tokenPrefix: getApiTokenPrefix(rawToken),
+      scopesJson: JSON.stringify(input.scopes),
+      createdAt: now,
+      lastUsedAt: null,
+      expiresAt: null,
+      revokedAt: null,
+    });
+
+    const token = await ctx.db.query.apiTokens.findFirst({
+      where: and(eq(apiTokens.id, tokenId), eq(apiTokens.userId, ctx.userId)),
+    });
+
+    if (!token) {
+      throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR' });
+    }
+
+    return {
+      token: toApiTokenSummary(token),
+      rawToken,
+    };
+  }),
+
+  revoke: protectedProcedure.input(RevokeApiTokenInputSchema).mutation(async ({ ctx, input }) => {
+    const now = Date.now();
+    const result = await ctx.db
+      .update(apiTokens)
+      .set({ revokedAt: now })
+      .where(
+        and(
+          eq(apiTokens.id, input.id),
+          eq(apiTokens.userId, ctx.userId),
+          isNull(apiTokens.revokedAt)
+        )
+      )
+      .returning({ id: apiTokens.id });
+
+    if (result.length === 0) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'API token not found' });
+    }
+
+    return { success: true as const };
+  }),
+});
+
+export type ApiTokensRouter = typeof apiTokensRouter;

--- a/docs/web-cloudflare-deployment.md
+++ b/docs/web-cloudflare-deployment.md
@@ -61,6 +61,21 @@ Required Cloudflare Worker secrets or vars:
 - `OAUTH_REDIRECT_URI`: Recommended only if you want the backend to force a single canonical callback origin. The web app derives its callback from the current origin, so this is not required when serving both `https://www.myzine.app` and `https://myzine.app` directly.
 - `CLERK_JWKS_URL`: Set this if you are not using the default `https://clerk.myzine.app/.well-known/jwks.json`.
 
+Personal access tokens are managed by signed-in users from Web Settings. No
+Worker secret is required for the `/api/v1` bookmark API.
+
+Personal API examples:
+
+```bash
+curl -H "Authorization: Bearer $ZINE_PAT" \
+  "https://api.myzine.app/api/v1/bookmarks?limit=10"
+
+curl -X POST "https://api.myzine.app/api/v1/bookmarks" \
+  -H "Authorization: Bearer $ZINE_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com/article"}'
+```
+
 Cloudflare production resources that must already exist and match `apps/worker/wrangler.toml`:
 
 - Production D1 database


### PR DESCRIPTION
## Summary

Adds a production-ready personal access token flow for bookmark API access:

- Adds `api_tokens` D1 schema/migration plus token generation, hashing, scope parsing, and safe summaries.
- Adds `apiTokens.list/create/revoke` tRPC procedures for signed-in Web Settings token management.
- Adds `/api/v1/openapi.json` and `/api/v1/bookmarks` GET/POST routes secured by PAT bearer auth with `bookmarks:read` and `bookmarks:write` scopes.
- Adds Web Settings UI to create, copy once, list, and revoke tokens.
- Documents the PAT model and `/api/v1` curl examples.

## Impact

Agents and scripts can now access Zine bookmarks without an interactive Clerk login loop. Users create a PAT from Web Settings, store it in their agent secret/env store, and call the REST API with `Authorization: Bearer zine_pat_...`.

No new Cloudflare secret is required. Production deploy should run the new D1 migration before deploying the Worker.

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run --cwd apps/web test`
- `bun run --cwd apps/worker test:run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'`
- Also previously ran full worker/web suites locally:
  - `bun run --cwd apps/worker test:run`
  - `bun run --cwd apps/web test`
  - `bun run --cwd apps/worker lint`
  - `bun run --cwd apps/web lint`
