### PR TITLE
[codex] Add REST bookmark finished state endpoint

### DIFF
--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
-import { ContentType, Provider } from '@zine/shared';
+import { ContentType, Provider, UserItemState } from '@zine/shared';
 import type { Env } from '../types';
 
 const {
@@ -15,6 +15,9 @@ const {
   mockLibrary,
   mockPreview,
   mockSave,
+  mockFindUserItem,
+  mockUserItemUpdateSet,
+  mockConsumptionInsertValues,
 } = vi.hoisted(() => ({
   mockCreateDb: vi.fn(),
   mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
@@ -25,6 +28,9 @@ const {
   mockLibrary: vi.fn(),
   mockPreview: vi.fn(),
   mockSave: vi.fn(),
+  mockFindUserItem: vi.fn(),
+  mockUserItemUpdateSet: vi.fn(),
+  mockConsumptionInsertValues: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -92,14 +98,45 @@ function createMockEnv(): Env['Bindings'] {
 function mockDbToken(token: ReturnType<typeof createTokenRecord> | null) {
   const tokenUpdateWhere = vi.fn().mockResolvedValue(undefined);
   const tokenUpdateSet = vi.fn().mockReturnValue({ where: tokenUpdateWhere });
+  const userItemUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  mockUserItemUpdateSet.mockReturnValue({ where: userItemUpdateWhere });
+  mockConsumptionInsertValues.mockResolvedValue(undefined);
+
   mockCreateDb.mockReturnValue({
     query: {
       apiTokens: {
         findFirst: vi.fn(async () => token),
       },
+      userItems: {
+        findFirst: mockFindUserItem,
+      },
     },
-    update: vi.fn().mockReturnValue({ set: tokenUpdateSet }),
+    update: vi.fn().mockReturnValueOnce({ set: tokenUpdateSet }).mockReturnValue({
+      set: mockUserItemUpdateSet,
+    }),
+    insert: vi.fn().mockReturnValue({ values: mockConsumptionInsertValues }),
   });
+}
+
+function createBookmarkRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ui_1',
+    userId: 'user_123',
+    itemId: 'item_1',
+    state: UserItemState.BOOKMARKED,
+    ingestedAt: '2026-01-01T00:00:00.000Z',
+    bookmarkedAt: '2026-01-01T00:00:00.000Z',
+    archivedAt: null,
+    lastOpenedAt: null,
+    progressPosition: null,
+    progressDuration: null,
+    progressUpdatedAt: null,
+    isFinished: false,
+    finishedAt: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
 }
 
 describe('apiV1Routes', () => {
@@ -128,6 +165,7 @@ describe('apiV1Routes', () => {
     expect(body.openapi).toBe('3.1.0');
     expect(body.paths).toHaveProperty('/api/v1/inbox');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}');
   });
 
   it('returns 401 for missing and invalid tokens', async () => {
@@ -331,6 +369,141 @@ describe('apiV1Routes', () => {
       },
       item: {
         title: 'Article title',
+      },
+    });
+  });
+
+  it('marks a bookmark as finished for tokens with write scope', async () => {
+    mockFindUserItem.mockResolvedValue(createBookmarkRecord());
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ isFinished: true }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockFindUserItem).toHaveBeenCalled();
+    expect(mockUserItemUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isFinished: true,
+        finishedAt: expect.any(String),
+        updatedAt: expect.any(String),
+      })
+    );
+    expect(mockConsumptionInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user_123',
+        userItemId: 'ui_1',
+        itemId: 'item_1',
+        eventType: 'FINISHED',
+        source: 'MANUAL_FINISH_TOGGLE',
+        metadata: JSON.stringify({ source: 'api_v1' }),
+      })
+    );
+    expect((await res.json()) as JsonBody).toMatchObject({
+      bookmark: {
+        id: 'ui_1',
+        itemId: 'item_1',
+        isFinished: true,
+      },
+    });
+  });
+
+  it('accepts completed/read/finished aliases but only one at a time', async () => {
+    mockFindUserItem.mockResolvedValue(createBookmarkRecord());
+    const app = createTestApp();
+
+    const completed = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ completed: true }),
+      }),
+      createMockEnv()
+    );
+
+    const ambiguous = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ completed: true, read: true }),
+      }),
+      createMockEnv()
+    );
+
+    expect(completed.status).toBe(200);
+    expect(ambiguous.status).toBe(400);
+    expect((await ambiguous.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_REQUEST_BODY',
+    });
+  });
+
+  it('returns 404 when marking a missing bookmark as finished', async () => {
+    mockFindUserItem.mockResolvedValue(null);
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/missing', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ read: true }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'BOOKMARK_NOT_FOUND',
+    });
+    expect(mockUserItemUpdateSet).not.toHaveBeenCalled();
+    expect(mockConsumptionInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('does not rewrite or emit an event when the requested finished state is unchanged', async () => {
+    mockFindUserItem.mockResolvedValue(
+      createBookmarkRecord({
+        isFinished: true,
+        finishedAt: '2026-01-02T00:00:00.000Z',
+      })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ finished: true }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUserItemUpdateSet).not.toHaveBeenCalled();
+    expect(mockConsumptionInsertValues).not.toHaveBeenCalled();
+    expect((await res.json()) as JsonBody).toMatchObject({
+      bookmark: {
+        isFinished: true,
+        finishedAt: '2026-01-02T00:00:00.000Z',
       },
     });
   });

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -2,10 +2,11 @@ import { Hono } from 'hono';
 import type { MiddlewareHandler } from 'hono';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { ContentTypeSchema, ProviderSchema } from '@zine/shared';
