### PR TITLE
[codex] fix X video bookmark duration saves

### DIFF
--- a/apps/worker/src/lib/link-preview.test.ts
+++ b/apps/worker/src/lib/link-preview.test.ts
@@ -359,6 +359,50 @@ describe('link-preview', () => {
         expect(result!.source).toBe('fxtwitter');
       });
 
+      it('rounds fractional FxTwitter video durations to whole seconds', async () => {
+        mockFetchFxTwitterByUrl.mockResolvedValue({
+          code: 200,
+          message: 'OK',
+          tweet: {
+            id: '2068396380327170238',
+            url: 'https://x.com/Baconbrix/status/2068396380327170238',
+            text: 'New in serve-sim',
+            created_at: 'Sat Jun 20 18:11:40 +0000 2026',
+            created_timestamp: 1781979100,
+            author: {
+              name: 'Evan Bacon',
+              screen_name: 'Baconbrix',
+              avatar_url: 'https://pbs.twimg.com/profile_images/avatar.jpg',
+            },
+            likes: 804,
+            retweets: 45,
+            replies: 33,
+            views: 52513,
+            lang: 'en',
+            source: 'Twitter Web App',
+            media: {
+              videos: [
+                {
+                  url: 'https://video.twimg.com/amplify_video/video.mp4',
+                  thumbnail_url: 'https://pbs.twimg.com/amplify_video_thumb/thumb.jpg',
+                  width: 1712,
+                  height: 1080,
+                  duration: 15.232,
+                },
+              ],
+            },
+          },
+        });
+
+        const result = await fetchLinkPreview(
+          'https://x.com/Baconbrix/status/2068396380327170238?s=20'
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.duration).toBe(15);
+        expect(result!.thumbnailUrl).toBe('https://pbs.twimg.com/amplify_video_thumb/thumb.jpg');
+      });
+
       it('uses article metadata when a link-only tweet has empty text', async () => {
         mockFetchFxTwitterByUrl.mockResolvedValue({
           code: 200,

--- a/apps/worker/src/lib/link-preview.ts
+++ b/apps/worker/src/lib/link-preview.ts
@@ -504,6 +504,14 @@ function getTweetTitle(tweet: FxTwitterTweet, creator: string): string {
   return `Post by ${creator}`;
 }
 
+function normalizeDurationSeconds(duration: number | null | undefined): number | null {
+  if (typeof duration !== 'number' || !Number.isFinite(duration)) {
+    return null;
+  }
+
+  return Math.max(0, Math.round(duration));
+}
+
 /**
  * Map FxTwitter response to LinkPreviewResult
  * If the tweet has no attached media but contains external URLs,
@@ -575,7 +583,7 @@ async function mapFxTwitterToPreview(
   const publishedAt = new Date(tweet.created_timestamp * 1000).toISOString();
 
   // Get video duration if available
-  const duration = tweet.media?.videos?.[0]?.duration ?? null;
+  const duration = normalizeDurationSeconds(tweet.media?.videos?.[0]?.duration);
 
   return {
     provider: parsedLink.provider,


### PR DESCRIPTION
## Summary

Fixes X video bookmark saves when FxTwitter returns fractional video durations.

## Root Cause

`POST /api/v1/bookmarks` previews X links through FxTwitter, then saves the preview through the existing bookmark save schema. FxTwitter can return video durations as fractional seconds, for example `15.232`, while the save schema requires integer seconds. That validation failure bubbled up as a 500 for otherwise valid X links.

## Changes

- Normalize FxTwitter video durations to whole seconds before returning the preview payload.
- Add regression coverage for an X video post with a fractional duration.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run design-system:check`
- `bun run test`
- `bun run build`
- `bun run --cwd apps/worker test:run src/lib/link-preview.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker lint`
- Live preview sanity check for `https://x.com/Baconbrix/status/2068396380327170238?s=20` returned `duration: 15`
