### PR TITLE
[codex] add browser bookmark extension

### DIFF
--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@zine/chrome-extension",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf dist .eslintcache",
+    "build": "bun run clean && tsc -p tsconfig.json && node scripts/copy-static.mjs",
+    "build:chrome": "bun run build",
+    "build:firefox": "bun run build",
+    "package": "bun run build && node scripts/package-extension.mjs",
+    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.2"
+  }
+}

--- a/apps/chrome-extension/public/manifest.json
+++ b/apps/chrome-extension/public/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 3,
+  "name": "Zine",
+  "version": "0.1.0",
+  "description": "Save the current page to your Zine bookmarks.",
+  "action": {
+    "default_title": "Save to Zine",
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/zine-logo.png",
+      "32": "icons/zine-logo.png",
+      "48": "icons/zine-logo.png",
+      "128": "icons/zine-logo.png"
+    }
+  },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Open Save to Zine"
+    }
+  },
+  "icons": {
+    "16": "icons/zine-logo.png",
+    "32": "icons/zine-logo.png",
+    "48": "icons/zine-logo.png",
+    "128": "icons/zine-logo.png"
+  },
+  "options_page": "options.html",
+  "permissions": ["activeTab", "contextMenus", "storage", "tabs"],
+  "host_permissions": ["https://api.myzine.app/*", "http://localhost/*", "http://127.0.0.1/*"]
+}

