### PR TITLE
Add tags to manual bookmarks

### DIFF
--- a/apps/chrome-extension/public/popup.html
+++ b/apps/chrome-extension/public/popup.html
@@ -33,6 +33,11 @@
         <p id="pageUrl" class="page-url"></p>
       </section>
 
+      <label class="tags-field" for="tagsInput">
+        <span>Tags</span>
+        <input id="tagsInput" type="text" placeholder="reading, ideas, work" autocomplete="off" />
+      </label>
+
       <section id="statusPanel" class="status-panel neutral">
         <span id="statusDot" class="status-dot"></span>
         <p id="statusText">Ready when you are.</p>

--- a/apps/chrome-extension/public/styles.css
+++ b/apps/chrome-extension/public/styles.css
@@ -129,6 +129,7 @@ input:focus-visible {
 
 .page-panel,
 .notice,
+.tags-field,
 .settings-form {
   display: grid;
   gap: 12px;
@@ -166,6 +167,26 @@ input:focus-visible {
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.tags-field {
+  gap: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.tags-field input {
+  min-height: 38px;
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  padding: 0 12px;
+}
+
+.tags-field input::placeholder {
+  color: var(--text-dim);
 }
 
 .notice {

--- a/apps/chrome-extension/src/api.ts
+++ b/apps/chrome-extension/src/api.ts
@@ -17,6 +17,10 @@ export interface SaveBookmarkFailure {
 
 export type SaveBookmarkResult = SaveBookmarkSuccess | SaveBookmarkFailure;
 
+export interface SaveBookmarkOptions {
+  tags?: string[];
+}
+
 interface SaveBookmarkResponse {
   bookmark?: {
     status?: SaveBookmarkSuccess['status'];
@@ -44,7 +48,8 @@ function getEndpoint(settings: ExtensionSettings): string {
 
 export async function saveBookmarkUrl(
   settings: ExtensionSettings,
-  url: string
+  url: string,
+  options: SaveBookmarkOptions = {}
 ): Promise<SaveBookmarkResult> {
   if (!settings.token) {
     return {
@@ -63,13 +68,18 @@ export async function saveBookmarkUrl(
   }
 
   try {
+    const payload: { url: string; tags?: string[] } = { url };
+    if (options.tags && options.tags.length > 0) {
+      payload.tags = options.tags;
+    }
+
     const response = await fetch(getEndpoint(settings), {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${settings.token}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ url }),
+      body: JSON.stringify(payload),
     });
 
     const body = (await response.json().catch(() => ({}))) as SaveBookmarkResponse;

--- a/apps/chrome-extension/src/popup.ts
+++ b/apps/chrome-extension/src/popup.ts
@@ -18,6 +18,7 @@ const setupPanel = document.querySelector<HTMLElement>('#setupPanel');
 const statusPanel = document.querySelector<HTMLElement>('#statusPanel');
 const statusText = document.querySelector<HTMLParagraphElement>('#statusText');
 const openZine = document.querySelector<HTMLAnchorElement>('#openZine');
+const tagsInput = document.querySelector<HTMLInputElement>('#tagsInput');
 
 let activePage: ActivePage | null = null;
 
@@ -40,6 +41,7 @@ const ui = {
   statusPanel: requireElement(statusPanel, 'statusPanel'),
   statusText: requireElement(statusText, 'statusText'),
   openZine: requireElement(openZine, 'openZine'),
+  tagsInput: requireElement(tagsInput, 'tagsInput'),
 };
 
 function setStatus(state: SaveState, message: string): void {
@@ -80,6 +82,25 @@ function setResult(result: SaveBookmarkResult): void {
   }
 }
 
+export function parseBookmarkTags(input: string): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+
+  for (const tag of input.split(',')) {
+    const trimmed = tag.trim();
+    const key = trimmed.toLowerCase();
+
+    if (!trimmed || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    tags.push(trimmed);
+  }
+
+  return tags;
+}
+
 async function openOptionsPage(): Promise<void> {
   await new Promise<void>((resolve) => {
     extensionApi.runtime.openOptionsPage(resolve);
@@ -96,7 +117,8 @@ async function handleSave(): Promise<void> {
   setStatus('saving', 'Saving this page...');
 
   const settings = await loadSettings();
-  const result = await saveBookmarkUrl(settings, activePage.url);
+  const tags = parseBookmarkTags(ui.tagsInput.value);
+  const result = await saveBookmarkUrl(settings, activePage.url, { tags });
   setResult(result);
   ui.saveButton.disabled = false;
 

--- a/apps/mobile/app/add-link.tsx
+++ b/apps/mobile/app/add-link.tsx
@@ -34,10 +34,12 @@ import * as Haptics from 'expo-haptics';
 import Animated from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { normalizeTagKey, normalizeTagName, sanitizeTagNames } from '@zine/shared/tags';
 
 import { Colors, Typography, Spacing, Radius, Shadows, type ThemeColors } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { usePreview, useSaveBookmark, isValidUrl } from '@/hooks/use-bookmarks';
+import { useUserTags } from '@/hooks/use-items-trpc';
 import { LinkPreviewCard } from '@/components/link-preview-card';
 import { showSuccess, showError as showErrorToast } from '@/lib/toast-utils';
 
@@ -183,6 +185,8 @@ export default function AddLinkScreen() {
   // Input state
   const [url, setUrl] = useState('');
   const [debouncedUrl, setDebouncedUrl] = useState('');
+  const [tagQuery, setTagQuery] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [keyboardOverlap, setKeyboardOverlap] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
   const inputRef = useRef<TextInput>(null);
@@ -260,8 +264,29 @@ export default function AddLinkScreen() {
     enabled: isValidUrl(debouncedUrl),
   });
 
+  const { data: tagsData, isLoading: tagsLoading } = useUserTags();
+
   // Save mutation
   const { saveFromPreviewAsync, isPending: isSaving, reset: resetSaveMutation } = useSaveBookmark();
+
+  const allTags = useMemo(() => tagsData?.tags ?? [], [tagsData?.tags]);
+
+  const selectedTagKeys = useMemo(
+    () => new Set(selectedTags.map((tag) => normalizeTagKey(tag))),
+    [selectedTags]
+  );
+
+  const normalizedTagQuery = normalizeTagName(tagQuery);
+  const normalizedTagQueryKey = normalizeTagKey(tagQuery);
+
+  const filteredTags = useMemo(() => {
+    if (!normalizedTagQuery) return allTags;
+    return allTags.filter((tag) => normalizeTagKey(tag.name).includes(normalizedTagQueryKey));
+  }, [allTags, normalizedTagQuery, normalizedTagQueryKey]);
+
+  const canCreateTag =
+    normalizedTagQuery.length > 0 &&
+    !allTags.some((tag) => normalizeTagKey(tag.name) === normalizedTagQueryKey);
 
   // Determine current state
   const hasInput = url.trim().length > 0;
@@ -276,6 +301,24 @@ export default function AddLinkScreen() {
   // Can save when we have a valid preview, not fetching, and not currently saving
   const canSave = preview && !isFetchingPreview && !isSaving;
   const isKeyboardVisible = keyboardOverlap > 0;
+
+  const toggleTag = useCallback((name: string) => {
+    const normalizedName = normalizeTagName(name);
+    const normalizedKey = normalizeTagKey(normalizedName);
+
+    if (!normalizedName || normalizedName.length > 32) {
+      return;
+    }
+
+    setSelectedTags((previous) => {
+      const index = previous.findIndex((tag) => normalizeTagKey(tag) === normalizedKey);
+      if (index >= 0) {
+        return previous.filter((tag) => normalizeTagKey(tag) !== normalizedKey);
+      }
+
+      return sanitizeTagNames([...previous, normalizedName]);
+    });
+  }, []);
 
   // Handle paste from clipboard
   // Note: On iOS, the paste button triggers the system paste permission dialog
@@ -293,7 +336,9 @@ export default function AddLinkScreen() {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     try {
-      const result = await saveFromPreviewAsync(preview, url.trim());
+      const result = await saveFromPreviewAsync(preview, url.trim(), {
+        tags: selectedTags,
+      });
 
       // Show appropriate toast based on status
       switch (result.status) {
@@ -313,7 +358,7 @@ export default function AddLinkScreen() {
     } catch (error) {
       showErrorToast(toast, error, 'Failed to save link', 'addLink.save');
     }
-  }, [preview, url, saveFromPreviewAsync, toast, router]);
+  }, [preview, url, selectedTags, saveFromPreviewAsync, toast, router]);
 
   // Handle close
   const handleClose = useCallback(() => {
@@ -334,6 +379,125 @@ export default function AddLinkScreen() {
     resetSaveMutation();
     inputRef.current?.focus();
   }, [resetSaveMutation]);
+
+  const renderTagSelector = () => (
+    <View style={styles.tagsSection}>
+      <Text style={[styles.tagsTitle, { color: colors.text }]}>Tags</Text>
+      <TextInput
+        value={tagQuery}
+        onChangeText={setTagQuery}
+        placeholder="Add or search tags"
+        placeholderTextColor={colors.textTertiary}
+        style={[
+          styles.tagInput,
+          {
+            color: colors.text,
+            borderColor: colors.border,
+            backgroundColor: colors.backgroundSecondary,
+          },
+        ]}
+        autoCapitalize="none"
+        autoCorrect={false}
+        returnKeyType="done"
+        onSubmitEditing={() => {
+          if (!normalizedTagQuery) {
+            Keyboard.dismiss();
+            return;
+          }
+
+          toggleTag(normalizedTagQuery);
+          setTagQuery('');
+        }}
+        accessibilityLabel="Tag input"
+      />
+
+      <View style={styles.selectedTags}>
+        {selectedTags.length === 0 ? (
+          <Text style={[styles.emptyTagsText, { color: colors.textTertiary }]}>
+            No tags selected
+          </Text>
+        ) : (
+          selectedTags.map((tag) => (
+            <Pressable
+              key={normalizeTagKey(tag)}
+              onPress={() => toggleTag(tag)}
+              style={({ pressed }) => [
+                styles.selectedTagChip,
+                {
+                  backgroundColor: colors.buttonPrimary,
+                  opacity: pressed ? 0.85 : 1,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Remove ${tag} tag`}
+            >
+              <Text style={[styles.selectedTagText, { color: colors.buttonPrimaryText }]}>
+                {tag} ×
+              </Text>
+            </Pressable>
+          ))
+        )}
+      </View>
+
+      <View style={styles.tagOptions}>
+        {canCreateTag && (
+          <Pressable
+            onPress={() => {
+              toggleTag(normalizedTagQuery);
+              setTagQuery('');
+            }}
+            style={({ pressed }) => [
+              styles.tagOption,
+              {
+                backgroundColor: colors.backgroundSecondary,
+                borderColor: colors.border,
+                opacity: pressed ? 0.85 : 1,
+              },
+            ]}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.tagOptionText, { color: colors.text }]}>
+              {`Create "${normalizedTagQuery}"`}
+            </Text>
+          </Pressable>
+        )}
+
+        {tagsLoading ? (
+          <View style={styles.tagsLoading}>
+            <ActivityIndicator size="small" color={colors.primary} />
+          </View>
+        ) : filteredTags.length === 0 ? (
+          <Text style={[styles.emptyTagsText, { color: colors.textTertiary }]}>No tags yet</Text>
+        ) : (
+          filteredTags.map((tag) => {
+            const selected = selectedTagKeys.has(normalizeTagKey(tag.name));
+
+            return (
+              <Pressable
+                key={tag.id}
+                onPress={() => toggleTag(tag.name)}
+                style={({ pressed }) => [
+                  styles.tagOption,
+                  {
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: selected ? colors.primary : colors.border,
+                    opacity: pressed ? 0.85 : 1,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+              >
+                <Text style={[styles.tagOptionText, { color: colors.text }]}>{tag.name}</Text>
+                {selected && (
+                  <Text style={[styles.tagSelectedText, { color: colors.primary }]}>Selected</Text>
+                )}
+              </Pressable>
+            );
+          })
+        )}
+      </View>
+    </View>
+  );
 
   const renderSaveButton = () => (
     <Pressable
@@ -489,6 +653,8 @@ export default function AddLinkScreen() {
               </Animated.View>
             )}
           </View>
+
+          {renderTagSelector()}
         </ScrollView>
       </SafeAreaView>
       <View
@@ -572,6 +738,60 @@ const styles = StyleSheet.create({
   previewSection: {
     flex: 1,
     minHeight: 200,
+  },
+
+  // Tags
+  tagsSection: {
+    gap: Spacing.sm,
+    marginTop: Spacing.xl,
+  },
+  tagsTitle: {
+    ...Typography.titleSmall,
+  },
+  tagInput: {
+    ...Typography.bodyMedium,
+    borderWidth: 1,
+    borderRadius: Radius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+  },
+  selectedTags: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+  },
+  selectedTagChip: {
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xs,
+  },
+  selectedTagText: {
+    ...Typography.labelSmall,
+  },
+  tagOptions: {
+    gap: Spacing.sm,
+  },
+  tagOption: {
+    borderWidth: 1,
+    borderRadius: Radius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  tagOptionText: {
+    ...Typography.bodyMedium,
+  },
+  tagSelectedText: {
+    ...Typography.labelSmall,
+  },
+  tagsLoading: {
+    paddingVertical: Spacing.sm,
+    alignItems: 'center',
+  },
+  emptyTagsText: {
+    ...Typography.bodySmall,
   },
 
   // State containers

--- a/apps/mobile/hooks/use-bookmarks.test.ts
+++ b/apps/mobile/hooks/use-bookmarks.test.ts
@@ -542,6 +542,23 @@ describe('useSaveBookmark', () => {
         })
       );
     });
+
+    it('passes sanitized tags to mutateAsync', async () => {
+      const { result } = renderHook(() => useSaveBookmark());
+      const preview = createMockPreview();
+
+      await act(async () => {
+        await result.current.saveFromPreviewAsync(preview, undefined, {
+          tags: [' Design ', 'design', 'Mobile   UX'],
+        });
+      });
+
+      expect(mockSaveMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ['Design', 'Mobile UX'],
+        })
+      );
+    });
   });
 
   describe('cache invalidation', () => {
@@ -590,6 +607,7 @@ describe('useSaveBookmark', () => {
       expect(updatedLibrary.items[0].title).toBe(preview.title);
       expect(updatedLibrary.items[0].state).toBe(UserItemState.BOOKMARKED);
       expect(updatedLibrary.items[0].id.startsWith('temp-')).toBe(true);
+      expect(updatedLibrary.items[0].tags).toEqual([]);
 
       const homeUpdater = mockHomeSetData.mock.calls[0][1];
       const updatedHome = homeUpdater({
@@ -604,6 +622,55 @@ describe('useSaveBookmark', () => {
 
       expect(updatedHome.recentBookmarks[0].title).toBe(preview.title);
       expect(updatedHome.byContentType.videos[0].title).toBe(preview.title);
+    });
+
+    it('includes selected tags in optimistic library and home items', async () => {
+      const preview = createMockPreview();
+      const existingItem = createMockLibraryItem();
+
+      mockLibraryGetData.mockReturnValue({ items: [existingItem], nextCursor: null });
+      mockHomeGetData.mockReturnValue({
+        recentBookmarks: [existingItem],
+        jumpBackIn: [],
+        byContentType: {
+          videos: [existingItem],
+          podcasts: [],
+          articles: [],
+        },
+      });
+
+      const { result } = renderHook(() => useSaveBookmark());
+
+      await act(async () => {
+        await result.current.saveFromPreviewAsync(preview, undefined, {
+          tags: ['Design', 'design', 'Mobile UX'],
+        });
+      });
+
+      const libraryCall = mockLibrarySetData.mock.calls.find((call) => call[0] === undefined);
+      const libraryUpdater = libraryCall?.[1];
+      const updatedLibrary = libraryUpdater({ items: [existingItem], nextCursor: null });
+
+      expect(updatedLibrary.items[0].tags).toEqual([
+        { id: 'temp-tag-design', name: 'Design' },
+        { id: 'temp-tag-mobile ux', name: 'Mobile UX' },
+      ]);
+
+      const homeUpdater = mockHomeSetData.mock.calls[0][1];
+      const updatedHome = homeUpdater({
+        recentBookmarks: [existingItem],
+        jumpBackIn: [],
+        byContentType: {
+          videos: [existingItem],
+          podcasts: [],
+          articles: [],
+        },
+      });
+
+      expect(updatedHome.recentBookmarks[0].tags).toEqual([
+        { id: 'temp-tag-design', name: 'Design' },
+        { id: 'temp-tag-mobile ux', name: 'Mobile UX' },
+      ]);
     });
 
     it('removes matching inbox items during optimistic update', async () => {

--- a/apps/mobile/hooks/use-bookmarks.ts
+++ b/apps/mobile/hooks/use-bookmarks.ts
@@ -10,6 +10,7 @@
 
 import { trpc } from '../lib/trpc';
 import { ContentType, Provider, UserItemState, isValidUrl } from '@zine/shared';
+import { normalizeTagKey, sanitizeTagNames } from '@zine/shared/tags';
 import * as Crypto from 'expo-crypto';
 import {
   getHomeQueryInputsForContentType,
@@ -75,7 +76,12 @@ interface SaveBookmarkInput {
   // X/Twitter-specific fields
   publishedAt?: string;
   rawMetadata?: string;
+  tags?: string[];
 }
+
+type SaveFromPreviewOptions = {
+  tags?: string[];
+};
 
 type TrpcUtils = ReturnType<typeof trpc.useUtils>;
 
@@ -114,6 +120,10 @@ function createOptimisticItem(input: SaveBookmarkInput): LibraryItem {
   const now = new Date().toISOString();
   const tempUserItemId = `temp-${Crypto.randomUUID()}`;
   const tempItemId = `temp-${Crypto.randomUUID()}`;
+  const optimisticTags = sanitizeTagNames(input.tags ?? []).map((name) => ({
+    id: `temp-tag-${normalizeTagKey(name)}`,
+    name,
+  }));
 
   return {
     id: tempUserItemId,
@@ -139,7 +149,36 @@ function createOptimisticItem(input: SaveBookmarkInput): LibraryItem {
     progress: null,
     isFinished: false,
     finishedAt: null,
-    tags: [],
+    tags: optimisticTags,
+  };
+}
+
+function createSaveBookmarkInput(
+  preview: LinkPreview,
+  originalUrl?: string,
+  options?: SaveFromPreviewOptions
+): SaveBookmarkInput {
+  return {
+    url: originalUrl ?? preview.canonicalUrl,
+    provider: preview.provider,
+    contentType: preview.contentType,
+    providerId: preview.providerId,
+    title: preview.title,
+    creator: preview.creator,
+    creatorImageUrl: preview.creatorImageUrl ?? null,
+    thumbnailUrl: preview.thumbnailUrl,
+    duration: preview.duration,
+    canonicalUrl: preview.canonicalUrl,
+    description: preview.description,
+    // Article-specific fields
+    siteName: preview.siteName,
+    wordCount: preview.wordCount,
+    readingTimeMinutes: preview.readingTimeMinutes,
+    hasArticleContent: preview.hasArticleContent,
+    // X/Twitter-specific fields
+    publishedAt: preview.publishedAt,
+    rawMetadata: preview.rawMetadata,
+    tags: sanitizeTagNames(options?.tags ?? []),
   };
 }
 
@@ -411,28 +450,12 @@ export function useSaveBookmark() {
    * @param preview - The LinkPreview to save
    * @param originalUrl - The original URL entered by the user (optional, defaults to canonicalUrl)
    */
-  const saveFromPreview = (preview: LinkPreview, originalUrl?: string) => {
-    mutation.mutate({
-      url: originalUrl ?? preview.canonicalUrl,
-      provider: preview.provider,
-      contentType: preview.contentType,
-      providerId: preview.providerId,
-      title: preview.title,
-      creator: preview.creator,
-      creatorImageUrl: preview.creatorImageUrl ?? null,
-      thumbnailUrl: preview.thumbnailUrl,
-      duration: preview.duration,
-      canonicalUrl: preview.canonicalUrl,
-      description: preview.description,
-      // Article-specific fields
-      siteName: preview.siteName,
-      wordCount: preview.wordCount,
-      readingTimeMinutes: preview.readingTimeMinutes,
-      hasArticleContent: preview.hasArticleContent,
-      // X/Twitter-specific fields
-      publishedAt: preview.publishedAt,
-      rawMetadata: preview.rawMetadata,
-    });
+  const saveFromPreview = (
+    preview: LinkPreview,
+    originalUrl?: string,
+    options?: SaveFromPreviewOptions
+  ) => {
+    mutation.mutate(createSaveBookmarkInput(preview, originalUrl, options));
   };
 
   /**
@@ -447,29 +470,10 @@ export function useSaveBookmark() {
    */
   const saveFromPreviewAsync = async (
     preview: LinkPreview,
-    originalUrl?: string
+    originalUrl?: string,
+    options?: SaveFromPreviewOptions
   ): Promise<SaveResult> => {
-    return mutation.mutateAsync({
-      url: originalUrl ?? preview.canonicalUrl,
-      provider: preview.provider,
-      contentType: preview.contentType,
-      providerId: preview.providerId,
-      title: preview.title,
-      creator: preview.creator,
-      creatorImageUrl: preview.creatorImageUrl ?? null,
-      thumbnailUrl: preview.thumbnailUrl,
-      duration: preview.duration,
-      canonicalUrl: preview.canonicalUrl,
-      description: preview.description,
-      // Article-specific fields
-      siteName: preview.siteName,
-      wordCount: preview.wordCount,
-      readingTimeMinutes: preview.readingTimeMinutes,
-      hasArticleContent: preview.hasArticleContent,
-      // X/Twitter-specific fields
-      publishedAt: preview.publishedAt,
-      rawMetadata: preview.rawMetadata,
-    });
+    return mutation.mutateAsync(createSaveBookmarkInput(preview, originalUrl, options));
   };
 
   return {

--- a/apps/mobile/lib/add-link-screen.test.tsx
+++ b/apps/mobile/lib/add-link-screen.test.tsx
@@ -4,6 +4,7 @@ import TestRenderer, { act } from 'react-test-renderer';
 const mockBack = jest.fn();
 const mockUsePreview = jest.fn();
 const mockUseSaveBookmark = jest.fn();
+const mockUseUserTags = jest.fn();
 const mockUseSafeAreaInsets = jest.fn();
 const keyboardListeners = new Map<
   string,
@@ -11,6 +12,7 @@ const keyboardListeners = new Map<
 >();
 
 type Renderer = ReturnType<typeof TestRenderer.create>;
+type TestNode = { props: { children?: React.ReactNode } };
 
 function flattenStyle(style: unknown): Record<string, unknown> {
   if (Array.isArray(style)) {
@@ -137,6 +139,10 @@ jest.mock('@/hooks/use-bookmarks', () => ({
   isValidUrl: (value: string) => value.startsWith('http://') || value.startsWith('https://'),
 }));
 
+jest.mock('@/hooks/use-items-trpc', () => ({
+  useUserTags: () => mockUseUserTags(),
+}));
+
 jest.mock('@/components/link-preview-card', () => ({
   LinkPreviewCard: () => React.createElement('link-preview-card'),
 }));
@@ -176,6 +182,15 @@ describe('AddLinkScreen keyboard layout', () => {
       saveFromPreviewAsync: jest.fn(),
       isPending: false,
       reset: jest.fn(),
+    });
+    mockUseUserTags.mockReturnValue({
+      data: {
+        tags: [
+          { id: 'tag-1', name: 'Design' },
+          { id: 'tag-2', name: 'Mobile UX' },
+        ],
+      },
+      isLoading: false,
     });
   });
 
@@ -251,5 +266,91 @@ describe('AddLinkScreen keyboard layout', () => {
     expect(style.flex).toBe(0);
     expect(style.justifyContent).toBe('flex-start');
     expect(style.paddingTop).toBe(Spacing.lg);
+  });
+
+  it('passes selected tags when saving a preview', async () => {
+    const saveFromPreviewAsync = jest.fn().mockResolvedValue({
+      itemId: 'item-1',
+      userItemId: 'user-item-1',
+      status: 'created',
+    });
+
+    mockUsePreview.mockReturnValue({
+      data: {
+        provider: 'YOUTUBE',
+        contentType: 'VIDEO',
+        providerId: 'video-1',
+        title: 'Preview title',
+        creator: 'Creator',
+        thumbnailUrl: null,
+        duration: null,
+        canonicalUrl: 'https://example.com/watch',
+        source: 'oembed',
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    mockUseSaveBookmark.mockReturnValue({
+      saveFromPreviewAsync,
+      isPending: false,
+      reset: jest.fn(),
+    });
+
+    let renderer: Renderer;
+
+    await act(async () => {
+      renderer = TestRenderer.create(<AddLinkScreen />);
+    });
+
+    const urlInput = renderer!.root.findByProps({ accessibilityLabel: 'URL input' });
+    await act(async () => {
+      urlInput.props.onChangeText('https://example.com/watch');
+    });
+
+    const designButton = renderer!.root.findAllByType('button').find((button: TestNode) => {
+      const children = button.props.children as any;
+      return (
+        Array.isArray(children) && children.some((child) => child?.props?.children === 'Design')
+      );
+    });
+
+    expect(designButton).toBeDefined();
+
+    await act(async () => {
+      designButton!.props.onPress();
+    });
+
+    const tagInput = renderer!.root.findByProps({ accessibilityLabel: 'Tag input' });
+    await act(async () => {
+      tagInput.props.onChangeText(' Personal   Reading ');
+    });
+
+    const createButton = renderer!.root.findAllByType('button').find((button: TestNode) => {
+      const children = button.props.children as any;
+      return children?.props?.children === 'Create "Personal Reading"';
+    });
+
+    expect(createButton).toBeDefined();
+
+    await act(async () => {
+      createButton!.props.onPress();
+    });
+
+    const saveButton = renderer!.root.findByProps({ accessibilityLabel: 'Save to library' });
+    await act(async () => {
+      await saveButton.props.onPress();
+    });
+
+    expect(saveFromPreviewAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Preview title',
+      }),
+      'https://example.com/watch',
+      {
+        tags: ['Design', 'Personal Reading'],
+      }
+    );
   });
 });

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -324,7 +324,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SaveBookmarkRequest"
+                "$ref": "#/components/schemas/PreviewBookmarkRequest"
               },
               "examples": {
                 "webArticle": {
@@ -1278,6 +1278,28 @@
             "type": "string",
             "format": "uri",
             "description": "HTTP or HTTPS URL to save."
+          },
+          "tags": {
+            "type": "array",
+            "description": "Optional tag names to add to the saved bookmark.",
+            "maxItems": 20,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          }
+        }
+      },
+      "PreviewBookmarkRequest": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTP or HTTPS URL to preview."
           }
         }
       },

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -813,7 +813,7 @@ describe('apiV1Routes', () => {
           Authorization: `Bearer ${READ_WRITE_TOKEN}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ url: 'https://example.com/article' }),
+        body: JSON.stringify({ url: 'https://example.com/article', tags: ['Design', ' api '] }),
       }),
       createMockEnv()
     );
@@ -824,6 +824,7 @@ describe('apiV1Routes', () => {
       expect.objectContaining({
         url: 'https://example.com/article',
         title: 'Article title',
+        tags: ['Design', ' api '],
       })
     );
     expect((await res.json()) as JsonBody).toMatchObject({
@@ -833,6 +834,41 @@ describe('apiV1Routes', () => {
       item: {
         title: 'Article title',
       },
+    });
+  });
+
+  it('maps bookmark save bad request errors to REST 400 responses', async () => {
+    mockPreview.mockResolvedValue({
+      provider: Provider.WEB,
+      contentType: ContentType.ARTICLE,
+      providerId: 'https://example.com/article',
+      title: 'Article title',
+      creator: 'Example',
+      thumbnailUrl: null,
+      duration: null,
+      canonicalUrl: 'https://example.com/article',
+      source: 'opengraph',
+      description: 'Article summary',
+    });
+    mockSave.mockRejectedValue(new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid tag' }));
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${READ_WRITE_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ url: 'https://example.com/article', tags: ['Invalid tag'] }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'BAD_REQUEST',
+      error: 'Invalid tag',
     });
   });
 

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -31,6 +31,11 @@ const MAX_BOOKMARKS_LIMIT = 50;
 
 const SaveBookmarkBodySchema = z.object({
   url: z.string().url('Invalid URL format'),
+  tags: z.array(z.string().min(1).max(64)).max(20).optional(),
+});
+
+const PreviewBookmarkBodySchema = z.object({
+  url: z.string().url('Invalid URL format'),
 });
 
 const InboxQuerySchema = z.object({
@@ -536,7 +541,7 @@ apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (
 
 apiV1Routes.post('/bookmarks/preview', personalAccessTokenAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
-  const parsedBody = SaveBookmarkBodySchema.safeParse(body);
+  const parsedBody = PreviewBookmarkBodySchema.safeParse(body);
 
   if (!parsedBody.success) {
     return c.json(
@@ -610,17 +615,22 @@ apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async
     );
   }
 
-  const bookmark = await caller.bookmarks.save({
-    ...preview,
-    url: parsedBody.data.url,
-  });
+  try {
+    const bookmark = await caller.bookmarks.save({
+      ...preview,
+      url: parsedBody.data.url,
+      tags: parsedBody.data.tags,
+    });
 
-  return c.json({
-    bookmark,
-    item: toPreviewItem(preview),
-    requestId: c.get('requestId'),
-    traceId: c.get('traceId'),
-  });
+    return c.json({
+      bookmark,
+      item: toPreviewItem(preview),
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
 });
 
 apiV1Routes.get('/bookmarks/:id', personalAccessTokenAuth('bookmarks:read'), async (c) => {

--- a/apps/worker/src/trpc/routers/bookmarks.ts
+++ b/apps/worker/src/trpc/routers/bookmarks.ts
@@ -36,6 +36,7 @@ import {
   extractCreatorFromMetadata,
   generateSyntheticCreatorId,
 } from '../../db/helpers/creators';
+import { mergeTagsForUserItem } from '../tagging';
 import type { createDb } from '../../db';
 import type { Bindings } from '../../types';
 
@@ -81,6 +82,7 @@ const SaveInputSchema = z.object({
   // X/Twitter-specific fields
   publishedAt: z.string().optional(), // ISO8601 timestamp
   rawMetadata: z.string().optional(), // JSON string of provider API response
+  tags: z.array(z.string().min(1).max(64)).max(20).optional(),
 });
 
 // Helper Functions
@@ -328,6 +330,10 @@ export const bookmarksRouter = router({
     if (existingUserItem) {
       // 3a. User already has this item
       if (existingUserItem.state === UserItemState.BOOKMARKED) {
+        if (input.tags && input.tags.length > 0) {
+          await mergeTagsForUserItem(ctx, existingUserItem.id, input.tags);
+        }
+
         // Already bookmarked - no change needed
         return {
           itemId,
@@ -357,6 +363,10 @@ export const bookmarksRouter = router({
         userItemId: existingUserItem.id,
         operation: 'bookmarks.save.rebookmark',
       });
+
+      if (input.tags && input.tags.length > 0) {
+        await mergeTagsForUserItem(ctx, existingUserItem.id, input.tags);
+      }
 
       return {
         itemId,
@@ -406,6 +416,10 @@ export const bookmarksRouter = router({
       userItemId,
       operation: 'bookmarks.save.create',
     });
+
+    if (input.tags && input.tags.length > 0) {
+      await mergeTagsForUserItem(ctx, userItemId, input.tags);
+    }
 
     return {
       itemId,

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -35,7 +35,6 @@ import {
   hasSubstackNewsletterIdentity,
   isSubstackArticleUrl,
 } from '@zine/shared';
-import { normalizeTagKey, normalizeTagName } from '@zine/shared/tags';
 import {
   userItems,
   items,
@@ -64,6 +63,7 @@ import {
   normalizePersonName,
   syncPeopleForUserItemBestEffort,
 } from '../../people/service';
+import { replaceTagsForUserItem } from '../tagging';
 
 export type ItemTag = {
   id: string;
@@ -1147,9 +1147,6 @@ export const itemsRouter = router({
       })
     )
     .mutation(async ({ input, ctx }) => {
-      const nowMs = Date.now();
-      const nowIso = new Date().toISOString();
-
       const existingItem = await ctx.db
         .select({ id: userItems.id, state: userItems.state })
         .from(userItems)
@@ -1170,105 +1167,7 @@ export const itemsRouter = router({
         });
       }
 
-      const normalizedMap = new Map<string, string>();
-      for (const rawTag of input.tags) {
-        const normalizedName = normalizeTagName(rawTag);
-        const normalizedKey = normalizeTagKey(rawTag);
-
-        if (!normalizedName) {
-          continue;
-        }
-        if (normalizedName.length > 32) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: `Tag "${normalizedName}" exceeds 32 characters`,
-          });
-        }
-
-        if (!normalizedMap.has(normalizedKey)) {
-          normalizedMap.set(normalizedKey, normalizedName);
-        }
-      }
-
-      const desiredTags = Array.from(normalizedMap.entries()).map(([normalizedName, name]) => ({
-        normalizedName,
-        name,
-      }));
-
-      const existingTags =
-        desiredTags.length > 0
-          ? await ctx.db
-              .select({
-                id: tags.id,
-                name: tags.name,
-                normalizedName: tags.normalizedName,
-              })
-              .from(tags)
-              .where(
-                and(
-                  eq(tags.userId, ctx.userId),
-                  inArray(
-                    tags.normalizedName,
-                    desiredTags.map((tag) => tag.normalizedName)
-                  )
-                )
-              )
-          : [];
-
-      const existingTagsByNormalized = new Map(
-        existingTags.map((tag) => [tag.normalizedName, { id: tag.id, name: tag.name }])
-      );
-
-      const finalTags: ItemTag[] = [];
-
-      for (const desiredTag of desiredTags) {
-        const existingTag = existingTagsByNormalized.get(desiredTag.normalizedName);
-
-        if (existingTag) {
-          await ctx.db
-            .update(tags)
-            .set({
-              name: desiredTag.name,
-              updatedAt: nowMs,
-            })
-            .where(eq(tags.id, existingTag.id));
-
-          finalTags.push({ id: existingTag.id, name: desiredTag.name });
-          continue;
-        }
-
-        const tagId = ulid();
-        await ctx.db.insert(tags).values({
-          id: tagId,
-          userId: ctx.userId,
-          name: desiredTag.name,
-          normalizedName: desiredTag.normalizedName,
-          createdAt: nowMs,
-          updatedAt: nowMs,
-        });
-
-        finalTags.push({ id: tagId, name: desiredTag.name });
-      }
-
-      await ctx.db.delete(userItemTags).where(eq(userItemTags.userItemId, input.id));
-
-      if (finalTags.length > 0) {
-        await ctx.db.insert(userItemTags).values(
-          finalTags.map((tag) => ({
-            id: ulid(),
-            userItemId: input.id,
-            tagId: tag.id,
-            createdAt: nowMs,
-          }))
-        );
-      }
-
-      await ctx.db
-        .update(userItems)
-        .set({
-          updatedAt: nowIso,
-        })
-        .where(eq(userItems.id, input.id));
+      const finalTags = await replaceTagsForUserItem(ctx, input.id, input.tags);
 
       return {
         success: true as const,

--- a/apps/worker/src/trpc/tagging.ts
+++ b/apps/worker/src/trpc/tagging.ts
@@ -1,0 +1,182 @@
+import { TRPCError } from '@trpc/server';
+import { and, eq, inArray } from 'drizzle-orm';
+import { ulid } from 'ulid';
+import { normalizeTagKey, normalizeTagName } from '@zine/shared/tags';
+import { tags, userItems, userItemTags } from '../db/schema';
+import type { Database } from '../db';
+
+export type AssignedTag = {
+  id: string;
+  name: string;
+};
+
+type TaggingContext = {
+  db: Database;
+  userId: string;
+};
+
+function normalizeRequestedTags(
+  tagNames: string[]
+): Array<{ normalizedName: string; name: string }> {
+  const normalizedMap = new Map<string, string>();
+
+  for (const rawTag of tagNames) {
+    const normalizedName = normalizeTagName(rawTag);
+    const normalizedKey = normalizeTagKey(rawTag);
+
+    if (!normalizedName) {
+      continue;
+    }
+    if (normalizedName.length > 32) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `Tag "${normalizedName}" exceeds 32 characters`,
+      });
+    }
+
+    if (!normalizedMap.has(normalizedKey)) {
+      normalizedMap.set(normalizedKey, normalizedName);
+    }
+  }
+
+  return Array.from(normalizedMap.entries()).map(([normalizedName, name]) => ({
+    normalizedName,
+    name,
+  }));
+}
+
+async function findOrCreateTags(
+  ctx: TaggingContext,
+  tagNames: string[],
+  nowMs: number
+): Promise<AssignedTag[]> {
+  const desiredTags = normalizeRequestedTags(tagNames);
+
+  const existingTags =
+    desiredTags.length > 0
+      ? await ctx.db
+          .select({
+            id: tags.id,
+            name: tags.name,
+            normalizedName: tags.normalizedName,
+          })
+          .from(tags)
+          .where(
+            and(
+              eq(tags.userId, ctx.userId),
+              inArray(
+                tags.normalizedName,
+                desiredTags.map((tag) => tag.normalizedName)
+              )
+            )
+          )
+      : [];
+
+  const existingTagsByNormalized = new Map(
+    existingTags.map((tag) => [tag.normalizedName, { id: tag.id, name: tag.name }])
+  );
+
+  const finalTags: AssignedTag[] = [];
+
+  for (const desiredTag of desiredTags) {
+    const existingTag = existingTagsByNormalized.get(desiredTag.normalizedName);
+
+    if (existingTag) {
+      await ctx.db
+        .update(tags)
+        .set({
+          name: desiredTag.name,
+          updatedAt: nowMs,
+        })
+        .where(eq(tags.id, existingTag.id));
+
+      finalTags.push({ id: existingTag.id, name: desiredTag.name });
+      continue;
+    }
+
+    const tagId = ulid();
+    await ctx.db.insert(tags).values({
+      id: tagId,
+      userId: ctx.userId,
+      name: desiredTag.name,
+      normalizedName: desiredTag.normalizedName,
+      createdAt: nowMs,
+      updatedAt: nowMs,
+    });
+
+    finalTags.push({ id: tagId, name: desiredTag.name });
+  }
+
+  return finalTags;
+}
+
+export async function replaceTagsForUserItem(
+  ctx: TaggingContext,
+  userItemId: string,
+  tagNames: string[]
+): Promise<AssignedTag[]> {
+  const nowMs = Date.now();
+  const nowIso = new Date().toISOString();
+  const finalTags = await findOrCreateTags(ctx, tagNames, nowMs);
+
+  await ctx.db.delete(userItemTags).where(eq(userItemTags.userItemId, userItemId));
+
+  if (finalTags.length > 0) {
+    await ctx.db.insert(userItemTags).values(
+      finalTags.map((tag) => ({
+        id: ulid(),
+        userItemId,
+        tagId: tag.id,
+        createdAt: nowMs,
+      }))
+    );
+  }
+
+  await ctx.db
+    .update(userItems)
+    .set({
+      updatedAt: nowIso,
+    })
+    .where(eq(userItems.id, userItemId));
+
+  return finalTags;
+}
+
+export async function mergeTagsForUserItem(
+  ctx: TaggingContext,
+  userItemId: string,
+  tagNames: string[]
+): Promise<AssignedTag[]> {
+  const nowMs = Date.now();
+  const nowIso = new Date().toISOString();
+  const submittedTags = await findOrCreateTags(ctx, tagNames, nowMs);
+
+  if (submittedTags.length > 0) {
+    const existingAssignments = await ctx.db
+      .select({ tagId: userItemTags.tagId })
+      .from(userItemTags)
+      .where(eq(userItemTags.userItemId, userItemId));
+    const existingTagIds = new Set(existingAssignments.map((assignment) => assignment.tagId));
+    const tagsToAssign = submittedTags.filter((tag) => !existingTagIds.has(tag.id));
+
+    if (tagsToAssign.length > 0) {
+      await ctx.db.insert(userItemTags).values(
+        tagsToAssign.map((tag) => ({
+          id: ulid(),
+          userItemId,
+          tagId: tag.id,
+          createdAt: nowMs,
+        }))
+      );
+    }
+  }
+
+  await ctx.db
+    .update(userItems)
+    .set({
+      updatedAt: nowIso,
+    })
+    .where(eq(userItems.id, userItemId));
+
+  return submittedTags;
+}

--- a/docs/api/openapi.proposed.json
+++ b/docs/api/openapi.proposed.json
@@ -324,7 +324,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SaveBookmarkRequest"
+                "$ref": "#/components/schemas/PreviewBookmarkRequest"
               },
               "examples": {
                 "webArticle": {
@@ -1278,6 +1278,28 @@
             "type": "string",
             "format": "uri",
             "description": "HTTP or HTTPS URL to save."
+          },
+          "tags": {
+            "type": "array",
+            "description": "Optional tag names to add to the saved bookmark.",
+            "maxItems": 20,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          }
+        }
+      },
+      "PreviewBookmarkRequest": {
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "HTTP or HTTPS URL to preview."
           }
         }
       },


### PR DESCRIPTION
## Summary
- add shared worker tag assignment helpers and allow `bookmarks.save` / `POST /api/v1/bookmarks` to accept optional tags
- add tag selection to the mobile Add Link flow with optimistic cache tags
- add comma-separated tag entry to the browser extension popup
- update REST OpenAPI artifacts and tests

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- pre-push hook passed: format, mobile design-system check, typecheck, web tests, worker CI subset
