### PR TITLE
fix(x-collector): resume stalled timeline captures

### DIFF
--- a/.codex/skills/zine-x-timeline-collector/SKILL.md
+++ b/.codex/skills/zine-x-timeline-collector/SKILL.md
@@ -24,25 +24,31 @@ Collect top-to-bottom Following timeline entries without exposing browser creden
    ```
 
    Wait for its one-line JSON readiness response. Record `receiverUrl` and `runId`.
+   If browser control restarts while the receiver is alive, reconnect to the same receiver and GET `<receiverUrl>/checkpoint`; do not start a second run.
 
 3. Follow the selected browser skill's bootstrap exactly, including reading its complete browser documentation. Reuse or claim an existing authenticated X tab when available.
 4. Navigate to `https://x.com/home`. If signed out, ask the user to sign in. Select the **Following** timeline and verify it is active before extracting.
 5. In the persistent browser-control JavaScript session:
-   - Import `apps/x-collector/src/browser-extractor.mjs` by absolute path.
-   - Keep a `Set` of accepted primary tweet IDs, a `Set` of seen ad keys, and a monotonically increasing position counter.
-   - Call `extractVisibleTimelineBatch` through the documented Playwright page-evaluation API, passing the seen ad keys as its argument. Add returned `adKeys` to the set before the next call.
-   - Remove timeline items already accepted. Assign new items positions `0...N-1` in observed DOM order.
-   - Keep every returned canonical post needed by those items, including quoted posts. Do not count quoted embedded posts toward N.
-   - POST each small batch directly from the JavaScript session to `<receiverUrl>/batch`. Do not emit raw post bodies through `nodeRepl.write` or copy them into the conversation.
+   - Import `apps/x-collector/src/browser-extractor.mjs` and `apps/x-collector/src/browser-session.mjs` by absolute path.
+   - GET `<receiverUrl>/checkpoint` and pass it to `createCollectionSession`. For a new receiver, the empty checkpoint starts positions at zero; after a browser-control restart, it restores accepted tweet IDs, accepted ad keys, and the next position.
+   - Call `extractVisibleTimelineBatch` through the documented Playwright page-evaluation API, passing the session's accepted ad keys as its argument.
+   - Pass the result, session state, and N to `prepareTimelineBatch`. It removes accepted primary posts, assigns stable positions, keeps quoted canonical posts, and produces the exact receiver payload.
+   - POST each non-empty prepared payload directly from the JavaScript session to `<receiverUrl>/batch`. Do not emit raw post bodies through `nodeRepl.write` or copy them into the conversation.
    - Scroll roughly one viewport, wait for X to settle, and repeat.
 
-6. Stop when one of these occurs:
+6. Recover transient stalls without splitting the logical capture:
+   - After five consecutive scrolls add no new primary entries, keep the receiver alive and perform one recovery cycle: wait three seconds, scroll up roughly one viewport, wait briefly, scroll down roughly two viewports, wait three seconds, then extract again.
+   - If recovery adds an entry, reset the stall and failed-recovery counters and continue the same run.
+   - If recovery adds nothing, increment the failed-recovery counter and repeat the cycle. Finalize as `PARTIAL` with `timeline_stalled` only after three consecutive recovery cycles fail.
+   - If browser control disconnects, reconnect, GET `/checkpoint`, rebuild the browser session state, and continue the same receiver/run when possible.
+
+7. Stop when one of these occurs:
    - N unique organic primary timeline entries have been accepted: complete as `COMPLETE`.
-   - Five consecutive scrolls add no new primary entries: complete as `PARTIAL` with `timeline_stalled`.
+   - Three stall-recovery cycles fail: complete as `PARTIAL` with `timeline_stalled`.
    - X blocks loading or the connection fails after supported recovery: complete as `PARTIAL` with a concise reason.
 
-7. POST the completion state to `<receiverUrl>/complete`. The receiver validates, chunks, uploads, finalizes the manifest, and reads the run back from the archive.
-8. Wait for the receiver process to exit successfully. Report the run ID, requested count, collected count, excluded-ad count, and verification result.
+8. POST the completion state to `<receiverUrl>/complete`. The receiver validates, chunks, uploads, finalizes the manifest, and reads the run back from the archive. Large uploads may outlive the browser request timeout; treat the receiver process result as authoritative.
+9. Wait for the receiver process to exit successfully. Report the run ID, requested count, collected count, excluded-ad count, recovery count, and verification result.
 
 ## Invariants
 
