### PR TITLE
[codex] Implement REST API contract

### DIFF
--- a/apps/web/src/settings-page.test.tsx
+++ b/apps/web/src/settings-page.test.tsx
@@ -258,6 +258,38 @@ describe('SettingsPage', () => {
       expect(screen.getByRole('button', { name: 'Copied' })).toBeVisible();
     });
 
+    test('creates an API token with sync scopes when selected', async () => {
+      const user = userEvent.setup();
+      mutationSpies.apiTokensCreate.mockResolvedValue({
+        token: {
+          id: 'token-3',
+          name: 'Sync runner',
+          tokenPrefix: 'zine_pat_sync',
+          scopes: ['bookmarks:read', 'bookmarks:write', 'sync:read', 'sync:write'],
+          createdAt: Date.now(),
+          lastUsedAt: null,
+          expiresAt: null,
+          revokedAt: null,
+        },
+        rawToken: 'zine_pat_sync_raw_token',
+      });
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      await user.type(screen.getByLabelText('Name'), 'Sync runner');
+      await user.click(screen.getByLabelText('Read sync status'));
+      await user.click(screen.getByLabelText('Start sync jobs'));
+      await user.click(screen.getByRole('button', { name: 'Create token' }));
+
+      expect(mutationSpies.apiTokensCreate).toHaveBeenCalledWith({
+        name: 'Sync runner',
+        scopes: ['bookmarks:read', 'bookmarks:write', 'sync:read', 'sync:write'],
+      });
+    });
+
     test('revokes an API token', async () => {
       const user = userEvent.setup();
       hookSpies.apiTokensListUseQuery.mockImplementation(() => ({

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -213,6 +213,8 @@ function ApiTokensSection() {
   const [name, setName] = useState('');
   const [readEnabled, setReadEnabled] = useState(true);
   const [writeEnabled, setWriteEnabled] = useState(true);
+  const [syncReadEnabled, setSyncReadEnabled] = useState(false);
+  const [syncWriteEnabled, setSyncWriteEnabled] = useState(false);
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -220,8 +222,10 @@ function ApiTokensSection() {
     const scopes: ApiTokenScope[] = [];
     if (readEnabled) scopes.push('bookmarks:read');
     if (writeEnabled) scopes.push('bookmarks:write');
+    if (syncReadEnabled) scopes.push('sync:read');
+    if (syncWriteEnabled) scopes.push('sync:write');
     return scopes;
-  }, [readEnabled, writeEnabled]);
+  }, [readEnabled, syncReadEnabled, syncWriteEnabled, writeEnabled]);
 
   const createToken = trpc.apiTokens.create.useMutation({
     onSuccess: (result) => {
@@ -307,6 +311,22 @@ function ApiTokensSection() {
               onChange={(event) => setWriteEnabled(event.target.checked)}
             />
             Add bookmarks
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={syncReadEnabled}
+              onChange={(event) => setSyncReadEnabled(event.target.checked)}
+            />
+            Read sync status
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={syncWriteEnabled}
+              onChange={(event) => setSyncWriteEnabled(event.target.checked)}
+            />
+            Start sync jobs
           </label>
         </div>
 

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -1,0 +1,1749 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Zine REST API",
+    "version": "1.1.0",
+    "description": "Personal access token REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, and subscription sync jobs."
+  },
+  "servers": [
+    {
+      "url": "https://api.myzine.app",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:8787",
+      "description": "Local worker development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Metadata",
+      "description": "API metadata and machine-readable documentation."
+    },
+    {
+      "name": "Inbox",
+      "description": "Read and triage unbookmarked inbox items."
+    },
+    {
+      "name": "Bookmarks",
+      "description": "Read, save, update, and remove bookmarked items."
+    },
+    {
+      "name": "Tags",
+      "description": "List and replace bookmark tags."
+    },
+    {
+      "name": "Reading",
+      "description": "Article content, opened events, and reading/playback progress."
+    },
+    {
+      "name": "Sync",
+      "description": "Trigger and inspect asynchronous subscription sync jobs."
+    }
+  ],
+  "paths": {
+    "/api/v1/openapi.json": {
+      "get": {
+        "tags": ["Metadata"],
+        "operationId": "getOpenApiSpec",
+        "summary": "Get the OpenAPI document",
+        "security": [],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "OpenAPI document for the Zine REST API."
+          }
+        }
+      }
+    },
+    "/api/v1/inbox": {
+      "get": {
+        "tags": ["Inbox"],
+        "operationId": "listInbox",
+        "summary": "List inbox items",
+        "description": "Returns unfinished items currently in the inbox, sorted by most recently ingested first.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Provider"
+          },
+          {
+            "$ref": "#/components/parameters/ContentType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/inbox/{id}/bookmark": {
+      "post": {
+        "tags": ["Inbox"],
+        "operationId": "bookmarkInboxItem",
+        "summary": "Move an inbox item to bookmarks",
+        "description": "REST equivalent of tRPC items.bookmark for inbox triage clients.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item moved to bookmarks.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/inbox/{id}/archive": {
+      "post": {
+        "tags": ["Inbox"],
+        "operationId": "archiveInboxItem",
+        "summary": "Archive an inbox item",
+        "description": "REST equivalent of tRPC items.archive for dismissing inbox items.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item archived.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "listBookmarks",
+        "summary": "List bookmarks",
+        "description": "Returns bookmarked items, sorted by most recently bookmarked first. Supports provider and contentType filters to match tRPC items.library.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Search"
+          },
+          {
+            "name": "isFinished",
+            "in": "query",
+            "description": "When true, returns finished bookmarks. When false or omitted, returns unfinished bookmarks.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Provider"
+          },
+          {
+            "$ref": "#/components/parameters/ContentType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmarked items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItems"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Bookmarks"],
+        "operationId": "saveBookmark",
+        "summary": "Save a URL as a bookmark",
+        "description": "Fetches a preview for the URL, creates or reuses the canonical item, and saves it as a bookmark for the token owner.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveBookmarkRequest"
+              },
+              "examples": {
+                "webArticle": {
+                  "value": {
+                    "url": "https://example.com/article"
+                  }
+                },
+                "xPost": {
+                  "value": {
+                    "url": "https://x.com/example/status/1234567890"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark saved, restored, or already present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveBookmarkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnsupportedUrl"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/preview": {
+      "post": {
+        "tags": ["Bookmarks"],
+        "operationId": "previewBookmarkUrl",
+        "summary": "Preview a URL before saving",
+        "description": "Read-only REST equivalent of tRPC bookmarks.preview for clients that want confirmation UI before saving.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveBookmarkRequest"
+              },
+              "examples": {
+                "webArticle": {
+                  "value": {
+                    "url": "https://example.com/article"
+                  }
+                },
+                "xPost": {
+                  "value": {
+                    "url": "https://x.com/example/status/1234567890"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Preview metadata for the URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewBookmarkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnsupportedUrl"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "getBookmark",
+        "summary": "Get a bookmark",
+        "description": "REST equivalent of tRPC items.get for a single bookmarked item.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark item.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Bookmarks"],
+        "operationId": "updateBookmarkFinishedState",
+        "summary": "Mark a bookmark as finished or unfinished",
+        "description": "Sets the finished state for a bookmarked item; idempotent when the requested state already matches the stored state.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBookmarkFinishedStateRequest"
+              },
+              "examples": {
+                "finished": {
+                  "value": {
+                    "isFinished": true
+                  }
+                },
+                "unreadAlias": {
+                  "value": {
+                    "read": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark finished state updated or already matched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBookmarkFinishedStateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Bookmarks"],
+        "operationId": "deleteBookmark",
+        "summary": "Remove a bookmark",
+        "description": "REST equivalent of tRPC items.unbookmark. Archives the user item and clears bookmarkedAt.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/tags": {
+      "put": {
+        "tags": ["Tags"],
+        "operationId": "setBookmarkTags",
+        "summary": "Replace tags on a bookmark",
+        "description": "REST equivalent of tRPC items.setTags.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTagsRequest"
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "tags": ["design", "api"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tags replaced.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetTagsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/opened": {
+      "post": {
+        "tags": ["Reading"],
+        "operationId": "markBookmarkOpened",
+        "summary": "Record that a bookmark was opened",
+        "description": "REST equivalent of tRPC items.markOpened for detail views and external readers.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Open event recorded when applicable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarkOpenedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/progress": {
+      "put": {
+        "tags": ["Reading"],
+        "operationId": "updateBookmarkProgress",
+        "summary": "Update reading or playback progress",
+        "description": "REST equivalent of tRPC items.updateProgress.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProgressRequest"
+              },
+              "examples": {
+                "video": {
+                  "value": {
+                    "position": 125.4,
+                    "duration": 600
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Progress updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/article-content": {
+      "get": {
+        "tags": ["Reading"],
+        "operationId": "getBookmarkArticleContent",
+        "summary": "Get stored article content",
+        "description": "REST equivalent of tRPC items.getArticleContent. Returns null content when no extracted article body is stored.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stored article content.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleContentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/tags": {
+      "get": {
+        "tags": ["Tags"],
+        "operationId": "listTags",
+        "summary": "List all tags",
+        "description": "REST equivalent of tRPC items.listTags.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "Tags for the token owner.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTagsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs": {
+      "post": {
+        "tags": ["Sync"],
+        "operationId": "createSyncJob",
+        "summary": "Trigger a subscription sync job",
+        "description": "REST endpoint for the existing asynchronous subscription sync process. The current implementation syncs active YouTube and Spotify subscriptions; source filtering and all-provider inbox refresh orchestration remain future work.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSyncJobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Sync job accepted, or an existing active job was returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncJobAccepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs/active": {
+      "get": {
+        "tags": ["Sync"],
+        "operationId": "getActiveSyncJob",
+        "summary": "Get the active sync job",
+        "description": "REST endpoint returning the token owner's active subscription sync job when one is still in progress.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "Active sync job state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveSyncJob"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs/{jobId}": {
+      "get": {
+        "tags": ["Sync"],
+        "operationId": "getSyncJob",
+        "summary": "Get sync job status",
+        "description": "REST endpoint returning status for a sync job owned by the token owner.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "Sync job ID returned by POST /api/v1/sync-jobs.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync job status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncJobStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Zine personal access token",
+        "description": "Use a Zine personal access token with the required operation scope."
+      }
+    },
+    "parameters": {
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Maximum number of items to return. Defaults to 10.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 10
+        }
+      },
+      "Cursor": {
+        "name": "cursor",
+        "in": "query",
+        "description": "Cursor returned by the previous page.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Search": {
+        "name": "search",
+        "in": "query",
+        "description": "Case-insensitive title or creator search.",
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        }
+      },
+      "Provider": {
+        "name": "provider",
+        "in": "query",
+        "description": "Filter items by source provider.",
+        "schema": {
+          "type": "string",
+          "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+        }
+      },
+      "ContentType": {
+        "name": "contentType",
+        "in": "query",
+        "description": "Filter items by content type.",
+        "schema": {
+          "type": "string",
+          "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+        }
+      },
+      "UserItemId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "User item ID.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "ValidationError": {
+        "description": "Invalid request body or query parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing, malformed, expired, revoked, or unknown token.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Token is missing the required scope.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found for this token owner.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UnsupportedUrl": {
+        "description": "URL could not be previewed or is unsupported.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "A sync job was started too recently.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds to wait before retrying.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RateLimitError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error", "code", "requestId", "traceId"],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error summary."
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable error code."
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "ValidationError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "issues": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "description": "Zod validation issues for the request."
+              }
+            }
+          }
+        ]
+      },
+      "RequestMetadata": {
+        "type": "object",
+        "required": ["requestId", "traceId"],
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "required": [
+          "id",
+          "itemId",
+          "title",
+          "thumbnailUrl",
+          "canonicalUrl",
+          "contentType",
+          "provider",
+          "creator",
+          "creatorImageUrl",
+          "creatorId",
+          "publisher",
+          "summary",
+          "duration",
+          "publishedAt",
+          "wordCount",
+          "readingTimeMinutes",
+          "state",
+          "ingestedAt",
+          "bookmarkedAt",
+          "lastOpenedAt",
+          "progress",
+          "isFinished",
+          "finishedAt",
+          "tags"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "User item ID."
+          },
+          "itemId": {
+            "type": "string",
+            "description": "Canonical item ID shared across users."
+          },
+          "title": {
+            "type": "string"
+          },
+          "thumbnailUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "contentType": {
+            "type": "string",
+            "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+          },
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "creator": {
+            "type": "string"
+          },
+          "creatorImageUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "creatorId": {
+            "type": ["string", "null"]
+          },
+          "publisher": {
+            "type": ["string", "null"]
+          },
+          "summary": {
+            "type": ["string", "null"]
+          },
+          "duration": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "publishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "wordCount": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "readingTimeMinutes": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "state": {
+            "type": "string",
+            "enum": ["INBOX", "BOOKMARKED", "ARCHIVED"]
+          },
+          "ingestedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "bookmarkedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "lastOpenedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "progress": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "required": ["position", "duration", "percent"],
+                "properties": {
+                  "position": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "duration": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "percent": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                  }
+                }
+              }
+            ]
+          },
+          "isFinished": {
+            "type": "boolean"
+          },
+          "finishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          }
+        }
+      },
+      "PaginatedItems": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["items", "nextCursor"],
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Item"
+                }
+              },
+              "nextCursor": {
+                "type": ["string", "null"],
+                "description": "Cursor to pass to the next request. Null means there are no more items."
+              }
+            }
+          }
+        ]
+      },
+      "ItemResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["item"],
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/Item"
+              }
+            }
+          }
+        ]
+      },
+      "SaveBookmarkRequest": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTP or HTTPS URL to save."
+          }
+        }
+      },
+      "PreviewItem": {
+        "type": "object",
+        "required": [
+          "provider",
+          "contentType",
+          "providerId",
+          "title",
+          "creator",
+          "creatorImageUrl",
+          "thumbnailUrl",
+          "duration",
+          "canonicalUrl",
+          "description",
+          "siteName",
+          "wordCount",
+          "readingTimeMinutes",
+          "publishedAt"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "contentType": {
+            "type": "string",
+            "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+          },
+          "providerId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "creatorImageUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "thumbnailUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "duration": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "siteName": {
+            "type": ["string", "null"]
+          },
+          "wordCount": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "readingTimeMinutes": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "publishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PreviewBookmarkResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["item"],
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/PreviewItem"
+              }
+            }
+          }
+        ]
+      },
+      "BookmarkSaveResult": {
+        "type": "object",
+        "required": ["itemId", "userItemId", "status"],
+        "properties": {
+          "itemId": {
+            "type": "string"
+          },
+          "userItemId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["created", "already_bookmarked", "rebookmarked"]
+          }
+        }
+      },
+      "SaveBookmarkResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["bookmark", "item"],
+            "properties": {
+              "bookmark": {
+                "$ref": "#/components/schemas/BookmarkSaveResult"
+              },
+              "item": {
+                "$ref": "#/components/schemas/PreviewItem"
+              }
+            }
+          }
+        ]
+      },
+      "UpdateBookmarkFinishedStateRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Provide exactly one alias. All aliases set the same bookmark finished state.",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "properties": {
+          "isFinished": {
+            "type": "boolean"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "read": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UpdateBookmarkFinishedStateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["bookmark"],
+            "properties": {
+              "bookmark": {
+                "type": "object",
+                "required": ["id", "itemId", "isFinished", "finishedAt"],
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "itemId": {
+                    "type": "string"
+                  },
+                  "isFinished": {
+                    "type": "boolean"
+                  },
+                  "finishedAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ActionResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              }
+            }
+          }
+        ]
+      },
+      "SetTagsRequest": {
+        "type": "object",
+        "required": ["tags"],
+        "additionalProperties": false,
+        "properties": {
+          "tags": {
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          }
+        }
+      },
+      "SetTagsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success", "tags"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ListTagsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["tags"],
+            "properties": {
+              "tags": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "MarkOpenedResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success", "updated"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              },
+              "updated": {
+                "type": "boolean"
+              },
+              "lastOpenedAt": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+        ]
+      },
+      "UpdateProgressRequest": {
+        "type": "object",
+        "required": ["position", "duration"],
+        "additionalProperties": false,
+        "properties": {
+          "position": {
+            "type": "number",
+            "minimum": 0
+          },
+          "duration": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      },
+      "ArticleContentResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["content"],
+            "properties": {
+              "content": {
+                "type": ["string", "null"],
+                "description": "Stored article HTML or null."
+              }
+            }
+          }
+        ]
+      },
+      "CreateSyncJobRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Reserved for future sync options. Omit the body or send an empty object in the current API.",
+        "properties": {}
+      },
+      "RateLimitError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "retryAfterSeconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Seconds to wait before retrying, when known."
+              }
+            }
+          }
+        ]
+      },
+      "SyncTelemetry": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Optional sync telemetry fields emitted by the worker."
+      },
+      "SyncJobAccepted": {
+        "type": "object",
+        "required": ["jobId", "total", "existing", "requestId", "traceId"],
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of subscriptions queued for the job."
+          },
+          "existing": {
+            "type": "boolean",
+            "description": "True when an active job already existed and was returned."
+          },
+          "telemetry": {
+            "$ref": "#/components/schemas/SyncTelemetry"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "ActiveSyncJob": {
+        "type": "object",
+        "required": ["inProgress", "requestId", "traceId"],
+        "properties": {
+          "inProgress": {
+            "type": "boolean"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "progress": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "completed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "status": {
+                "type": "string"
+              }
+            }
+          },
+          "telemetry": {
+            "$ref": "#/components/schemas/SyncTelemetry"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "SyncJobStatus": {
+        "type": "object",
+        "required": [
+          "jobId",
+          "status",
+          "total",
+          "completed",
+          "succeeded",
+          "failed",
+          "itemsFound",
+          "progress",
+          "errors",
+          "requestId",
+          "traceId"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "processing", "completed", "failed", "partial"]
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "completed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "succeeded": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "failed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "itemsFound": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "progress": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -4,6 +4,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { TRPCError } from '@trpc/server';
 import { ContentType, Provider, UserItemState } from '@zine/shared';
 import type { Env } from '../types';
 
@@ -13,8 +14,21 @@ const {
   mockCreateCaller,
   mockInbox,
   mockLibrary,
+  mockGetItem,
+  mockBookmarkInboxItem,
+  mockArchiveInboxItem,
+  mockUnbookmark,
+  mockSetTags,
+  mockMarkOpened,
+  mockUpdateProgress,
+  mockGetArticleContent,
+  mockListTags,
   mockPreview,
   mockSave,
+  mockInitiateSyncJob,
+  mockGetActiveSyncJob,
+  mockGetJobStatus,
+  mockGetSyncStatus,
   mockFindUserItem,
   mockUserItemUpdateSet,
   mockConsumptionInsertValues,
@@ -26,8 +40,21 @@ const {
   mockCreateCaller: vi.fn(),
   mockInbox: vi.fn(),
   mockLibrary: vi.fn(),
+  mockGetItem: vi.fn(),
+  mockBookmarkInboxItem: vi.fn(),
+  mockArchiveInboxItem: vi.fn(),
+  mockUnbookmark: vi.fn(),
+  mockSetTags: vi.fn(),
+  mockMarkOpened: vi.fn(),
+  mockUpdateProgress: vi.fn(),
+  mockGetArticleContent: vi.fn(),
+  mockListTags: vi.fn(),
   mockPreview: vi.fn(),
   mockSave: vi.fn(),
+  mockInitiateSyncJob: vi.fn(),
+  mockGetActiveSyncJob: vi.fn(),
+  mockGetJobStatus: vi.fn(),
+  mockGetSyncStatus: vi.fn(),
   mockFindUserItem: vi.fn(),
   mockUserItemUpdateSet: vi.fn(),
   mockConsumptionInsertValues: vi.fn(),
@@ -47,7 +74,25 @@ vi.mock('../trpc/router', () => ({
   },
 }));
 
+vi.mock('../sync/service', async () => {
+  class RateLimitError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'RateLimitError';
+    }
+  }
+
+  return {
+    initiateSyncJob: mockInitiateSyncJob,
+    getActiveSyncJob: mockGetActiveSyncJob,
+    getJobStatus: mockGetJobStatus,
+    getSyncStatus: mockGetSyncStatus,
+    RateLimitError,
+  };
+});
+
 import apiV1Routes from './api-v1';
+import { RateLimitError } from '../sync/service';
 
 type JsonBody = Record<string, unknown>;
 
@@ -147,6 +192,15 @@ describe('apiV1Routes', () => {
       items: {
         inbox: mockInbox,
         library: mockLibrary,
+        get: mockGetItem,
+        bookmark: mockBookmarkInboxItem,
+        archive: mockArchiveInboxItem,
+        unbookmark: mockUnbookmark,
+        setTags: mockSetTags,
+        markOpened: mockMarkOpened,
+        updateProgress: mockUpdateProgress,
+        getArticleContent: mockGetArticleContent,
+        listTags: mockListTags,
       },
       bookmarks: {
         preview: mockPreview,
@@ -164,8 +218,19 @@ describe('apiV1Routes', () => {
     const body = (await res.json()) as JsonBody;
     expect(body.openapi).toBe('3.1.0');
     expect(body.paths).toHaveProperty('/api/v1/inbox');
+    expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/bookmark');
+    expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/archive');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/preview');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/tags');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/opened');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/progress');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/article-content');
+    expect(body.paths).toHaveProperty('/api/v1/tags');
+    expect(body.paths).toHaveProperty('/api/v1/sync-jobs');
+    expect(body.paths).toHaveProperty('/api/v1/sync-jobs/{jobId}');
+    expect(body.paths).toHaveProperty('/api/v1/sync-jobs/active');
   });
 
   it('returns 401 for missing and invalid tokens', async () => {
@@ -243,6 +308,235 @@ describe('apiV1Routes', () => {
     expect(mockInbox).not.toHaveBeenCalled();
   });
 
+  it('starts a sync job for tokens with sync write scope', async () => {
+    mockDbToken(createTokenRecord(['sync:write']));
+    mockInitiateSyncJob.mockResolvedValue({
+      jobId: 'job_1',
+      total: 2,
+      existing: false,
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(202);
+    expect(mockInitiateSyncJob).toHaveBeenCalledWith(
+      'user_123',
+      expect.anything(),
+      expect.objectContaining({ ENVIRONMENT: 'test' }),
+      expect.objectContaining({
+        requestId: 'test-request-id',
+        traceId: 'test-trace-id',
+        source: 'api.v1.syncJobs.create',
+      })
+    );
+    expect((await res.json()) as JsonBody).toMatchObject({
+      jobId: 'job_1',
+      total: 2,
+      existing: false,
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
+  it('returns 403 when starting a sync job without sync write scope', async () => {
+    mockDbToken(createTokenRecord(['sync:read']));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(403);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockInitiateSyncJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects request bodies for sync job creation until source filtering is supported', async () => {
+    mockDbToken(createTokenRecord(['sync:write']));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ sources: ['YOUTUBE'] }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'INVALID_REQUEST_BODY' });
+    expect(mockInitiateSyncJob).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON when starting a sync job', async () => {
+    mockDbToken(createTokenRecord(['sync:write']));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: '{',
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'INVALID_REQUEST_BODY' });
+    expect(mockInitiateSyncJob).not.toHaveBeenCalled();
+  });
+
+  it('maps sync job rate limits to 429', async () => {
+    mockDbToken(createTokenRecord(['sync:write']));
+    mockInitiateSyncJob.mockRejectedValue(new RateLimitError('Please wait 90 seconds'));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('90');
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'RATE_LIMITED',
+      error: 'Please wait 90 seconds',
+      retryAfterSeconds: 90,
+    });
+  });
+
+  it('returns the active sync job for tokens with sync read scope', async () => {
+    mockDbToken(createTokenRecord(['sync:read']));
+    mockGetActiveSyncJob.mockResolvedValue({
+      inProgress: true,
+      jobId: 'job_1',
+      progress: { total: 2, completed: 1, status: 'processing' },
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs/active', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetActiveSyncJob).toHaveBeenCalledWith('user_123', expect.anything());
+    expect((await res.json()) as JsonBody).toMatchObject({
+      inProgress: true,
+      jobId: 'job_1',
+      progress: { total: 2, completed: 1, status: 'processing' },
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
+  it('returns sync job status for tokens with sync read scope', async () => {
+    mockDbToken(createTokenRecord(['sync:read']));
+    mockGetJobStatus.mockResolvedValue({
+      jobId: 'job_1',
+      userId: 'user_123',
+      status: 'completed',
+      total: 2,
+      completed: 2,
+      succeeded: 2,
+      failed: 0,
+      itemsFound: 3,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      errors: [],
+    });
+    mockGetSyncStatus.mockResolvedValue({
+      jobId: 'job_1',
+      status: 'completed',
+      total: 2,
+      completed: 2,
+      succeeded: 2,
+      failed: 0,
+      itemsFound: 3,
+      progress: 100,
+      errors: [],
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs/job_1', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetJobStatus).toHaveBeenCalledWith('job_1', expect.anything());
+    expect(mockGetSyncStatus).toHaveBeenCalledWith('job_1', expect.anything());
+    expect((await res.json()) as JsonBody).toMatchObject({
+      jobId: 'job_1',
+      status: 'completed',
+      total: 2,
+      completed: 2,
+      succeeded: 2,
+      failed: 0,
+      itemsFound: 3,
+      progress: 100,
+      errors: [],
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
+  it('returns 404 for missing or foreign sync jobs', async () => {
+    mockDbToken(createTokenRecord(['sync:read']));
+    mockGetJobStatus.mockResolvedValue({
+      jobId: 'job_1',
+      userId: 'someone_else',
+      status: 'processing',
+      total: 2,
+      completed: 1,
+      succeeded: 1,
+      failed: 0,
+      itemsFound: 1,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      errors: [],
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/sync-jobs/job_1', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'SYNC_JOB_NOT_FOUND',
+    });
+    expect(mockGetSyncStatus).not.toHaveBeenCalled();
+  });
+
   it('lists inbox items for the token owner', async () => {
     mockInbox.mockResolvedValue({
       items: [{ id: 'ui_inbox_1', title: 'Inbox item' }],
@@ -314,6 +608,8 @@ describe('apiV1Routes', () => {
       cursor: 'abc',
       search: 'recent',
       filter: {
+        provider: undefined,
+        contentType: undefined,
         isFinished: undefined,
       },
     });
@@ -321,6 +617,173 @@ describe('apiV1Routes', () => {
       items: [{ title: 'Recent bookmark' }],
       nextCursor: 'next-cursor',
     });
+  });
+
+  it('passes bookmark provider and content type filters to the library caller', async () => {
+    mockLibrary.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request(
+        'http://localhost/api/v1/bookmarks?provider=WEB&contentType=ARTICLE&isFinished=true',
+        {
+          headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+        }
+      ),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockLibrary).toHaveBeenCalledWith({
+      limit: 10,
+      cursor: undefined,
+      search: undefined,
+      filter: {
+        provider: Provider.WEB,
+        contentType: ContentType.ARTICLE,
+        isFinished: true,
+      },
+    });
+  });
+
+  it('rejects invalid bookmark filters', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks?contentType=BOOK', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_QUERY_PARAMETERS',
+    });
+    expect(mockLibrary).not.toHaveBeenCalled();
+  });
+
+  it('moves an inbox item to bookmarks', async () => {
+    mockBookmarkInboxItem.mockResolvedValue({ success: true });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/inbox/ui_inbox_1/bookmark', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockBookmarkInboxItem).toHaveBeenCalledWith({ id: 'ui_inbox_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      success: true,
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
+  it('archives an inbox item', async () => {
+    mockArchiveInboxItem.mockResolvedValue({ success: true });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/inbox/ui_inbox_1/archive', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockArchiveInboxItem).toHaveBeenCalledWith({ id: 'ui_inbox_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({ success: true });
+  });
+
+  it('maps tRPC not found errors to REST 404 responses', async () => {
+    mockGetItem.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'Item missing not found' })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/missing', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(404);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'NOT_FOUND',
+      error: 'Item missing not found',
+    });
+  });
+
+  it('previews a bookmark URL without saving it', async () => {
+    mockPreview.mockResolvedValue({
+      provider: Provider.WEB,
+      contentType: ContentType.ARTICLE,
+      providerId: 'https://example.com/article',
+      title: 'Preview title',
+      creator: 'Example',
+      creatorImageUrl: null,
+      thumbnailUrl: null,
+      duration: null,
+      canonicalUrl: 'https://example.com/article',
+      description: 'Preview summary',
+      siteName: 'Example',
+      wordCount: 500,
+      readingTimeMinutes: 3,
+      publishedAt: null,
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/preview', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ url: 'https://example.com/article' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPreview).toHaveBeenCalledWith({ url: 'https://example.com/article' });
+    expect(mockSave).not.toHaveBeenCalled();
+    expect((await res.json()) as JsonBody).toMatchObject({
+      item: {
+        title: 'Preview title',
+        wordCount: 500,
+      },
+    });
+  });
+
+  it('returns 422 when bookmark preview cannot resolve the URL', async () => {
+    mockPreview.mockResolvedValue(null);
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/preview', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ url: 'https://example.com/unsupported' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(422);
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'UNSUPPORTED_URL' });
   });
 
   it('previews and saves a bookmark URL for tokens with write scope', async () => {
@@ -373,6 +836,34 @@ describe('apiV1Routes', () => {
     });
   });
 
+  it('gets a bookmark by ID', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_1',
+      itemId: 'item_1',
+      title: 'Detailed bookmark',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetItem).toHaveBeenCalledWith({ id: 'ui_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      item: {
+        id: 'ui_1',
+        itemId: 'item_1',
+        title: 'Detailed bookmark',
+      },
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
   it('marks a bookmark as finished for tokens with write scope', async () => {
     mockFindUserItem.mockResolvedValue(createBookmarkRecord());
     const app = createTestApp();
@@ -414,6 +905,237 @@ describe('apiV1Routes', () => {
         itemId: 'item_1',
         isFinished: true,
       },
+    });
+  });
+
+  it('removes a bookmark', async () => {
+    mockUnbookmark.mockResolvedValue({ success: true });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUnbookmark).toHaveBeenCalledWith({ id: 'ui_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({ success: true });
+  });
+
+  it('maps unbookmark bad request errors to REST 400 responses', async () => {
+    mockUnbookmark.mockRejectedValue(
+      new TRPCError({ code: 'BAD_REQUEST', message: 'Item is not bookmarked' })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_inbox', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'BAD_REQUEST',
+      error: 'Item is not bookmarked',
+    });
+  });
+
+  it('replaces bookmark tags', async () => {
+    mockSetTags.mockResolvedValue({
+      success: true,
+      tags: [
+        { id: 'tag_1', name: 'design' },
+        { id: 'tag_2', name: 'api' },
+      ],
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/tags', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tags: ['design', 'api'] }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockSetTags).toHaveBeenCalledWith({ id: 'ui_1', tags: ['design', 'api'] });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      success: true,
+      tags: [{ name: 'design' }, { name: 'api' }],
+    });
+  });
+
+  it('rejects invalid bookmark tags bodies', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/tags', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tags: Array.from({ length: 21 }, (_, index) => `tag-${index}`) }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_REQUEST_BODY',
+    });
+    expect(mockSetTags).not.toHaveBeenCalled();
+  });
+
+  it('records bookmark open events', async () => {
+    mockMarkOpened.mockResolvedValue({
+      success: true,
+      updated: true,
+      lastOpenedAt: '2026-01-02T00:00:00.000Z',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/opened', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockMarkOpened).toHaveBeenCalledWith({ id: 'ui_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      success: true,
+      updated: true,
+      lastOpenedAt: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('returns null lastOpenedAt when mark opened does not update the item', async () => {
+    mockMarkOpened.mockResolvedValue({ success: true, updated: false });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/opened', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      success: true,
+      updated: false,
+      lastOpenedAt: null,
+    });
+  });
+
+  it('updates bookmark progress', async () => {
+    mockUpdateProgress.mockResolvedValue({ success: true });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/progress', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ position: 125.4, duration: 600 }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProgress).toHaveBeenCalledWith({
+      id: 'ui_1',
+      position: 125.4,
+      duration: 600,
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({ success: true });
+  });
+
+  it('rejects invalid progress bodies', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/progress', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ position: -1, duration: 600 }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_REQUEST_BODY',
+    });
+    expect(mockUpdateProgress).not.toHaveBeenCalled();
+  });
+
+  it('gets bookmark article content by resolving the user item first', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_1',
+      itemId: 'item_1',
+      title: 'Article',
+    });
+    mockGetArticleContent.mockResolvedValue({ content: '<article>Body</article>' });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetItem).toHaveBeenCalledWith({ id: 'ui_1' });
+    expect(mockGetArticleContent).toHaveBeenCalledWith({ itemId: 'item_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      content: '<article>Body</article>',
+    });
+  });
+
+  it('lists tags', async () => {
+    mockListTags.mockResolvedValue({
+      tags: [
+        { id: 'tag_1', name: 'design' },
+        { id: 'tag_2', name: 'api' },
+      ],
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/tags', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockListTags).toHaveBeenCalledWith();
+    expect((await res.json()) as JsonBody).toMatchObject({
+      tags: [{ name: 'design' }, { name: 'api' }],
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
     });
   });
 

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import type { MiddlewareHandler } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
+import { TRPCError } from '@trpc/server';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { ulid } from 'ulid';
@@ -9,6 +10,14 @@ import { createDb } from '../db';
 import { apiTokens, userItemConsumptionEvents, userItems } from '../db/schema';
 import { appRouter } from '../trpc/router';
 import { createContext } from '../trpc/context';
+import openApiSpec from './api-v1.openapi.json';
+import {
+  getActiveSyncJob,
+  getJobStatus,
+  getSyncStatus,
+  initiateSyncJob,
+  RateLimitError,
+} from '../sync/service';
 import {
   type ApiTokenScope,
   API_TOKEN_PREFIX,
@@ -28,6 +37,26 @@ const InboxQuerySchema = z.object({
   provider: ProviderSchema.optional(),
   contentType: ContentTypeSchema.optional(),
 });
+
+const BookmarkQuerySchema = z.object({
+  provider: ProviderSchema.optional(),
+  contentType: ContentTypeSchema.optional(),
+});
+
+const SyncJobBodySchema = z.object({}).strict().optional();
+
+const SetTagsBodySchema = z
+  .object({
+    tags: z.array(z.string().min(1).max(64)).max(20),
+  })
+  .strict();
+
+const UpdateProgressBodySchema = z
+  .object({
+    position: z.number().min(0),
+    duration: z.number().min(0),
+  })
+  .strict();
 
 const FinishBookmarkBodySchema = z
   .object({
@@ -91,162 +120,90 @@ function parseBoolean(value: string | undefined): boolean | undefined {
   return undefined;
 }
 
-function openApiSpec() {
+function getRetryAfterSeconds(message: string): number | undefined {
+  const match = message.match(/wait (\d+) seconds/i);
+  if (!match) {
+    return undefined;
+  }
+
+  const seconds = Number.parseInt(match[1], 10);
+  return Number.isFinite(seconds) ? seconds : undefined;
+}
+
+function toPreviewItem(preview: {
+  provider: string;
+  contentType: string;
+  providerId: string;
+  title: string;
+  creator: string;
+  creatorImageUrl?: string | null;
+  thumbnailUrl: string | null;
+  duration: number | null;
+  canonicalUrl: string;
+  description?: string | null;
+  siteName?: string | null;
+  wordCount?: number | null;
+  readingTimeMinutes?: number | null;
+  publishedAt?: string | null;
+}) {
   return {
-    openapi: '3.1.0',
-    info: {
-      title: 'Zine API',
-      version: '1.0.0',
-      description: 'REST API for personal access token access to Zine bookmarks.',
-    },
-    servers: [{ url: 'https://api.myzine.app' }],
-    security: [{ bearerAuth: [] }],
-    paths: {
-      '/api/v1/inbox': {
-        get: {
-          operationId: 'listInbox',
-          summary: 'List inbox items',
-          parameters: [
-            {
-              name: 'limit',
-              in: 'query',
-              schema: {
-                type: 'integer',
-                minimum: 1,
-                maximum: MAX_BOOKMARKS_LIMIT,
-                default: DEFAULT_BOOKMARKS_LIMIT,
-              },
-            },
-            { name: 'cursor', in: 'query', schema: { type: 'string' } },
-            {
-              name: 'provider',
-              in: 'query',
-              schema: {
-                type: 'string',
-                enum: Object.values(ProviderSchema.enum),
-              },
-            },
-            {
-              name: 'contentType',
-              in: 'query',
-              schema: {
-                type: 'string',
-                enum: Object.values(ContentTypeSchema.enum),
-              },
-            },
-          ],
-          responses: {
-            '200': { description: 'Inbox items' },
-            '400': { description: 'Invalid query parameters' },
-            '401': { description: 'Missing or invalid personal access token' },
-            '403': { description: 'Token is missing bookmarks:read scope' },
-          },
-        },
-      },
-      '/api/v1/bookmarks': {
-        get: {
-          operationId: 'listBookmarks',
-          summary: 'List bookmarks',
-          parameters: [
-            {
-              name: 'limit',
-              in: 'query',
-              schema: {
-                type: 'integer',
-                minimum: 1,
-                maximum: MAX_BOOKMARKS_LIMIT,
-                default: DEFAULT_BOOKMARKS_LIMIT,
-              },
-            },
-            { name: 'cursor', in: 'query', schema: { type: 'string' } },
-            { name: 'search', in: 'query', schema: { type: 'string' } },
-            {
-              name: 'isFinished',
-              in: 'query',
-              schema: { type: 'boolean', default: false },
-            },
-          ],
-          responses: {
-            '200': { description: 'Bookmarks' },
-            '401': { description: 'Missing or invalid personal access token' },
-            '403': { description: 'Token is missing bookmarks:read scope' },
-          },
-        },
-        post: {
-          operationId: 'saveBookmark',
-          summary: 'Save a URL as a bookmark',
-          requestBody: {
-            required: true,
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  required: ['url'],
-                  properties: {
-                    url: { type: 'string', format: 'uri' },
-                  },
-                },
-              },
-            },
-          },
-          responses: {
-            '200': { description: 'Bookmark saved or already present' },
-            '400': { description: 'Invalid request body' },
-            '401': { description: 'Missing or invalid personal access token' },
-            '403': { description: 'Token is missing bookmarks:write scope' },
-            '422': { description: 'URL could not be previewed or saved' },
-          },
-        },
-      },
-      '/api/v1/bookmarks/{id}': {
-        patch: {
-          operationId: 'updateBookmarkFinishedState',
-          summary: 'Mark a bookmark as finished or unfinished',
-          parameters: [
-            {
-              name: 'id',
-              in: 'path',
-              required: true,
-              schema: { type: 'string' },
-            },
-          ],
-          requestBody: {
-            required: true,
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    isFinished: { type: 'boolean' },
-                    finished: { type: 'boolean' },
-                    completed: { type: 'boolean' },
-                    read: { type: 'boolean' },
-                  },
-                  minProperties: 1,
-                  maxProperties: 1,
-                },
-              },
-            },
-          },
-          responses: {
-            '200': { description: 'Bookmark finished state updated' },
-            '400': { description: 'Invalid request body' },
-            '401': { description: 'Missing or invalid personal access token' },
-            '403': { description: 'Token is missing bookmarks:write scope' },
-            '404': { description: 'Bookmark not found' },
-          },
-        },
-      },
-    },
-    components: {
-      securitySchemes: {
-        bearerAuth: {
-          type: 'http',
-          scheme: 'bearer',
-        },
-      },
-    },
+    provider: preview.provider,
+    contentType: preview.contentType,
+    providerId: preview.providerId,
+    title: preview.title,
+    creator: preview.creator,
+    creatorImageUrl: preview.creatorImageUrl ?? null,
+    thumbnailUrl: preview.thumbnailUrl,
+    duration: preview.duration,
+    canonicalUrl: preview.canonicalUrl,
+    description: preview.description ?? null,
+    siteName: preview.siteName ?? null,
+    wordCount: preview.wordCount ?? null,
+    readingTimeMinutes: preview.readingTimeMinutes ?? null,
+    publishedAt: preview.publishedAt ?? null,
   };
+}
+
+function trpcErrorResponse(c: Context<Env>, error: unknown) {
+  if (error instanceof TRPCError) {
+    if (error.code === 'NOT_FOUND') {
+      return c.json(
+        {
+          error: error.message,
+          code: 'NOT_FOUND',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        404
+      );
+    }
+
+    if (error.code === 'BAD_REQUEST') {
+      return c.json(
+        {
+          error: error.message,
+          code: 'BAD_REQUEST',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+
+    if (error.code === 'UNAUTHORIZED') {
+      return c.json(
+        {
+          error: 'Unauthorized',
+          code: 'UNAUTHORIZED',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        401
+      );
+    }
+  }
+
+  throw error;
 }
 
 function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
@@ -311,7 +268,159 @@ function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
 
 const apiV1Routes = new Hono<Env>();
 
-apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec()));
+apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec));
+
+apiV1Routes.post('/sync-jobs', personalAccessTokenAuth('sync:write'), async (c) => {
+  let body: unknown;
+  const contentLength = c.req.header('content-length');
+  const hasPositiveContentLength =
+    contentLength !== undefined && Number.parseInt(contentLength, 10) > 0;
+  const hasJsonBody =
+    hasPositiveContentLength ||
+    (contentLength === undefined && c.req.header('content-type')?.includes('application/json'));
+
+  if (hasJsonBody) {
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        {
+          error: 'Invalid request body',
+          code: 'INVALID_REQUEST_BODY',
+          issues: [{ message: 'Expected a valid JSON request body' }],
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+  }
+
+  const parsedBody = SyncJobBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const userId = c.get('userId');
+  if (!userId) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  try {
+    const result = await initiateSyncJob(userId, createDb(c.env.DB), c.env, {
+      traceId: c.get('traceId'),
+      requestId: c.get('requestId'),
+      clientRequestId: c.get('clientRequestId'),
+      source: 'api.v1.syncJobs.create',
+    });
+
+    return c.json(
+      {
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      202
+    );
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      const retryAfterSeconds = getRetryAfterSeconds(error.message);
+      if (retryAfterSeconds !== undefined) {
+        c.header('Retry-After', String(retryAfterSeconds));
+      }
+
+      return c.json(
+        {
+          error: error.message,
+          code: 'RATE_LIMITED',
+          retryAfterSeconds,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        429
+      );
+    }
+    throw error;
+  }
+});
+
+apiV1Routes.get('/sync-jobs/active', personalAccessTokenAuth('sync:read'), async (c) => {
+  const userId = c.get('userId');
+  if (!userId) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const result = await getActiveSyncJob(userId, c.env.OAUTH_STATE_KV);
+
+  return c.json({
+    ...result,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.get('/sync-jobs/:jobId', personalAccessTokenAuth('sync:read'), async (c) => {
+  const userId = c.get('userId');
+  if (!userId) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const jobId = c.req.param('jobId');
+  const storedStatus = await getJobStatus(jobId, c.env.OAUTH_STATE_KV);
+  if (!storedStatus || storedStatus.userId !== userId) {
+    return c.json(
+      {
+        error: 'Sync job not found',
+        code: 'SYNC_JOB_NOT_FOUND',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      404
+    );
+  }
+
+  const result = await getSyncStatus(jobId, c.env.OAUTH_STATE_KV);
+
+  return c.json({
+    ...result,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
 
 apiV1Routes.get('/inbox', personalAccessTokenAuth('bookmarks:read'), async (c) => {
   const parsedQuery = InboxQuerySchema.safeParse({
@@ -352,7 +461,55 @@ apiV1Routes.get('/inbox', personalAccessTokenAuth('bookmarks:read'), async (c) =
   });
 });
 
+apiV1Routes.post('/inbox/:id/bookmark', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.bookmark({ id: c.req.param('id') });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/inbox/:id/archive', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.archive({ id: c.req.param('id') });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
 apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+  const parsedQuery = BookmarkQuerySchema.safeParse({
+    provider: c.req.query('provider'),
+    contentType: c.req.query('contentType'),
+  });
+
+  if (!parsedQuery.success) {
+    return c.json(
+      {
+        error: 'Invalid query parameters',
+        code: 'INVALID_QUERY_PARAMETERS',
+        issues: parsedQuery.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
   const caller = appRouter.createCaller(await createContext(c));
   const cursor = c.req.query('cursor');
   const search = c.req.query('search')?.trim();
@@ -363,6 +520,8 @@ apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (
     cursor: cursor && cursor.length > 0 ? cursor : undefined,
     search: search && search.length > 0 ? search : undefined,
     filter: {
+      provider: parsedQuery.data.provider,
+      contentType: parsedQuery.data.contentType,
       isFinished,
     },
   });
@@ -373,6 +532,50 @@ apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),
   });
+});
+
+apiV1Routes.post('/bookmarks/preview', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = SaveBookmarkBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const preview = await caller.bookmarks.preview({ url: parsedBody.data.url });
+
+    if (!preview) {
+      return c.json(
+        {
+          error: 'URL could not be previewed',
+          code: 'UNSUPPORTED_URL',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        422
+      );
+    }
+
+    return c.json({
+      item: toPreviewItem(preview),
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
 });
 
 apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async (c) => {
@@ -414,25 +617,25 @@ apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async
 
   return c.json({
     bookmark,
-    item: {
-      provider: preview.provider,
-      contentType: preview.contentType,
-      providerId: preview.providerId,
-      title: preview.title,
-      creator: preview.creator,
-      creatorImageUrl: preview.creatorImageUrl ?? null,
-      thumbnailUrl: preview.thumbnailUrl,
-      duration: preview.duration,
-      canonicalUrl: preview.canonicalUrl,
-      description: preview.description ?? null,
-      siteName: preview.siteName ?? null,
-      wordCount: preview.wordCount ?? null,
-      readingTimeMinutes: preview.readingTimeMinutes ?? null,
-      publishedAt: preview.publishedAt ?? null,
-    },
+    item: toPreviewItem(preview),
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),
   });
+});
+
+apiV1Routes.get('/bookmarks/:id', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const item = await caller.items.get({ id: c.req.param('id') });
+    return c.json({
+      item,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
 });
 
 apiV1Routes.patch('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), async (c) => {
@@ -524,6 +727,141 @@ apiV1Routes.patch('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), 
       isFinished,
       finishedAt,
     },
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.delete('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.unbookmark({ id: c.req.param('id') });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.put('/bookmarks/:id/tags', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = SetTagsBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.setTags({
+      id: c.req.param('id'),
+      tags: parsedBody.data.tags,
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/bookmarks/:id/opened', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.markOpened({ id: c.req.param('id') });
+    return c.json({
+      ...result,
+      lastOpenedAt: 'lastOpenedAt' in result ? result.lastOpenedAt : null,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.put(
+  '/bookmarks/:id/progress',
+  personalAccessTokenAuth('bookmarks:write'),
+  async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsedBody = UpdateProgressBodySchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json(
+        {
+          error: 'Invalid request body',
+          code: 'INVALID_REQUEST_BODY',
+          issues: parsedBody.error.issues,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+
+    const caller = appRouter.createCaller(await createContext(c));
+
+    try {
+      const result = await caller.items.updateProgress({
+        id: c.req.param('id'),
+        position: parsedBody.data.position,
+        duration: parsedBody.data.duration,
+      });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  }
+);
+
+apiV1Routes.get(
+  '/bookmarks/:id/article-content',
+  personalAccessTokenAuth('bookmarks:read'),
+  async (c) => {
+    const caller = appRouter.createCaller(await createContext(c));
+
+    try {
+      const item = await caller.items.get({ id: c.req.param('id') });
+      const result = await caller.items.getArticleContent({ itemId: item.itemId });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  }
+);
+
+apiV1Routes.get('/tags', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  const result = await caller.items.listTags();
+  return c.json({
+    ...result,
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),
   });

--- a/docs/api/openapi.proposed.json
+++ b/docs/api/openapi.proposed.json
@@ -1,0 +1,1749 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Zine REST API - Proposed",
+    "version": "1.1.0-draft",
+    "description": "Implemented REST API contract based on the REST vs tRPC gap analysis. Includes bookmark and inbox triage, preview, item detail, bookmark lifecycle, tags, article content, opened events, progress tracking, and subscription sync jobs."
+  },
+  "servers": [
+    {
+      "url": "https://api.myzine.app",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:8787",
+      "description": "Local worker development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Metadata",
+      "description": "API metadata and machine-readable documentation."
+    },
+    {
+      "name": "Inbox",
+      "description": "Read and triage unbookmarked inbox items."
+    },
+    {
+      "name": "Bookmarks",
+      "description": "Read, save, update, and remove bookmarked items."
+    },
+    {
+      "name": "Tags",
+      "description": "List and replace bookmark tags."
+    },
+    {
+      "name": "Reading",
+      "description": "Article content, opened events, and reading/playback progress."
+    },
+    {
+      "name": "Sync",
+      "description": "Trigger and inspect asynchronous subscription sync jobs."
+    }
+  ],
+  "paths": {
+    "/api/v1/openapi.json": {
+      "get": {
+        "tags": ["Metadata"],
+        "operationId": "getOpenApiSpec",
+        "summary": "Get the OpenAPI document",
+        "security": [],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "OpenAPI document for the Zine REST API."
+          }
+        }
+      }
+    },
+    "/api/v1/inbox": {
+      "get": {
+        "tags": ["Inbox"],
+        "operationId": "listInbox",
+        "summary": "List inbox items",
+        "description": "Returns unfinished items currently in the inbox, sorted by most recently ingested first.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Provider"
+          },
+          {
+            "$ref": "#/components/parameters/ContentType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItems"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/inbox/{id}/bookmark": {
+      "post": {
+        "tags": ["Inbox"],
+        "operationId": "bookmarkInboxItem",
+        "summary": "Move an inbox item to bookmarks",
+        "description": "REST equivalent of tRPC items.bookmark for inbox triage clients.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item moved to bookmarks.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/inbox/{id}/archive": {
+      "post": {
+        "tags": ["Inbox"],
+        "operationId": "archiveInboxItem",
+        "summary": "Archive an inbox item",
+        "description": "REST equivalent of tRPC items.archive for dismissing inbox items.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item archived.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "listBookmarks",
+        "summary": "List bookmarks",
+        "description": "Returns bookmarked items, sorted by most recently bookmarked first. Supports provider and contentType filters to match tRPC items.library.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Limit"
+          },
+          {
+            "$ref": "#/components/parameters/Cursor"
+          },
+          {
+            "$ref": "#/components/parameters/Search"
+          },
+          {
+            "name": "isFinished",
+            "in": "query",
+            "description": "When true, returns finished bookmarks. When false or omitted, returns unfinished bookmarks.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Provider"
+          },
+          {
+            "$ref": "#/components/parameters/ContentType"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmarked items.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedItems"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Bookmarks"],
+        "operationId": "saveBookmark",
+        "summary": "Save a URL as a bookmark",
+        "description": "Fetches a preview for the URL, creates or reuses the canonical item, and saves it as a bookmark for the token owner.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveBookmarkRequest"
+              },
+              "examples": {
+                "webArticle": {
+                  "value": {
+                    "url": "https://example.com/article"
+                  }
+                },
+                "xPost": {
+                  "value": {
+                    "url": "https://x.com/example/status/1234567890"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark saved, restored, or already present.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveBookmarkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnsupportedUrl"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/preview": {
+      "post": {
+        "tags": ["Bookmarks"],
+        "operationId": "previewBookmarkUrl",
+        "summary": "Preview a URL before saving",
+        "description": "Read-only REST equivalent of tRPC bookmarks.preview for clients that want confirmation UI before saving.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveBookmarkRequest"
+              },
+              "examples": {
+                "webArticle": {
+                  "value": {
+                    "url": "https://example.com/article"
+                  }
+                },
+                "xPost": {
+                  "value": {
+                    "url": "https://x.com/example/status/1234567890"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Preview metadata for the URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewBookmarkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnsupportedUrl"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "getBookmark",
+        "summary": "Get a bookmark",
+        "description": "REST equivalent of tRPC items.get for a single bookmarked item.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark item.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Bookmarks"],
+        "operationId": "updateBookmarkFinishedState",
+        "summary": "Mark a bookmark as finished or unfinished",
+        "description": "Sets the finished state for a bookmarked item; idempotent when the requested state already matches the stored state.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBookmarkFinishedStateRequest"
+              },
+              "examples": {
+                "finished": {
+                  "value": {
+                    "isFinished": true
+                  }
+                },
+                "unreadAlias": {
+                  "value": {
+                    "read": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark finished state updated or already matched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBookmarkFinishedStateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Bookmarks"],
+        "operationId": "deleteBookmark",
+        "summary": "Remove a bookmark",
+        "description": "REST equivalent of tRPC items.unbookmark. Archives the user item and clears bookmarkedAt.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmark removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/tags": {
+      "put": {
+        "tags": ["Tags"],
+        "operationId": "setBookmarkTags",
+        "summary": "Replace tags on a bookmark",
+        "description": "REST equivalent of tRPC items.setTags.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTagsRequest"
+              },
+              "examples": {
+                "example": {
+                  "value": {
+                    "tags": ["design", "api"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tags replaced.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetTagsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/opened": {
+      "post": {
+        "tags": ["Reading"],
+        "operationId": "markBookmarkOpened",
+        "summary": "Record that a bookmark was opened",
+        "description": "REST equivalent of tRPC items.markOpened for detail views and external readers.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Open event recorded when applicable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MarkOpenedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/progress": {
+      "put": {
+        "tags": ["Reading"],
+        "operationId": "updateBookmarkProgress",
+        "summary": "Update reading or playback progress",
+        "description": "REST equivalent of tRPC items.updateProgress.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProgressRequest"
+              },
+              "examples": {
+                "video": {
+                  "value": {
+                    "position": 125.4,
+                    "duration": 600
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Progress updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/article-content": {
+      "get": {
+        "tags": ["Reading"],
+        "operationId": "getBookmarkArticleContent",
+        "summary": "Get stored article content",
+        "description": "REST equivalent of tRPC items.getArticleContent. Returns null content when no extracted article body is stored.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/UserItemId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stored article content.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArticleContentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/v1/tags": {
+      "get": {
+        "tags": ["Tags"],
+        "operationId": "listTags",
+        "summary": "List all tags",
+        "description": "REST equivalent of tRPC items.listTags.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "Tags for the token owner.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTagsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs": {
+      "post": {
+        "tags": ["Sync"],
+        "operationId": "createSyncJob",
+        "summary": "Trigger a subscription sync job",
+        "description": "REST endpoint for the existing asynchronous subscription sync process. The current implementation syncs active YouTube and Spotify subscriptions; source filtering and all-provider inbox refresh orchestration remain future work.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSyncJobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Sync job accepted, or an existing active job was returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncJobAccepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs/active": {
+      "get": {
+        "tags": ["Sync"],
+        "operationId": "getActiveSyncJob",
+        "summary": "Get the active sync job",
+        "description": "REST endpoint returning the token owner's active subscription sync job when one is still in progress.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "Active sync job state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveSyncJob"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/v1/sync-jobs/{jobId}": {
+      "get": {
+        "tags": ["Sync"],
+        "operationId": "getSyncJob",
+        "summary": "Get sync job status",
+        "description": "REST endpoint returning status for a sync job owned by the token owner.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "Sync job ID returned by POST /api/v1/sync-jobs.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sync job status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncJobStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Zine personal access token",
+        "description": "Use a Zine personal access token with the required operation scope."
+      }
+    },
+    "parameters": {
+      "Limit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Maximum number of items to return. Defaults to 10.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 10
+        }
+      },
+      "Cursor": {
+        "name": "cursor",
+        "in": "query",
+        "description": "Cursor returned by the previous page.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Search": {
+        "name": "search",
+        "in": "query",
+        "description": "Case-insensitive title or creator search.",
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        }
+      },
+      "Provider": {
+        "name": "provider",
+        "in": "query",
+        "description": "Filter items by source provider.",
+        "schema": {
+          "type": "string",
+          "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+        }
+      },
+      "ContentType": {
+        "name": "contentType",
+        "in": "query",
+        "description": "Filter items by content type.",
+        "schema": {
+          "type": "string",
+          "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+        }
+      },
+      "UserItemId": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "description": "User item ID.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "ValidationError": {
+        "description": "Invalid request body or query parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Missing, malformed, expired, revoked, or unknown token.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Token is missing the required scope.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found for this token owner.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UnsupportedUrl": {
+        "description": "URL could not be previewed or is unsupported.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "A sync job was started too recently.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds to wait before retrying.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RateLimitError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "required": ["error", "code", "requestId", "traceId"],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error summary."
+          },
+          "code": {
+            "type": "string",
+            "description": "Stable machine-readable error code."
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "ValidationError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "issues": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "description": "Zod validation issues for the request."
+              }
+            }
+          }
+        ]
+      },
+      "RequestMetadata": {
+        "type": "object",
+        "required": ["requestId", "traceId"],
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "required": [
+          "id",
+          "itemId",
+          "title",
+          "thumbnailUrl",
+          "canonicalUrl",
+          "contentType",
+          "provider",
+          "creator",
+          "creatorImageUrl",
+          "creatorId",
+          "publisher",
+          "summary",
+          "duration",
+          "publishedAt",
+          "wordCount",
+          "readingTimeMinutes",
+          "state",
+          "ingestedAt",
+          "bookmarkedAt",
+          "lastOpenedAt",
+          "progress",
+          "isFinished",
+          "finishedAt",
+          "tags"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "User item ID."
+          },
+          "itemId": {
+            "type": "string",
+            "description": "Canonical item ID shared across users."
+          },
+          "title": {
+            "type": "string"
+          },
+          "thumbnailUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "contentType": {
+            "type": "string",
+            "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+          },
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "creator": {
+            "type": "string"
+          },
+          "creatorImageUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "creatorId": {
+            "type": ["string", "null"]
+          },
+          "publisher": {
+            "type": ["string", "null"]
+          },
+          "summary": {
+            "type": ["string", "null"]
+          },
+          "duration": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "publishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "wordCount": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "readingTimeMinutes": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "state": {
+            "type": "string",
+            "enum": ["INBOX", "BOOKMARKED", "ARCHIVED"]
+          },
+          "ingestedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "bookmarkedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "lastOpenedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "progress": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "required": ["position", "duration", "percent"],
+                "properties": {
+                  "position": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "duration": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "percent": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                  }
+                }
+              }
+            ]
+          },
+          "isFinished": {
+            "type": "boolean"
+          },
+          "finishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          }
+        }
+      },
+      "PaginatedItems": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["items", "nextCursor"],
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Item"
+                }
+              },
+              "nextCursor": {
+                "type": ["string", "null"],
+                "description": "Cursor to pass to the next request. Null means there are no more items."
+              }
+            }
+          }
+        ]
+      },
+      "ItemResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["item"],
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/Item"
+              }
+            }
+          }
+        ]
+      },
+      "SaveBookmarkRequest": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTP or HTTPS URL to save."
+          }
+        }
+      },
+      "PreviewItem": {
+        "type": "object",
+        "required": [
+          "provider",
+          "contentType",
+          "providerId",
+          "title",
+          "creator",
+          "creatorImageUrl",
+          "thumbnailUrl",
+          "duration",
+          "canonicalUrl",
+          "description",
+          "siteName",
+          "wordCount",
+          "readingTimeMinutes",
+          "publishedAt"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "contentType": {
+            "type": "string",
+            "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+          },
+          "providerId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "creatorImageUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "thumbnailUrl": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "duration": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "siteName": {
+            "type": ["string", "null"]
+          },
+          "wordCount": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "readingTimeMinutes": {
+            "type": ["integer", "null"],
+            "minimum": 0
+          },
+          "publishedAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PreviewBookmarkResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["item"],
+            "properties": {
+              "item": {
+                "$ref": "#/components/schemas/PreviewItem"
+              }
+            }
+          }
+        ]
+      },
+      "BookmarkSaveResult": {
+        "type": "object",
+        "required": ["itemId", "userItemId", "status"],
+        "properties": {
+          "itemId": {
+            "type": "string"
+          },
+          "userItemId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["created", "already_bookmarked", "rebookmarked"]
+          }
+        }
+      },
+      "SaveBookmarkResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["bookmark", "item"],
+            "properties": {
+              "bookmark": {
+                "$ref": "#/components/schemas/BookmarkSaveResult"
+              },
+              "item": {
+                "$ref": "#/components/schemas/PreviewItem"
+              }
+            }
+          }
+        ]
+      },
+      "UpdateBookmarkFinishedStateRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Provide exactly one alias. All aliases set the same bookmark finished state.",
+        "minProperties": 1,
+        "maxProperties": 1,
+        "properties": {
+          "isFinished": {
+            "type": "boolean"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "completed": {
+            "type": "boolean"
+          },
+          "read": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UpdateBookmarkFinishedStateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["bookmark"],
+            "properties": {
+              "bookmark": {
+                "type": "object",
+                "required": ["id", "itemId", "isFinished", "finishedAt"],
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "itemId": {
+                    "type": "string"
+                  },
+                  "isFinished": {
+                    "type": "boolean"
+                  },
+                  "finishedAt": {
+                    "type": ["string", "null"],
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ActionResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              }
+            }
+          }
+        ]
+      },
+      "SetTagsRequest": {
+        "type": "object",
+        "required": ["tags"],
+        "additionalProperties": false,
+        "properties": {
+          "tags": {
+            "type": "array",
+            "maxItems": 20,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          }
+        }
+      },
+      "SetTagsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success", "tags"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ListTagsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["tags"],
+            "properties": {
+              "tags": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Tag"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "MarkOpenedResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["success", "updated"],
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "const": true
+              },
+              "updated": {
+                "type": "boolean"
+              },
+              "lastOpenedAt": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              }
+            }
+          }
+        ]
+      },
+      "UpdateProgressRequest": {
+        "type": "object",
+        "required": ["position", "duration"],
+        "additionalProperties": false,
+        "properties": {
+          "position": {
+            "type": "number",
+            "minimum": 0
+          },
+          "duration": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      },
+      "ArticleContentResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RequestMetadata"
+          },
+          {
+            "type": "object",
+            "required": ["content"],
+            "properties": {
+              "content": {
+                "type": ["string", "null"],
+                "description": "Stored article HTML or null."
+              }
+            }
+          }
+        ]
+      },
+      "CreateSyncJobRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Reserved for future sync options. Omit the body or send an empty object in the current API.",
+        "properties": {}
+      },
+      "RateLimitError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Error"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "retryAfterSeconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Seconds to wait before retrying, when known."
+              }
+            }
+          }
+        ]
+      },
+      "SyncTelemetry": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Optional sync telemetry fields emitted by the worker."
+      },
+      "SyncJobAccepted": {
+        "type": "object",
+        "required": ["jobId", "total", "existing", "requestId", "traceId"],
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of subscriptions queued for the job."
+          },
+          "existing": {
+            "type": "boolean",
+            "description": "True when an active job already existed and was returned."
+          },
+          "telemetry": {
+            "$ref": "#/components/schemas/SyncTelemetry"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "ActiveSyncJob": {
+        "type": "object",
+        "required": ["inProgress", "requestId", "traceId"],
+        "properties": {
+          "inProgress": {
+            "type": "boolean"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "progress": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "completed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "status": {
+                "type": "string"
+              }
+            }
+          },
+          "telemetry": {
+            "$ref": "#/components/schemas/SyncTelemetry"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      },
+      "SyncJobStatus": {
+        "type": "object",
+        "required": [
+          "jobId",
+          "status",
+          "total",
+          "completed",
+          "succeeded",
+          "failed",
+          "itemsFound",
+          "progress",
+          "errors",
+          "requestId",
+          "traceId"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "processing", "completed", "failed", "partial"]
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "completed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "succeeded": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "failed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "itemsFound": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "progress": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "traceId": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/swagger-proposed.html
+++ b/docs/api/swagger-proposed.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Zine REST API - Proposed</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <style>
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+
+      .topbar {
+        display: none;
+      }
+
+      .swagger-ui .info {
+        margin: 32px 0 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({
+        url: './openapi.proposed.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        displayRequestDuration: true,
+        persistAuthorization: true,
+        tryItOutEnabled: false,
+        layout: 'BaseLayout'
+      });
+    </script>
+  </body>
+</html>

--- a/packages/shared/src/api-tokens.ts
+++ b/packages/shared/src/api-tokens.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod';
 
-export const ApiTokenScopeSchema = z.enum(['bookmarks:read', 'bookmarks:write']);
+export const ApiTokenScopeSchema = z.enum([
+  'bookmarks:read',
+  'bookmarks:write',
+  'sync:read',
+  'sync:write',
+]);
 export const ApiTokenScopesSchema = z
   .array(ApiTokenScopeSchema)
   .min(1)
-  .max(2)
+  .max(4)
   .refine((scopes) => new Set(scopes).size === scopes.length, {
     message: 'Scopes must be unique',
   });


### PR DESCRIPTION
## Summary
- implement the expanded REST API contract for inbox, bookmarks, tags, article content, progress, opened events, and sync jobs
- add current/proposed OpenAPI JSON artifacts plus Swagger review page
- add sync PAT scopes and expose them in the settings token form
- update REST route and settings tests for the new surface

## Validation
- bun run lint
- bun run design-system:check
- bun run format:check
- bun run typecheck
- bun run build
- bun run test
- bun run --cwd apps/worker test:run src/routes/api-v1.test.ts
- bun run test:worker:ci
- manual local curl verification across the REST endpoints with seeded local D1 data

## Notes
- The local global zine-api Codex skill at /Users/erikjohansson/.codex/skills/zine-api/SKILL.md was updated to document the new REST surface, but that file lives outside this repository and is not part of this PR.