--- a/apps/chrome-extension/public/options.html
+++ b/apps/chrome-extension/public/options.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Zine Extension Settings</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="options-body">
+    <main class="options-shell">
+      <header class="settings-header">
+        <div class="brand">
+          <img src="icons/zine-logo.png" alt="" />
+          <div>
+            <p>Zine</p>
+            <span>Chrome extension</span>
+          </div>
+        </div>
+        <a
+          class="secondary-button"
+          href="https://www.myzine.app/settings"
+          target="_blank"
+          rel="noreferrer"
+          >Create token</a
+        >
+      </header>
+
+      <form id="settingsForm" class="settings-form">
+        <label>
+          <span>API token</span>
+          <input
+            id="tokenInput"
+            name="token"
+            type="password"
+            autocomplete="off"
+            placeholder="zine_pat_..."
+          />
+        </label>
+
+        <label>
+          <span>API URL</span>
+          <input id="apiBaseUrlInput" name="apiBaseUrl" type="url" required />
+        </label>
+
+        <label>
+          <span>Web app URL</span>
+          <input id="webBaseUrlInput" name="webBaseUrl" type="url" required />
+        </label>
+
+        <div id="optionsStatus" class="status-panel neutral">
+          <span class="status-dot"></span>
+          <p>Paste a write-scoped API token to enable saving.</p>
+        </div>
+
+        <div class="action-row">
+          <button class="primary-button" type="submit">Save settings</button>
+          <button id="clearTokenButton" class="secondary-button" type="button">Clear token</button>
+        </div>
+      </form>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/apps/chrome-extension/public/popup.html
+++ b/apps/chrome-extension/public/popup.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Save to Zine</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="popup-body">
+    <main class="popup-shell" aria-live="polite">
+      <header class="topbar">
+        <div class="brand">
+          <img src="icons/zine-logo.png" alt="" />
+          <div>
+            <p>Zine</p>
+            <span>Bookmark saver</span>
+          </div>
+        </div>
+        <button id="openOptions" class="secondary-button compact-button" type="button">
+          Settings
+        </button>
+      </header>
+
+      <section id="setupPanel" class="notice hidden">
+        <p class="notice-title">Connect your API token</p>
+        <p>Create a token in Zine Settings with Add bookmarks enabled, then paste it here once.</p>
+        <button id="setupButton" class="primary-button" type="button">Open settings</button>
+      </section>
+
+      <section id="pagePanel" class="page-panel">
+        <p id="pageDomain" class="page-domain">Current page</p>
+        <h1 id="pageTitle">Loading page...</h1>
+        <p id="pageUrl" class="page-url"></p>
+      </section>
+
+      <section id="statusPanel" class="status-panel neutral">
+        <span id="statusDot" class="status-dot"></span>
+        <p id="statusText">Ready when you are.</p>
+      </section>
+
+      <div class="action-row">
+        <button id="saveButton" class="primary-button" type="button" disabled>Save page</button>
+        <a
+          id="openZine"
+          class="secondary-button"
+          href="https://www.myzine.app/library/bookmarks"
+          target="_blank"
+          rel="noreferrer"
+          >Open Zine</a
+        >
+      </div>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/apps/chrome-extension/public/styles.css
+++ b/apps/chrome-extension/public/styles.css
@@ -1,0 +1,310 @@
+:root {
+  color-scheme: dark;
+  --bg: #050505;
+  --surface: #111111;
+  --surface-raised: #191919;
+  --line: rgba(255, 255, 255, 0.12);
+  --line-strong: rgba(255, 255, 255, 0.2);
+  --text: #f6f6f6;
+  --text-muted: rgba(246, 246, 246, 0.68);
+  --text-dim: rgba(246, 246, 246, 0.5);
+  --success: #58d68d;
+  --warning: #f4c95d;
+  --danger: #ff6b6b;
+  --focus: #ffffff;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 var(--font-family, inherit);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.popup-body {
+  width: 360px;
+  min-height: 360px;
+}
+
+.options-body {
+  min-width: 100vw;
+  min-height: 100vh;
+  display: grid;
+  place-items: start center;
+  padding: 48px 20px;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(255, 255, 255, 0.08), transparent 28%), var(--bg);
+}
+
+.popup-shell,
+.options-shell {
+  width: 100%;
+  display: grid;
+  gap: 16px;
+}
+
+.popup-shell {
+  padding: 16px;
+}
+
+.options-shell {
+  max-width: 520px;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.topbar,
+.settings-header,
+.action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.brand {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand img {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+}
+
+.brand p,
+.brand span,
+.page-panel p,
+.page-panel h1,
+.status-panel p,
+.notice p {
+  margin: 0;
+}
+
+.brand p {
+  font-size: 16px;
+  font-weight: 750;
+  letter-spacing: 0;
+}
+
+.brand span {
+  display: block;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.page-panel,
+.notice,
+.settings-form {
+  display: grid;
+  gap: 12px;
+}
+
+.page-panel {
+  min-height: 126px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.page-domain {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.page-panel h1 {
+  display: -webkit-box;
+  min-height: 48px;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.page-url {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notice {
+  padding: 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--surface-raised);
+}
+
+.notice-title {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.notice p:not(.notice-title) {
+  color: var(--text-muted);
+}
+
+.status-panel {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--text-muted);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--text-dim);
+}
+
+.status-panel.success .status-dot {
+  background: var(--success);
+}
+
+.status-panel.warning .status-dot {
+  background: var(--warning);
+}
+
+.status-panel.danger .status-dot {
+  background: var(--danger);
+}
+
+.status-panel.success {
+  border-color: rgba(88, 214, 141, 0.35);
+}
+
+.status-panel.warning {
+  border-color: rgba(244, 201, 93, 0.35);
+}
+
+.status-panel.danger {
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.primary-button,
+.secondary-button {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.primary-button {
+  flex: 1 1 auto;
+  border: 1px solid var(--text);
+  background: var(--text);
+  color: #050505;
+}
+
+.primary-button:hover:not(:disabled) {
+  background: rgba(246, 246, 246, 0.86);
+}
+
+.primary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.secondary-button {
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--text);
+}
+
+.secondary-button:hover {
+  background: var(--surface-raised);
+}
+
+.compact-button {
+  min-height: 32px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.settings-form label {
+  display: grid;
+  gap: 7px;
+  color: var(--text-muted);
+}
+
+.settings-form input {
+  min-height: 42px;
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: #090909;
+  color: var(--text);
+  padding: 0 12px;
+}
+
+.settings-form input::placeholder {
+  color: var(--text-dim);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primary-button,
+  .secondary-button {
+    transition: none;
+  }
+}

--- a/apps/chrome-extension/scripts/copy-static.mjs
+++ b/apps/chrome-extension/scripts/copy-static.mjs
@@ -1,0 +1,59 @@
+import { copyFile, cp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = join(root, '..');
+const repoRoot = join(extensionRoot, '..', '..');
+const dist = join(extensionRoot, 'dist');
+const compiled = join(dist, '.compiled');
+
+const staticFiles = [
+  ['public/popup.html', 'popup.html'],
+  ['public/options.html', 'options.html'],
+  ['public/styles.css', 'styles.css'],
+];
+
+const manifestTemplate = JSON.parse(
+  await readFile(join(extensionRoot, 'public', 'manifest.json'), 'utf8')
+);
+
+const variants = {
+  chrome: {
+    background: {
+      service_worker: 'background.js',
+      type: 'module',
+    },
+  },
+  firefox: {
+    background: {
+      scripts: ['background.js'],
+      type: 'module',
+    },
+    browser_specific_settings: {
+      gecko: {
+        id: 'zine-bookmark-saver@myzine.app',
+        strict_min_version: '121.0',
+      },
+    },
+  },
+};
+
+for (const [browser, overrides] of Object.entries(variants)) {
+  const targetRoot = join(dist, browser);
+  await mkdir(join(targetRoot, 'icons'), { recursive: true });
+  await cp(compiled, targetRoot, { recursive: true });
+
+  for (const [source, target] of staticFiles) {
+    await copyFile(join(extensionRoot, source), join(targetRoot, target));
+  }
+
+  await copyFile(join(repoRoot, 'zine-logo.png'), join(targetRoot, 'icons', 'zine-logo.png'));
+
+  const manifest = {
+    ...manifestTemplate,
+    ...overrides,
+    version: process.env.npm_package_version ?? manifestTemplate.version,
+  };
+  await writeFile(join(targetRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+}

--- a/apps/chrome-extension/scripts/package-extension.mjs
+++ b/apps/chrome-extension/scripts/package-extension.mjs
@@ -1,0 +1,33 @@
+import { rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const root = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = join(root, '..');
+const dist = join(extensionRoot, 'dist');
+
+const packages = [
+  {
+    source: join(dist, 'chrome'),
+    target: join(dist, 'zine-chrome.zip'),
+  },
+  {
+    source: join(dist, 'firefox'),
+    target: join(dist, 'zine-firefox.xpi'),
+  },
+];
+
+for (const extensionPackage of packages) {
+  await rm(extensionPackage.target, { force: true });
+  await execFileAsync('zip', ['-qr', extensionPackage.target, '.'], {
+    cwd: extensionPackage.source,
+  });
+}
+
+console.log('Created browser extension packages:');
+for (const extensionPackage of packages) {
+  console.log(`- ${extensionPackage.target}`);
+}

--- a/apps/chrome-extension/src/api.ts
+++ b/apps/chrome-extension/src/api.ts
@@ -1,0 +1,134 @@
+import type { ExtensionSettings } from './settings.js';
+
+export type SaveState = 'idle' | 'saving' | 'success' | 'warning' | 'danger';
+
+export interface SaveBookmarkSuccess {
+  ok: true;
+  status: 'created' | 'already_bookmarked' | 'rebookmarked';
+  title: string | null;
+  userItemId: string | null;
+}
+
+export interface SaveBookmarkFailure {
+  ok: false;
+  code: 'missing_token' | 'invalid_url' | 'unauthorized' | 'forbidden' | 'unsupported' | 'network';
+  message: string;
+}
+
+export type SaveBookmarkResult = SaveBookmarkSuccess | SaveBookmarkFailure;
+
+interface SaveBookmarkResponse {
+  bookmark?: {
+    status?: SaveBookmarkSuccess['status'];
+    userItemId?: string;
+  };
+  item?: {
+    title?: string;
+  };
+  error?: string;
+  code?: string;
+}
+
+function canSaveUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getEndpoint(settings: ExtensionSettings): string {
+  return `${settings.apiBaseUrl}/api/v1/bookmarks`;
+}
+
+export async function saveBookmarkUrl(
+  settings: ExtensionSettings,
+  url: string
+): Promise<SaveBookmarkResult> {
+  if (!settings.token) {
+    return {
+      ok: false,
+      code: 'missing_token',
+      message: 'Add a Zine API token before saving.',
+    };
+  }
+
+  if (!canSaveUrl(url)) {
+    return {
+      ok: false,
+      code: 'invalid_url',
+      message: 'Chrome pages and local browser screens cannot be saved.',
+    };
+  }
+
+  try {
+    const response = await fetch(getEndpoint(settings), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${settings.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url }),
+    });
+
+    const body = (await response.json().catch(() => ({}))) as SaveBookmarkResponse;
+
+    if (response.ok) {
+      return {
+        ok: true,
+        status: body.bookmark?.status ?? 'created',
+        title: body.item?.title ?? null,
+        userItemId: body.bookmark?.userItemId ?? null,
+      };
+    }
+
+    if (response.status === 401) {
+      return {
+        ok: false,
+        code: 'unauthorized',
+        message: 'That API token was not accepted.',
+      };
+    }
+
+    if (response.status === 403) {
+      return {
+        ok: false,
+        code: 'forbidden',
+        message: 'This token needs Add bookmarks enabled.',
+      };
+    }
+
+    if (response.status === 422) {
+      return {
+        ok: false,
+        code: 'unsupported',
+        message: body.error ?? 'Zine could not preview this URL.',
+      };
+    }
+
+    return {
+      ok: false,
+      code: 'network',
+      message: body.error ?? `Zine returned HTTP ${response.status}.`,
+    };
+  } catch {
+    return {
+      ok: false,
+      code: 'network',
+      message: 'Could not reach the Zine API.',
+    };
+  }
+}
+
+export function getSuccessMessage(result: SaveBookmarkSuccess): string {
+  if (result.status === 'already_bookmarked') {
+    return 'Already saved in Zine.';
+  }
+
+  if (result.status === 'rebookmarked') {
+    return 'Restored to your bookmarks.';
+  }
+
+  return 'Saved to Zine.';
+}

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -1,0 +1,54 @@
+import { getSuccessMessage, saveBookmarkUrl, type SaveBookmarkResult } from './api.js';
+import { extensionApi } from './extension-api.js';
+import { loadSettings } from './settings.js';
+
+const CONTEXT_MENU_ID = 'save-page-to-zine';
+
+function setBadge(tabId: number | undefined, result: SaveBookmarkResult): void {
+  if (!tabId) {
+    return;
+  }
+
+  if (result.ok) {
+    void extensionApi.action.setBadgeText({ tabId, text: 'OK' });
+    void extensionApi.action.setBadgeBackgroundColor({ color: '#2da85f' });
+    void extensionApi.action.setTitle({ tabId, title: getSuccessMessage(result) });
+    return;
+  }
+
+  void extensionApi.action.setBadgeText({ tabId, text: '!' });
+  void extensionApi.action.setBadgeBackgroundColor({ color: '#d64545' });
+  void extensionApi.action.setTitle({ tabId, title: result.message });
+}
+
+async function saveFromTab(tab?: { id?: number; url?: string }): Promise<void> {
+  if (!tab?.url) {
+    return;
+  }
+
+  const settings = await loadSettings();
+  const result = await saveBookmarkUrl(settings, tab.url);
+  setBadge(tab.id, result);
+
+  if (!result.ok && result.code === 'missing_token') {
+    extensionApi.runtime.openOptionsPage();
+  }
+}
+
+extensionApi.runtime.onInstalled.addListener(() => {
+  extensionApi.contextMenus.removeAll(() => {
+    extensionApi.contextMenus.create({
+      id: CONTEXT_MENU_ID,
+      title: 'Save page to Zine',
+      contexts: ['page'],
+    });
+  });
+});
+
+extensionApi.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId !== CONTEXT_MENU_ID) {
+    return;
+  }
+
+  void saveFromTab(tab);
+});

--- a/apps/chrome-extension/src/chrome.d.ts
+++ b/apps/chrome-extension/src/chrome.d.ts
@@ -1,0 +1,60 @@
+export {};
+
+interface ChromeTab {
+  id?: number;
+  title?: string;
+  url?: string;
+}
+
+interface ChromeContextMenuInfo {
+  menuItemId: string | number;
+  pageUrl?: string;
+  linkUrl?: string;
+}
+
+interface ChromeRuntime {
+  getURL(path: string): string;
+  openOptionsPage(callback?: () => void): void;
+  lastError?: { message?: string };
+  onInstalled: {
+    addListener(listener: () => void): void;
+  };
+}
+
+interface ChromeAction {
+  setBadgeText(details: { tabId?: number; text: string }): Promise<void> | void;
+  setBadgeBackgroundColor(details: { color: string }): Promise<void> | void;
+  setTitle(details: { tabId?: number; title: string }): Promise<void> | void;
+}
+
+interface ChromeContextMenus {
+  create(details: { id: string; title: string; contexts: string[] }): void;
+  removeAll(callback?: () => void): void;
+  onClicked: {
+    addListener(listener: (info: ChromeContextMenuInfo, tab?: ChromeTab) => void): void;
+  };
+}
+
+interface ChromeStorageArea {
+  get<T>(keys: string | string[] | Record<string, unknown> | null): Promise<T>;
+  set(items: Record<string, unknown>): Promise<void>;
+}
+
+interface ChromeTabs {
+  query(queryInfo: { active?: boolean; currentWindow?: boolean }): Promise<ChromeTab[]>;
+}
+
+interface ChromeNamespace {
+  action: ChromeAction;
+  contextMenus: ChromeContextMenus;
+  runtime: ChromeRuntime;
+  storage: {
+    local: ChromeStorageArea;
+  };
+  tabs: ChromeTabs;
+}
+
+declare global {
+  var chrome: ChromeNamespace;
+  var browser: ChromeNamespace | undefined;
+}

--- a/apps/chrome-extension/src/extension-api.ts
+++ b/apps/chrome-extension/src/extension-api.ts
@@ -1,0 +1,1 @@
+export const extensionApi = globalThis.browser ?? globalThis.chrome;

--- a/apps/chrome-extension/src/options.ts
+++ b/apps/chrome-extension/src/options.ts
@@ -1,0 +1,98 @@
+import {
+  DEFAULT_API_BASE_URL,
+  DEFAULT_WEB_BASE_URL,
+  loadSettings,
+  saveSettings,
+} from './settings.js';
+
+const form = document.querySelector<HTMLFormElement>('#settingsForm');
+const tokenInput = document.querySelector<HTMLInputElement>('#tokenInput');
+const apiBaseUrlInput = document.querySelector<HTMLInputElement>('#apiBaseUrlInput');
+const webBaseUrlInput = document.querySelector<HTMLInputElement>('#webBaseUrlInput');
+const clearTokenButton = document.querySelector<HTMLButtonElement>('#clearTokenButton');
+const optionsStatus = document.querySelector<HTMLElement>('#optionsStatus');
+
+function requireElement<T extends Element>(element: T | null, name: string): T {
+  if (!element) {
+    throw new Error(`Missing ${name}`);
+  }
+
+  return element;
+}
+
+const ui = {
+  form: requireElement(form, 'settingsForm'),
+  tokenInput: requireElement(tokenInput, 'tokenInput'),
+  apiBaseUrlInput: requireElement(apiBaseUrlInput, 'apiBaseUrlInput'),
+  webBaseUrlInput: requireElement(webBaseUrlInput, 'webBaseUrlInput'),
+  clearTokenButton: requireElement(clearTokenButton, 'clearTokenButton'),
+  optionsStatus: requireElement(optionsStatus, 'optionsStatus'),
+};
+
+function setStatus(kind: 'neutral' | 'success' | 'warning' | 'danger', message: string): void {
+  ui.optionsStatus.className = `status-panel ${kind}`;
+  const text = ui.optionsStatus.querySelector('p');
+
+  if (text) {
+    text.textContent = message;
+  }
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function load(): Promise<void> {
+  const settings = await loadSettings();
+  ui.tokenInput.value = settings.token;
+  ui.apiBaseUrlInput.value = settings.apiBaseUrl || DEFAULT_API_BASE_URL;
+  ui.webBaseUrlInput.value = settings.webBaseUrl || DEFAULT_WEB_BASE_URL;
+}
+
+async function handleSubmit(event: SubmitEvent): Promise<void> {
+  event.preventDefault();
+
+  const token = ui.tokenInput.value.trim();
+  const apiBaseUrl = ui.apiBaseUrlInput.value.trim();
+  const webBaseUrl = ui.webBaseUrlInput.value.trim();
+
+  if (token && !token.startsWith('zine_pat_')) {
+    setStatus('warning', 'This does not look like a Zine API token.');
+    return;
+  }
+
+  if (!isValidUrl(apiBaseUrl) || !isValidUrl(webBaseUrl)) {
+    setStatus('danger', 'Use valid http or https URLs.');
+    return;
+  }
+
+  await saveSettings({ apiBaseUrl, token, webBaseUrl });
+  setStatus(
+    token ? 'success' : 'warning',
+    token ? 'Settings saved.' : 'Settings saved without a token.'
+  );
+}
+
+async function clearToken(): Promise<void> {
+  const settings = await loadSettings();
+  await saveSettings({
+    ...settings,
+    token: '',
+  });
+  ui.tokenInput.value = '';
+  setStatus('warning', 'Token cleared.');
+}
+
+ui.form.addEventListener('submit', (event) => {
+  void handleSubmit(event);
+});
+ui.clearTokenButton.addEventListener('click', () => {
+  void clearToken();
+});
+
+void load();

--- a/apps/chrome-extension/src/popup.ts
+++ b/apps/chrome-extension/src/popup.ts
@@ -1,0 +1,133 @@
+import {
+  getSuccessMessage,
+  saveBookmarkUrl,
+  type SaveBookmarkResult,
+  type SaveState,
+} from './api.js';
+import { extensionApi } from './extension-api.js';
+import { loadSettings } from './settings.js';
+import { getActivePage, getDisplayDomain, type ActivePage } from './tabs.js';
+
+const pageTitle = document.querySelector<HTMLHeadingElement>('#pageTitle');
+const pageUrl = document.querySelector<HTMLParagraphElement>('#pageUrl');
+const pageDomain = document.querySelector<HTMLParagraphElement>('#pageDomain');
+const saveButton = document.querySelector<HTMLButtonElement>('#saveButton');
+const openOptions = document.querySelector<HTMLButtonElement>('#openOptions');
+const setupButton = document.querySelector<HTMLButtonElement>('#setupButton');
+const setupPanel = document.querySelector<HTMLElement>('#setupPanel');
+const statusPanel = document.querySelector<HTMLElement>('#statusPanel');
+const statusText = document.querySelector<HTMLParagraphElement>('#statusText');
+const openZine = document.querySelector<HTMLAnchorElement>('#openZine');
+
+let activePage: ActivePage | null = null;
+
+function requireElement<T extends Element>(element: T | null, name: string): T {
+  if (!element) {
+    throw new Error(`Missing ${name}`);
+  }
+
+  return element;
+}
+
+const ui = {
+  pageTitle: requireElement(pageTitle, 'pageTitle'),
+  pageUrl: requireElement(pageUrl, 'pageUrl'),
+  pageDomain: requireElement(pageDomain, 'pageDomain'),
+  saveButton: requireElement(saveButton, 'saveButton'),
+  openOptions: requireElement(openOptions, 'openOptions'),
+  setupButton: requireElement(setupButton, 'setupButton'),
+  setupPanel: requireElement(setupPanel, 'setupPanel'),
+  statusPanel: requireElement(statusPanel, 'statusPanel'),
+  statusText: requireElement(statusText, 'statusText'),
+  openZine: requireElement(openZine, 'openZine'),
+};
+
+function setStatus(state: SaveState, message: string): void {
+  ui.statusPanel.className = `status-panel ${state === 'idle' || state === 'saving' ? 'neutral' : state}`;
+  ui.statusText.textContent = message;
+}
+
+function setPage(page: ActivePage | null): void {
+  activePage = page;
+
+  if (!page) {
+    ui.pageTitle.textContent = 'No active page found';
+    ui.pageUrl.textContent = '';
+    ui.pageDomain.textContent = 'Current page';
+    ui.saveButton.disabled = true;
+    setStatus('danger', 'Open a tab with a web page and try again.');
+    return;
+  }
+
+  ui.pageTitle.textContent = page.title;
+  ui.pageUrl.textContent = page.url;
+  ui.pageDomain.textContent = getDisplayDomain(page.url);
+}
+
+function setResult(result: SaveBookmarkResult): void {
+  if (result.ok) {
+    setStatus('success', getSuccessMessage(result));
+    ui.saveButton.textContent = 'Saved';
+    return;
+  }
+
+  const state =
+    result.code === 'missing_token' || result.code === 'invalid_url' ? 'warning' : 'danger';
+  setStatus(state, result.message);
+
+  if (result.code === 'missing_token') {
+    ui.setupPanel.classList.remove('hidden');
+  }
+}
+
+async function openOptionsPage(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    extensionApi.runtime.openOptionsPage(resolve);
+  });
+}
+
+async function handleSave(): Promise<void> {
+  if (!activePage) {
+    return;
+  }
+
+  ui.saveButton.disabled = true;
+  ui.saveButton.textContent = 'Saving...';
+  setStatus('saving', 'Saving this page...');
+
+  const settings = await loadSettings();
+  const result = await saveBookmarkUrl(settings, activePage.url);
+  setResult(result);
+  ui.saveButton.disabled = false;
+
+  if (!result.ok) {
+    ui.saveButton.textContent = 'Try again';
+  }
+}
+
+async function init(): Promise<void> {
+  const [settings, page] = await Promise.all([loadSettings(), getActivePage()]);
+
+  ui.openZine.href = `${settings.webBaseUrl}/library/bookmarks`;
+  ui.setupPanel.classList.toggle('hidden', settings.token.length > 0);
+  setPage(page);
+
+  if (page && settings.token.length > 0) {
+    ui.saveButton.disabled = false;
+    setStatus('idle', 'Ready when you are.');
+  } else if (page) {
+    setStatus('warning', 'Add an API token before saving.');
+  }
+}
+
+ui.saveButton.addEventListener('click', () => {
+  void handleSave();
+});
+ui.openOptions.addEventListener('click', () => {
+  void openOptionsPage();
+});
+ui.setupButton.addEventListener('click', () => {
+  void openOptionsPage();
+});
+
+void init();

--- a/apps/chrome-extension/src/settings.ts
+++ b/apps/chrome-extension/src/settings.ts
@@ -1,0 +1,51 @@
+import { extensionApi } from './extension-api.js';
+
+export const DEFAULT_API_BASE_URL = 'https://api.myzine.app';
+export const DEFAULT_WEB_BASE_URL = 'https://www.myzine.app';
+
+const SETTINGS_KEY = 'zineExtensionSettings';
+
+export interface ExtensionSettings {
+  apiBaseUrl: string;
+  token: string;
+  webBaseUrl: string;
+}
+
+interface StoredSettings {
+  zineExtensionSettings?: Partial<ExtensionSettings>;
+}
+
+export function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+export function defaultSettings(): ExtensionSettings {
+  return {
+    apiBaseUrl: DEFAULT_API_BASE_URL,
+    token: '',
+    webBaseUrl: DEFAULT_WEB_BASE_URL,
+  };
+}
+
+export async function loadSettings(): Promise<ExtensionSettings> {
+  const stored = await extensionApi.storage.local.get<StoredSettings>(SETTINGS_KEY);
+  const settings = stored.zineExtensionSettings ?? {};
+
+  return {
+    ...defaultSettings(),
+    ...settings,
+    apiBaseUrl: normalizeBaseUrl(settings.apiBaseUrl ?? DEFAULT_API_BASE_URL),
+    token: settings.token?.trim() ?? '',
+    webBaseUrl: normalizeBaseUrl(settings.webBaseUrl ?? DEFAULT_WEB_BASE_URL),
+  };
+}
+
+export async function saveSettings(settings: ExtensionSettings): Promise<void> {
+  await extensionApi.storage.local.set({
+    [SETTINGS_KEY]: {
+      apiBaseUrl: normalizeBaseUrl(settings.apiBaseUrl),
+      token: settings.token.trim(),
+      webBaseUrl: normalizeBaseUrl(settings.webBaseUrl),
+    },
+  });
+}

--- a/apps/chrome-extension/src/tabs.ts
+++ b/apps/chrome-extension/src/tabs.ts
@@ -1,0 +1,27 @@
+import { extensionApi } from './extension-api.js';
+
+export interface ActivePage {
+  title: string;
+  url: string;
+}
+
+export async function getActivePage(): Promise<ActivePage | null> {
+  const [tab] = await extensionApi.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab?.url) {
+    return null;
+  }
+
+  return {
+    title: tab.title?.trim() || 'Untitled page',
+    url: tab.url,
+  };
+}
+
+export function getDisplayDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return 'Current page';
+  }
+}

--- a/apps/chrome-extension/tsconfig.json
+++ b/apps/chrome-extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "lib": ["ES2022", "DOM"],
+    "noEmit": false,
+    "outDir": "dist/.compiled",
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/mobile/app/(tabs)/index/index.tsx
+++ b/apps/mobile/app/(tabs)/index/index.tsx
@@ -350,7 +350,7 @@ export default function HomeScreen() {
   const handleOpenCollection = useCallback(
     (collectionId: string) => {
       router.push({
-        pathname: '/(tabs)/collection/[id]',
+        pathname: '/(tabs)/index/collection/[id]',
         params: { id: collectionId },
       });
     },
@@ -365,7 +365,7 @@ export default function HomeScreen() {
       }
 
       router.push({
-        pathname: '/(tabs)/section/[section]',
+        pathname: '/(tabs)/index/section/[section]',
         params,
       });
     },

--- a/apps/mobile/app/(tabs)/library/index.tsx
+++ b/apps/mobile/app/(tabs)/library/index.tsx
@@ -613,7 +613,7 @@ export default function LibraryScreen() {
   const handleOpenCollection = useCallback(
     (collectionId: string) => {
       router.push({
-        pathname: '/(tabs)/collection/[id]',
+        pathname: '/(tabs)/index/collection/[id]',
         params: { id: collectionId },
       });
     },

--- a/apps/mobile/lib/home-screen.test.tsx
+++ b/apps/mobile/lib/home-screen.test.tsx
@@ -635,7 +635,7 @@ describe('HomeScreen', () => {
     });
 
     expect(mockPush).toHaveBeenCalledWith({
-      pathname: '/(tabs)/collection/[id]',
+      pathname: '/(tabs)/index/collection/[id]',
       params: { id: 'collection-1' },
     });
   });
@@ -685,7 +685,7 @@ describe('HomeScreen', () => {
       });
 
       expect(mockPush).toHaveBeenLastCalledWith({
-        pathname: '/(tabs)/section/[section]',
+        pathname: '/(tabs)/index/section/[section]',
         params: { section },
       });
     });
@@ -737,7 +737,7 @@ describe('HomeScreen', () => {
     });
 
     expect(mockPush).toHaveBeenLastCalledWith({
-      pathname: '/(tabs)/section/[section]',
+      pathname: '/(tabs)/index/section/[section]',
       params: { section: 'recently-bookmarked', contentType: 'article' },
     });
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,13 @@
         "typescript-eslint": "^8.49.0",
       },
     },