+import { ulid } from 'ulid';
+import { ContentTypeSchema, ProviderSchema, UserItemState } from '@zine/shared';
 import type { Env } from '../types';
 import { createDb } from '../db';
-import { apiTokens } from '../db/schema';
+import { apiTokens, userItemConsumptionEvents, userItems } from '../db/schema';
 import { appRouter } from '../trpc/router';
 import { createContext } from '../trpc/context';
 import {
@@ -27,6 +28,30 @@ const InboxQuerySchema = z.object({
   provider: ProviderSchema.optional(),
   contentType: ContentTypeSchema.optional(),
 });
+
+const FinishBookmarkBodySchema = z
+  .object({
+    isFinished: z.boolean().optional(),
+    finished: z.boolean().optional(),
+    completed: z.boolean().optional(),
+    read: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((body, ctx) => {
+    const fields = ['isFinished', 'finished', 'completed', 'read'] as const;
+    const provided = fields.filter((field) => body[field] !== undefined);
+
+    if (provided.length !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide exactly one of isFinished, finished, completed, or read',
+      });
+    }
+  });
+
+function getRequestedFinishedState(body: z.infer<typeof FinishBookmarkBodySchema>): boolean {
+  return Boolean(body.isFinished ?? body.finished ?? body.completed ?? body.read);
+}
 
 function extractBearerToken(authHeader: string | undefined): string | null {
   if (!authHeader?.startsWith('Bearer ')) {
@@ -170,6 +195,45 @@ function openApiSpec() {
             '401': { description: 'Missing or invalid personal access token' },
             '403': { description: 'Token is missing bookmarks:write scope' },
             '422': { description: 'URL could not be previewed or saved' },
+          },
+        },
+      },
+      '/api/v1/bookmarks/{id}': {
+        patch: {
+          operationId: 'updateBookmarkFinishedState',
+          summary: 'Mark a bookmark as finished or unfinished',
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    isFinished: { type: 'boolean' },
+                    finished: { type: 'boolean' },
+                    completed: { type: 'boolean' },
+                    read: { type: 'boolean' },
+                  },
+                  minProperties: 1,
+                  maxProperties: 1,
+                },
+              },
+            },
+          },
+          responses: {
+            '200': { description: 'Bookmark finished state updated' },
+            '400': { description: 'Invalid request body' },
+            '401': { description: 'Missing or invalid personal access token' },
+            '403': { description: 'Token is missing bookmarks:write scope' },
+            '404': { description: 'Bookmark not found' },
           },
         },
       },
@@ -365,6 +429,100 @@ apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async
       wordCount: preview.wordCount ?? null,
       readingTimeMinutes: preview.readingTimeMinutes ?? null,
       publishedAt: preview.publishedAt ?? null,
+    },
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.patch('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = FinishBookmarkBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const bookmarkId = c.req.param('id');
+  const userId = c.get('userId');
+  if (!userId) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const db = createDb(c.env.DB);
+  const bookmark = await db.query.userItems.findFirst({
+    where: and(
+      eq(userItems.id, bookmarkId),
+      eq(userItems.userId, userId),
+      eq(userItems.state, UserItemState.BOOKMARKED)
+    ),
+  });
+
+  if (!bookmark) {
+    return c.json(
+      {
+        error: 'Bookmark not found',
+        code: 'BOOKMARK_NOT_FOUND',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      404
+    );
+  }
+
+  const isFinished = getRequestedFinishedState(parsedBody.data);
+  const finishedAt = isFinished ? (bookmark.finishedAt ?? new Date().toISOString()) : null;
+
+  if (bookmark.isFinished !== isFinished) {
+    const now = Date.now();
+
+    await db
+      .update(userItems)
+      .set({
+        isFinished,
+        finishedAt,
+        updatedAt: new Date(now).toISOString(),
+      })
+      .where(eq(userItems.id, bookmarkId));
+
+    await db.insert(userItemConsumptionEvents).values({
+      id: ulid(),
+      userId,
+      userItemId: bookmark.id,
+      itemId: bookmark.itemId,
+      eventType: isFinished ? 'FINISHED' : 'UNFINISHED',
+      occurredAt: now,
+      positionSeconds: null,
+      durationSeconds: null,
+      deltaSeconds: null,
+      source: 'MANUAL_FINISH_TOGGLE',
+      metadata: JSON.stringify({ source: 'api_v1' }),
+    });
+  }
+
+  return c.json({
+    bookmark: {
+      id: bookmark.id,
+      itemId: bookmark.itemId,
+      isFinished,
+      finishedAt,
     },
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),


### PR DESCRIPTION
## Summary

Adds a REST API endpoint for marking saved bookmarks as finished or unfinished:

- `PATCH /api/v1/bookmarks/:id` accepts exactly one boolean field from `isFinished`, `finished`, `completed`, or `read`.
- Updates only bookmarked user items owned by the personal access token user.
- Emits a consumption event when the finished state changes and returns a no-op success when the requested state is already current.
- Documents the new endpoint in the OpenAPI response and expands route coverage.

## Validation

- `bun run format:check`
- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker test:run`
- Pre-push hook: format check, mobile design-system check, repo typecheck, web tests, worker CI subset