@@ -51,6 +57,7 @@ Collect top-to-bottom Following timeline entries without exposing browser creden
 - Never include promoted or sponsored entries.
 - Treat a repost as a timeline presentation pointing to the original canonical tweet; do not manufacture a duplicate tweet.
 - Preserve the first observed position when a tweet repeats in one run.
+- Keep one receiver alive through browser reconnections and transient X stalls so a logical capture remains one run.
 - Let the receiver/API perform canonical deduplication across runs.
 - Do not download media; retain media URLs and visible metadata only.
 - Leave an interrupted run resumable. Do not fabricate success when the browser connection or upload verification fails.

--- a/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
+++ b/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
@@ -18,6 +18,7 @@ Use the repository extractor at `apps/x-collector/src/browser-extractor.mjs`. It
 - Keep deduplication state outside the page because mounted cards are recycled.
 - Pass the previously returned ad keys into the next extractor call so recycled ads are counted once.
 - Scroll one viewport at a time. Large jumps can skip cards.
+- After five empty scrolls, perform the bounded up/down recovery sequence in SKILL.md before declaring a stall.
 
 ## Primary versus referenced posts
 
@@ -33,7 +34,7 @@ The extractor rejects cards with promoted, sponsored, or ad markers outside the 
 
 ## Partial completion
 
-Use `PARTIAL` when the requested number cannot be reached. Valid concise reasons include:
+Use `PARTIAL` only when the requested number cannot be reached after supported recovery. Valid concise reasons include:
 
 - `timeline_stalled`
 - `x_rate_limited`
@@ -43,10 +44,15 @@ Use `PARTIAL` when the requested number cannot be reached. Valid concise reasons
 
 The receiver retains and uploads every successfully collected item before the failure.
 
+## Resumable browser session
+
+Use `createCollectionSession(checkpoint)` and `prepareTimelineBatch(rawBatch, state, requestedCount)` from `apps/x-collector/src/browser-session.mjs`. The receiver owns the authoritative in-progress data; browser state can be rebuilt from its checkpoint without changing the run ID or item positions.
+
 ## Local receiver API
 
 - `GET /session` returns run identity and current counts.
-- `POST /batch` accepts `{ posts, items, excludedAds }`.
+- `GET /checkpoint` returns accepted tweet IDs, accepted ad keys, and the next position for reconnecting browser control.
+- `POST /batch` accepts `{ posts, items, adKeys, excludedAds }`; stable ad keys make retries idempotent.
 - `POST /complete` accepts `{ status, failureReason }` and performs the verified Cloudflare upload.
 
 The receiver binds only to `127.0.0.1` and keeps the Zine PAT out of the X page context.

--- a/apps/x-collector/package.json
+++ b/apps/x-collector/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "bun build src/cli.ts --target bun --outdir dist",
-    "lint": "eslint src --ext .ts --cache --cache-location .eslintcache",
+    "lint": "eslint src --ext .ts,.mjs --cache --cache-location .eslintcache",
     "typecheck": "tsc --noEmit",
     "test": "bun test src",
     "upload": "bun run src/cli.ts upload",

