### PR TITLE
feat(x-archive): add following timeline collection

### DIFF
--- a/.codex/skills/zine-x-timeline-collector/SKILL.md
+++ b/.codex/skills/zine-x-timeline-collector/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: zine-x-timeline-collector
+description: Collect the latest configurable number of organic entries from the authenticated X Following timeline in Chrome or the integrated Codex browser and upload them to Zine's Cloudflare X archive. Use when the user asks to collect, crawl, capture, sync, or archive their X following feed or latest N timeline posts.
+---
+
+# Zine X Timeline Collector
+
+Collect top-to-bottom Following timeline entries without exposing browser credentials or large tweet payloads to the conversation. Keep replies, reposts, and quote posts. Exclude ads.
+
+## Requirements
+
+- Work from the Zine repository root.
+- Use the browser the user explicitly selects. Follow `chrome:control-chrome` for Chrome or `browser:control-in-app-browser` for the integrated Codex browser. If the user does not select one, prefer Chrome for its existing signed-in session and use the integrated browser only with the user's approval.
+- Require `ZINE_X_ARCHIVE_TOKEN` with `x-archive:write` and `x-archive:read`. Never print it.
+- Read [references/extraction-contract.md](references/extraction-contract.md) before collection.
+
+## Workflow
+
+1. Resolve the requested count. Default to `500`; accept larger values as requested.
+2. Start the local receiver in a PTY and keep the session alive:
+
+   ```bash
+   bun run --cwd apps/x-collector receive --count <N>
+   ```
+
+   Wait for its one-line JSON readiness response. Record `receiverUrl` and `runId`.
+
+3. Follow the selected browser skill's bootstrap exactly, including reading its complete browser documentation. Reuse or claim an existing authenticated X tab when available.
+4. Navigate to `https://x.com/home`. If signed out, ask the user to sign in. Select the **Following** timeline and verify it is active before extracting.
+5. In the persistent browser-control JavaScript session:
+   - Import `apps/x-collector/src/browser-extractor.mjs` by absolute path.
+   - Keep a `Set` of accepted primary tweet IDs, a `Set` of seen ad keys, and a monotonically increasing position counter.
+   - Call `extractVisibleTimelineBatch` through the documented Playwright page-evaluation API, passing the seen ad keys as its argument. Add returned `adKeys` to the set before the next call.
+   - Remove timeline items already accepted. Assign new items positions `0...N-1` in observed DOM order.
+   - Keep every returned canonical post needed by those items, including quoted posts. Do not count quoted embedded posts toward N.
+   - POST each small batch directly from the JavaScript session to `<receiverUrl>/batch`. Do not emit raw post bodies through `nodeRepl.write` or copy them into the conversation.
+   - Scroll roughly one viewport, wait for X to settle, and repeat.
+
+6. Stop when one of these occurs:
+   - N unique organic primary timeline entries have been accepted: complete as `COMPLETE`.
+   - Five consecutive scrolls add no new primary entries: complete as `PARTIAL` with `timeline_stalled`.
+   - X blocks loading or the connection fails after supported recovery: complete as `PARTIAL` with a concise reason.
+
+7. POST the completion state to `<receiverUrl>/complete`. The receiver validates, chunks, uploads, finalizes the manifest, and reads the run back from the archive.
+8. Wait for the receiver process to exit successfully. Report the run ID, requested count, collected count, excluded-ad count, and verification result.
+
+## Invariants
+
+- “Latest N” means the first N unique organic entries observed top-to-bottom in Following.
+- Never upload cookies, local storage, request headers, CSRF values, or authentication data from X.
+- Never include promoted or sponsored entries.
+- Treat a repost as a timeline presentation pointing to the original canonical tweet; do not manufacture a duplicate tweet.
+- Preserve the first observed position when a tweet repeats in one run.
+- Let the receiver/API perform canonical deduplication across runs.
+- Do not download media; retain media URLs and visible metadata only.
+- Leave an interrupted run resumable. Do not fabricate success when the browser connection or upload verification fails.

--- a/.codex/skills/zine-x-timeline-collector/agents/openai.yaml
+++ b/.codex/skills/zine-x-timeline-collector/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'X Timeline Collector'
+  short_description: 'Collect and archive the X Following timeline'
+  default_prompt: 'Use $zine-x-timeline-collector to collect the latest 500 organic posts from my X Following timeline.'

--- a/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
+++ b/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
@@ -1,0 +1,52 @@
+# Extraction contract
+
+Use the repository extractor at `apps/x-collector/src/browser-extractor.mjs`. It reads currently mounted `article[data-testid="tweet"]` elements and returns:
+
+```js
+{
+  posts: XPost[],
+  items: Array<Omit<XTimelineItem, "position">>,
+  excludedAds: number,
+  adKeys: string[]
+}
+```
+
+## Browser state
+
+- Collect only after the X Home page visibly shows the active Following tab.
+- X virtualizes the timeline. Extract visible/mounted cards before every scroll.
+- Keep deduplication state outside the page because mounted cards are recycled.
+- Pass the previously returned ad keys into the next extractor call so recycled ads are counted once.
+- Scroll one viewport at a time. Large jumps can skip cards.
+
+## Primary versus referenced posts
+
+Each timeline card contributes at most one primary `item`. Its canonical post appears in `posts`.
+
+A visible quoted post may contribute another canonical post and a `QUOTE_OF` relationship, but it does not contribute another timeline item or count toward N.
+
+X renders a repost as the original tweet plus social context. Store the original tweet once and set the timeline item's `presentation` to `REPOST`, with `repostedBy` when visible.
+
+## Ads
+
+The extractor rejects cards with promoted, sponsored, or ad markers outside the tweet text. It keeps page-level state so the same mounted ad is counted only once. Do not weaken this filter to reach N.
+
+## Partial completion
+
+Use `PARTIAL` when the requested number cannot be reached. Valid concise reasons include:
+
+- `timeline_stalled`
+- `x_rate_limited`
+- `browser_disconnected`
+- `x_auth_required`
+- `collector_error: <short message>`
+
+The receiver retains and uploads every successfully collected item before the failure.
+
+## Local receiver API
+
+- `GET /session` returns run identity and current counts.
+- `POST /batch` accepts `{ posts, items, excludedAds }`.
+- `POST /complete` accepts `{ status, failureReason }` and performs the verified Cloudflare upload.
+
+The receiver binds only to `127.0.0.1` and keeps the Zine PAT out of the X page context.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,22 @@ jobs:
       - name: Run worker tests
         run: bun run test:worker:ci
 
+  test-x-archive:
+    name: X Archive Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run X archive and collector tests
+        run: bun run x:archive:test
+
   test-web:
     name: Web Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-x-archive.yml
