### PR TITLE
[codex] fix mobile live inbox refresh

### DIFF
--- a/apps/mobile/constants/query.ts
+++ b/apps/mobile/constants/query.ts
@@ -17,6 +17,12 @@
 export const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
 /**
+ * 15 seconds in milliseconds.
+ * Used by inbox queries so newly synced feed items appear without tab navigation.
+ */
+export const LIVE_INBOX_REFETCH_INTERVAL_MS = 15 * 1000;
+
+/**
  * 24 hours in milliseconds.
  * Used as default gcTime (garbage collection time) for queries.
  *

--- a/apps/mobile/hooks/use-items-trpc.test.ts
+++ b/apps/mobile/hooks/use-items-trpc.test.ts
@@ -64,6 +64,7 @@ import {
   useArchiveItem,
   useToggleFinished,
 } from './use-items-trpc';
+import { LIVE_INBOX_REFETCH_INTERVAL_MS } from '@/constants/query';
 
 function createMockItem(overrides: Record<string, unknown> = {}) {
   return {
@@ -444,6 +445,9 @@ describe('useItems list queries', () => {
     const callArgs = mockInboxUseQuery.mock.calls[0][1];
     expect(callArgs.placeholderData).toBeDefined();
     expect(typeof callArgs.placeholderData).toBe('function');
+    expect(callArgs.refetchInterval).toBe(LIVE_INBOX_REFETCH_INTERVAL_MS);
+    expect(callArgs.refetchOnMount).toBe('always');
+    expect(callArgs.staleTime).toBe(0);
   });
 
   it('uses placeholderData for library items', () => {
@@ -494,6 +498,9 @@ describe('useItems list queries', () => {
       expect.objectContaining({
         getNextPageParam: expect.any(Function),
         placeholderData: expect.any(Function),
+        refetchInterval: LIVE_INBOX_REFETCH_INTERVAL_MS,
+        refetchOnMount: 'always',
+        staleTime: 0,
       })
     );
 

--- a/apps/mobile/hooks/use-items-trpc.ts
+++ b/apps/mobile/hooks/use-items-trpc.ts
@@ -7,6 +7,7 @@
 import { keepPreviousData } from '@tanstack/react-query';
 import { useRef } from 'react';
 import { trpc } from '@/lib/trpc';
+import { LIVE_INBOX_REFETCH_INTERVAL_MS } from '@/constants/query';
 import { ContentType, Provider, UserItemState } from '@zine/shared';
 import {
   buildHomeItemsInput,
@@ -361,6 +362,9 @@ function buildLibraryItemsInput(options?: LibraryItemsOptions) {
 export function useInboxItems(options?: InboxItemsOptions) {
   return trpc.items.inbox.useQuery(buildInboxItemsInput(options), {
     placeholderData: keepPreviousData,
+    refetchInterval: LIVE_INBOX_REFETCH_INTERVAL_MS,
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
 }
 
@@ -368,6 +372,9 @@ export function useInfiniteInboxItems(options?: InboxItemsOptions) {
   return trpc.items.inbox.useInfiniteQuery(buildInboxItemsInput(options) ?? {}, {
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,
+    refetchInterval: LIVE_INBOX_REFETCH_INTERVAL_MS,
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
 }
 


### PR DESCRIPTION
## Summary
- Add an inbox-specific 15-second live refetch interval for mobile inbox queries.
- Force inbox queries to refetch on mount and treat inbox data as immediately stale.
- Cover both standard and infinite inbox query hooks with unit assertions.

## Why
The mobile inbox query inherited the general five-minute fresh cache window. When new synced inbox items arrived while the user stayed on Inbox or the Home inbox section, React Query could continue serving cached data until the user navigated away and back.

## Impact
The Inbox tab and Home inbox component now update automatically while mounted, without waiting for tab navigation.

## Validation
- `bun run --cwd apps/mobile test hooks/use-items-trpc.test.ts --runInBand`
- `bun run typecheck`
- `bun run --cwd apps/mobile lint` (passed with existing warnings only)
- Pre-push hook: `prettier --check`, mobile design-system check, typecheck, web tests, worker CI test subset