--- a/apps/x-collector/src/browser-session.mjs
+++ b/apps/x-collector/src/browser-session.mjs
@@ -1,0 +1,47 @@
+export function createCollectionSession(checkpoint = {}) {
+  const acceptedTweetIds = new Set(checkpoint.acceptedTweetIds || []);
+  const acceptedAdKeys = new Set(checkpoint.acceptedAdKeys || []);
+  const nextPosition = Number.isInteger(checkpoint.nextPosition)
+    ? checkpoint.nextPosition
+    : acceptedTweetIds.size;
+
+  return { acceptedTweetIds, acceptedAdKeys, nextPosition };
+}
+
+export function prepareTimelineBatch(rawBatch, state, requestedCount) {
+  const remaining = Math.max(0, requestedCount - state.acceptedTweetIds.size);
+  const newAdKeys = [];
+  for (const adKey of rawBatch.adKeys || []) {
+    if (state.acceptedAdKeys.has(adKey)) continue;
+    state.acceptedAdKeys.add(adKey);
+    newAdKeys.push(adKey);
+  }
+
+  const items = [];
+  for (const item of rawBatch.items || []) {
+    if (items.length >= remaining || state.acceptedTweetIds.has(item.tweetId)) continue;
+    state.acceptedTweetIds.add(item.tweetId);
+    items.push({ ...item, position: state.nextPosition++ });
+  }
+
+  const neededPostIds = new Set(items.map((item) => item.tweetId));
+  for (const post of rawBatch.posts || []) {
+    if (!neededPostIds.has(post.tweetId)) continue;
+    for (const relationship of post.relationships || []) {
+      neededPostIds.add(relationship.tweetId);
+    }
+  }
+
+  const hasStableAdKeys = Array.isArray(rawBatch.adKeys);
+  return {
+    payload: {
+      posts: (rawBatch.posts || []).filter((post) => neededPostIds.has(post.tweetId)),
+      items,
+      adKeys: newAdKeys,
+      excludedAds: hasStableAdKeys ? newAdKeys.length : rawBatch.excludedAds || 0,
+    },
+    addedItems: items.length,
+    totalAccepted: state.acceptedTweetIds.size,
+    complete: state.acceptedTweetIds.size >= requestedCount,
+  };
+}

--- a/apps/x-collector/src/browser-session.test.mjs
+++ b/apps/x-collector/src/browser-session.test.mjs
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import { createCollectionSession, prepareTimelineBatch } from './browser-session.mjs';
+
+describe('X browser collection session', () => {
+  it('resumes positions and filters accepted posts and ads from a receiver checkpoint', () => {
+    const state = createCollectionSession({
+      acceptedTweetIds: ['100'],
+      acceptedAdKeys: ['ad-1'],
+      nextPosition: 1,
+    });
+    const result = prepareTimelineBatch(
+      {
+        posts: [
+          { tweetId: '100', relationships: [] },
+          { tweetId: '200', relationships: [{ type: 'QUOTE_OF', tweetId: '201' }] },
+          { tweetId: '201', relationships: [] },
+        ],
+        items: [
+          { tweetId: '100', observedAt: '2026-07-11T12:00:00.000Z' },
+          { tweetId: '200', observedAt: '2026-07-11T12:01:00.000Z' },
+        ],
+        adKeys: ['ad-1', 'ad-2'],
+        excludedAds: 2,
+      },
+      state,
+      2
+    );
+
+    expect(result).toMatchObject({
+      addedItems: 1,
+      totalAccepted: 2,
+      complete: true,
+      payload: {
+        items: [{ tweetId: '200', position: 1 }],
+        adKeys: ['ad-2'],
+        excludedAds: 1,
+      },
+    });
+    expect(result.payload.posts.map((post) => post.tweetId)).toEqual(['200', '201']);
+
+    const repeated = prepareTimelineBatch(
+      { posts: [], items: [{ tweetId: '200' }], adKeys: ['ad-2'], excludedAds: 1 },
+      state,
+      2
+    );
+    expect(repeated).toMatchObject({
+      addedItems: 0,
+      totalAccepted: 2,
+      payload: { items: [], posts: [], adKeys: [], excludedAds: 0 },
+    });
+  });
+});

--- a/apps/x-collector/src/receiver.test.ts
+++ b/apps/x-collector/src/receiver.test.ts
@@ -23,13 +23,13 @@ describe('local browser receiver', () => {
         }
         if (url.pathname.includes('/chunks/')) return Response.json({ accepted: true });
         if (url.pathname.endsWith('/complete')) {
-          return Response.json({ run: { id: 'receiver-run-001', collectedCount: 1 } });
+          return Response.json({ run: { id: 'receiver-run-001', collectedCount: 2 } });
         }
-        return Response.json({ run: { id: 'receiver-run-001', collectedCount: 1 } });
+        return Response.json({ run: { id: 'receiver-run-001', collectedCount: 2 } });
       },
     });
     receiver = startReceiver({
-      requestedCount: 1,
+      requestedCount: 2,
       apiUrl: `http://${apiServer.hostname}:${apiServer.port}`,
       token: 'zine_pat_receiver-test',
       port: 0,
@@ -62,6 +62,7 @@ describe('local browser receiver', () => {
             presentation: 'POST',
           },
         ],
+        adKeys: ['ad-100'],
         excludedAds: 1,
       }),
     });