+++ b/.github/workflows/deploy-x-archive.yml
@@ -1,0 +1,58 @@
+name: Deploy X Archive
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/x-archive/**'
+      - 'packages/x-archive-schema/**'
+      - '.github/workflows/deploy-x-archive.yml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'bunfig.toml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-x-archive-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.4
+
+      - name: Validate required deployment configuration
+        run: |
+          missing=0
+          for name in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN
+          do
+            if [ -z "${!name}" ]; then
+              echo "Missing required deployment setting: $name" >&2
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run X archive database migrations
+        run: bun run --cwd apps/x-archive db:migrate:production
+
+      - name: Deploy X archive Worker
+        run: bun run --cwd apps/x-archive deploy:production
+
+      - name: Verify production health
+        run: curl --fail --retry 5 --retry-all-errors https://x-archive-api.myzine.app/health

--- a/apps/web/src/settings-page.test.tsx
+++ b/apps/web/src/settings-page.test.tsx
@@ -290,6 +290,38 @@ describe('SettingsPage', () => {
       });
     });
 
+    test('creates an API token with X archive scopes when selected', async () => {
+      const user = userEvent.setup();
+      mutationSpies.apiTokensCreate.mockResolvedValue({
+        token: {
+          id: 'token-archive',
+          name: 'X collector',
+          tokenPrefix: 'zine_pat_archive',
+          scopes: ['bookmarks:read', 'bookmarks:write', 'x-archive:read', 'x-archive:write'],
+          createdAt: Date.now(),
+          lastUsedAt: null,
+          expiresAt: null,
+          revokedAt: null,
+        },
+        rawToken: 'zine_pat_archive_raw_token',
+      });
+
+      renderRoute(<SettingsPage />, {
+        route: '/settings',
+        path: '/settings',
+      });
+
+      await user.type(screen.getByLabelText('Name'), 'X collector');
+      await user.click(screen.getByLabelText('Read X archive'));
+      await user.click(screen.getByLabelText('Collect X timeline'));
+      await user.click(screen.getByRole('button', { name: 'Create token' }));
+
+      expect(mutationSpies.apiTokensCreate).toHaveBeenCalledWith({
+        name: 'X collector',
+        scopes: ['bookmarks:read', 'bookmarks:write', 'x-archive:read', 'x-archive:write'],
+      });
+    });
+
     test('revokes an API token', async () => {
       const user = userEvent.setup();
       hookSpies.apiTokensListUseQuery.mockImplementation(() => ({

--- a/apps/web/src/settings-page.tsx
+++ b/apps/web/src/settings-page.tsx
@@ -215,6 +215,8 @@ function ApiTokensSection() {
   const [writeEnabled, setWriteEnabled] = useState(true);
   const [syncReadEnabled, setSyncReadEnabled] = useState(false);
   const [syncWriteEnabled, setSyncWriteEnabled] = useState(false);
+  const [xArchiveReadEnabled, setXArchiveReadEnabled] = useState(false);
+  const [xArchiveWriteEnabled, setXArchiveWriteEnabled] = useState(false);
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -224,8 +226,17 @@ function ApiTokensSection() {
     if (writeEnabled) scopes.push('bookmarks:write');
     if (syncReadEnabled) scopes.push('sync:read');
     if (syncWriteEnabled) scopes.push('sync:write');
+    if (xArchiveReadEnabled) scopes.push('x-archive:read');
+    if (xArchiveWriteEnabled) scopes.push('x-archive:write');
     return scopes;
-  }, [readEnabled, syncReadEnabled, syncWriteEnabled, writeEnabled]);
+  }, [
+    readEnabled,
+    syncReadEnabled,
+    syncWriteEnabled,
+    writeEnabled,
+    xArchiveReadEnabled,
+    xArchiveWriteEnabled,
+  ]);
 
   const createToken = trpc.apiTokens.create.useMutation({
     onSuccess: (result) => {
@@ -327,6 +338,22 @@ function ApiTokensSection() {
               onChange={(event) => setSyncWriteEnabled(event.target.checked)}
             />
             Start sync jobs
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={xArchiveReadEnabled}
+              onChange={(event) => setXArchiveReadEnabled(event.target.checked)}
+            />
+            Read X archive
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={xArchiveWriteEnabled}
+              onChange={(event) => setXArchiveWriteEnabled(event.target.checked)}
+            />
+            Collect X timeline
           </label>
         </div>
 

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -129,7 +129,7 @@ index_name = "zine-item-vectors-staging"
 [[env.staging.d1_databases]]
 binding = "DB"
 database_name = "zine-db-staging"
-database_id = "bc9e61b1-94b2-4f3c-b19b-b3a50936b811"
+database_id = "feaff315-9e1d-41ce-94c4-563489ccffba"
 migrations_dir = "src/db/migrations"
 [env.staging.vars]
 ENVIRONMENT = "staging"

--- a/apps/x-archive/package.json
+++ b/apps/x-archive/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@zine/x-archive",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "wrangler deploy --dry-run --outdir dist",
+    "dev": "wrangler dev --port ${X_ARCHIVE_PORT:-8790}",
+    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
+    "db:migrate:local": "wrangler d1 migrations apply ARCHIVE_DB --local",
+    "db:migrate:staging": "wrangler d1 migrations apply ARCHIVE_DB --env staging --remote",
+    "db:migrate:production": "wrangler d1 migrations apply ARCHIVE_DB --env production --remote"
+  },
+  "dependencies": {
+    "@zine/x-archive-schema": "workspace:*",
+    "hono": "^4.6.14",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.33",
+    "@cloudflare/workers-types": "^4.20241205.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8",
+    "wrangler": "^3.95.0"
+  }
+}

--- a/apps/x-archive/src/db/migrations/0000_initial.sql
+++ b/apps/x-archive/src/db/migrations/0000_initial.sql
@@ -1,0 +1,105 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS x_timeline_runs (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  requested_count INTEGER NOT NULL,
+  collected_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'CAPTURING',
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  excluded_ads INTEGER NOT NULL DEFAULT 0,
+  collector_version TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  manifest_key TEXT,
+  failure_reason TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS x_timeline_runs_user_started_idx
+  ON x_timeline_runs(user_id, started_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS x_authors (
+  user_id TEXT NOT NULL,
+  author_key TEXT NOT NULL,
+  x_user_id TEXT,
+  username TEXT NOT NULL,
+  name TEXT NOT NULL,
+  profile_url TEXT,
+  profile_image_url TEXT,
+  verified INTEGER,
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, author_key)
+);
+
+CREATE INDEX IF NOT EXISTS x_authors_user_username_idx ON x_authors(user_id, username);
+
+CREATE TABLE IF NOT EXISTS x_posts (
+  user_id TEXT NOT NULL,
+  tweet_id TEXT NOT NULL,
+  url TEXT NOT NULL,
+  text TEXT NOT NULL,
+  published_at INTEGER,
+  lang TEXT,
+  kind TEXT NOT NULL,
+  author_key TEXT NOT NULL,
+  media_json TEXT NOT NULL,
+  metrics_json TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  first_run_id TEXT NOT NULL,
+  latest_run_id TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  PRIMARY KEY (user_id, tweet_id),
+  FOREIGN KEY (user_id, author_key) REFERENCES x_authors(user_id, author_key)
+);
+
+CREATE INDEX IF NOT EXISTS x_posts_user_last_seen_idx
+  ON x_posts(user_id, last_seen_at DESC, tweet_id DESC);
+CREATE INDEX IF NOT EXISTS x_posts_user_author_idx ON x_posts(user_id, author_key, published_at DESC);
+CREATE INDEX IF NOT EXISTS x_posts_user_published_idx ON x_posts(user_id, published_at DESC, tweet_id DESC);
+
+CREATE TABLE IF NOT EXISTS x_post_relationships (
+  user_id TEXT NOT NULL,
+  source_tweet_id TEXT NOT NULL,
+  relationship_type TEXT NOT NULL,
+  target_tweet_id TEXT NOT NULL,
+  target_url TEXT,
+  PRIMARY KEY (user_id, source_tweet_id, relationship_type, target_tweet_id),
+  FOREIGN KEY (user_id, source_tweet_id) REFERENCES x_posts(user_id, tweet_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS x_post_relationships_target_idx
+  ON x_post_relationships(user_id, target_tweet_id);
+
+CREATE TABLE IF NOT EXISTS x_timeline_run_items (
+  run_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  tweet_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  observed_at INTEGER NOT NULL,
+  presentation TEXT NOT NULL DEFAULT 'POST',
+  reposted_by_json TEXT,
+  PRIMARY KEY (run_id, tweet_id),
+  UNIQUE (run_id, position),
+  FOREIGN KEY (run_id) REFERENCES x_timeline_runs(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id, tweet_id) REFERENCES x_posts(user_id, tweet_id)
+);
+
+CREATE INDEX IF NOT EXISTS x_timeline_run_items_user_tweet_idx
+  ON x_timeline_run_items(user_id, tweet_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS x_ingest_chunks (
+  run_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  checksum TEXT NOT NULL,
+  posts_received INTEGER NOT NULL,
+  timeline_items_received INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (run_id, chunk_index),
+  FOREIGN KEY (run_id) REFERENCES x_timeline_runs(id) ON DELETE CASCADE
+);

--- a/apps/x-archive/src/index.test.ts
+++ b/apps/x-archive/src/index.test.ts
@@ -1,0 +1,187 @@
+import { env, SELF } from 'cloudflare:test';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const TOKEN = 'zine_pat_test-token-for-x-archive';
+const USER_ID = 'user_test';
+const testEnv = env as unknown as Env;
+
+async function tokenHash(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function api(path: string, init: RequestInit = {}) {
+  return SELF.fetch(`https://example.com${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+}
+
+function post(tweetId: string) {
+  return {
+    tweetId,
+    url: `https://x.com/example/status/${tweetId}`,
+    text: `Post ${tweetId}`,
+    publishedAt: '2026-07-11T12:00:00.000Z',
+    kind: 'POST',
+    author: {
+      id: 'author-1',
+      username: 'example',
+      name: 'Example',
+      profileUrl: 'https://x.com/example',
+    },
+    media: [{ type: 'IMAGE', url: 'https://pbs.twimg.com/media/example.jpg' }],
+    relationships: [],
+    metrics: { likes: 10 },
+    capturedAt: '2026-07-11T13:00:00.000Z',
+  };
+}
+
+beforeEach(async () => {
+  await testEnv.AUTH_DB.exec('DELETE FROM api_tokens;');
+  await testEnv.ARCHIVE_DB.exec(
+    'DELETE FROM x_ingest_chunks; DELETE FROM x_timeline_run_items; DELETE FROM x_post_relationships; DELETE FROM x_posts; DELETE FROM x_authors; DELETE FROM x_timeline_runs;'
+  );
+  await testEnv.AUTH_DB.prepare(
+    `INSERT INTO api_tokens
+      (id, user_id, name, token_hash, token_prefix, scopes_json, created_at, last_used_at, expires_at, revoked_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)`
+  )
+    .bind(
+      'token-1',
+      USER_ID,
+      'Archive test',
+      await tokenHash(TOKEN),
+      'zine_pat_test',
+      JSON.stringify(['x-archive:read', 'x-archive:write']),
+      Date.now()
+    )
+    .run();
+});
+
+describe('X archive worker', () => {
+  it('captures, deduplicates, completes, reads, and exports a run', async () => {
+    const create = await api('/api/v1/x-timeline/runs', {
+      method: 'POST',
+      body: JSON.stringify({
+        runId: 'run-00000001',
+        requestedCount: 1,
+        startedAt: '2026-07-11T13:00:00.000Z',
+        collectorVersion: 'test-v1',
+      }),
+    });
+    expect(create.status).toBe(201);
+
+    const chunkBody = {
+      posts: [post('100')],
+      items: [
+        {
+          tweetId: '100',
+          position: 0,
+          observedAt: '2026-07-11T13:00:00.000Z',
+          presentation: 'REPOST',
+          repostedBy: { username: 'reposter', name: 'Reposter' },
+        },
+      ],
+    };
+    const chunk = await api('/api/v1/x-timeline/runs/run-00000001/chunks/0', {
+      method: 'PUT',
+      body: JSON.stringify(chunkBody),
+    });
+    expect(chunk.status).toBe(200);
+    expect(await chunk.json()).toMatchObject({
+      duplicateChunk: false,
+      canonicalPosts: { created: 1, updated: 0, unchanged: 0 },
+    });
+
+    const retry = await api('/api/v1/x-timeline/runs/run-00000001/chunks/0', {
+      method: 'PUT',
+      body: JSON.stringify(chunkBody),
+    });
+    expect(await retry.json()).toMatchObject({ duplicateChunk: true });
+
+    const complete = await api('/api/v1/x-timeline/runs/run-00000001/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        collectedCount: 1,
+        completedAt: '2026-07-11T13:01:00.000Z',
+        excludedAds: 2,
+        status: 'COMPLETE',
+        failureReason: null,
+      }),
+    });
+    expect(complete.status).toBe(200);
+    expect(await complete.json()).toMatchObject({
+      run: { id: 'run-00000001', collectedCount: 1, excludedAds: 2, status: 'COMPLETE' },
+    });
+
+    const read = await api('/api/v1/x-timeline/runs/run-00000001');
+    expect(await read.json()).toMatchObject({
+      items: [
+        {
+          position: 0,
+          presentation: 'REPOST',
+          repostedBy: { username: 'reposter' },
+          post: { tweetId: '100', text: 'Post 100' },
+        },
+      ],
+    });
+
+    expect(await testEnv.ARCHIVE_BUCKET.head('users/user_test/posts/100.json.gz')).not.toBeNull();
+    const exported = await api('/api/v1/x-timeline/runs/run-00000001/export');
+    expect(exported.status).toBe(200);
+    expect(exported.headers.get('content-encoding')).toBe('gzip');
+  });
+
+  it('stores one canonical post across multiple runs', async () => {
+    for (const [index, runId] of ['run-00000001', 'run-00000002'].entries()) {
+      await api('/api/v1/x-timeline/runs', {
+        method: 'POST',
+        body: JSON.stringify({
+          runId,
+          requestedCount: 1,
+          startedAt: `2026-07-1${index + 1}T13:00:00.000Z`,
+          collectorVersion: 'test-v1',
+        }),
+      });
+      const response = await api(`/api/v1/x-timeline/runs/${runId}/chunks/0`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          posts: [post('100')],
+          items: [
+            {
+              tweetId: '100',
+              position: 0,
+              observedAt: `2026-07-1${index + 1}T13:00:00.000Z`,
+              presentation: 'POST',
+            },
+          ],
+        }),
+      });
+      expect(response.status).toBe(200);
+    }
+
+    const posts = await testEnv.ARCHIVE_DB.prepare('SELECT COUNT(*) AS count FROM x_posts').first<{
+      count: number;
+    }>();
+    const pointers = await testEnv.ARCHIVE_DB.prepare(
+      'SELECT COUNT(*) AS count FROM x_timeline_run_items'
+    ).first<{ count: number }>();
+    expect(posts?.count).toBe(1);
+    expect(pointers?.count).toBe(2);
+  });
+
+  it('requires archive-specific token scopes', async () => {
+    await testEnv.AUTH_DB.prepare('UPDATE api_tokens SET scopes_json = ? WHERE id = ?')
+      .bind(JSON.stringify(['bookmarks:write']), 'token-1')
+      .run();
+    const response = await api('/api/v1/x-timeline/runs');
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/x-archive/src/index.ts
+++ b/apps/x-archive/src/index.ts
@@ -1,0 +1,730 @@
+import { Hono } from 'hono';
+import {
+  CompleteXTimelineRunSchema,
+  CreateXTimelineRunSchema,
+  UploadXTimelineChunkSchema,
+  X_ARCHIVE_SCHEMA_VERSION,
+  type XPost,
+} from '@zine/x-archive-schema';
+
+type Bindings = Env;
+type Variables = { userId: string; requestId: string };
+type AppEnv = { Bindings: Bindings; Variables: Variables };
+
+const API_TOKEN_PREFIX = 'zine_pat_';
+const MAX_PAGE_SIZE = 100;
+
+type TokenRow = {
+  id: string;
+  user_id: string;
+  scopes_json: string;
+  expires_at: number | null;
+  revoked_at: number | null;
+};
+
+type RunRow = {
+  id: string;
+  user_id: string;
+  requested_count: number;
+  collected_count: number;
+  status: string;
+  started_at: number;
+  completed_at: number | null;
+  excluded_ads: number;
+  collector_version: string;
+  schema_version: number;
+  manifest_key: string | null;
+  failure_reason: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type PostRow = {
+  tweet_id: string;
+  url: string;
+  text: string;
+  published_at: number | null;
+  lang: string | null;
+  kind: string;
+  author_key: string;
+  username: string;
+  author_name: string;
+  profile_url: string | null;
+  profile_image_url: string | null;
+  verified: number | null;
+  media_json: string;
+  metrics_json: string;
+  r2_key: string;
+  content_hash: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  first_run_id: string;
+  latest_run_id: string;
+  schema_version: number;
+};
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function gzipJson(value: unknown): Promise<ArrayBuffer> {
+  const source = new Blob([JSON.stringify(value)]).stream();
+  return new Response(source.pipeThrough(new CompressionStream('gzip'))).arrayBuffer();
+}
+
+function postObjectKey(userId: string, tweetId: string): string {
+  return `users/${encodeURIComponent(userId)}/posts/${encodeURIComponent(tweetId)}.json.gz`;
+}
+
+function runManifestKey(userId: string, runId: string): string {
+  return `users/${encodeURIComponent(userId)}/runs/${encodeURIComponent(runId)}.json.gz`;
+}
+
+function authorKey(post: XPost): string {
+  return post.author.id
+    ? `id:${post.author.id}`
+    : `username:${post.author.username.toLocaleLowerCase()}`;
+}
+
+function toEpoch(value: string | null | undefined): number | null {
+  return value ? Date.parse(value) : null;
+}
+
+function parseLimit(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? '50', 10);
+  return Number.isFinite(parsed) ? Math.min(MAX_PAGE_SIZE, Math.max(1, parsed)) : 50;
+}
+
+function encodeCursor(lastSeenAt: number, tweetId: string): string {
+  return btoa(JSON.stringify([lastSeenAt, tweetId]));
+}
+
+function decodeCursor(value: string | undefined): [number, string] | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(atob(value)) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      typeof parsed[0] === 'number' &&
+      typeof parsed[1] === 'string'
+    ) {
+      return [parsed[0], parsed[1]];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function publicRun(row: RunRow) {
+  return {
+    id: row.id,
+    requestedCount: row.requested_count,
+    collectedCount: row.collected_count,
+    status: row.status,
+    startedAt: new Date(row.started_at).toISOString(),
+    completedAt: row.completed_at ? new Date(row.completed_at).toISOString() : null,
+    excludedAds: row.excluded_ads,
+    collectorVersion: row.collector_version,
+    schemaVersion: row.schema_version,
+    failureReason: row.failure_reason,
+    createdAt: new Date(row.created_at).toISOString(),
+    updatedAt: new Date(row.updated_at).toISOString(),
+  };
+}
+
+function publicPost(row: PostRow) {
+  return {
+    tweetId: row.tweet_id,
+    url: row.url,
+    text: row.text,
+    publishedAt: row.published_at ? new Date(row.published_at).toISOString() : null,
+    lang: row.lang,
+    kind: row.kind,
+    author: {
+      key: row.author_key,
+      username: row.username,
+      name: row.author_name,
+      profileUrl: row.profile_url,
+      profileImageUrl: row.profile_image_url,
+      verified: row.verified === null ? null : Boolean(row.verified),
+    },
+    media: JSON.parse(row.media_json) as unknown,
+    metrics: JSON.parse(row.metrics_json) as unknown,
+    archiveKey: row.r2_key,
+    contentHash: row.content_hash,
+    firstSeenAt: new Date(row.first_seen_at).toISOString(),
+    lastSeenAt: new Date(row.last_seen_at).toISOString(),
+    firstRunId: row.first_run_id,
+    latestRunId: row.latest_run_id,
+    schemaVersion: row.schema_version,
+  };
+}
+
+const app = new Hono<AppEnv>();
+
+app.use('*', async (c, next) => {
+  const requestId = c.req.header('X-Request-ID') ?? crypto.randomUUID();
+  c.set('requestId', requestId);
+  c.header('X-Request-ID', requestId);
+  await next();
+});
+
+app.onError((error, c) => {
+  console.error('X archive request failed', {
+    requestId: c.get('requestId'),
+    path: c.req.path,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  return c.json(
+    { error: 'Internal server error', code: 'INTERNAL_ERROR', requestId: c.get('requestId') },
+    500
+  );
+});
+
+app.get('/health', (c) =>
+  c.json({
+    status: 'ok',
+    service: 'x-archive',
+    environment: c.env.ENVIRONMENT,
+    schemaVersion: X_ARCHIVE_SCHEMA_VERSION,
+    timestamp: new Date().toISOString(),
+  })
+);
+
+app.use('/api/*', async (c, next) => {
+  const header = c.req.header('Authorization');
+  const token = header?.startsWith('Bearer ') ? header.slice(7).trim() : '';
+  if (!token.startsWith(API_TOKEN_PREFIX)) {
+    return c.json(
+      { error: 'Unauthorized', code: 'UNAUTHORIZED', requestId: c.get('requestId') },
+      401
+    );
+  }
+
+  const tokenHash = await sha256Hex(token);
+  const row = await c.env.AUTH_DB.prepare(
+    `SELECT id, user_id, scopes_json, expires_at, revoked_at
+     FROM api_tokens WHERE token_hash = ? LIMIT 1`
+  )
+    .bind(tokenHash)
+    .first<TokenRow>();
+
+  if (
+    !row ||
+    row.revoked_at !== null ||
+    (row.expires_at !== null && row.expires_at <= Date.now())
+  ) {
+    return c.json(
+      { error: 'Unauthorized', code: 'UNAUTHORIZED', requestId: c.get('requestId') },
+      401
+    );
+  }
+
+  let scopes: unknown;
+  try {
+    scopes = JSON.parse(row.scopes_json);
+  } catch {
+    scopes = [];
+  }
+  const requiredScope = c.req.method === 'GET' ? 'x-archive:read' : 'x-archive:write';
+  if (!Array.isArray(scopes) || !scopes.includes(requiredScope)) {
+    return c.json({ error: 'Forbidden', code: 'FORBIDDEN', requestId: c.get('requestId') }, 403);
+  }
+
+  await c.env.AUTH_DB.prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
+    .bind(Date.now(), row.id)
+    .run();
+  c.set('userId', row.user_id);
+  await next();
+});
+
+app.post('/api/v1/x-timeline/runs', async (c) => {
+  const parsed = CreateXTimelineRunSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json(
+      { error: 'Invalid run payload', code: 'INVALID_INPUT', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  const userId = c.get('userId');
+  const input = parsed.data;
+  const existing = await c.env.ARCHIVE_DB.prepare('SELECT * FROM x_timeline_runs WHERE id = ?')
+    .bind(input.runId)
+    .first<RunRow>();
+  if (existing) {
+    if (existing.user_id !== userId) {
+      return c.json({ error: 'Run already exists', code: 'RUN_CONFLICT' }, 409);
+    }
+    return c.json({ run: publicRun(existing), created: false });
+  }
+
+  const now = Date.now();
+  await c.env.ARCHIVE_DB.prepare(
+    `INSERT INTO x_timeline_runs
+      (id, user_id, requested_count, status, started_at, collector_version, schema_version, created_at, updated_at)
+     VALUES (?, ?, ?, 'CAPTURING', ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      input.runId,
+      userId,
+      input.requestedCount,
+      Date.parse(input.startedAt),
+      input.collectorVersion,
+      X_ARCHIVE_SCHEMA_VERSION,
+      now,
+      now
+    )
+    .run();
+
+  const created = await c.env.ARCHIVE_DB.prepare('SELECT * FROM x_timeline_runs WHERE id = ?')
+    .bind(input.runId)
+    .first<RunRow>();
+  return c.json({ run: publicRun(created!), created: true }, 201);
+});
+
+app.put('/api/v1/x-timeline/runs/:runId/chunks/:chunkIndex', async (c) => {
+  const routeChunkIndex = Number.parseInt(c.req.param('chunkIndex'), 10);
+  const body = await c.req.json().catch(() => null);
+  const parsed = UploadXTimelineChunkSchema.safeParse(
+    body && typeof body === 'object' ? { ...(body as object), chunkIndex: routeChunkIndex } : body
+  );
+  if (!parsed.success) {
+    return c.json(
+      { error: 'Invalid chunk payload', code: 'INVALID_INPUT', issues: parsed.error.issues },
+      400
+    );
+  }
+
+  const userId = c.get('userId');
+  const runId = c.req.param('runId');
+  const run = await c.env.ARCHIVE_DB.prepare(
+    'SELECT * FROM x_timeline_runs WHERE id = ? AND user_id = ?'
+  )
+    .bind(runId, userId)
+    .first<RunRow>();
+  if (!run) return c.json({ error: 'Run not found', code: 'NOT_FOUND' }, 404);
+
+  const input = parsed.data;
+  const checksum = await sha256Hex(JSON.stringify(input));
+  const priorChunk = await c.env.ARCHIVE_DB.prepare(
+    'SELECT checksum, posts_received, timeline_items_received FROM x_ingest_chunks WHERE run_id = ? AND chunk_index = ?'
+  )
+    .bind(runId, input.chunkIndex)
+    .first<{ checksum: string; posts_received: number; timeline_items_received: number }>();
+  if (priorChunk) {
+    if (priorChunk.checksum !== checksum) {
+      return c.json(
+        { error: 'Chunk index already contains different data', code: 'CHUNK_CONFLICT' },
+        409
+      );
+    }
+    return c.json({
+      accepted: true,
+      duplicateChunk: true,
+      postsReceived: priorChunk.posts_received,
+      timelineItemsReceived: priorChunk.timeline_items_received,
+    });
+  }
+  if (run.status !== 'CAPTURING') {
+    return c.json({ error: 'Run is already finalized', code: 'RUN_FINALIZED' }, 409);
+  }
+
+  const postsById = new Map(input.posts.map((post) => [post.tweetId, post]));
+  const postIds = [...postsById.keys()];
+  const placeholders = postIds.map(() => '?').join(', ');
+  const existingRows = postIds.length
+    ? await c.env.ARCHIVE_DB.prepare(
+        `SELECT tweet_id, content_hash FROM x_posts WHERE user_id = ? AND tweet_id IN (${placeholders})`
+      )
+        .bind(userId, ...postIds)
+        .all<{ tweet_id: string; content_hash: string }>()
+    : { results: [] };
+  const existingHashes = new Map(
+    existingRows.results.map((row) => [row.tweet_id, row.content_hash])
+  );
+
+  const hashes = new Map<string, string>();
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  for (const post of postsById.values()) {
+    const hash = await sha256Hex(JSON.stringify(post));
+    hashes.set(post.tweetId, hash);
+    const previous = existingHashes.get(post.tweetId);
+    if (previous === hash) {
+      unchanged++;
+      continue;
+    }
+
+    const key = postObjectKey(userId, post.tweetId);
+    await c.env.ARCHIVE_BUCKET.put(
+      key,
+      await gzipJson({ schemaVersion: X_ARCHIVE_SCHEMA_VERSION, post }),
+      {
+        httpMetadata: { contentType: 'application/json', contentEncoding: 'gzip' },
+        customMetadata: { userId, tweetId: post.tweetId, contentHash: hash },
+      }
+    );
+    if (previous) updated++;
+    else created++;
+  }
+
+  const now = Date.now();
+  const statements: D1PreparedStatement[] = [];
+  for (const post of postsById.values()) {
+    const key = authorKey(post);
+    const seenAt = Date.parse(post.capturedAt);
+    statements.push(
+      c.env.ARCHIVE_DB.prepare(
+        `INSERT INTO x_authors
+          (user_id, author_key, x_user_id, username, name, profile_url, profile_image_url, verified, first_seen_at, last_seen_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id, author_key) DO UPDATE SET
+          x_user_id = COALESCE(excluded.x_user_id, x_authors.x_user_id),
+          username = excluded.username,
+          name = excluded.name,
+          profile_url = COALESCE(excluded.profile_url, x_authors.profile_url),
+          profile_image_url = COALESCE(excluded.profile_image_url, x_authors.profile_image_url),
+          verified = COALESCE(excluded.verified, x_authors.verified),
+          last_seen_at = MAX(x_authors.last_seen_at, excluded.last_seen_at)`
+      ).bind(
+        userId,
+        key,
+        post.author.id ?? null,
+        post.author.username,
+        post.author.name,
+        post.author.profileUrl ?? null,
+        post.author.profileImageUrl ?? null,
+        post.author.verified === undefined || post.author.verified === null
+          ? null
+          : post.author.verified
+            ? 1
+            : 0,
+        seenAt,
+        seenAt
+      )
+    );
+    statements.push(
+      c.env.ARCHIVE_DB.prepare(
+        `INSERT INTO x_posts
+          (user_id, tweet_id, url, text, published_at, lang, kind, author_key, media_json, metrics_json,
+           r2_key, content_hash, first_seen_at, last_seen_at, first_run_id, latest_run_id, schema_version)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(user_id, tweet_id) DO UPDATE SET
+          url = excluded.url,
+          text = excluded.text,
+          published_at = COALESCE(excluded.published_at, x_posts.published_at),
+          lang = COALESCE(excluded.lang, x_posts.lang),
+          kind = excluded.kind,
+          author_key = excluded.author_key,
+          media_json = excluded.media_json,
+          metrics_json = excluded.metrics_json,
+          r2_key = excluded.r2_key,
+          content_hash = excluded.content_hash,
+          last_seen_at = MAX(x_posts.last_seen_at, excluded.last_seen_at),
+          latest_run_id = excluded.latest_run_id,
+          schema_version = excluded.schema_version`
+      ).bind(
+        userId,
+        post.tweetId,
+        post.url,
+        post.text,
+        toEpoch(post.publishedAt),
+        post.lang ?? null,
+        post.kind,
+        key,
+        JSON.stringify(post.media),
+        JSON.stringify(post.metrics),
+        postObjectKey(userId, post.tweetId),
+        hashes.get(post.tweetId)!,
+        seenAt,
+        seenAt,
+        runId,
+        runId,
+        X_ARCHIVE_SCHEMA_VERSION
+      )
+    );
+    statements.push(
+      c.env.ARCHIVE_DB.prepare(
+        'DELETE FROM x_post_relationships WHERE user_id = ? AND source_tweet_id = ?'
+      ).bind(userId, post.tweetId)
+    );
+    for (const relationship of post.relationships) {
+      statements.push(
+        c.env.ARCHIVE_DB.prepare(
+          `INSERT INTO x_post_relationships
+            (user_id, source_tweet_id, relationship_type, target_tweet_id, target_url)
+           VALUES (?, ?, ?, ?, ?)`
+        ).bind(
+          userId,
+          post.tweetId,
+          relationship.type,
+          relationship.tweetId,
+          relationship.url ?? null
+        )
+      );
+    }
+  }
+  for (const item of input.items) {
+    statements.push(
+      c.env.ARCHIVE_DB.prepare(
+        `INSERT INTO x_timeline_run_items
+          (run_id, user_id, tweet_id, position, observed_at, presentation, reposted_by_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(run_id, tweet_id) DO UPDATE SET
+           position = MIN(x_timeline_run_items.position, excluded.position),
+           observed_at = MIN(x_timeline_run_items.observed_at, excluded.observed_at),
+           presentation = excluded.presentation,
+           reposted_by_json = excluded.reposted_by_json`
+      ).bind(
+        runId,
+        userId,
+        item.tweetId,
+        item.position,
+        Date.parse(item.observedAt),
+        item.presentation,
+        item.repostedBy ? JSON.stringify(item.repostedBy) : null
+      )
+    );
+  }
+  statements.push(
+    c.env.ARCHIVE_DB.prepare(
+      `INSERT INTO x_ingest_chunks
+        (run_id, chunk_index, checksum, posts_received, timeline_items_received, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).bind(runId, input.chunkIndex, checksum, postsById.size, input.items.length, now)
+  );
+  statements.push(
+    c.env.ARCHIVE_DB.prepare(
+      `UPDATE x_timeline_runs
+       SET collected_count = (SELECT COUNT(*) FROM x_timeline_run_items WHERE run_id = ?), updated_at = ?
+       WHERE id = ? AND user_id = ?`
+    ).bind(runId, now, runId, userId)
+  );
+  await c.env.ARCHIVE_DB.batch(statements);
+
+  return c.json({
+    accepted: true,
+    duplicateChunk: false,
+    postsReceived: postsById.size,
+    timelineItemsReceived: input.items.length,
+    canonicalPosts: { created, updated, unchanged },
+  });
+});
+
+app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
+  const parsed = CompleteXTimelineRunSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json(
+      { error: 'Invalid completion payload', code: 'INVALID_INPUT', issues: parsed.error.issues },
+      400
+    );
+  }
+  const userId = c.get('userId');
+  const runId = c.req.param('runId');
+  const run = await c.env.ARCHIVE_DB.prepare(
+    'SELECT * FROM x_timeline_runs WHERE id = ? AND user_id = ?'
+  )
+    .bind(runId, userId)
+    .first<RunRow>();
+  if (!run) return c.json({ error: 'Run not found', code: 'NOT_FOUND' }, 404);
+
+  const items = await c.env.ARCHIVE_DB.prepare(
+    `SELECT tweet_id, position, observed_at, presentation, reposted_by_json
+     FROM x_timeline_run_items WHERE run_id = ? ORDER BY position ASC`
+  )
+    .bind(runId)
+    .all<{
+      tweet_id: string;
+      position: number;
+      observed_at: number;
+      presentation: string;
+      reposted_by_json: string | null;
+    }>();
+  if (items.results.length !== parsed.data.collectedCount) {
+    return c.json(
+      {
+        error: `Collected count does not match uploaded timeline items (${items.results.length})`,
+        code: 'COUNT_MISMATCH',
+      },
+      409
+    );
+  }
+
+  const key = runManifestKey(userId, runId);
+  const completedAt = parsed.data.completedAt ? Date.parse(parsed.data.completedAt) : Date.now();
+  await c.env.ARCHIVE_BUCKET.put(
+    key,
+    await gzipJson({
+      schemaVersion: X_ARCHIVE_SCHEMA_VERSION,
+      runId,
+      requestedCount: run.requested_count,
+      collectedCount: parsed.data.collectedCount,
+      status: parsed.data.status,
+      startedAt: new Date(run.started_at).toISOString(),
+      completedAt: new Date(completedAt).toISOString(),
+      excludedAds: parsed.data.excludedAds,
+      collectorVersion: run.collector_version,
+      failureReason: parsed.data.failureReason ?? null,
+      items: items.results.map((item) => ({
+        tweetId: item.tweet_id,
+        position: item.position,
+        observedAt: new Date(item.observed_at).toISOString(),
+        presentation: item.presentation,
+        repostedBy: item.reposted_by_json ? (JSON.parse(item.reposted_by_json) as unknown) : null,
+      })),
+    }),
+    {
+      httpMetadata: { contentType: 'application/json', contentEncoding: 'gzip' },
+      customMetadata: { userId, runId },
+    }
+  );
+
+  await c.env.ARCHIVE_DB.prepare(
+    `UPDATE x_timeline_runs SET
+      collected_count = ?, status = ?, completed_at = ?, excluded_ads = ?, manifest_key = ?,
+      failure_reason = ?, updated_at = ?
+     WHERE id = ? AND user_id = ?`
+  )
+    .bind(
+      parsed.data.collectedCount,
+      parsed.data.status,
+      completedAt,
+      parsed.data.excludedAds,
+      key,
+      parsed.data.failureReason ?? null,
+      Date.now(),
+      runId,
+      userId
+    )
+    .run();
+
+  const completed = await c.env.ARCHIVE_DB.prepare('SELECT * FROM x_timeline_runs WHERE id = ?')
+    .bind(runId)
+    .first<RunRow>();
+  return c.json({ run: publicRun(completed!), manifestKey: key });
+});
+
+app.get('/api/v1/x-timeline/runs', async (c) => {
+  const userId = c.get('userId');
+  const limit = parseLimit(c.req.query('limit'));
+  const rows = await c.env.ARCHIVE_DB.prepare(
+    `SELECT * FROM x_timeline_runs WHERE user_id = ? ORDER BY started_at DESC, id DESC LIMIT ?`
+  )
+    .bind(userId, limit)
+    .all<RunRow>();
+  return c.json({ runs: rows.results.map(publicRun) });
+});
+
+app.get('/api/v1/x-timeline/runs/:runId/export', async (c) => {
+  const userId = c.get('userId');
+  const run = await c.env.ARCHIVE_DB.prepare(
+    'SELECT manifest_key FROM x_timeline_runs WHERE id = ? AND user_id = ?'
+  )
+    .bind(c.req.param('runId'), userId)
+    .first<{ manifest_key: string | null }>();
+  if (!run?.manifest_key)
+    return c.json({ error: 'Completed run not found', code: 'NOT_FOUND' }, 404);
+  const object = await c.env.ARCHIVE_BUCKET.get(run.manifest_key);
+  if (!object) return c.json({ error: 'Run manifest is missing', code: 'ARCHIVE_MISSING' }, 500);
+  return new Response(object.body, {
+    headers: {
+      'content-type': 'application/json',
+      'content-encoding': 'gzip',
+      etag: object.httpEtag,
+    },
+  });
+});
+
+app.get('/api/v1/x-timeline/runs/:runId', async (c) => {
+  const userId = c.get('userId');
+  const run = await c.env.ARCHIVE_DB.prepare(
+    'SELECT * FROM x_timeline_runs WHERE id = ? AND user_id = ?'
+  )
+    .bind(c.req.param('runId'), userId)
+    .first<RunRow>();
+  if (!run) return c.json({ error: 'Run not found', code: 'NOT_FOUND' }, 404);
+  const items = await c.env.ARCHIVE_DB.prepare(
+    `SELECT i.position, i.observed_at, i.presentation, i.reposted_by_json,
+      p.tweet_id, p.url, p.text, p.published_at, p.lang, p.kind,
+      p.author_key, a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified,
+      p.media_json, p.metrics_json, p.r2_key, p.content_hash, p.first_seen_at, p.last_seen_at,
+      p.first_run_id, p.latest_run_id, p.schema_version
+     FROM x_timeline_run_items i
+     JOIN x_posts p ON p.user_id = i.user_id AND p.tweet_id = i.tweet_id
+     JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+     WHERE i.run_id = ? AND i.user_id = ? ORDER BY i.position ASC`
+  )
+    .bind(run.id, userId)
+    .all<
+      PostRow & {
+        position: number;
+        observed_at: number;
+        presentation: string;
+        reposted_by_json: string | null;
+      }
+    >();
+  return c.json({
+    run: publicRun(run),
+    items: items.results.map((item) => ({
+      position: item.position,
+      observedAt: new Date(item.observed_at).toISOString(),
+      presentation: item.presentation,
+      repostedBy: item.reposted_by_json ? (JSON.parse(item.reposted_by_json) as unknown) : null,
+      post: publicPost(item),
+    })),
+  });
+});
+
+app.get('/api/v1/x-timeline/posts/:tweetId', async (c) => {
+  const userId = c.get('userId');
+  const row = await c.env.ARCHIVE_DB.prepare(
+    `SELECT p.*, a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified
+     FROM x_posts p JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+     WHERE p.user_id = ? AND p.tweet_id = ?`
+  )
+    .bind(userId, c.req.param('tweetId'))
+    .first<PostRow>();
+  if (!row) return c.json({ error: 'Post not found', code: 'NOT_FOUND' }, 404);
+  const relationships = await c.env.ARCHIVE_DB.prepare(
+    `SELECT relationship_type AS type, target_tweet_id AS tweetId, target_url AS url
+     FROM x_post_relationships WHERE user_id = ? AND source_tweet_id = ?`
+  )
+    .bind(userId, row.tweet_id)
+    .all();
+  return c.json({ post: { ...publicPost(row), relationships: relationships.results } });
+});
+
+app.get('/api/v1/x-timeline/posts', async (c) => {
+  const userId = c.get('userId');
+  const limit = parseLimit(c.req.query('limit'));
+  const cursor = decodeCursor(c.req.query('cursor'));
+  const statement = cursor
+    ? c.env.ARCHIVE_DB.prepare(
+        `SELECT p.*, a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified
+         FROM x_posts p JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+         WHERE p.user_id = ? AND (p.last_seen_at < ? OR (p.last_seen_at = ? AND p.tweet_id < ?))
+         ORDER BY p.last_seen_at DESC, p.tweet_id DESC LIMIT ?`
+      ).bind(userId, cursor[0], cursor[0], cursor[1], limit)
+    : c.env.ARCHIVE_DB.prepare(
+        `SELECT p.*, a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified
+         FROM x_posts p JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+         WHERE p.user_id = ? ORDER BY p.last_seen_at DESC, p.tweet_id DESC LIMIT ?`
+      ).bind(userId, limit);
+  const rows = await statement.all<PostRow>();
+  const last = rows.results.at(-1);
+  return c.json({
+    posts: rows.results.map(publicPost),
+    nextCursor:
+      rows.results.length === limit && last ? encodeCursor(last.last_seen_at, last.tweet_id) : null,
+  });
+});
+
+export { app };
+export default app;

--- a/apps/x-archive/src/test/auth-migrations/0000_auth.sql
+++ b/apps/x-archive/src/test/auth-migrations/0000_auth.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS api_tokens (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  token_prefix TEXT NOT NULL,
+  scopes_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  last_used_at INTEGER,
+  expires_at INTEGER,
+  revoked_at INTEGER
+);
+CREATE UNIQUE INDEX IF NOT EXISTS api_tokens_token_hash_idx ON api_tokens(token_hash);

--- a/apps/x-archive/src/test/setup.ts
+++ b/apps/x-archive/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { applyD1Migrations, env, type D1Migration } from 'cloudflare:test';
+import { beforeAll } from 'vitest';
+
+beforeAll(async () => {
+  const bindings = env as Env & {
+    AUTH_MIGRATIONS: D1Migration[];
+    ARCHIVE_MIGRATIONS: D1Migration[];
+  };
+  await applyD1Migrations(bindings.AUTH_DB, bindings.AUTH_MIGRATIONS);
+  await applyD1Migrations(bindings.ARCHIVE_DB, bindings.ARCHIVE_MIGRATIONS);
+});

--- a/apps/x-archive/tsconfig.json
+++ b/apps/x-archive/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers", "vitest/globals"],
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "worker-configuration.d.ts"]
+}

--- a/apps/x-archive/vitest.config.ts
+++ b/apps/x-archive/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineWorkersConfig, readD1Migrations } from '@cloudflare/vitest-pool-workers/config';
+
+const authMigrations = await readD1Migrations('src/test/auth-migrations');
+const archiveMigrations = await readD1Migrations('src/db/migrations');
+
+export default defineWorkersConfig({
+  test: {
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    poolOptions: {
+      workers: {
+        isolatedStorage: false,
+        wrangler: { configPath: './wrangler.test.toml' },
+        miniflare: {
+          bindings: { AUTH_MIGRATIONS: authMigrations, ARCHIVE_MIGRATIONS: archiveMigrations },
+        },
+      },
+    },
+  },
+});

--- a/apps/x-archive/worker-configuration.d.ts
+++ b/apps/x-archive/worker-configuration.d.ts
@@ -1,0 +1,6 @@
+interface Env {
+  AUTH_DB: D1Database;
+  ARCHIVE_DB: D1Database;
+  ARCHIVE_BUCKET: R2Bucket;
+  ENVIRONMENT: string;
+}

--- a/apps/x-archive/wrangler.test.toml
+++ b/apps/x-archive/wrangler.test.toml
@@ -1,0 +1,23 @@
+name = "zine-x-archive-test"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "AUTH_DB"
+database_name = "zine-x-archive-auth-test"
+database_id = "x-archive-auth-test"
+migrations_dir = "src/test/auth-migrations"
+
+[[d1_databases]]
+binding = "ARCHIVE_DB"
+database_name = "zine-x-archive-test"
+database_id = "x-archive-test"
+migrations_dir = "src/db/migrations"
+
+[[r2_buckets]]
+binding = "ARCHIVE_BUCKET"
+bucket_name = "zine-x-archive-test"
+
+[vars]
+ENVIRONMENT = "test"

--- a/apps/x-archive/wrangler.toml
+++ b/apps/x-archive/wrangler.toml
@@ -1,0 +1,72 @@
+name = "zine-x-archive-dev"
+main = "src/index.ts"
+compatibility_date = "2026-07-11"
+compatibility_flags = ["nodejs_compat"]
+workers_dev = true
+
+[[d1_databases]]
+binding = "AUTH_DB"
+database_name = "zine-db-dev"
+database_id = "2ce5331a-233c-48ec-9265-d04ecb539599"
+
+[[d1_databases]]
+binding = "ARCHIVE_DB"
+database_name = "zine-x-archive-dev"
+database_id = "a69f0e9e-2c1c-4c10-8538-0ef4c03418c0"
+migrations_dir = "src/db/migrations"
+
+[[r2_buckets]]
+binding = "ARCHIVE_BUCKET"
+bucket_name = "zine-x-archive-dev"
+
+[vars]
+ENVIRONMENT = "development"
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+[env.staging]
+name = "zine-x-archive-staging"
+workers_dev = true
+
+[[env.staging.d1_databases]]
+binding = "AUTH_DB"
+database_name = "zine-db-staging"
+database_id = "feaff315-9e1d-41ce-94c4-563489ccffba"
+
+[[env.staging.d1_databases]]
+binding = "ARCHIVE_DB"
+database_name = "zine-x-archive-staging"
+database_id = "8eee0d54-70e4-4afd-b62b-908574ef301b"
+migrations_dir = "src/db/migrations"
+
+[[env.staging.r2_buckets]]
+binding = "ARCHIVE_BUCKET"
+bucket_name = "zine-x-archive-staging"
+
+[env.staging.vars]
+ENVIRONMENT = "staging"
+
+[env.production]
+name = "zine-x-archive-production"
+workers_dev = true
+routes = [{ pattern = "x-archive-api.myzine.app", custom_domain = true }]
+
+[[env.production.d1_databases]]
+binding = "AUTH_DB"
+database_name = "zine-db-production"
+database_id = "82911dea-5a6b-411b-ab4b-4145cb0c191d"
+
+[[env.production.d1_databases]]
+binding = "ARCHIVE_DB"
+database_name = "zine-x-archive-production"
+database_id = "ad6f4c42-f2e9-449d-a9c6-7780fc08e9fa"
+migrations_dir = "src/db/migrations"
+
+[[env.production.r2_buckets]]
+binding = "ARCHIVE_BUCKET"
+bucket_name = "zine-x-archive-production"
+
+[env.production.vars]
+ENVIRONMENT = "production"

--- a/apps/x-collector/package.json
+++ b/apps/x-collector/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zine/x-collector",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "zine-x-collector": "./src/cli.ts"
+  },
+  "scripts": {
+    "build": "bun build src/cli.ts --target bun --outdir dist",
+    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test src",
+    "upload": "bun run src/cli.ts upload",
+    "validate": "bun run src/cli.ts validate",
+    "receive": "bun run src/cli.ts receive"
+  },
+  "dependencies": {
+    "@zine/x-archive-schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "linkedom": "^0.18.12",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/x-collector/src/browser-extractor.mjs
+++ b/apps/x-collector/src/browser-extractor.mjs
@@ -1,0 +1,191 @@
+/* global document */
+
+export function extractVisibleTimelineBatch(seenAdKeys = []) {
+  function metricNumber(value) {
+    if (!value) return null;
+    const match = String(value)
+      .replace(/,/g, '')
+      .match(/([\d.]+)\s*([KMB])?/i);
+    if (!match) return null;
+    const number = Number(match[1]);
+    const multiplier =
+      { K: 1_000, M: 1_000_000, B: 1_000_000_000 }[(match[2] || '').toUpperCase()] || 1;
+    return Number.isFinite(number) ? Math.round(number * multiplier) : null;
+  }
+
+  function statusIdentity(href) {
+    if (!href) return null;
+    const match = href.match(/^\/?([^/?#]+)\/status\/(\d+)/);
+    if (!match) return null;
+    return {
+      tweetId: match[2],
+      username: match[1],
+      url: `https://x.com/${match[1]}/status/${match[2]}`,
+    };
+  }
+
+  function authorFromContainer(container, fallbackUsername = 'unknown') {
+    const nameRoot = container?.querySelector?.('[data-testid="User-Name"]') || container;
+    const links = [...(nameRoot?.querySelectorAll?.('a[href]') || [])];
+    const handleLink = links.find((link) => /^\/[^/]+$/.test(link.getAttribute('href') || ''));
+    const username =
+      handleLink?.getAttribute('href')?.slice(1) ||
+      [...(nameRoot?.querySelectorAll?.('span') || [])]
+        .map((span) => span.textContent?.trim())
+        .find((text) => text?.startsWith('@'))
+        ?.slice(1) ||
+      fallbackUsername;
+    const spanTexts = [...(nameRoot?.querySelectorAll?.('span') || [])]
+      .map((span) => span.textContent?.trim())
+      .filter(Boolean);
+    const name = spanTexts.find((text) => text !== `@${username}`) || username;
+    const avatar =
+      container?.querySelector?.('img[src*="profile_images"]')?.getAttribute('src') || null;
+    return {
+      username,
+      name,
+      profileUrl: `https://x.com/${username}`,
+      profileImageUrl: avatar,
+    };
+  }
+
+  function isPromoted(article) {
+    const social = article.querySelector('[data-testid="socialContext"]')?.textContent || '';
+    if (/\bPromoted\b|\bSponsored\b/i.test(social)) return true;
+    const tweetText = article.querySelector('[data-testid="tweetText"]');
+    return [...article.querySelectorAll('span')].some((span) => {
+      if (tweetText?.contains(span)) return false;
+      return /^(Ad|Promoted|Sponsored)$/i.test(span.textContent?.trim() || '');
+    });
+  }
+
+  function extractMetrics(article) {
+    const valueFor = (testId) => {
+      const node = article.querySelector(`[data-testid="${testId}"]`);
+      return metricNumber(node?.getAttribute('aria-label') || node?.textContent);
+    };
+    const viewsNode = [...article.querySelectorAll('a[href*="/analytics"]')][0];
+    return {
+      replies: valueFor('reply'),
+      reposts: valueFor('retweet'),
+      likes: valueFor('like') ?? valueFor('unlike'),
+      views: metricNumber(viewsNode?.getAttribute('aria-label') || viewsNode?.textContent),
+    };
+  }
+
+  function extractMedia(article) {
+    const seen = new Set();
+    const media = [];
+    for (const image of article.querySelectorAll('img[src*="pbs.twimg.com/media"]')) {
+      const url = image.getAttribute('src');
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      media.push({
+        type: 'IMAGE',
+        url,
+        altText: image.getAttribute('alt') || null,
+        width: image.naturalWidth || null,
+        height: image.naturalHeight || null,
+      });
+    }
+    for (const video of article.querySelectorAll('video')) {
+      const url = video.getAttribute('src') || video.getAttribute('poster');
+      if (!url || seen.has(url)) continue;
+      seen.add(url);
+      media.push({
+        type: 'VIDEO',
+        url,
+        previewUrl: video.getAttribute('poster') || null,
+        width: video.videoWidth || null,
+        height: video.videoHeight || null,
+        durationMs: Number.isFinite(video.duration) ? Math.round(video.duration * 1000) : null,
+      });
+    }
+    return media;
+  }
+
+  function extractQuotedPost(article, primaryIdentity, capturedAt) {
+    const identities = [...article.querySelectorAll('a[href*="/status/"]')]
+      .map((link) => statusIdentity(link.getAttribute('href')))
+      .filter(Boolean);
+    const quotedIdentity = identities.find(
+      (identity) => identity.tweetId !== primaryIdentity.tweetId
+    );
+    const textNodes = [...article.querySelectorAll('[data-testid="tweetText"]')];
+    if (!quotedIdentity || textNodes.length < 2) return null;
+    const quotedText = textNodes.at(-1);
+    const quotedContainer = quotedText.closest('[role="link"]') || quotedText.parentElement;
+    return {
+      tweetId: quotedIdentity.tweetId,
+      url: quotedIdentity.url,
+      text: quotedText.textContent?.trim() || '',
+      publishedAt: quotedContainer?.querySelector('time')?.getAttribute('datetime') || null,
+      kind: 'POST',
+      author: authorFromContainer(quotedContainer, quotedIdentity.username),
+      media: extractMedia(quotedContainer || article),
+      relationships: [],
+      metrics: {},
+      capturedAt,
+    };
+  }
+
+  function extractBatch() {
+    const capturedAt = new Date().toISOString();
+    const posts = [];
+    const items = [];
+    let excludedAds = 0;
+    const knownAdKeys = new Set(Array.isArray(seenAdKeys) ? seenAdKeys : []);
+    const adKeys = [];
+
+    for (const article of document.querySelectorAll('article[data-testid="tweet"]')) {
+      if (isPromoted(article)) {
+        const adKey =
+          article.querySelector('a[href*="/status/"]')?.getAttribute('href') ||
+          article.textContent?.trim().slice(0, 500) ||
+          `ad-${knownAdKeys.size}`;
+        if (!knownAdKeys.has(adKey)) {
+          knownAdKeys.add(adKey);
+          adKeys.push(adKey);
+          excludedAds++;
+        }
+        continue;
+      }
+      const timeLink = article.querySelector('a[href*="/status/"]:has(time)');
+      const identity = statusIdentity(timeLink?.getAttribute('href'));
+      if (!identity) continue;
+      const textNodes = [...article.querySelectorAll('[data-testid="tweetText"]')];
+      const text = textNodes[0]?.textContent?.trim() || '';
+      const socialContext = article.querySelector('[data-testid="socialContext"]');
+      const reposted = /reposted/i.test(socialContext?.textContent || '');
+      const quoted = extractQuotedPost(article, identity, capturedAt);
+      const reply = /Replying to/i.test(article.textContent || '');
+      const relationships = [];
+      if (quoted)
+        relationships.push({ type: 'QUOTE_OF', tweetId: quoted.tweetId, url: quoted.url });
+      const post = {
+        tweetId: identity.tweetId,
+        url: identity.url,
+        text,
+        publishedAt: article.querySelector('time')?.getAttribute('datetime') || null,
+        lang: article.querySelector('[data-testid="tweetText"]')?.getAttribute('lang') || null,
+        kind: quoted ? 'QUOTE' : reply ? 'REPLY' : 'POST',
+        author: authorFromContainer(article, identity.username),
+        media: extractMedia(article),
+        relationships,
+        metrics: extractMetrics(article),
+        capturedAt,
+      };
+      posts.push(post);
+      if (quoted) posts.push(quoted);
+      items.push({
+        tweetId: identity.tweetId,
+        observedAt: capturedAt,
+        presentation: reposted ? 'REPOST' : 'POST',
+        repostedBy: reposted ? authorFromContainer(socialContext, 'unknown') : null,
+      });
+    }
+    return { posts, items, excludedAds, adKeys };
+  }
+
+  return extractBatch();
+}

--- a/apps/x-collector/src/browser-extractor.test.mjs
+++ b/apps/x-collector/src/browser-extractor.test.mjs
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { parseHTML } from 'linkedom';
+import { extractVisibleTimelineBatch } from './browser-extractor.mjs';
+
+afterEach(() => {
+  delete globalThis.document;
+});
+
+describe('X browser extractor', () => {
+  it('keeps organic posts, repost context, and quote pointers while excluding ads', () => {
+    const { document } = parseHTML(`
+      <main>
+        <article data-testid="tweet">
+          <div data-testid="User-Name">
+            <span>Original Author</span><span>@original</span><a href="/original"></a>
+          </div>
+          <a href="/original/status/100"><time datetime="2026-07-11T12:00:00.000Z"></time></a>
+          <div data-testid="tweetText" lang="en">An original post</div>
+          <button data-testid="like" aria-label="12 Likes"></button>
+        </article>
+
+        <article data-testid="tweet">
+          <span>Ad</span>
+          <div data-testid="User-Name"><span>Advertiser</span><a href="/advertiser"></a></div>
+          <a href="/advertiser/status/200"><time datetime="2026-07-11T12:01:00.000Z"></time></a>
+          <div data-testid="tweetText">Buy something</div>
+        </article>
+
+        <article data-testid="tweet">
+          <div data-testid="socialContext"><a href="/reposter"></a><span>Reposter reposted</span></div>
+          <div data-testid="User-Name">
+            <span>Quote Author</span><span>@quoteauthor</span><a href="/quoteauthor"></a>
+          </div>
+          <a href="/quoteauthor/status/300"><time datetime="2026-07-11T12:02:00.000Z"></time></a>
+          <div data-testid="tweetText">My comment</div>
+          <div role="link">
+            <div data-testid="User-Name"><span>Quoted</span><span>@quoted</span><a href="/quoted"></a></div>
+            <a href="/quoted/status/301"><time datetime="2026-07-11T11:00:00.000Z"></time></a>
+            <div data-testid="tweetText">Quoted text</div>
+          </div>
+        </article>
+      </main>
+    `);
+    globalThis.document = document;
+
+    const result = extractVisibleTimelineBatch();
+
+    expect(result.excludedAds).toBe(1);
+    expect(result.adKeys).toHaveLength(1);
+    expect(result.items.map((item) => item.tweetId)).toEqual(['100', '300']);
+    expect(result.posts.map((post) => post.tweetId)).toEqual(['100', '300', '301']);
+    expect(result.items[1]).toMatchObject({ presentation: 'REPOST' });
+    expect(result.posts[1]).toMatchObject({
+      kind: 'QUOTE',
+      relationships: [{ type: 'QUOTE_OF', tweetId: '301' }],
+    });
+
+    const repeated = extractVisibleTimelineBatch(result.adKeys);
+    expect(repeated.excludedAds).toBe(0);
+    expect(repeated.adKeys).toEqual([]);
+  });
+});

--- a/apps/x-collector/src/cli.ts
+++ b/apps/x-collector/src/cli.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+
+import { readFile } from 'node:fs/promises';
+import { XTimelineCaptureSchema } from '@zine/x-archive-schema';
+import { startReceiver } from './receiver';
+import { uploadCapture } from './upload';
+
+type Args = { _: string[]; [key: string]: string | boolean | string[] };
+
+function parseArgs(argv: string[]): Args {
+  const result: Args = { _: [] };
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index]!;
+    if (!value.startsWith('--')) {
+      result._.push(value);
+      continue;
+    }
+    const key = value.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      index++;
+    } else {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+async function readInput(path: string | boolean | undefined): Promise<unknown> {
+  const text = typeof path === 'string' ? await readFile(path, 'utf8') : await Bun.stdin.text();
+  return JSON.parse(text) as unknown;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  bun run --cwd apps/x-collector validate [--file capture.json]
+  bun run --cwd apps/x-collector upload [--file capture.json] [--api-url URL] [--token TOKEN]
+  bun run --cwd apps/x-collector receive --count 500 [--port 4319] [--api-url URL] [--token TOKEN]
+
+Environment:
+  ZINE_X_ARCHIVE_API_URL   defaults to https://x-archive-api.myzine.app
+  ZINE_X_ARCHIVE_TOKEN     PAT with x-archive:write and preferably x-archive:read`);
+  process.exit(2);
+}
+
+const args = parseArgs(Bun.argv.slice(2));
+const command = args._[0];
+if (command !== 'validate' && command !== 'upload' && command !== 'receive') usage();
+
+try {
+  if (command === 'receive') {
+    const token =
+      (typeof args.token === 'string' ? args.token : undefined) ?? process.env.ZINE_X_ARCHIVE_TOKEN;
+    if (!token) throw new Error('ZINE_X_ARCHIVE_TOKEN or --token is required');
+    const requestedCount = typeof args.count === 'string' ? Number.parseInt(args.count, 10) : 500;
+    if (!Number.isFinite(requestedCount) || requestedCount < 1 || requestedCount > 100_000) {
+      throw new Error('--count must be between 1 and 100000');
+    }
+    const port = typeof args.port === 'string' ? Number.parseInt(args.port, 10) : 4319;
+    const apiUrl =
+      (typeof args['api-url'] === 'string' ? args['api-url'] : undefined) ??
+      process.env.ZINE_X_ARCHIVE_API_URL ??
+      'https://x-archive-api.myzine.app';
+    const receiver = startReceiver({ requestedCount, apiUrl, token, port });
+    console.log(
+      JSON.stringify({
+        ready: true,
+        receiverUrl: receiver.url,
+        runId: receiver.runId,
+        requestedCount,
+      })
+    );
+    const result = await receiver.completed;
+    console.log(JSON.stringify({ success: true, ...result }, null, 2));
+    process.exit(0);
+  }
+
+  const raw = await readInput(typeof args.file === 'string' ? args.file : undefined);
+  const capture = XTimelineCaptureSchema.parse(raw);
+  if (command === 'validate') {
+    console.log(
+      JSON.stringify(
+        {
+          valid: true,
+          runId: capture.runId,
+          requestedCount: capture.requestedCount,
+          collectedCount: capture.items.length,
+          canonicalPosts: capture.posts.length,
+          excludedAds: capture.excludedAds,
+        },
+        null,
+        2
+      )
+    );
+    process.exit(0);
+  }
+
+  const apiUrl =
+    (typeof args['api-url'] === 'string' ? args['api-url'] : undefined) ??
+    process.env.ZINE_X_ARCHIVE_API_URL ??
+    'https://x-archive-api.myzine.app';
+  const token =
+    (typeof args.token === 'string' ? args.token : undefined) ?? process.env.ZINE_X_ARCHIVE_TOKEN;
+  if (!token) throw new Error('ZINE_X_ARCHIVE_TOKEN or --token is required');
+  const chunkSize =
+    typeof args['chunk-size'] === 'string' ? Number.parseInt(args['chunk-size'], 10) : undefined;
+
+  const result = await uploadCapture(capture, {
+    apiUrl,
+    token,
+    chunkSize,
+    verify: args['no-verify'] !== true,
+  });
+  console.log(JSON.stringify({ success: true, ...result }, null, 2));
+} catch (error) {
+  console.error(
+    JSON.stringify(
+      { success: false, error: error instanceof Error ? error.message : String(error) },
+      null,
+      2
+    )
+  );
+  process.exit(1);
+}

--- a/apps/x-collector/src/receiver.test.ts
+++ b/apps/x-collector/src/receiver.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { startReceiver, type ReceiverHandle } from './receiver';
+
+let receiver: ReceiverHandle | null = null;
+let apiServer: ReturnType<typeof Bun.serve> | null = null;
+
+afterEach(() => {
+  receiver?.stop();
+  apiServer?.stop();
+  receiver = null;
+  apiServer = null;
+});
+
+describe('local browser receiver', () => {
+  it('accumulates browser batches and performs a verified upload', async () => {
+    apiServer = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname.endsWith('/runs') && request.method === 'POST') {
+          return Response.json({ run: { id: 'receiver-run-001' } }, { status: 201 });
+        }
+        if (url.pathname.includes('/chunks/')) return Response.json({ accepted: true });
+        if (url.pathname.endsWith('/complete')) {
+          return Response.json({ run: { id: 'receiver-run-001', collectedCount: 1 } });
+        }
+        return Response.json({ run: { id: 'receiver-run-001', collectedCount: 1 } });
+      },
+    });
+    receiver = startReceiver({
+      requestedCount: 1,
+      apiUrl: `http://${apiServer.hostname}:${apiServer.port}`,
+      token: 'zine_pat_receiver-test',
+      port: 0,
+      runId: 'receiver-run-001',
+      startedAt: '2026-07-11T13:00:00.000Z',
+    });
+
+    const batch = await fetch(`${receiver.url}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        posts: [
+          {
+            tweetId: '100',
+            url: 'https://x.com/example/status/100',
+            text: 'Hello',
+            kind: 'POST',
+            author: { username: 'example', name: 'Example' },
+            media: [],
+            relationships: [],
+            metrics: {},
+            capturedAt: '2026-07-11T13:00:00.000Z',
+          },
+        ],
+        items: [
+          {
+            tweetId: '100',
+            position: 0,
+            observedAt: '2026-07-11T13:00:00.000Z',
+            presentation: 'POST',
+          },
+        ],
+        excludedAds: 1,
+      }),
+    });
+    expect(await batch.json()).toMatchObject({
+      timelineItems: 1,
+      canonicalPosts: 1,
+      excludedAds: 1,
+    });
+
+    const complete = await fetch(`${receiver.url}/complete`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'COMPLETE' }),
+    });
+    expect(complete.status).toBe(200);
+    await expect(receiver.completed).resolves.toMatchObject({
+      runId: 'receiver-run-001',
+      timelineItemsSubmitted: 1,
+      verified: true,
+    });
+  });
+});

--- a/apps/x-collector/src/receiver.ts
+++ b/apps/x-collector/src/receiver.ts
@@ -1,0 +1,149 @@
+import {
+  XPostSchema,
+  XTimelineCaptureSchema,
+  XTimelineItemSchema,
+  type XPost,
+  type XTimelineItem,
+} from '@zine/x-archive-schema';
+import { z } from 'zod';
+import { uploadCapture, type UploadResult } from './upload';
+
+const BatchSchema = z
+  .object({
+    posts: z.array(XPostSchema).max(200),
+    items: z.array(XTimelineItemSchema).max(100),
+    excludedAds: z.number().int().nonnegative().default(0),
+  })
+  .strict();
+
+const CompleteSchema = z
+  .object({
+    status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
+    failureReason: z.string().max(2_000).nullable().optional(),
+  })
+  .strict();
+
+export type ReceiverOptions = {
+  requestedCount: number;
+  apiUrl: string;
+  token: string;
+  port?: number;
+  collectorVersion?: string;
+  runId?: string;
+  startedAt?: string;
+};
+
+export type ReceiverHandle = {
+  url: string;
+  runId: string;
+  completed: Promise<UploadResult>;
+  stop: () => void;
+};
+
+function corsHeaders() {
+  return {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  };
+}
+
+export function startReceiver(options: ReceiverOptions): ReceiverHandle {
+  const runId = options.runId ?? crypto.randomUUID();
+  const startedAt = options.startedAt ?? new Date().toISOString();
+  const posts = new Map<string, XPost>();
+  const items = new Map<string, XTimelineItem>();
+  let excludedAds = 0;
+  let resolveCompleted!: (result: UploadResult) => void;
+  let rejectCompleted!: (error: unknown) => void;
+  const completed = new Promise<UploadResult>((resolve, reject) => {
+    resolveCompleted = resolve;
+    rejectCompleted = reject;
+  });
+
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: options.port ?? 4319,
+    async fetch(request) {
+      if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders() });
+      const url = new URL(request.url);
+      if (request.method === 'GET' && url.pathname === '/session') {
+        return Response.json(
+          {
+            runId,
+            startedAt,
+            requestedCount: options.requestedCount,
+            collectorVersion: options.collectorVersion ?? 'chrome-dom-v1',
+            posts: posts.size,
+            items: items.size,
+            excludedAds,
+          },
+          { headers: corsHeaders() }
+        );
+      }
+      if (request.method === 'POST' && url.pathname === '/batch') {
+        const parsed = BatchSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+          return Response.json(
+            { error: 'Invalid collector batch', issues: parsed.error.issues },
+            { status: 400, headers: corsHeaders() }
+          );
+        }
+        for (const post of parsed.data.posts) posts.set(post.tweetId, post);
+        for (const item of parsed.data.items) {
+          if (!items.has(item.tweetId)) items.set(item.tweetId, item);
+        }
+        excludedAds += parsed.data.excludedAds;
+        return Response.json(
+          { accepted: true, canonicalPosts: posts.size, timelineItems: items.size, excludedAds },
+          { headers: corsHeaders() }
+        );
+      }
+      if (request.method === 'POST' && url.pathname === '/complete') {
+        const parsed = CompleteSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+          return Response.json(
+            { error: 'Invalid completion payload', issues: parsed.error.issues },
+            { status: 400, headers: corsHeaders() }
+          );
+        }
+        try {
+          const capture = XTimelineCaptureSchema.parse({
+            runId,
+            requestedCount: options.requestedCount,
+            startedAt,
+            completedAt: new Date().toISOString(),
+            collectorVersion: options.collectorVersion ?? 'chrome-dom-v1',
+            excludedAds,
+            status: parsed.data.status,
+            failureReason: parsed.data.failureReason ?? null,
+            posts: [...posts.values()],
+            items: [...items.values()].sort((left, right) => left.position - right.position),
+          });
+          const result = await uploadCapture(capture, {
+            apiUrl: options.apiUrl,
+            token: options.token,
+            verify: true,
+          });
+          resolveCompleted(result);
+          setTimeout(() => server.stop(), 100);
+          return Response.json({ success: true, ...result }, { headers: corsHeaders() });
+        } catch (error) {
+          rejectCompleted(error);
+          return Response.json(
+            { success: false, error: error instanceof Error ? error.message : String(error) },
+            { status: 500, headers: corsHeaders() }
+          );
+        }
+      }
+      return Response.json({ error: 'Not found' }, { status: 404, headers: corsHeaders() });
+    },
+  });
+
+  return {
+    url: `http://${server.hostname}:${server.port}`,
+    runId,
+    completed,
+    stop: () => server.stop(),
+  };
+}

--- a/apps/x-collector/src/upload.test.ts
+++ b/apps/x-collector/src/upload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildUploadChunks, uploadCapture } from './upload';
+
+function capture(count = 26) {
+  const posts = Array.from({ length: count }, (_, index) => ({
+    tweetId: String(1000 + index),
+    url: `https://x.com/example/status/${1000 + index}`,
+    text: `Post ${index}`,
+    kind: 'POST' as const,
+    author: { username: 'example', name: 'Example' },
+    media: [],
+    relationships: [],
+    metrics: {},
+    capturedAt: '2026-07-11T13:00:00.000Z',
+  }));
+  return {
+    runId: 'run-collector-001',
+    requestedCount: count,
+    startedAt: '2026-07-11T13:00:00.000Z',
+    completedAt: '2026-07-11T13:05:00.000Z',
+    collectorVersion: 'test-v1',
+    excludedAds: 0,
+    status: 'COMPLETE' as const,
+    posts,
+    items: posts.map((post, position) => ({
+      tweetId: post.tweetId,
+      position,
+      observedAt: '2026-07-11T13:00:00.000Z',
+      presentation: 'POST' as const,
+    })),
+  };
+}
+
+describe('X collector uploader', () => {
+  it('chunks primary timeline items without duplicating post payloads', () => {
+    const chunks = buildUploadChunks(capture(), 25);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.items).toHaveLength(25);
+    expect(chunks[1]?.items).toHaveLength(1);
+    expect(chunks.flatMap((chunk) => chunk.posts)).toHaveLength(26);
+  });
+
+  it('uploads and verifies a complete capture', async () => {
+    const requests: Array<{ url: string; method: string }> = [];
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({ url, method: init?.method ?? 'GET' });
+      if (url.endsWith('/api/v1/x-timeline/runs') && init?.method === 'POST') {
+        return Response.json({ run: { id: 'run-collector-001' } }, { status: 201 });
+      }
+      if (url.includes('/chunks/')) return Response.json({ accepted: true });
+      if (url.endsWith('/complete')) {
+        return Response.json({ run: { id: 'run-collector-001', collectedCount: 26 } });
+      }
+      return Response.json({ run: { id: 'run-collector-001', collectedCount: 26 } });
+    }) as unknown as typeof fetch;
+
+    const result = await uploadCapture(capture(), {
+      apiUrl: 'https://archive.example.com/',
+      token: 'zine_pat_test',
+      fetchImpl,
+    });
+    expect(result).toMatchObject({ chunksUploaded: 2, timelineItemsSubmitted: 26, verified: true });
+    expect(requests.map((request) => request.method)).toEqual([
+      'POST',
+      'PUT',
+      'PUT',
+      'POST',
+      'GET',
+    ]);
+  });
+});

