### PR TITLE
feat(ios): add native library client

### DIFF
--- a/apps/ios/Configuration/Config.xcconfig
+++ b/apps/ios/Configuration/Config.xcconfig
@@ -1,0 +1,4 @@
+ZINE_API_BASE_URL = https:/$()/api.myzine.app
+ZINE_CLERK_PUBLISHABLE_KEY = pk_live_Y2xlcmsubXl6aW5lLmFwcCQ
+
+#include? "Local.xcconfig"

--- a/apps/ios/Configuration/Info.plist
+++ b/apps/ios/Configuration/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Clerk callback</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>app.zine.native</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>ZINEAPIBaseURL</key>
+	<string>$(ZINE_API_BASE_URL)</string>
+	<key>ZINEClerkPublishableKey</key>
+	<string>$(ZINE_CLERK_PUBLISHABLE_KEY)</string>
+</dict>
+</plist>

--- a/apps/ios/Configuration/Local.xcconfig.example
+++ b/apps/ios/Configuration/Local.xcconfig.example
@@ -1,0 +1,6 @@
+// Copy this file to Local.xcconfig and use the publishable key for Zine's
+// Clerk instance. Local.xcconfig is ignored by the repository's *.local rule.
+ZINE_CLERK_PUBLISHABLE_KEY = pk_test_replace_me
+
+// Optional for local worker development.
+// ZINE_API_BASE_URL = http:/$()/localhost:8787

--- a/apps/ios/Configuration/ZineNative.entitlements
+++ b/apps/ios/Configuration/ZineNative.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:clerk.myzine.app</string>
+	</array>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -1,0 +1,27 @@
+# Zine Native iOS
+
+This is an additive SwiftUI app that lives alongside `apps/mobile`. It uses the
+same Zine account and production data, but it has its own bundle identifier
+(`app.zine.native`) so both apps can remain installed.
+
+## Configure
+
+The production Clerk publishable key, native application registration, callback
+scheme, associated domain, Apple Team ID, and Sign in with Apple entitlement are
+configured for `app.zine.native`.
+
+For a development Clerk instance or local worker, copy
+`Configuration/Local.xcconfig.example` to `Configuration/Local.xcconfig` and
+override the relevant values there.
+
+The API defaults to `https://api.myzine.app`. Override
+`ZINE_API_BASE_URL` in `Local.xcconfig` for local worker development.
+
+## Build
+
+Open `ZineNative.xcodeproj`, select the `ZineNative` scheme, and run it on an
+iOS 18 or newer simulator or device.
+
+The first iteration intentionally contains only authentication and the Library
+vertical slice: list, pagination, refresh, search, filters, detail, and finished
+state. It does not replace or modify the React Native app.

--- a/apps/ios/ZineNative.xcodeproj/project.pbxproj
+++ b/apps/ios/ZineNative.xcodeproj/project.pbxproj
@@ -1,0 +1,329 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10000000000000000000001 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000031 /* ClerkKit */; };
+		A10000000000000000000002 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000032 /* ClerkKitUI */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A10000000000000000000003 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000010 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A10000000000000000000011;
+			remoteInfo = ZineNative;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A10000000000000000000004 /* ZineNative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZineNative.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000005 /* ZineNativeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZineNativeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000000000000000000006 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		A10000000000000000000007 /* Local.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig.example; sourceTree = "<group>"; };
+		A10000000000000000000008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A10000000000000000000009 /* ZineNative.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ZineNative.entitlements; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A1000000000000000000000A /* ZineNative */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ZineNative;
+			sourceTree = "<group>";
+		};
+		A1000000000000000000000B /* ZineNativeTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ZineNativeTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1000000000000000000000C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000001 /* ClerkKit in Frameworks */,
+				A10000000000000000000002 /* ClerkKitUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1000000000000000000000D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1000000000000000000000E = {
+			isa = PBXGroup;
+			children = (
+				A1000000000000000000000A /* ZineNative */,
+				A1000000000000000000000B /* ZineNativeTests */,
+				A1000000000000000000000F /* Configuration */,
+				A10000000000000000000012 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1000000000000000000000F /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000006 /* Config.xcconfig */,
+				A10000000000000000000007 /* Local.xcconfig.example */,
+				A10000000000000000000008 /* Info.plist */,
+				A10000000000000000000009 /* ZineNative.entitlements */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		A10000000000000000000012 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A10000000000000000000004 /* ZineNative.app */,
+				A10000000000000000000005 /* ZineNativeTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A10000000000000000000011 /* ZineNative */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000020 /* Build configuration list for PBXNativeTarget "ZineNative" */;
+			buildPhases = (
+				A10000000000000000000013 /* Sources */,
+				A1000000000000000000000C /* Frameworks */,
+				A10000000000000000000014 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000000A /* ZineNative */,
+			);
+			name = ZineNative;
+			packageProductDependencies = (
+				A10000000000000000000031 /* ClerkKit */,
+				A10000000000000000000032 /* ClerkKitUI */,
+			);
+			productName = ZineNative;
+			productReference = A10000000000000000000004 /* ZineNative.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A10000000000000000000015 /* ZineNativeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A10000000000000000000021 /* Build configuration list for PBXNativeTarget "ZineNativeTests" */;
+			buildPhases = (
+				A10000000000000000000016 /* Sources */,
+				A1000000000000000000000D /* Frameworks */,
+				A10000000000000000000017 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A10000000000000000000018 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A1000000000000000000000B /* ZineNativeTests */,
+			);
+			name = ZineNativeTests;
+			productName = ZineNativeTests;
+			productReference = A10000000000000000000005 /* ZineNativeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A10000000000000000000010 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2620;
+				LastUpgradeCheck = 2620;
+				TargetAttributes = {
+					A10000000000000000000011 = { CreatedOnToolsVersion = 26.2; };
+					A10000000000000000000015 = { CreatedOnToolsVersion = 26.2; TestTargetID = A10000000000000000000011; };
+				};
+			};
+			buildConfigurationList = A10000000000000000000022 /* Build configuration list for PBXProject "ZineNative" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (en, Base);
+			mainGroup = A1000000000000000000000E;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A10000000000000000000012 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A10000000000000000000011 /* ZineNative */,
+				A10000000000000000000015 /* ZineNativeTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A10000000000000000000014 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A10000000000000000000017 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A10000000000000000000013 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A10000000000000000000016 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A10000000000000000000018 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = A10000000000000000000011 /* ZineNative */; targetProxy = A10000000000000000000003 /* PBXContainerItemProxy */; };
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A10000000000000000000023 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A10000000000000000000024 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
+		A10000000000000000000025 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A10000000000000000000006 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Configuration/ZineNative.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TRA7965NM5;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Configuration/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native;
+				PRODUCT_MODULE_NAME = ZineNative;
+				PRODUCT_NAME = "Zine Native";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A10000000000000000000026 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A10000000000000000000006 /* Config.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Configuration/ZineNative.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TRA7965NM5;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Configuration/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native;
+				PRODUCT_MODULE_NAME = ZineNative;
+				PRODUCT_NAME = "Zine Native";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A10000000000000000000027 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zine Native.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zine Native";
+			};
+			name = Debug;
+		};
+		A10000000000000000000028 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Zine Native.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Zine Native";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A10000000000000000000020 /* Build configuration list for PBXNativeTarget "ZineNative" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000025 /* Debug */, A10000000000000000000026 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A10000000000000000000021 /* Build configuration list for PBXNativeTarget "ZineNativeTests" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000027 /* Debug */, A10000000000000000000028 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A10000000000000000000022 /* Build configuration list for PBXProject "ZineNative" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000023 /* Debug */, A10000000000000000000024 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/clerk/clerk-ios";
+			requirement = { kind = upToNextMajorVersion; minimumVersion = 1.3.1; };
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A10000000000000000000031 /* ClerkKit */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */; productName = ClerkKit; };
+		A10000000000000000000032 /* ClerkKitUI */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */; productName = ClerkKitUI; };
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A10000000000000000000010 /* Project object */;
+}

