### PR TITLE
[codex] add inbox REST endpoint

### DIFF
--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -7,17 +7,25 @@ import { Hono } from 'hono';
 import { ContentType, Provider } from '@zine/shared';
 import type { Env } from '../types';
 
-const { mockCreateDb, mockCreateContext, mockCreateCaller, mockLibrary, mockPreview, mockSave } =
-  vi.hoisted(() => ({
-    mockCreateDb: vi.fn(),
-    mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
-      userId: c.get('userId'),
-    })),
-    mockCreateCaller: vi.fn(),
-    mockLibrary: vi.fn(),
-    mockPreview: vi.fn(),
-    mockSave: vi.fn(),
-  }));
+const {
+  mockCreateDb,
+  mockCreateContext,
+  mockCreateCaller,
+  mockInbox,
+  mockLibrary,
+  mockPreview,
+  mockSave,
+} = vi.hoisted(() => ({
+  mockCreateDb: vi.fn(),
+  mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
+    userId: c.get('userId'),
+  })),
+  mockCreateCaller: vi.fn(),
+  mockInbox: vi.fn(),
+  mockLibrary: vi.fn(),
+  mockPreview: vi.fn(),
+  mockSave: vi.fn(),
+}));
 
 vi.mock('../db', () => ({
   createDb: mockCreateDb,
@@ -100,6 +108,7 @@ describe('apiV1Routes', () => {
     mockDbToken(createTokenRecord(['bookmarks:read', 'bookmarks:write']));
     mockCreateCaller.mockReturnValue({
       items: {
+        inbox: mockInbox,
         library: mockLibrary,
       },
       bookmarks: {
@@ -117,6 +126,7 @@ describe('apiV1Routes', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as JsonBody;
     expect(body.openapi).toBe('3.1.0');
+    expect(body.paths).toHaveProperty('/api/v1/inbox');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks');
   });
 
@@ -177,6 +187,72 @@ describe('apiV1Routes', () => {
     expect(res.status).toBe(403);
     expect((await res.json()) as JsonBody).toMatchObject({ code: 'FORBIDDEN' });
     expect(mockPreview).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when listing inbox without read scope', async () => {
+    mockDbToken(createTokenRecord(['bookmarks:write']));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/inbox', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockInbox).not.toHaveBeenCalled();
+  });
+
+  it('lists inbox items for the token owner', async () => {
+    mockInbox.mockResolvedValue({
+      items: [{ id: 'ui_inbox_1', title: 'Inbox item' }],
+      nextCursor: 'next-cursor',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request(
+        'http://localhost/api/v1/inbox?limit=20&cursor=abc&provider=YOUTUBE&contentType=VIDEO',
+        {
+          headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+        }
+      ),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateCaller).toHaveBeenCalledWith({ userId: 'user_123' });
+    expect(mockInbox).toHaveBeenCalledWith({
+      limit: 20,
+      cursor: 'abc',
+      filter: {
+        provider: Provider.YOUTUBE,
+        contentType: ContentType.VIDEO,
+      },
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      items: [{ title: 'Inbox item' }],
+      nextCursor: 'next-cursor',
+    });
+  });
+
+  it('rejects invalid inbox filters', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/inbox?provider=NOT_A_PROVIDER', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_QUERY_PARAMETERS',
+    });
+    expect(mockInbox).not.toHaveBeenCalled();
   });
 
   it('lists bookmarks for the token owner', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { MiddlewareHandler } from 'hono';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { ContentTypeSchema, ProviderSchema } from '@zine/shared';
 import type { Env } from '../types';
 import { createDb } from '../db';
 import { apiTokens } from '../db/schema';
@@ -20,6 +21,11 @@ const MAX_BOOKMARKS_LIMIT = 50;
 
 const SaveBookmarkBodySchema = z.object({
   url: z.string().url('Invalid URL format'),
+});
+
+const InboxQuerySchema = z.object({
+  provider: ProviderSchema.optional(),
+  contentType: ContentTypeSchema.optional(),
 });
 
 function extractBearerToken(authHeader: string | undefined): string | null {
@@ -71,6 +77,47 @@ function openApiSpec() {
     servers: [{ url: 'https://api.myzine.app' }],
     security: [{ bearerAuth: [] }],
     paths: {
+      '/api/v1/inbox': {
+        get: {
+          operationId: 'listInbox',
+          summary: 'List inbox items',
+          parameters: [
+            {
+              name: 'limit',
+              in: 'query',
+              schema: {
+                type: 'integer',
+                minimum: 1,
+                maximum: MAX_BOOKMARKS_LIMIT,
+                default: DEFAULT_BOOKMARKS_LIMIT,
+              },
+            },
+            { name: 'cursor', in: 'query', schema: { type: 'string' } },
+            {
+              name: 'provider',
+              in: 'query',
+              schema: {
+                type: 'string',
+                enum: Object.values(ProviderSchema.enum),
+              },
+            },
+            {
+              name: 'contentType',
+              in: 'query',
+              schema: {
+                type: 'string',
+                enum: Object.values(ContentTypeSchema.enum),
+              },
+            },
+          ],
+          responses: {
+            '200': { description: 'Inbox items' },
+            '400': { description: 'Invalid query parameters' },
+            '401': { description: 'Missing or invalid personal access token' },
+            '403': { description: 'Token is missing bookmarks:read scope' },
+          },
+        },
+      },
       '/api/v1/bookmarks': {
         get: {
           operationId: 'listBookmarks',
@@ -201,6 +248,45 @@ function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
 const apiV1Routes = new Hono<Env>();
 
 apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec()));
+
+apiV1Routes.get('/inbox', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+  const parsedQuery = InboxQuerySchema.safeParse({
+    provider: c.req.query('provider'),
+    contentType: c.req.query('contentType'),
+  });
+
+  if (!parsedQuery.success) {
+    return c.json(
+      {
+        error: 'Invalid query parameters',
+        code: 'INVALID_QUERY_PARAMETERS',
+        issues: parsedQuery.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+
+  const result = await caller.items.inbox({
+    limit: parseLimit(c.req.query('limit')),
+    cursor: cursor && cursor.length > 0 ? cursor : undefined,
+    filter: {
+      provider: parsedQuery.data.provider,
+      contentType: parsedQuery.data.contentType,
+    },
+  });
+
+  return c.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
 
 apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));

--- a/docs/web-cloudflare-deployment.md
+++ b/docs/web-cloudflare-deployment.md
@@ -62,11 +62,14 @@ Required Cloudflare Worker secrets or vars:
 - `CLERK_JWKS_URL`: Set this if you are not using the default `https://clerk.myzine.app/.well-known/jwks.json`.
 
 Personal access tokens are managed by signed-in users from Web Settings. No
-Worker secret is required for the `/api/v1` bookmark API.
+Worker secret is required for the `/api/v1` personal API.
 
 Personal API examples:
 
 ```bash
+curl -H "Authorization: Bearer $ZINE_PAT" \
+  "https://api.myzine.app/api/v1/inbox?limit=10"
+
 curl -H "Authorization: Bearer $ZINE_PAT" \
   "https://api.myzine.app/api/v1/bookmarks?limit=10"
 


### PR DESCRIPTION
## Summary

Adds a read-only `/api/v1/inbox` REST endpoint for personal access token clients. The endpoint reuses the existing `items.inbox` tRPC procedure so API clients receive the same inbox item shape as the apps.

## Details

- Adds OpenAPI coverage for `GET /api/v1/inbox`.
- Supports `limit`, `cursor`, `provider`, and `contentType` query parameters.
- Uses the existing `bookmarks:read` personal access token scope.
- Returns `400 INVALID_QUERY_PARAMETERS` for invalid provider/content type filters.
- Updates deployment docs with inbox API examples.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- Push pre-hook: format, design-system check, typecheck, web tests, worker CI subset

Note: the global local Codex skill at `~/.codex/skills/zine-api` was also updated on this machine to mention the new inbox endpoint, but that file is outside this repository and is not part of this PR.