### PR TITLE
[codex] fix mobile auth resume resilience

### DIFF
--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -76,6 +76,7 @@ jest.mock('expo-router/react-navigation', () => ({
 
 // Mock expo-secure-store
 jest.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'AFTER_FIRST_UNLOCK',
   getItemAsync: jest.fn(() => Promise.resolve(null)),
   setItemAsync: jest.fn(() => Promise.resolve()),
   deleteItemAsync: jest.fn(() => Promise.resolve()),

--- a/apps/mobile/lib/auth.test.ts
+++ b/apps/mobile/lib/auth.test.ts
@@ -19,6 +19,9 @@ import { authLogger } from './logger';
 
 const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
 const mockAuthLogger = authLogger as jest.Mocked<typeof authLogger>;
+const secureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
 
 // Store original env value
 const originalClerkKey = process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY;
@@ -45,7 +48,10 @@ describe('tokenCache on native platforms (iOS/Android)', () => {
       const result = await tokenCache.getToken('clerk-token-key');
 
       expect(result).toBe('test-token-value');
-      expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith('clerk-token-key');
+      expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+        'clerk-token-key',
+        secureStoreOptions
+      );
     });
 
     it('returns null when token does not exist', async () => {
@@ -54,7 +60,10 @@ describe('tokenCache on native platforms (iOS/Android)', () => {
       const result = await tokenCache.getToken('non-existent-key');
 
       expect(result).toBeNull();
-      expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith('non-existent-key');
+      expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+        'non-existent-key',
+        secureStoreOptions
+      );
     });
 
     it('logs debug message on successful retrieval', async () => {
@@ -86,7 +95,10 @@ describe('tokenCache on native platforms (iOS/Android)', () => {
       expect(mockAuthLogger.error).toHaveBeenCalledWith('SecureStore getToken error', {
         error: secureStoreError,
       });
-      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('corrupted-key');
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        'corrupted-key',
+        secureStoreOptions
+      );
     });
   });
 
@@ -98,7 +110,8 @@ describe('tokenCache on native platforms (iOS/Android)', () => {
 
       expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
         'clerk-token-key',
-        'new-token-value'
+        'new-token-value',
+        secureStoreOptions
       );
     });
 
@@ -135,7 +148,10 @@ describe('tokenCache on native platforms (iOS/Android)', () => {
 
       await tokenCache.clearToken('clerk-token-key');
 
-      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('clerk-token-key');
+      expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+        'clerk-token-key',
+        secureStoreOptions
+      );
     });
 
     it('logs debug message on clear', async () => {

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -11,6 +11,10 @@ import { authLogger } from './logger';
 
 // Token Cache Implementation
 
+const secureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
+
 /**
  * Creates a token cache that uses expo-secure-store on native platforms
  * and falls back to no caching on web (Clerk handles web storage internally).
@@ -21,21 +25,21 @@ function createTokenCache(): TokenCache {
   return {
     async getToken(key: string): Promise<string | undefined | null> {
       try {
-        const item = await SecureStore.getItemAsync(key);
+        const item = await SecureStore.getItemAsync(key, secureStoreOptions);
         if (item) {
           authLogger.debug('Token retrieved', { key: key.substring(0, 20) + '...' });
         }
         return item;
       } catch (error) {
         authLogger.error('SecureStore getToken error', { error });
-        await SecureStore.deleteItemAsync(key);
+        await SecureStore.deleteItemAsync(key, secureStoreOptions);
         return null;
       }
     },
 
     async saveToken(key: string, value: string): Promise<void> {
       try {
-        await SecureStore.setItemAsync(key, value);
+        await SecureStore.setItemAsync(key, value, secureStoreOptions);
         authLogger.debug('Token saved', { key: key.substring(0, 20) + '...' });
       } catch (error) {
         authLogger.error('SecureStore saveToken error', { error });
@@ -44,7 +48,7 @@ function createTokenCache(): TokenCache {
 
     async clearToken(key: string): Promise<void> {
       try {
-        await SecureStore.deleteItemAsync(key);
+        await SecureStore.deleteItemAsync(key, secureStoreOptions);
         authLogger.debug('Token cleared', { key: key.substring(0, 20) + '...' });
       } catch (error) {
         authLogger.error('SecureStore clearToken error', { error });

--- a/apps/mobile/lib/trpc-offline-client.ts
+++ b/apps/mobile/lib/trpc-offline-client.ts
@@ -55,6 +55,9 @@ export function notifyQueueProcessed(): void {
  * This must match the key used by Clerk's tokenCache.
  */
 const CLERK_SESSION_TOKEN_KEY = '__clerk_client_jwt';
+const secureStoreOptions = {
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+};
 
 /**
  * Get authentication headers for tRPC requests outside of React context.
@@ -67,7 +70,7 @@ const CLERK_SESSION_TOKEN_KEY = '__clerk_client_jwt';
  */
 export async function getAuthHeaders(): Promise<Record<string, string>> {
   try {
-    const token = await SecureStore.getItemAsync(CLERK_SESSION_TOKEN_KEY);
+    const token = await SecureStore.getItemAsync(CLERK_SESSION_TOKEN_KEY, secureStoreOptions);
     if (token) {
       return { Authorization: `Bearer ${token}` };
     }

--- a/apps/mobile/lib/trpc-provider.test.tsx
+++ b/apps/mobile/lib/trpc-provider.test.tsx
@@ -30,7 +30,6 @@ type PersistOptions = {
 
 let mockUserId = 'user-123';
 const mockGetToken = jest.fn();
-const mockSignOut = jest.fn(async () => undefined);
 const mockUseAuthAvailability = jest.fn(() => ({ isEnabled: true }));
 let latestPersistOptions: PersistOptions | null = null;
 const mockRemoveClient = jest.fn(async () => undefined);
@@ -103,9 +102,6 @@ jest.mock('@clerk/clerk-expo', () => ({
     isSignedIn: true,
     userId: mockUserId,
   }),
-  useClerk: () => ({
-    signOut: mockSignOut,
-  }),
 }));
 
 jest.mock('@/lib/oauth', () => ({
@@ -139,7 +135,6 @@ describe('TRPCProvider offline queue invalidation', () => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
     mockGetToken.mockResolvedValue('token');
-    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);
@@ -190,7 +185,6 @@ describe('TRPCProvider transport wiring', () => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
     mockGetToken.mockResolvedValue('token');
-    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);
@@ -299,7 +293,39 @@ describe('TRPCProvider transport wiring', () => {
     const retryInit = (telemetryFetch as jest.Mock).mock.calls[1][1] as RequestInit;
     expect(new Headers(retryInit.headers).get('Authorization')).toBe('Bearer refreshed-token');
     expect(response.status).toBe(200);
-    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+
+  it('retries forbidden auth failures with a refreshed token', async () => {
+    mockGetToken.mockResolvedValueOnce('refreshed-token');
+    const forbiddenAuthResponse = {
+      status: 403,
+      headers: new Headers({ 'X-Zine-Auth-Error': 'EXPIRED_TOKEN' }),
+    } as Response;
+    const successResponse = { status: 200 } as Response;
+    (telemetryFetch as jest.Mock)
+      .mockResolvedValueOnce(forbiddenAuthResponse)
+      .mockResolvedValueOnce(successResponse);
+
+    act(() => {
+      create(
+        <TRPCProvider>
+          <></>
+        </TRPCProvider>
+      );
+    });
+
+    const fetchFn = (httpBatchLink as jest.Mock).mock.calls[0][0].fetch as typeof fetch;
+    const response = await fetchFn('https://api.myzine.app/trpc/items.home', {
+      headers: { Authorization: 'Bearer expired-token' },
+      method: 'GET',
+    });
+
+    expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
+    expect(telemetryFetch).toHaveBeenCalledTimes(2);
+
+    const retryInit = (telemetryFetch as jest.Mock).mock.calls[1][1] as RequestInit;
+    expect(new Headers(retryInit.headers).get('Authorization')).toBe('Bearer refreshed-token');
+    expect(response.status).toBe(200);
   });
 
   it('reuses the forced token refresh started on app resume', async () => {
@@ -348,11 +374,19 @@ describe('TRPCProvider transport wiring', () => {
     });
   });
 
-  it('signs out after an unauthorized retry also fails', async () => {
+  it('returns unauthorized response without clearing local auth state after retry also fails', async () => {
     const clearSpy = jest.spyOn(QueryClient.prototype, 'clear');
 
     mockGetToken.mockResolvedValueOnce('refreshed-token');
-    const unauthorizedResponse = { status: 401 } as Response;
+    const unauthorizedResponse = {
+      status: 401,
+      headers: new Headers({
+        'X-Zine-Auth-Error': 'JWKS_ERROR',
+        'X-Trace-ID': 'trc_auth_failure',
+        'X-Request-ID': 'req_auth_failure',
+        'X-Client-Request-ID': 'creq_auth_failure',
+      }),
+    } as Response;
     (telemetryFetch as jest.Mock)
       .mockResolvedValueOnce(unauthorizedResponse)
       .mockResolvedValueOnce(unauthorizedResponse);
@@ -373,8 +407,7 @@ describe('TRPCProvider transport wiring', () => {
 
     expect(mockGetToken).toHaveBeenCalledWith({ skipCache: true });
     expect(response.status).toBe(401);
-    expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(clearSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -383,7 +416,6 @@ describe('TRPCProvider cache persistence', () => {
     jest.clearAllMocks();
     mockUserId = 'user-123';
     mockGetToken.mockResolvedValue('token');
-    mockSignOut.mockResolvedValue(undefined);
     latestPersistOptions = null;
     mockUseIsRestoring.mockReturnValue(false);
     mockGetItem.mockResolvedValue(null);

--- a/apps/mobile/providers/trpc-provider.tsx
+++ b/apps/mobile/providers/trpc-provider.tsx
@@ -19,7 +19,12 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { getQueryKey } from '@trpc/react-query';
 import { httpBatchLink } from '@trpc/client';
 import superjson from 'superjson';
-import { useAuth, useClerk } from '@clerk/clerk-expo';
+import {
+  TELEMETRY_CLIENT_REQUEST_HEADER,
+  TELEMETRY_REQUEST_HEADER,
+  TELEMETRY_TRACE_HEADER,
+} from '@zine/shared';
+import { useAuth } from '@clerk/clerk-expo';
 import { trpc, API_URL } from '@/lib/trpc';
 import { setTokenGetter } from '@/lib/oauth';
 import { setQueueProcessedCallback } from '@/lib/trpc-offline-client';
@@ -40,13 +45,29 @@ interface TRPCProviderProps {
 }
 
 const AUTH_RESUME_REFRESH_GRACE_MS = 5_000;
+const AUTH_ERROR_CODE_HEADER = 'X-Zine-Auth-Error';
 
 function isRequest(input: RequestInfo | URL): input is Request {
   return typeof Request !== 'undefined' && input instanceof Request;
 }
 
-function isUnauthorizedResponse(response: Response): boolean {
-  return response.status === 401;
+function isAuthFailureResponse(response: Response): boolean {
+  return response.status === 401 || response.status === 403;
+}
+
+function readResponseHeader(response: Response, name: string): string | undefined {
+  return response.headers.get(name) ?? undefined;
+}
+
+function getAuthFailureLogContext(response: Response, url: string) {
+  return {
+    url,
+    httpStatus: response.status,
+    authErrorCode: readResponseHeader(response, AUTH_ERROR_CODE_HEADER),
+    traceId: readResponseHeader(response, TELEMETRY_TRACE_HEADER),
+    requestId: readResponseHeader(response, TELEMETRY_REQUEST_HEADER),
+    clientRequestId: readResponseHeader(response, TELEMETRY_CLIENT_REQUEST_HEADER),
+  };
 }
 
 function buildRetryRequest(
@@ -101,14 +122,11 @@ export function TRPCProvider({ children }: TRPCProviderProps) {
 
 function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
   const { getToken, userId, isLoaded, isSignedIn } = useAuth();
-  const { signOut } = useClerk();
 
   // Store getToken in a ref to avoid recreating the tRPC client when auth changes
   const getTokenRef = useRef(getToken);
   getTokenRef.current = getToken;
-  const signOutRef = useRef(signOut);
-  signOutRef.current = signOut;
-  const hasTriggeredSignOutRef = useRef(false);
+  const hasLoggedAuthFailureRef = useRef(false);
   const appStateRef = useRef<AppStateStatus>(AppState.currentState);
   const resumeTokenRefreshRef = useRef<Promise<string | null> | null>(null);
   const lastResumeAtRef = useRef<number | null>(null);
@@ -162,7 +180,7 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
   }, [getTokenForAuthRequest]);
 
   useEffect(() => {
-    hasTriggeredSignOutRef.current = false;
+    hasLoggedAuthFailureRef.current = false;
     resumeTokenRefreshRef.current = null;
     lastResumeAtRef.current = null;
   }, [userId]);
@@ -288,8 +306,9 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
 
     const fetchWithAuthRecovery: typeof telemetryFetch = async (input, init) => {
       const response = await telemetryFetch(isRequest(input) ? input.clone() : input, init);
+      let finalAuthFailureResponse = response;
 
-      if (!isUnauthorizedResponse(response)) {
+      if (!isAuthFailureResponse(response)) {
         return response;
       }
 
@@ -297,15 +316,16 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
         const refreshedToken = await getTokenForAuthRequest({ skipCache: true });
 
         if (refreshedToken) {
-          trpcLogger.warn('Retrying unauthorized tRPC request with refreshed auth token', {
+          trpcLogger.warn('Retrying auth-failed tRPC request with refreshed auth token', {
             url,
             httpStatus: response.status,
           });
 
           const retryRequest = buildRetryRequest(input, init, refreshedToken);
           const retryResponse = await telemetryFetch(retryRequest.input, retryRequest.init);
+          finalAuthFailureResponse = retryResponse;
 
-          if (!isUnauthorizedResponse(retryResponse)) {
+          if (!isAuthFailureResponse(retryResponse)) {
             return retryResponse;
           }
         } else {
@@ -323,15 +343,12 @@ function AuthenticatedTRPCProvider({ children }: TRPCProviderProps) {
         });
       }
 
-      if (!hasTriggeredSignOutRef.current) {
-        hasTriggeredSignOutRef.current = true;
-        queryClient.clear();
-        void signOutRef.current().catch((error) => {
-          trpcLogger.warn('Failed to sign out after repeated unauthorized tRPC request', {
-            error,
-            url,
-          });
-        });
+      if (!hasLoggedAuthFailureRef.current) {
+        hasLoggedAuthFailureRef.current = true;
+        trpcLogger.warn(
+          'Auth retry still failed; leaving Clerk session state unchanged',
+          getAuthFailureLogContext(finalAuthFailureResponse, url)
+        );
       }
 
       return response;

--- a/apps/worker/src/middleware/auth.test.ts
+++ b/apps/worker/src/middleware/auth.test.ts
@@ -94,6 +94,7 @@ describe('authMiddleware', () => {
     const res = await app.fetch(req, createMockEnv({ ENVIRONMENT: 'production' }));
 
     expect(res.status).toBe(401);
+    expect(res.headers.get('X-Zine-Auth-Error')).toBe('MISSING_AUTH_HEADER');
     expect((await res.json()) as AuthResponse).toMatchObject({
       code: 'MISSING_AUTH_HEADER',
       error: 'Authorization header is required',
@@ -123,5 +124,29 @@ describe('authMiddleware', () => {
       'test-token',
       'https://clerk.myzine.app/.well-known/jwks.json'
     );
+  });
+
+  it('returns auth error code header when Clerk token verification fails', async () => {
+    mockVerifyClerkToken.mockResolvedValue({
+      success: false,
+      code: 'JWKS_ERROR',
+      error: 'No matching key found in JWKS',
+    });
+
+    const app = createTestApp();
+    const req = new Request('http://localhost/protected', {
+      headers: {
+        Authorization: 'Bearer test-token',
+      },
+    });
+
+    const res = await app.fetch(req, createMockEnv({ ENVIRONMENT: 'production' }));
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get('X-Zine-Auth-Error')).toBe('JWKS_ERROR');
+    expect((await res.json()) as AuthResponse).toMatchObject({
+      code: 'JWKS_ERROR',
+      error: 'No matching key found in JWKS',
+    });
   });
 });

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -34,6 +34,8 @@ interface AuthErrorResponse {
   requestId: string;
 }
 
+const AUTH_ERROR_CODE_HEADER = 'X-Zine-Auth-Error';
+
 /**
  * Create a structured auth error response
  */
@@ -83,6 +85,11 @@ export function authMiddleware(): MiddlewareHandler<Env> {
   return async (c, next) => {
     const requestId = c.get('requestId') || 'unknown';
 
+    const authError = (message: string, code: string, status: 401 | 403) => {
+      c.header(AUTH_ERROR_CODE_HEADER, code);
+      return c.json(createAuthError(message, code, requestId), status);
+    };
+
     // Development bypass: use mock user ID when no auth is configured
     if (shouldUseDevelopmentAuthBypass(c.env)) {
       // Ensure dev user exists in database (only once per process)
@@ -114,28 +121,18 @@ export function authMiddleware(): MiddlewareHandler<Env> {
 
     // Check for Authorization header
     if (!authHeader) {
-      return c.json(
-        createAuthError('Authorization header is required', 'MISSING_AUTH_HEADER', requestId),
-        401
-      );
+      return authError('Authorization header is required', 'MISSING_AUTH_HEADER', 401);
     }
 
     // Check for Bearer token format
     if (!authHeader.startsWith('Bearer ')) {
-      return c.json(
-        createAuthError(
-          'Authorization header must use Bearer scheme',
-          'INVALID_AUTH_SCHEME',
-          requestId
-        ),
-        401
-      );
+      return authError('Authorization header must use Bearer scheme', 'INVALID_AUTH_SCHEME', 401);
     }
 
     const token = authHeader.slice(7); // Remove "Bearer " prefix
 
     if (!token) {
-      return c.json(createAuthError('Bearer token is empty', 'EMPTY_TOKEN', requestId), 401);
+      return authError('Bearer token is empty', 'EMPTY_TOKEN', 401);
     }
 
     // Get JWKS URL from environment or use default
@@ -149,7 +146,7 @@ export function authMiddleware(): MiddlewareHandler<Env> {
       const statusCode =
         result.code === 'EXPIRED_TOKEN' || result.code === 'INVALID_TOKEN' ? 403 : 401;
 
-      return c.json(createAuthError(result.error, result.code, requestId), statusCode);
+      return authError(result.error, result.code, statusCode);
     }
 
     // Set userId in context for downstream handlers

--- a/scripts/lib/observability.ts
+++ b/scripts/lib/observability.ts
@@ -399,22 +399,23 @@ export function runCloudflareLogQuery(
 
   command.push('--limit', String(query.limit ?? 200));
 
-  const process = Bun.spawnSync(command, {
+  const childProcess = Bun.spawnSync(command, {
     cwd: repoRoot,
     env: process.env,
     stderr: 'pipe',
     stdout: 'pipe',
   });
 
-  const stdout = process.stdout.toString();
-  const stderr = process.stderr.toString().trim();
+  const stdout = childProcess.stdout.toString();
+  const stderr = childProcess.stderr.toString().trim();
 
-  if (process.exitCode !== 0) {
+  if (childProcess.exitCode !== 0) {
     return {
       ok: false,
       command,
       records: [],
-      error: stderr || stdout.trim() || `Cloudflare log query exited with code ${process.exitCode}`,
+      error:
+        stderr || stdout.trim() || `Cloudflare log query exited with code ${childProcess.exitCode}`,
       stderr,
     };
   }


### PR DESCRIPTION
## Summary
- keep mobile auth retry failures from forcing Clerk sign-out or clearing React Query state
- retry both 401 and 403 auth failures with a fresh Clerk token and log auth/trace context when retry still fails
- align Clerk SecureStore token access with `AFTER_FIRST_UNLOCK` and expose worker auth error codes through `X-Zine-Auth-Error`
- fix the Cloudflare log diagnostics wrapper process-shadowing bug

## Root Cause
A transient tRPC auth failure after app resume could be promoted into a real local Clerk sign-out after one failed retry. Worker auth failures also did not expose a stable response header for mobile diagnostics, and expired-token 403 responses were not refresh-retried.

## Validation
- `bun run --cwd apps/mobile test --runInBand lib/trpc-provider.test.tsx lib/auth.test.ts`
- `bun run --cwd apps/worker test:run src/middleware/auth.test.ts`
- `bun run --cwd apps/worker typecheck`
- `bun run typecheck`
- `bun run --cwd apps/mobile lint` (passes with existing unrelated warnings)
- `git diff --check`
- pre-push hook passed: `format:check`, `design-system:check`, `typecheck`, `test:web`, worker CI subset