--- a/apps/x-collector/src/upload.ts
+++ b/apps/x-collector/src/upload.ts
@@ -1,0 +1,168 @@
+import {
+  XTimelineCaptureSchema,
+  X_ARCHIVE_MAX_TIMELINE_ITEMS_PER_CHUNK,
+  type XPost,
+  type XTimelineCapture,
+  type XTimelineItem,
+} from '@zine/x-archive-schema';
+
+export type UploadOptions = {
+  apiUrl: string;
+  token: string;
+  chunkSize?: number;
+  verify?: boolean;
+  fetchImpl?: typeof fetch;
+};
+
+export type UploadResult = {
+  runId: string;
+  chunksUploaded: number;
+  postsSubmitted: number;
+  timelineItemsSubmitted: number;
+  verified: boolean | null;
+  run: unknown;
+};
+
+type Chunk = { posts: XPost[]; items: XTimelineItem[] };
+
+export function buildUploadChunks(capture: XTimelineCapture, requestedChunkSize = 25): Chunk[] {
+  const chunkSize = Math.min(
+    X_ARCHIVE_MAX_TIMELINE_ITEMS_PER_CHUNK,
+    Math.max(1, requestedChunkSize)
+  );
+  const postById = new Map(capture.posts.map((post) => [post.tweetId, post]));
+  const submittedPostIds = new Set<string>();
+  const chunks: Chunk[] = [];
+
+  for (let offset = 0; offset < capture.items.length; offset += chunkSize) {
+    const items = capture.items.slice(offset, offset + chunkSize);
+    const posts = items.map((item) => {
+      const post = postById.get(item.tweetId);
+      if (!post) throw new Error(`Missing canonical post ${item.tweetId}`);
+      submittedPostIds.add(post.tweetId);
+      return post;
+    });
+    chunks.push({ posts, items });
+  }
+
+  const remainingPosts = capture.posts.filter((post) => !submittedPostIds.has(post.tweetId));
+  for (let offset = 0; offset < remainingPosts.length; offset += chunkSize) {
+    chunks.push({ posts: remainingPosts.slice(offset, offset + chunkSize), items: [] });
+  }
+  return chunks;
+}
+
+async function requestJson<T>(
+  url: string,
+  init: RequestInit,
+  fetchImpl: typeof fetch,
+  attempts = 3
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetchImpl(url, init);
+      const text = await response.text();
+      const body = text ? (JSON.parse(text) as unknown) : null;
+      if (response.ok) return body as T;
+      const retryable = response.status === 429 || response.status >= 500;
+      if (!retryable || attempt === attempts) {
+        throw new Error(`Archive API ${response.status}: ${text || response.statusText}`);
+      }
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, attempt * 500));
+  }
+  throw lastError;
+}
+
+export async function uploadCapture(
+  rawCapture: unknown,
+  options: UploadOptions
+): Promise<UploadResult> {
+  const capture = XTimelineCaptureSchema.parse(rawCapture);
+  const apiUrl = options.apiUrl.replace(/\/$/, '');
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const headers = {
+    Authorization: `Bearer ${options.token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const create = await requestJson<{ run: unknown }>(
+    `${apiUrl}/api/v1/x-timeline/runs`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        runId: capture.runId,
+        requestedCount: capture.requestedCount,
+        startedAt: capture.startedAt,
+        collectorVersion: capture.collectorVersion,
+      }),
+    },
+    fetchImpl
+  );
+
+  const chunks = buildUploadChunks(capture, options.chunkSize);
+  let postsSubmitted = 0;
+  let timelineItemsSubmitted = 0;
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    await requestJson(
+      `${apiUrl}/api/v1/x-timeline/runs/${encodeURIComponent(capture.runId)}/chunks/${chunkIndex}`,
+      {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(chunk),
+      },
+      fetchImpl
+    );
+    postsSubmitted += chunk.posts.length;
+    timelineItemsSubmitted += chunk.items.length;
+  }
+
+  const completed = await requestJson<{ run: unknown }>(
+    `${apiUrl}/api/v1/x-timeline/runs/${encodeURIComponent(capture.runId)}/complete`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        collectedCount: capture.items.length,
+        completedAt: capture.completedAt ?? new Date().toISOString(),
+        excludedAds: capture.excludedAds,
+        status: capture.status,
+        failureReason: capture.failureReason ?? null,
+      }),
+    },
+    fetchImpl
+  );
+
+  let verified: boolean | null = null;
+  if (options.verify !== false) {
+    try {
+      const verification = await requestJson<{ run: { id: string; collectedCount: number } }>(
+        `${apiUrl}/api/v1/x-timeline/runs/${encodeURIComponent(capture.runId)}`,
+        { headers: { Authorization: `Bearer ${options.token}` } },
+        fetchImpl,
+        1
+      );
+      verified =
+        verification.run.id === capture.runId &&
+        verification.run.collectedCount === capture.items.length;
+      if (!verified) throw new Error('Archive verification did not match the uploaded capture');
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('403')) verified = null;
+      else throw error;
+    }
+  }
+
+  return {
+    runId: capture.runId,
+    chunksUploaded: chunks.length,
+    postsSubmitted,
+    timelineItemsSubmitted,
+    verified,
+    run: completed.run ?? create.run,
+  };
+}

--- a/apps/x-collector/tsconfig.json
+++ b/apps/x-collector/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun-types", "vitest/globals"],
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,38 @@
         "wrangler": "^3.95.0",
       },
     },
+    "apps/x-archive": {
+      "name": "@zine/x-archive",
+      "version": "0.0.1",
+      "dependencies": {
+        "@zine/x-archive-schema": "workspace:*",
+        "hono": "^4.6.14",
+        "zod": "^3.24.1",
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.33",
+        "@cloudflare/workers-types": "^4.20241205.0",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8",
+        "wrangler": "^3.95.0",
+      },
+    },
+    "apps/x-collector": {
+      "name": "@zine/x-collector",
+      "version": "0.0.1",
+      "bin": {
+        "zine-x-collector": "./src/cli.ts",
+      },
+      "dependencies": {
+        "@zine/x-archive-schema": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "linkedom": "^0.18.12",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8",
+      },
+    },
     "packages/design-system": {
       "name": "@zine/design-system",
       "version": "0.0.1",
@@ -192,6 +224,18 @@
       "devDependencies": {
         "tsup": "^8.3.0",
         "typescript": "^5.7.2",
+      },
+    },
+    "packages/x-archive-schema": {
+      "name": "@zine/x-archive-schema",
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^3.24.1",
+      },
+      "devDependencies": {
+        "tsup": "^8.3.0",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8",
       },
     },
   },
@@ -1345,6 +1389,12 @@
     "@zine/web": ["@zine/web@workspace:apps/web"],
 
     "@zine/worker": ["@zine/worker@workspace:apps/worker"],
+
+    "@zine/x-archive": ["@zine/x-archive@workspace:apps/x-archive"],
+
+    "@zine/x-archive-schema": ["@zine/x-archive-schema@workspace:packages/x-archive-schema"],
+
+    "@zine/x-collector": ["@zine/x-collector@workspace:apps/x-collector"],
 
     "@zxcvbn-ts/core": ["@zxcvbn-ts/core@3.0.4", "", { "dependencies": { "fastest-levenshtein": "1.0.16" } }, "sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw=="],
 
@@ -3524,6 +3574,8 @@
 
     "@zine/mobile/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "@zine/x-collector/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -4109,6 +4161,8 @@
     "@vitest/mocker/@vitest/spy/tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
 
     "@vitest/mocker/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@zine/x-collector/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/docs/x-timeline-archive.md
+++ b/docs/x-timeline-archive.md
@@ -1,0 +1,94 @@
+# X Following Timeline Archive
+
+## Scope
+
+The X archive captures a configurable number of organic entries from the authenticated X Following timeline. It retains posts, replies, repost presentations, quotes, ordering, authors, relationships, metrics, and media links. It excludes ads and does not download media.
+
+Collection is intentionally separate from Zine Inbox, bookmarks, enrichment, and analysis.
+
+## Components
+
+- `.codex/skills/zine-x-timeline-collector`: Chrome or integrated Codex browser collection workflow.
+- `apps/x-collector`: local receiver, validator, chunked uploader, and verification client.
+- `apps/x-archive`: dedicated Cloudflare Worker providing ingestion and read APIs.
+- `packages/x-archive-schema`: shared versioned capture contracts.
+- Dedicated D1 databases: query index, run ordering, relationships, and idempotency.
+- Dedicated R2 buckets: one canonical compressed JSON object per post and one pointer-only manifest per run.
+
+## Identity and deduplication
+
+Canonical post identity is `(Zine user ID, X tweet ID)`. Repeated collection updates `last_seen_at` and the single canonical payload; it does not create another post. Each run stores lightweight ordered pointers to canonical posts.
+
+Reposts are modeled as run-item presentation metadata pointing to the original canonical tweet. Quote, reply, and repost relationships point to target tweet IDs instead of embedding duplicate post records.
+
+## Authentication
+
+Create a Zine API token in web Settings with:
+
+- `Read X archive`
+- `Collect X timeline`
+
+Set it locally without committing it:
+
+```bash
+export ZINE_X_ARCHIVE_TOKEN="zine_pat_..."
+```
+
+The production archive API defaults to `https://x-archive-api.myzine.app`.
+
+## Collection
+
+Ask Codex to use the `zine-x-timeline-collector` skill, or start its receiver explicitly:
+
+```bash
+bun run x:archive:receive -- --count 500
+```
+
+The receiver listens only on `127.0.0.1`, accepts small browser-extracted batches, uploads chunks of at most 25 primary timeline entries, finalizes the R2 run manifest, then reads the run back for verification.
+
+For an existing capture JSON file:
+
+```bash
+bun run --cwd apps/x-collector validate --file capture.json
+bun run --cwd apps/x-collector upload --file capture.json
+```
+
+## API
+
+All `/api/*` routes require a Zine PAT.
+
+### Write scope
+
+- `POST /api/v1/x-timeline/runs`
+- `PUT /api/v1/x-timeline/runs/{runId}/chunks/{chunkIndex}`
+- `POST /api/v1/x-timeline/runs/{runId}/complete`
+
+Chunk indexes are idempotent. Reusing an index with the same body succeeds; reusing it with different data returns `409`.
+
+### Read scope
+
+- `GET /api/v1/x-timeline/runs`
+- `GET /api/v1/x-timeline/runs/{runId}`
+- `GET /api/v1/x-timeline/runs/{runId}/export`
+- `GET /api/v1/x-timeline/posts`
+- `GET /api/v1/x-timeline/posts/{tweetId}`
+
+Post listing uses an opaque keyset cursor.
+
+## Development and verification
+
+```bash
+bun run x:archive:test
+bun run --cwd apps/x-archive typecheck
+bun run --cwd apps/x-collector typecheck
+bun run --cwd apps/x-archive build
+```
+
+Apply and deploy production resources:
+
+```bash
+bun run --cwd apps/x-archive db:migrate:production
+bun run --cwd apps/x-archive deploy:production
+```
+
+The archive health endpoint is `GET /health`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "diag:release": "bun run ./scripts/diag-release.mjs",
     "diag:queue:dlq": "bun run ./scripts/diag-queue-dlq.mjs",
     "diag:incident": "bun run ./scripts/diag-incident.mjs",
+    "x:archive:test": "bun run --cwd apps/x-archive test:run && bun run --cwd apps/x-collector test",
+    "x:archive:receive": "bun run --cwd apps/x-collector receive",
     "test": "bun run test:mobile && bun run test:worker && bun run test:web",
     "test:mobile": "bun run --cwd apps/mobile test",
     "test:web": "bun run --cwd apps/web test",

--- a/packages/shared/src/api-tokens.ts
+++ b/packages/shared/src/api-tokens.ts
@@ -5,11 +5,13 @@ export const ApiTokenScopeSchema = z.enum([
   'bookmarks:write',
   'sync:read',
   'sync:write',
+  'x-archive:read',
+  'x-archive:write',
 ]);
 export const ApiTokenScopesSchema = z
   .array(ApiTokenScopeSchema)
   .min(1)
-  .max(4)
+  .max(6)
   .refine((scopes) => new Set(scopes).size === scopes.length, {
     message: 'Scopes must be unique',
   });

--- a/packages/x-archive-schema/package.json
+++ b/packages/x-archive-schema/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@zine/x-archive-schema",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/x-archive-schema/src/index.ts
+++ b/packages/x-archive-schema/src/index.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+
+export const X_ARCHIVE_SCHEMA_VERSION = 1;
+export const X_ARCHIVE_MAX_TIMELINE_ITEMS_PER_CHUNK = 25;
+export const X_ARCHIVE_MAX_POSTS_PER_CHUNK = 75;
+
+const OptionalUrlSchema = z.string().url().nullable().optional();
+
+export const XPostKindSchema = z.enum(['POST', 'REPLY', 'REPOST', 'QUOTE']);
+export type XPostKind = z.infer<typeof XPostKindSchema>;
+
+export const XPostRelationshipTypeSchema = z.enum(['REPLY_TO', 'REPOST_OF', 'QUOTE_OF']);
+export type XPostRelationshipType = z.infer<typeof XPostRelationshipTypeSchema>;
+
+export const XAuthorSchema = z
+  .object({
+    id: z.string().min(1).nullable().optional(),
+    username: z.string().trim().min(1).max(64),
+    name: z.string().trim().min(1).max(200),
+    profileUrl: OptionalUrlSchema,
+    profileImageUrl: OptionalUrlSchema,
+    verified: z.boolean().nullable().optional(),
+  })
+  .strict();
+export type XAuthor = z.infer<typeof XAuthorSchema>;
+
+export const XMediaSchema = z
+  .object({
+    type: z.enum(['IMAGE', 'VIDEO', 'GIF', 'UNKNOWN']),
+    url: z.string().url(),
+    previewUrl: OptionalUrlSchema,
+    altText: z.string().max(10_000).nullable().optional(),
+    width: z.number().int().positive().nullable().optional(),
+    height: z.number().int().positive().nullable().optional(),
+    durationMs: z.number().int().nonnegative().nullable().optional(),
+  })
+  .strict();
+export type XMedia = z.infer<typeof XMediaSchema>;
+
+export const XPostRelationshipSchema = z
+  .object({
+    type: XPostRelationshipTypeSchema,
+    tweetId: z.string().min(1).max(64),
+    url: OptionalUrlSchema,
+  })
+  .strict();
+export type XPostRelationship = z.infer<typeof XPostRelationshipSchema>;
+
+export const XPostMetricsSchema = z
+  .object({
+    replies: z.number().int().nonnegative().nullable().optional(),
+    reposts: z.number().int().nonnegative().nullable().optional(),
+    likes: z.number().int().nonnegative().nullable().optional(),
+    views: z.number().int().nonnegative().nullable().optional(),
+    bookmarks: z.number().int().nonnegative().nullable().optional(),
+  })
+  .strict();
+
+export const XPostSchema = z
+  .object({
+    tweetId: z.string().min(1).max(64),
+    url: z.string().url(),
+    text: z.string().max(100_000),
+    publishedAt: z.string().datetime().nullable().optional(),
+    lang: z.string().max(32).nullable().optional(),
+    kind: XPostKindSchema,
+    author: XAuthorSchema,
+    media: z.array(XMediaSchema).max(20).default([]),
+    relationships: z.array(XPostRelationshipSchema).max(20).default([]),
+    metrics: XPostMetricsSchema.default({}),
+    capturedAt: z.string().datetime(),
+  })
+  .strict();
+export type XPost = z.infer<typeof XPostSchema>;
+
+export const XTimelineItemSchema = z
+  .object({
+    tweetId: z.string().min(1).max(64),
+    position: z.number().int().nonnegative(),
+    observedAt: z.string().datetime(),
+    presentation: z.enum(['POST', 'REPOST']).default('POST'),
+    repostedBy: XAuthorSchema.nullable().optional(),
+  })
+  .strict();
+export type XTimelineItem = z.infer<typeof XTimelineItemSchema>;
+
+export const XTimelineCaptureSchema = z
+  .object({
+    runId: z.string().min(8).max(80),
+    requestedCount: z.number().int().positive().max(100_000),
+    startedAt: z.string().datetime(),
+    completedAt: z.string().datetime().nullable().optional(),
+    collectorVersion: z.string().min(1).max(80),
+    excludedAds: z.number().int().nonnegative().default(0),
+    status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
+    failureReason: z.string().max(2_000).nullable().optional(),
+    posts: z.array(XPostSchema),
+    items: z.array(XTimelineItemSchema),
+  })
+  .strict()
+  .superRefine((capture, ctx) => {
+    const postIds = new Set(capture.posts.map((post) => post.tweetId));
+    const itemIds = new Set<string>();
+    const positions = new Set<number>();
+    for (const item of capture.items) {
+      if (!postIds.has(item.tweetId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Timeline item ${item.tweetId} has no canonical post payload`,
+        });
+      }
+      if (itemIds.has(item.tweetId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate timeline tweet ${item.tweetId}`,
+        });
+      }
+      if (positions.has(item.position)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate timeline position ${item.position}`,
+        });
+      }
+      itemIds.add(item.tweetId);
+      positions.add(item.position);
+    }
+  });
+export type XTimelineCapture = z.infer<typeof XTimelineCaptureSchema>;
+
+export const CreateXTimelineRunSchema = z
+  .object({
+    runId: z.string().min(8).max(80),
+    requestedCount: z.number().int().positive().max(100_000),
+    startedAt: z.string().datetime(),
+    collectorVersion: z.string().min(1).max(80),
+  })
+  .strict();
+export type CreateXTimelineRun = z.infer<typeof CreateXTimelineRunSchema>;
+
+export const UploadXTimelineChunkSchema = z
+  .object({
+    chunkIndex: z.number().int().nonnegative(),
+    posts: z.array(XPostSchema).max(X_ARCHIVE_MAX_POSTS_PER_CHUNK),
+    items: z.array(XTimelineItemSchema).max(X_ARCHIVE_MAX_TIMELINE_ITEMS_PER_CHUNK),
+  })
+  .strict()
+  .superRefine((chunk, ctx) => {
+    const postIds = new Set(chunk.posts.map((post) => post.tweetId));
+    for (const item of chunk.items) {
+      if (!postIds.has(item.tweetId)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Timeline item ${item.tweetId} is missing from this chunk's post payloads`,
+        });
+      }
+    }
+  });
+export type UploadXTimelineChunk = z.infer<typeof UploadXTimelineChunkSchema>;
+
+export const CompleteXTimelineRunSchema = z
+  .object({
+    completedAt: z.string().datetime().nullable().optional(),
+    excludedAds: z.number().int().nonnegative(),
+    status: z.enum(['COMPLETE', 'PARTIAL']),
+    failureReason: z.string().max(2_000).nullable().optional(),
+    collectedCount: z.number().int().nonnegative(),
+  })
+  .strict();
+export type CompleteXTimelineRun = z.infer<typeof CompleteXTimelineRunSchema>;

--- a/packages/x-archive-schema/tsconfig.json
+++ b/packages/x-archive-schema/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/x-archive-schema/tsup.config.ts
+++ b/packages/x-archive-schema/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+  outDir: 'dist',
+});


### PR DESCRIPTION
## Summary

- add a dedicated Cloudflare X archive Worker backed by D1 indexes and canonical gzip JSON in R2
- add a Bun timeline collector and integrated-browser/Chrome extraction workflow with ad filtering, replies, reposts, quotes, and deduplication
- add scoped PAT controls, production documentation, focused CI coverage, and an archive deployment workflow

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (1125 mobile, 1553 worker, 75 web tests)
- `bun run x:archive:test` (3 archive and 4 collector tests)
- `bun run build`
- `bun run design-system:check`
- `bun run format:check`
- live integrated-browser extraction smoke: 10 unique organic entries collected; 2 ads excluded
- production archive API disposable E2E: create, chunk upload, idempotent retry, complete, readback, and gzip R2 export

## Deployment

Merging to `main` deploys the web app, main Worker, and X archive Worker through their path-filtered workflows. The X archive workflow applies production D1 migrations before deploying and verifies the production health endpoint.