@@ -71,6 +72,54 @@ describe('local browser receiver', () => {
       excludedAds: 1,
     });
 
+    const duplicateAd = await fetch(`${receiver.url}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ posts: [], items: [], adKeys: ['ad-100'], excludedAds: 1 }),
+    });
+    expect(await duplicateAd.json()).toMatchObject({ timelineItems: 1, excludedAds: 1 });
+
+    const checkpoint = await fetch(`${receiver.url}/checkpoint`);
+    expect(await checkpoint.json()).toMatchObject({
+      runId: 'receiver-run-001',
+      requestedCount: 2,
+      acceptedTweetIds: ['100'],
+      acceptedAdKeys: ['ad-100'],
+      nextPosition: 1,
+      excludedAds: 1,
+    });
+
+    const resumedBatch = await fetch(`${receiver.url}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        posts: [
+          {
+            tweetId: '200',
+            url: 'https://x.com/example/status/200',
+            text: 'Resumed',
+            kind: 'POST',
+            author: { username: 'example', name: 'Example' },
+            media: [],
+            relationships: [],
+            metrics: {},
+            capturedAt: '2026-07-11T13:01:00.000Z',
+          },
+        ],
+        items: [
+          {
+            tweetId: '200',
+            position: 1,
+            observedAt: '2026-07-11T13:01:00.000Z',
+            presentation: 'POST',
+          },
+        ],
+        adKeys: ['ad-200'],
+        excludedAds: 1,
+      }),
+    });
+    expect(await resumedBatch.json()).toMatchObject({ timelineItems: 2, excludedAds: 2 });
+
     const complete = await fetch(`${receiver.url}/complete`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -79,7 +128,7 @@ describe('local browser receiver', () => {
     expect(complete.status).toBe(200);
     await expect(receiver.completed).resolves.toMatchObject({
       runId: 'receiver-run-001',
-      timelineItemsSubmitted: 1,
+      timelineItemsSubmitted: 2,
       verified: true,
     });
   });

--- a/apps/x-collector/src/receiver.ts
+++ b/apps/x-collector/src/receiver.ts
@@ -12,6 +12,7 @@ const BatchSchema = z
   .object({
     posts: z.array(XPostSchema).max(200),
     items: z.array(XTimelineItemSchema).max(100),
+    adKeys: z.array(z.string().min(1).max(1_000)).max(200).default([]),
     excludedAds: z.number().int().nonnegative().default(0),
   })
   .strict();
@@ -53,7 +54,8 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
   const startedAt = options.startedAt ?? new Date().toISOString();
   const posts = new Map<string, XPost>();
   const items = new Map<string, XTimelineItem>();
-  let excludedAds = 0;
+  const acceptedAdKeys = new Set<string>();
+  let legacyExcludedAds = 0;
   let resolveCompleted!: (result: UploadResult) => void;
   let rejectCompleted!: (error: unknown) => void;
   const completed = new Promise<UploadResult>((resolve, reject) => {
@@ -67,15 +69,42 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
     async fetch(request) {
       if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders() });
       const url = new URL(request.url);
+      const excludedAds = legacyExcludedAds + acceptedAdKeys.size;
       if (request.method === 'GET' && url.pathname === '/session') {
         return Response.json(
           {
             runId,
             startedAt,
             requestedCount: options.requestedCount,
-            collectorVersion: options.collectorVersion ?? 'chrome-dom-v1',
+            collectorVersion: options.collectorVersion ?? 'browser-dom-v2',
             posts: posts.size,
             items: items.size,
+            excludedAds,
+            nextPosition:
+              items.size === 0
+                ? 0
+                : Math.max(...[...items.values()].map((item) => item.position)) + 1,
+          },
+          { headers: corsHeaders() }
+        );
+      }
+      if (request.method === 'GET' && url.pathname === '/checkpoint') {
+        const orderedItems = [...items.values()].sort(
+          (left, right) => left.position - right.position
+        );
+        return Response.json(
+          {
+            runId,
+            startedAt,
+            requestedCount: options.requestedCount,
+            collectorVersion: options.collectorVersion ?? 'browser-dom-v2',
+            acceptedTweetIds: orderedItems.map((item) => item.tweetId),
+            acceptedAdKeys: [...acceptedAdKeys],
+            nextPosition:
+              orderedItems.length === 0
+                ? 0
+                : Math.max(...orderedItems.map((item) => item.position)) + 1,
+            canonicalPosts: posts.size,
             excludedAds,
           },
           { headers: corsHeaders() }
@@ -93,9 +122,19 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
         for (const item of parsed.data.items) {
           if (!items.has(item.tweetId)) items.set(item.tweetId, item);
         }
-        excludedAds += parsed.data.excludedAds;
+        if (parsed.data.adKeys.length > 0) {
+          for (const adKey of parsed.data.adKeys) acceptedAdKeys.add(adKey);
+        } else {
+          legacyExcludedAds += parsed.data.excludedAds;
+        }
+        const updatedExcludedAds = legacyExcludedAds + acceptedAdKeys.size;
         return Response.json(
-          { accepted: true, canonicalPosts: posts.size, timelineItems: items.size, excludedAds },
+          {
+            accepted: true,
+            canonicalPosts: posts.size,
+            timelineItems: items.size,
+            excludedAds: updatedExcludedAds,
+          },
           { headers: corsHeaders() }
         );
       }
@@ -113,8 +152,8 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             requestedCount: options.requestedCount,
             startedAt,
             completedAt: new Date().toISOString(),
-            collectorVersion: options.collectorVersion ?? 'chrome-dom-v1',
-            excludedAds,
+            collectorVersion: options.collectorVersion ?? 'browser-dom-v2',
+            excludedAds: legacyExcludedAds + acceptedAdKeys.size,
             status: parsed.data.status,
             failureReason: parsed.data.failureReason ?? null,
             posts: [...posts.values()],

--- a/docs/x-timeline-archive.md
+++ b/docs/x-timeline-archive.md
@@ -44,7 +44,7 @@ Ask Codex to use the `zine-x-timeline-collector` skill, or start its receiver ex
 bun run x:archive:receive -- --count 500
 ```
 
-The receiver listens only on `127.0.0.1`, accepts small browser-extracted batches, uploads chunks of at most 25 primary timeline entries, finalizes the R2 run manifest, then reads the run back for verification.
+The receiver listens only on `127.0.0.1`, accepts small browser-extracted batches, and exposes a checkpoint that lets browser control reconnect without changing the run or item positions. The collector performs bounded up/down recovery after transient X stalls before falling back to a partial run. On completion, the receiver uploads chunks of at most 25 primary timeline entries, finalizes the R2 run manifest, then reads the run back for verification.
 
 For an existing capture JSON file:
 


### PR DESCRIPTION
## Summary

- expose an in-memory receiver checkpoint so browser-control restarts resume the same run, accepted IDs, ad keys, and positions
- add a reusable browser-session helper for deterministic batch deduplication and checkpoint restoration
- replace immediate five-scroll partial completion with bounded up/down recovery cycles while keeping one logical run alive
- make ad counting idempotent across retried batches and identify new captures as `browser-dom-v2`

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run x:archive:test` (3 archive and 5 collector tests)
- `bun run test` (1125 mobile, 1553 worker, 75 web tests)
- `bun run build`
- `bun run design-system:check`
- `bun run format:check`
- skill validation via `quick_validate.py`
- production overlap run `7f206dce-dddb-4e56-b10b-5e352e5ef61d`: 10/10 posts overlapped the prior archive; all 10 preserved their canonical R2 key and first-run identity while updating only the latest-run pointer

## Recovery behavior

After five empty scrolls, the collector keeps the receiver alive and performs up/down recovery with backoff. Browser reconnections restore state from `/checkpoint`. Only three consecutive failed recovery cycles finalize a partial run.