--- a/apps/ios/ZineNative.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/ZineNative.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "e6155bcb55384e0fcde0a157fe2ab6f9ec771195d96ecdac0026f000177a4685",
+  "pins" : [
+    {
+      "identity" : "clerk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/clerk/clerk-ios",
+      "state" : {
+        "revision" : "5ea88c7344b32f8a8bff15ec98fdc437cd11c929",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "63a8fcbd6621340a2410bc3e9575ac97058615f4",
+        "version" : "13.0.6"
+      }
+    },
+    {
+      "identity" : "phonenumberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PhoneNumberKit/PhoneNumberKit",
+      "state" : {
+        "revision" : "ab06a8333394f4a4fb6eecca447dae0aa06c1eca",
+        "version" : "5.0.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/apps/ios/ZineNative/App/AppConfiguration.swift
+++ b/apps/ios/ZineNative/App/AppConfiguration.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct AppConfiguration {
+    let apiBaseURL: URL
+    let clerkPublishableKey: String
+
+    var isClerkConfigured: Bool {
+        clerkPublishableKey.hasPrefix("pk_") && !clerkPublishableKey.contains("replace_me")
+    }
+
+    static let current: AppConfiguration = {
+        let values = Bundle.main.infoDictionary ?? [:]
+        let apiURLString = values["ZINEAPIBaseURL"] as? String ?? "https://api.myzine.app"
+        let key = values["ZINEClerkPublishableKey"] as? String ?? ""
+
+        return AppConfiguration(
+            apiBaseURL: URL(string: apiURLString) ?? URL(string: "https://api.myzine.app")!,
+            clerkPublishableKey: key.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }()
+}

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -1,0 +1,39 @@
+import ClerkKit
+import ClerkKitUI
+import SwiftUI
+
+struct AppRootView: View {
+    let configuration: AppConfiguration
+
+    @Environment(Clerk.self) private var clerk
+
+    var body: some View {
+        Group {
+            if clerk.user != nil {
+                LibraryView(
+                    client: APIClient(
+                        baseURL: configuration.apiBaseURL,
+                        tokenProvider: {
+                            guard let token = try await Clerk.shared.auth.getToken() else {
+                                throw APIError.missingSession
+                            }
+                            return token
+                        }
+                    )
+                )
+            } else {
+                AuthView(isDismissible: false)
+            }
+        }
+    }
+}
+
+struct ConfigurationRequiredView: View {
+    var body: some View {
+        ContentUnavailableView {
+            Label("Clerk configuration required", systemImage: "key")
+        } description: {
+            Text("Copy Configuration/Local.xcconfig.example to Local.xcconfig and add Zine’s Clerk publishable key.")
+        }
+    }
+}

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -1,0 +1,45 @@
+import ClerkKit
+import SwiftUI
+
+@main
+struct ZineNativeApp: App {
+    private let configuration = AppConfiguration.current
+
+    init() {
+        if configuration.isClerkConfigured {
+            Clerk.configure(publishableKey: configuration.clerkPublishableKey)
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            rootView
+        }
+    }
+
+    @ViewBuilder
+    private var rootView: some View {
+#if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-fixtures") {
+            ScreenshotLibraryView()
+        } else {
+            configuredRootView
+        }
+#else
+        configuredRootView
+#endif
+    }
+
+    @ViewBuilder
+    private var configuredRootView: some View {
+        if configuration.isClerkConfigured {
+            AppRootView(configuration: configuration)
+                .environment(Clerk.shared)
+                .onOpenURL { url in
+                    Task { try? await Clerk.shared.handle(url) }
+                }
+        } else {
+            ConfigurationRequiredView()
+        }
+    }
+}

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct LibraryQuery: Hashable {
+    var search = ""
+    var isFinished = false
+    var provider: Provider?
+    var contentType: ContentType?
+}
+
+struct APIClient {
+    typealias TokenProvider = () async throws -> String
+
+    let baseURL: URL
+    let tokenProvider: TokenProvider
+    var session: URLSession = .shared
+
+    func listBookmarks(
+        query: LibraryQuery,
+        cursor: String? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/bookmarks"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "isFinished", value: String(query.isFinished)),
+        ]
+        if !query.search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            items.append(URLQueryItem(name: "search", value: query.search))
+        }
+        if let provider = query.provider {
+            items.append(URLQueryItem(name: "provider", value: provider.rawValue))
+        }
+        if let contentType = query.contentType {
+            items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
+        }
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func getBookmark(id: String) async throws -> Bookmark {
+        let response: BookmarkResponse = try await request(
+            url: baseURL.appending(path: "/api/v1/bookmarks/\(id)")
+        )
+        return response.item
+    }
+
+    func setFinished(id: String, isFinished: Bool) async throws -> FinishedStateResponse.FinishedBookmark {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)"))
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(["isFinished": isFinished])
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let response: FinishedStateResponse = try await send(request)
+        return response.bookmark
+    }
+
+    func markOpened(id: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/opened"))
+        request.httpMethod = "POST"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    private func request<Response: Decodable>(url: URL) async throws -> Response {
+        try await send(URLRequest(url: url))
+    }
+
+    private func send<Response: Decodable>(_ input: URLRequest) async throws -> Response {
+        var request = input
+        let token = try await tokenProvider()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let payload = try? JSONDecoder().decode(APIErrorPayload.self, from: data)
+            throw APIError.server(
+                status: http.statusCode,
+                message: payload?.error ?? HTTPURLResponse.localizedString(forStatusCode: http.statusCode),
+                code: payload?.code
+            )
+        }
+        return try JSONDecoder().decode(Response.self, from: data)
+    }
+}
+
+private struct EmptyResponse: Decodable {}

--- a/apps/ios/ZineNative/Core/API/APIError.swift
+++ b/apps/ios/ZineNative/Core/API/APIError.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum APIError: LocalizedError {
+    case invalidResponse
+    case missingSession
+    case server(status: Int, message: String, code: String?)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "Zine returned an invalid response."
+        case .missingSession:
+            "Your session is unavailable. Please sign in again."
+        case .server(_, let message, _):
+            message
+        }
+    }
+}
+
+struct APIErrorPayload: Decodable {
+    let error: String?
+    let code: String?
+}