+    "apps/chrome-extension": {
+      "name": "@zine/chrome-extension",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "~5.9.2",
+      },
+    },
     "apps/mobile": {
       "name": "@zine/mobile",
       "version": "1.0.0",
@@ -1326,6 +1333,8 @@
     "@wallet-standard/wallet": ["@wallet-standard/wallet@1.1.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0" } }, "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+
+    "@zine/chrome-extension": ["@zine/chrome-extension@workspace:apps/chrome-extension"],
 
     "@zine/design-system": ["@zine/design-system@workspace:packages/design-system"],
 

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -1,0 +1,66 @@
+# Zine Browser Extension
+
+The browser extension saves the active browser tab to Zine through the public
+personal access token API.
+
+## Build
+
+```bash
+bun run --cwd apps/chrome-extension build
+```
+
+The loadable extension is written to `apps/chrome-extension/dist`.
+
+To also create packaged browser files:
+
+```bash
+bun run --cwd apps/chrome-extension package
+```
+
+This creates:
+
+```text
+apps/chrome-extension/dist/zine-chrome.zip
+apps/chrome-extension/dist/zine-firefox.xpi
+```
+
+## Chrome or Chromium Install
+
+1. Open `chrome://extensions`.
+2. Enable Developer mode.
+3. Choose **Load unpacked**.
+4. Select `apps/chrome-extension/dist/chrome`.
+
+## Firefox Install
+
+For a file-based install, use:
+
+```text
+apps/chrome-extension/dist/zine-firefox.xpi
+```
+
+Firefox Release generally requires installed add-ons to be signed by Mozilla. For
+local development without signing, use the temporary install flow:
+
+1. Open `about:debugging#/runtime/this-firefox`.
+2. Choose **Load Temporary Add-on**.
+3. Select `apps/chrome-extension/dist/firefox/manifest.json`.
+
+Temporary Firefox add-ons are removed when Firefox restarts.
+
+## Configure
+
+Create a token in Zine web Settings with **Add bookmarks** enabled, then paste it
+into the extension options page. The default API URL is:
+
+```text
+https://api.myzine.app
+```
+
+## Behavior
+
+- The popup saves the active `http` or `https` tab.
+- The page context menu includes **Save page to Zine**.
+- Browser-internal pages such as `chrome://extensions` cannot be saved.
+- Private content behind a site login is saved as a URL; Zine's server-side
+  preview can only fetch metadata that is reachable from the Worker.


### PR DESCRIPTION
## Summary

- Adds a shared browser extension package for saving the active tab to Zine via the existing `/api/v1/bookmarks` personal access token API.
- Builds separate Chrome/Chromium and Firefox outputs, including `zine-chrome.zip` and `zine-firefox.xpi` package generation.
- Documents local install, temporary Firefox loading, and the Mozilla signing caveat.
- Fixes mobile typed route pathnames for Home and Library collection/section navigation so the full test suite passes with current Expo Router generated routes.

## Validation

- `bun run format:check`
- `bun run lint` (passes with existing mobile warning in `apps/mobile/components/insights/weekly-recap-card.test.tsx`)
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run --cwd apps/chrome-extension package`
- Push preflight hook: format check, design-system check, typecheck, web tests, worker CI subset

## Notes

Firefox Release requires Mozilla-signed extensions for persistent installation. The generated `.xpi` is useful for signing/submission, while local development should use `about:debugging#/runtime/this-firefox` temporary loading.