--- a/apps/ios/ZineNative/Core/API/APIResponses.swift
+++ b/apps/ios/ZineNative/Core/API/APIResponses.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct PaginatedBookmarksResponse: Decodable {
+    let items: [Bookmark]
+    let nextCursor: String?
+}
+
+struct BookmarkResponse: Decodable {
+    let item: Bookmark
+}
+
+struct FinishedStateResponse: Decodable {
+    struct FinishedBookmark: Decodable {
+        let id: String
+        let itemId: String
+        let isFinished: Bool
+        let finishedAt: String?
+    }
+
+    let bookmark: FinishedBookmark
+}

--- a/apps/ios/ZineNative/Core/Models/Bookmark.swift
+++ b/apps/ios/ZineNative/Core/Models/Bookmark.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+enum ContentType: String, Codable, CaseIterable, Identifiable {
+    case video = "VIDEO"
+    case podcast = "PODCAST"
+    case article = "ARTICLE"
+    case post = "POST"
+
+    var id: String { rawValue }
+
+    var title: String { rawValue.capitalized }
+
+    var systemImage: String {
+        switch self {
+        case .video: "play.rectangle"
+        case .podcast: "waveform"
+        case .article: "doc.text"
+        case .post: "text.bubble"
+        }
+    }
+}
+
+enum Provider: String, Codable, CaseIterable, Identifiable {
+    case youtube = "YOUTUBE"
+    case spotify = "SPOTIFY"
+    case gmail = "GMAIL"
+    case rss = "RSS"
+    case substack = "SUBSTACK"
+    case web = "WEB"
+    case x = "X"
+
+    var id: String { rawValue }
+    var title: String { rawValue == "RSS" || rawValue == "X" ? rawValue : rawValue.capitalized }
+}
+
+struct BookmarkTag: Codable, Hashable, Identifiable {
+    let id: String
+    let name: String
+}
+
+struct BookmarkProgress: Codable, Hashable {
+    let position: Double
+    let duration: Double
+    let percent: Double
+}
+
+struct Bookmark: Codable, Hashable, Identifiable {
+    let id: String
+    let itemId: String
+    let title: String
+    let thumbnailUrl: URL?
+    let canonicalUrl: URL
+    let contentType: ContentType
+    let provider: Provider
+    let creator: String
+    let creatorImageUrl: URL?
+    let creatorId: String?
+    let publisher: String?
+    let summary: String?
+    let duration: Int?
+    let publishedAt: String?
+    let wordCount: Int?
+    let readingTimeMinutes: Int?
+    let state: String
+    let ingestedAt: String
+    let bookmarkedAt: String?
+    let lastOpenedAt: String?
+    let progress: BookmarkProgress?
+    var isFinished: Bool
+    var finishedAt: String?
+    let tags: [BookmarkTag]
+
+    var consumptionLabel: String? {
+        if let readingTimeMinutes {
+            return "\(readingTimeMinutes) min read"
+        }
+        guard let duration else { return nil }
+        let minutes = max(1, duration / 60)
+        if minutes < 60 { return "\(minutes) min" }
+        return "\(minutes / 60) hr \(minutes % 60) min"
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+struct BookmarkDetailView: View {
+    @State private var bookmark: Bookmark
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    let client: APIClient
+    let onUpdate: (Bookmark) -> Void
+
+    init(bookmark: Bookmark, client: APIClient, onUpdate: @escaping (Bookmark) -> Void) {
+        _bookmark = State(initialValue: bookmark)
+        self.client = client
+        self.onUpdate = onUpdate
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                hero
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(bookmark.title)
+                        .font(.title.bold())
+                    Text(bookmark.creator)
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    metadata
+                }
+
+                if let summary = bookmark.summary, !summary.isEmpty {
+                    Text(summary)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !bookmark.tags.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(bookmark.tags) { tag in
+                                Text(tag.name)
+                                    .font(.caption)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(.secondary.opacity(0.12), in: .capsule)
+                            }
+                        }
+                    }
+                }
+
+                Link(destination: bookmark.canonicalUrl) {
+                    Label("Open original", systemImage: "arrow.up.right.square")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    Task { await toggleFinished() }
+                } label: {
+                    Label(
+                        bookmark.isFinished ? "Mark unfinished" : "Mark finished",
+                        systemImage: bookmark.isFinished ? "arrow.uturn.backward.circle" : "checkmark.circle"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isSaving)
+            }
+            .padding()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            try? await client.markOpened(id: bookmark.id)
+            if let refreshed = try? await client.getBookmark(id: bookmark.id) {
+                bookmark = refreshed
+            }
+        }
+        .alert("Couldn’t update bookmark", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "Please try again.")
+        }
+    }
+
+    private var hero: some View {
+        AsyncImage(url: bookmark.thumbnailUrl) { phase in
+            switch phase {
+            case .success(let image): image.resizable().scaledToFill()
+            default:
+                ZStack {
+                    Color.secondary.opacity(0.12)
+                    Image(systemName: bookmark.contentType.systemImage)
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .aspectRatio(16 / 9, contentMode: .fit)
+        .clipShape(.rect(cornerRadius: 16))
+    }
+
+    private var metadata: some View {
+        HStack(spacing: 10) {
+            Label(bookmark.provider.title, systemImage: bookmark.contentType.systemImage)
+            if let label = bookmark.consumptionLabel {
+                Text(label)
+            }
+        }
+        .font(.subheadline)
+        .foregroundStyle(.tertiary)
+    }
+
+    private func toggleFinished() async {
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            let result = try await client.setFinished(
+                id: bookmark.id,
+                isFinished: !bookmark.isFinished
+            )
+            bookmark.isFinished = result.isFinished
+            bookmark.finishedAt = result.finishedAt
+            onUpdate(bookmark)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct BookmarkRow: View {
+    let bookmark: Bookmark
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 6) {
+                Text(bookmark.title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(3)
+
+                Text(bookmark.creator)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                HStack(spacing: 8) {
+                    Label(bookmark.provider.title, systemImage: bookmark.contentType.systemImage)
+                    if let label = bookmark.consumptionLabel {
+                        Text(label)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 5)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var thumbnail: some View {
+        AsyncImage(url: bookmark.thumbnailUrl) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            default:
+                ZStack {
+                    Color.secondary.opacity(0.12)
+                    Image(systemName: bookmark.contentType.systemImage)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(width: 96, height: 68)
+        .clipShape(.rect(cornerRadius: 10))
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class LibraryStore {
+    private(set) var items: [Bookmark] = []
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var errorMessage: String?
+    private(set) var nextCursor: String?
+
+    private let client: APIClient
+    private var activeQuery = LibraryQuery()
+
+    init(client: APIClient) {
+        self.client = client
+    }
+
+    func reload(query: LibraryQuery) async {
+        activeQuery = query
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await client.listBookmarks(query: query)
+            guard !Task.isCancelled, activeQuery == query else { return }
+            items = response.items
+            nextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeQuery == query else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadMoreIfNeeded(current item: Bookmark) async {
+        guard item.id == items.last?.id,
+              let nextCursor,
+              !isLoading,
+              !isLoadingMore
+        else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await client.listBookmarks(
+                query: activeQuery,
+                cursor: nextCursor
+            )
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(items.map(\.id))
+            items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
+            self.nextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func update(_ bookmark: Bookmark) {
+        if let index = items.firstIndex(where: { $0.id == bookmark.id }) {
+            if bookmark.isFinished == activeQuery.isFinished {
+                items[index] = bookmark
+            } else {
+                items.remove(at: index)
+            }
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -1,0 +1,122 @@
+import ClerkKitUI
+import SwiftUI
+
+struct LibraryView: View {
+    let client: APIClient
+
+    @State private var store: LibraryStore
+    @State private var search = ""
+    @State private var showsFinished = false
+    @State private var provider: Provider?
+    @State private var contentType: ContentType?
+
+    init(client: APIClient) {
+        self.client = client
+        _store = State(initialValue: LibraryStore(client: client))
+    }
+
+    private var query: LibraryQuery {
+        LibraryQuery(
+            search: search,
+            isFinished: showsFinished,
+            provider: provider,
+            contentType: contentType
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Library")
+                .searchable(text: $search, prompt: "Search your library")
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        filterMenu
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        UserButton()
+                    }
+                }
+                .navigationDestination(for: Bookmark.self) { bookmark in
+                    BookmarkDetailView(bookmark: bookmark, client: client) { updated in
+                        store.update(updated)
+                    }
+                }
+        }
+        .task(id: query) {
+            if !search.isEmpty {
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+            guard !Task.isCancelled else { return }
+            await store.reload(query: query)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.items.isEmpty {
+            ProgressView("Loading library…")
+        } else if let error = store.errorMessage, store.items.isEmpty {
+            ContentUnavailableView {
+                Label("Library unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") {
+                    Task { await store.reload(query: query) }
+                }
+            }
+        } else if store.items.isEmpty {
+            ContentUnavailableView.search(text: search)
+        } else {
+            List(store.items) { bookmark in
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+                .task {
+                    await store.loadMoreIfNeeded(current: bookmark)
+                }
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload(query: query)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Picker("Status", selection: $showsFinished) {
+                Text("Unfinished").tag(false)
+                Text("Finished").tag(true)
+            }
+
+            Picker("Provider", selection: $provider) {
+                Text("All providers").tag(Provider?.none)
+                ForEach(Provider.allCases) { value in
+                    Text(value.title).tag(Provider?.some(value))
+                }
+            }
+
+            Picker("Format", selection: $contentType) {
+                Text("All formats").tag(ContentType?.none)
+                ForEach(ContentType.allCases) { value in
+                    Text(value.title).tag(ContentType?.some(value))
+                }
+            }
+        } label: {
+            Label("Filter", systemImage: hasFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+        }
+        .accessibilityLabel("Filter library")
+    }
+
+    private var hasFilters: Bool {
+        showsFinished || provider != nil || contentType != nil
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -1,0 +1,126 @@
+#if DEBUG
+import SwiftUI
+
+struct ScreenshotLibraryView: View {
+    private let client = APIClient(
+        baseURL: URL(string: "https://example.invalid")!,
+        tokenProvider: { "screenshot-fixture" }
+    )
+
+    var body: some View {
+        NavigationStack {
+            List(ScreenshotFixtures.bookmarks) { bookmark in
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+            }
+            .listStyle(.plain)
+            .navigationTitle("Library")
+            .searchable(text: .constant(""), prompt: "Search your library")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {} label: {
+                        Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Image(systemName: "person.crop.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationDestination(for: Bookmark.self) { bookmark in
+                BookmarkDetailView(bookmark: bookmark, client: client) { _ in }
+            }
+        }
+    }
+}
+
+private enum ScreenshotFixtures {
+    static let bookmarks: [Bookmark] = [
+        make(
+            id: "1",
+            title: "Joy & Curiosity #91",
+            creator: "Thorsten Ball",
+            provider: .substack,
+            contentType: .article,
+            readingTime: 8,
+            summary: "Notes on software, craft, curiosity, and the ideas worth returning to."
+        ),
+        make(
+            id: "2",
+            title: "In defense of not understanding your codebase",
+            creator: "Sean Goedecke",
+            provider: .rss,
+            contentType: .article,
+            readingTime: 7,
+            summary: "Why productive software work rarely requires holding an entire system in your head."
+        ),
+        make(
+            id: "3",
+            title: "Why AI Agents Don’t Actually Understand You",
+            creator: "Latent Space",
+            provider: .youtube,
+            contentType: .video,
+            duration: 2_846,
+            summary: "A conversation about models, intent, and what today’s agents still miss."
+        ),
+        make(
+            id: "4",
+            title: "Never Twice the Same Color",
+            creator: "Two’s Complement",
+            provider: .spotify,
+            contentType: .podcast,
+            duration: 2_652,
+            summary: "A discussion about product design, systems, and the details that shape software."
+        ),
+        make(
+            id: "5",
+            title: "The End of Determinism: What’s Left for Engineers When AI Writes the Code",
+            creator: "Tom Enden",
+            provider: .web,
+            contentType: .article,
+            readingTime: 11,
+            summary: "A reflection on engineering judgment in a world of generated software."
+        ),
+    ]
+
+    private static func make(
+        id: String,
+        title: String,
+        creator: String,
+        provider: Provider,
+        contentType: ContentType,
+        duration: Int? = nil,
+        readingTime: Int? = nil,
+        summary: String
+    ) -> Bookmark {
+        Bookmark(
+            id: id,
+            itemId: "item_\(id)",
+            title: title,
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/items/\(id)")!,
+            contentType: contentType,
+            provider: provider,
+            creator: creator,
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: creator,
+            summary: summary,
+            duration: duration,
+            publishedAt: "2026-07-11T12:00:00Z",
+            wordCount: nil,
+            readingTimeMinutes: readingTime,
+            state: "BOOKMARKED",
+            ingestedAt: "2026-07-11T12:00:00Z",
+            bookmarkedAt: "2026-07-11T12:00:00Z",
+            lastOpenedAt: nil,
+            progress: nil,
+            isFinished: false,
+            finishedAt: nil,
+            tags: id == "1" ? [BookmarkTag(id: "tag_1", name: "software")] : []
+        )
+    }
+}
+#endif

--- a/apps/ios/ZineNative/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios/ZineNative/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors": [
+    {
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios/ZineNative/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/ios/ZineNative/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios/ZineNative/Resources/Assets.xcassets/Contents.json
+++ b/apps/ios/ZineNative/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import ZineNative
+
+final class BookmarkTests: XCTestCase {
+    func testDecodesBookmarkAndFormatsDuration() throws {
+        let data = Data(
+            """
+            {
+              "id":"ui_1","itemId":"item_1","title":"A long conversation",
+              "thumbnailUrl":null,"canonicalUrl":"https://example.com/item",
+              "contentType":"PODCAST","provider":"SPOTIFY","creator":"Example Show",
+              "creatorImageUrl":null,"creatorId":null,"publisher":null,"summary":null,
+              "duration":5570,"publishedAt":null,"wordCount":null,"readingTimeMinutes":null,
+              "state":"BOOKMARKED","ingestedAt":"2026-07-11T00:00:00Z",
+              "bookmarkedAt":"2026-07-11T00:00:00Z","lastOpenedAt":null,"progress":null,
+              "isFinished":false,"finishedAt":null,"tags":[]
+            }
+            """.utf8
+        )
+
+        let bookmark = try JSONDecoder().decode(Bookmark.self, from: data)
+
+        XCTAssertEqual(bookmark.provider, .spotify)
+        XCTAssertEqual(bookmark.consumptionLabel, "1 hr 32 min")
+    }
+
+    func testLibraryQueryIdentityIncludesEveryFilter() {
+        let first = LibraryQuery(search: "swift", isFinished: false, provider: .rss, contentType: .article)
+        let second = LibraryQuery(search: "swift", isFinished: true, provider: .rss, contentType: .article)
+
+        XCTAssertNotEqual(first, second)
+    }
+}

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -5,6 +5,7 @@
 import type { MiddlewareHandler } from 'hono';
 import type { Env } from '../types';
 import { verifyClerkToken } from '../lib/auth';
+import type { VerifyTokenResponse } from '../lib/auth';
 import { authLogger } from '../lib/logger';
 import { createDb } from '../db';
 import { users } from '../db/schema';
@@ -53,6 +54,13 @@ function shouldUseDevelopmentAuthBypass(env: Env['Bindings']): boolean {
 
 function getClerkJwksUrl(env: Env['Bindings']): string {
   return env.CLERK_JWKS_URL || DEFAULT_CLERK_JWKS_URL;
+}
+
+export function verifyClerkRequestToken(
+  token: string,
+  env: Env['Bindings']
+): Promise<VerifyTokenResponse> {
+  return verifyClerkToken(token, getClerkJwksUrl(env));
 }
 
 /**
@@ -136,10 +144,8 @@ export function authMiddleware(): MiddlewareHandler<Env> {
     }
 
     // Get JWKS URL from environment or use default
-    const jwksUrl = getClerkJwksUrl(c.env);
-
     // Verify the token
-    const result = await verifyClerkToken(token, jwksUrl);
+    const result = await verifyClerkRequestToken(token, c.env);
 
     if (!result.success) {
       // Map error codes to HTTP status codes

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.1.0",
-    "description": "Personal access token REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, and subscription sync jobs."
+    "version": "1.2.0",
+    "description": "REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, and subscription sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
     {
@@ -1036,8 +1036,8 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "Zine personal access token",
-        "description": "Use a Zine personal access token with the required operation scope."
+        "bearerFormat": "Clerk session JWT or Zine personal access token",
+        "description": "Use a Clerk session JWT for a signed-in Zine user, or a Zine personal access token with the required operation scope."
       }
     },
     "parameters": {

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -32,6 +32,7 @@ const {
   mockFindUserItem,
   mockUserItemUpdateSet,
   mockConsumptionInsertValues,
+  mockVerifyClerkRequestToken,
 } = vi.hoisted(() => ({
   mockCreateDb: vi.fn(),
   mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
@@ -58,6 +59,7 @@ const {
   mockFindUserItem: vi.fn(),
   mockUserItemUpdateSet: vi.fn(),
   mockConsumptionInsertValues: vi.fn(),
+  mockVerifyClerkRequestToken: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -72,6 +74,10 @@ vi.mock('../trpc/router', () => ({
   appRouter: {
     createCaller: mockCreateCaller,
   },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  verifyClerkRequestToken: mockVerifyClerkRequestToken,
 }));
 
 vi.mock('../sync/service', async () => {
@@ -188,6 +194,11 @@ describe('apiV1Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDbToken(createTokenRecord(['bookmarks:read', 'bookmarks:write']));
+    mockVerifyClerkRequestToken.mockResolvedValue({
+      success: true,
+      userId: 'clerk_user_123',
+      payload: { sub: 'clerk_user_123' },
+    });
     mockCreateCaller.mockReturnValue({
       items: {
         inbox: mockInbox,
@@ -273,6 +284,47 @@ describe('apiV1Routes', () => {
     );
 
     expect(res.status).toBe(401);
+  });
+
+  it('accepts a Clerk session token without looking up a personal access token', async () => {
+    mockLibrary.mockResolvedValue({ items: [], nextCursor: null });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        headers: { Authorization: 'Bearer clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockVerifyClerkRequestToken).toHaveBeenCalledWith(
+      'clerk-session-jwt',
+      expect.objectContaining({ ENVIRONMENT: 'test' })
+    );
+    expect(mockCreateContext).toHaveBeenCalled();
+    expect(mockCreateDb).not.toHaveBeenCalled();
+  });
+
+  it('returns the Clerk authentication error for an invalid session token', async () => {
+    mockVerifyClerkRequestToken.mockResolvedValue({
+      success: false,
+      error: 'Token has expired',
+      code: 'EXPIRED_TOKEN',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks', {
+        headers: { Authorization: 'Bearer expired-clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.headers.get('X-Zine-Auth-Error')).toBe('EXPIRED_TOKEN');
+    expect((await res.json()) as JsonBody).toMatchObject({ code: 'EXPIRED_TOKEN' });
+    expect(mockLibrary).not.toHaveBeenCalled();
   });
 
   it('returns 403 when the token is missing the required scope', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -34,6 +34,7 @@ import {
   listEditorialEditions,
   storeEditorialEdition,
 } from '../lib/editorial-storage';
+import { verifyClerkRequestToken } from '../middleware/auth';
 
 const DEFAULT_BOOKMARKS_LIMIT = 10;
 const MAX_BOOKMARKS_LIMIT = 50;
@@ -102,7 +103,7 @@ function extractBearerToken(authHeader: string | undefined): string | null {
   }
 
   const token = authHeader.slice(7).trim();
-  return token.startsWith(API_TOKEN_PREFIX) ? token : null;
+  return token.length > 0 ? token : null;
 }
 
 function parseLimit(value: string | undefined): number {
@@ -220,7 +221,7 @@ function trpcErrorResponse(c: Context<Env>, error: unknown) {
   throw error;
 }
 
-function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
+function apiAuth(requiredPatScope: ApiTokenScope) {
   const middleware: MiddlewareHandler<Env> = async (c, next) => {
     const requestId = c.get('requestId');
     const traceId = c.get('traceId');
@@ -236,6 +237,26 @@ function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
         },
         401
       );
+    }
+
+    if (!rawToken.startsWith(API_TOKEN_PREFIX)) {
+      const result = await verifyClerkRequestToken(rawToken, c.env);
+      if (!result.success) {
+        c.header('X-Zine-Auth-Error', result.code);
+        return c.json(
+          {
+            error: result.error,
+            code: result.code,
+            requestId,
+            traceId,
+          },
+          result.code === 'INVALID_TOKEN' || result.code === 'EXPIRED_TOKEN' ? 403 : 401
+        );
+      }
+
+      c.set('userId', result.userId);
+      await next();
+      return;
     }
 
     const tokenHash = await hashApiToken(rawToken);
@@ -256,7 +277,7 @@ function personalAccessTokenAuth(requiredScope: ApiTokenScope) {
       );
     }
 
-    if (!hasApiTokenScope(token, requiredScope)) {
+    if (!hasApiTokenScope(token, requiredPatScope)) {
       return c.json(
         {
           error: 'Forbidden',
@@ -284,7 +305,7 @@ const apiV1Routes = new Hono<Env>();
 
 apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec));
 
-apiV1Routes.post('/sync-jobs', personalAccessTokenAuth('sync:write'), async (c) => {
+apiV1Routes.post('/sync-jobs', apiAuth('sync:write'), async (c) => {
   let body: unknown;
   const contentLength = c.req.header('content-length');
   const hasPositiveContentLength =
@@ -376,7 +397,7 @@ apiV1Routes.post('/sync-jobs', personalAccessTokenAuth('sync:write'), async (c) 
   }
 });
 
-apiV1Routes.get('/sync-jobs/active', personalAccessTokenAuth('sync:read'), async (c) => {
+apiV1Routes.get('/sync-jobs/active', apiAuth('sync:read'), async (c) => {
   const userId = c.get('userId');
   if (!userId) {
     return c.json(
@@ -399,7 +420,7 @@ apiV1Routes.get('/sync-jobs/active', personalAccessTokenAuth('sync:read'), async
   });
 });
 
-apiV1Routes.get('/sync-jobs/:jobId', personalAccessTokenAuth('sync:read'), async (c) => {
+apiV1Routes.get('/sync-jobs/:jobId', apiAuth('sync:read'), async (c) => {
   const userId = c.get('userId');
   if (!userId) {
     return c.json(
@@ -436,7 +457,7 @@ apiV1Routes.get('/sync-jobs/:jobId', personalAccessTokenAuth('sync:read'), async
   });
 });
 
-apiV1Routes.get('/inbox', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/inbox', apiAuth('bookmarks:read'), async (c) => {
   const parsedQuery = InboxQuerySchema.safeParse({
     provider: c.req.query('provider'),
     contentType: c.req.query('contentType'),
@@ -475,7 +496,7 @@ apiV1Routes.get('/inbox', personalAccessTokenAuth('bookmarks:read'), async (c) =
   });
 });
 
-apiV1Routes.post('/inbox/:id/bookmark', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/inbox/:id/bookmark', apiAuth('bookmarks:write'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
@@ -490,7 +511,7 @@ apiV1Routes.post('/inbox/:id/bookmark', personalAccessTokenAuth('bookmarks:write
   }
 });
 
-apiV1Routes.post('/inbox/:id/archive', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/inbox/:id/archive', apiAuth('bookmarks:write'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
@@ -505,7 +526,7 @@ apiV1Routes.post('/inbox/:id/archive', personalAccessTokenAuth('bookmarks:write'
   }
 });
 
-apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/bookmarks', apiAuth('bookmarks:read'), async (c) => {
   const parsedQuery = BookmarkQuerySchema.safeParse({
     provider: c.req.query('provider'),
     contentType: c.req.query('contentType'),
@@ -548,7 +569,7 @@ apiV1Routes.get('/bookmarks', personalAccessTokenAuth('bookmarks:read'), async (
   });
 });
 
-apiV1Routes.post('/bookmarks/preview', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/bookmarks/preview', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsedBody = PreviewBookmarkBodySchema.safeParse(body);
 
@@ -592,7 +613,7 @@ apiV1Routes.post('/bookmarks/preview', personalAccessTokenAuth('bookmarks:write'
   }
 });
 
-apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/bookmarks', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsedBody = SaveBookmarkBodySchema.safeParse(body);
 
@@ -642,7 +663,7 @@ apiV1Routes.post('/bookmarks', personalAccessTokenAuth('bookmarks:write'), async
   }
 });
 
-apiV1Routes.get('/bookmarks/:id', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/bookmarks/:id', apiAuth('bookmarks:read'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
@@ -657,7 +678,7 @@ apiV1Routes.get('/bookmarks/:id', personalAccessTokenAuth('bookmarks:read'), asy
   }
 });
 
-apiV1Routes.patch('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.patch('/bookmarks/:id', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsedBody = FinishBookmarkBodySchema.safeParse(body);
 
@@ -751,7 +772,7 @@ apiV1Routes.patch('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), 
   });
 });
 
-apiV1Routes.delete('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.delete('/bookmarks/:id', apiAuth('bookmarks:write'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
@@ -766,7 +787,7 @@ apiV1Routes.delete('/bookmarks/:id', personalAccessTokenAuth('bookmarks:write'),
   }
 });
 
-apiV1Routes.put('/bookmarks/:id/tags', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.put('/bookmarks/:id/tags', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsedBody = SetTagsBodySchema.safeParse(body);
 
@@ -800,7 +821,7 @@ apiV1Routes.put('/bookmarks/:id/tags', personalAccessTokenAuth('bookmarks:write'
   }
 });
 
-apiV1Routes.post('/bookmarks/:id/opened', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/bookmarks/:id/opened', apiAuth('bookmarks:write'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
@@ -816,66 +837,58 @@ apiV1Routes.post('/bookmarks/:id/opened', personalAccessTokenAuth('bookmarks:wri
   }
 });
 
-apiV1Routes.put(
-  '/bookmarks/:id/progress',
-  personalAccessTokenAuth('bookmarks:write'),
-  async (c) => {
-    const body = await c.req.json().catch(() => null);
-    const parsedBody = UpdateProgressBodySchema.safeParse(body);
+apiV1Routes.put('/bookmarks/:id/progress', apiAuth('bookmarks:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = UpdateProgressBodySchema.safeParse(body);
 
-    if (!parsedBody.success) {
-      return c.json(
-        {
-          error: 'Invalid request body',
-          code: 'INVALID_REQUEST_BODY',
-          issues: parsedBody.error.issues,
-          requestId: c.get('requestId'),
-          traceId: c.get('traceId'),
-        },
-        400
-      );
-    }
-
-    const caller = appRouter.createCaller(await createContext(c));
-
-    try {
-      const result = await caller.items.updateProgress({
-        id: c.req.param('id'),
-        position: parsedBody.data.position,
-        duration: parsedBody.data.duration,
-      });
-      return c.json({
-        ...result,
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
         requestId: c.get('requestId'),
         traceId: c.get('traceId'),
-      });
-    } catch (error) {
-      return trpcErrorResponse(c, error);
-    }
+      },
+      400
+    );
   }
-);
 
-apiV1Routes.get(
-  '/bookmarks/:id/article-content',
-  personalAccessTokenAuth('bookmarks:read'),
-  async (c) => {
-    const caller = appRouter.createCaller(await createContext(c));
+  const caller = appRouter.createCaller(await createContext(c));
 
-    try {
-      const item = await caller.items.get({ id: c.req.param('id') });
-      const result = await caller.items.getArticleContent({ itemId: item.itemId });
-      return c.json({
-        ...result,
-        requestId: c.get('requestId'),
-        traceId: c.get('traceId'),
-      });
-    } catch (error) {
-      return trpcErrorResponse(c, error);
-    }
+  try {
+    const result = await caller.items.updateProgress({
+      id: c.req.param('id'),
+      position: parsedBody.data.position,
+      duration: parsedBody.data.duration,
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
   }
-);
+});
 
-apiV1Routes.get('/tags', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/bookmarks/:id/article-content', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const item = await caller.items.get({ id: c.req.param('id') });
+    const result = await caller.items.getArticleContent({ itemId: item.itemId });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/tags', apiAuth('bookmarks:read'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
   const result = await caller.items.listTags();
@@ -886,7 +899,7 @@ apiV1Routes.get('/tags', personalAccessTokenAuth('bookmarks:read'), async (c) =>
   });
 });
 
-apiV1Routes.get('/editorial/editions', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/editorial/editions', apiAuth('bookmarks:read'), async (c) => {
   const editions = await listEditorialEditions(
     c.env.DB,
     c.get('userId')!,
@@ -895,26 +908,22 @@ apiV1Routes.get('/editorial/editions', personalAccessTokenAuth('bookmarks:read')
   return c.json({ editions, requestId: c.get('requestId'), traceId: c.get('traceId') });
 });
 
-apiV1Routes.get(
-  '/editorial/editions/latest',
-  personalAccessTokenAuth('bookmarks:read'),
-  async (c) => {
-    const result = await getEditorialEdition(c.env.DB, c.env.ARTICLE_CONTENT, c.get('userId')!);
-    if (!result) {
-      return c.json(
-        { error: 'Edition not found', code: 'NOT_FOUND', requestId: c.get('requestId') },
-        404
-      );
-    }
-    return c.json({
-      edition: result.edition,
-      requestId: c.get('requestId'),
-      traceId: c.get('traceId'),
-    });
+apiV1Routes.get('/editorial/editions/latest', apiAuth('bookmarks:read'), async (c) => {
+  const result = await getEditorialEdition(c.env.DB, c.env.ARTICLE_CONTENT, c.get('userId')!);
+  if (!result) {
+    return c.json(
+      { error: 'Edition not found', code: 'NOT_FOUND', requestId: c.get('requestId') },
+      404
+    );
   }
-);
+  return c.json({
+    edition: result.edition,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
 
-apiV1Routes.get('/editorial/editions/:id', personalAccessTokenAuth('bookmarks:read'), async (c) => {
+apiV1Routes.get('/editorial/editions/:id', apiAuth('bookmarks:read'), async (c) => {
   const result = await getEditorialEdition(
     c.env.DB,
     c.env.ARTICLE_CONTENT,
@@ -936,7 +945,7 @@ apiV1Routes.get('/editorial/editions/:id', personalAccessTokenAuth('bookmarks:re
 
 apiV1Routes.get(
   '/editorial/editions/:id/artifacts/:artifact',
-  personalAccessTokenAuth('bookmarks:read'),
+  apiAuth('bookmarks:read'),
   async (c) => {
     const artifact = c.req.param('artifact');
     if (!['markdown', 'snapshot', 'validation'].includes(artifact)) {
@@ -956,7 +965,7 @@ apiV1Routes.get(
   }
 );
 
-apiV1Routes.post('/editorial/editions', personalAccessTokenAuth('bookmarks:write'), async (c) => {
+apiV1Routes.post('/editorial/editions', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsed = PublishEditorialEditionSchema.safeParse(body);
   if (!parsed.success) {


### PR DESCRIPTION
## Summary

- add a standalone native SwiftUI iOS app alongside the existing React Native client
- implement Clerk sign-in and the first Library browsing/detail slice
- allow Clerk session JWTs on the existing REST API while preserving scoped personal access tokens
- update REST API tests and OpenAPI authentication documentation

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test:worker:ci` (1,534 tests)
- `bun run --cwd apps/worker test:run src/routes/api-v1.test.ts` (42 tests)
- XcodeBuildMCP `test_sim` on iPhone 17 / iOS 26.2 (2 tests)