### PR TITLE
feat(ios): refine native library experience

### DIFF
--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -1,9 +1,44 @@
 import ClerkKit
 import SwiftUI
 
+enum AppAppearance: String, CaseIterable, Identifiable {
+    static let storageKey = "appAppearance"
+
+    case system
+    case light
+    case dark
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .system: "circle.lefthalf.filled"
+        case .light: "sun.max"
+        case .dark: "moon"
+        }
+    }
+
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}
+
 @main
 struct ZineNativeApp: App {
     private let configuration = AppConfiguration.current
+    @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
 
     init() {
         if configuration.isClerkConfigured {
@@ -14,7 +49,12 @@ struct ZineNativeApp: App {
     var body: some Scene {
         WindowGroup {
             rootView
+                .preferredColorScheme(appearance.colorScheme)
         }
+    }
+
+    private var appearance: AppAppearance {
+        AppAppearance(rawValue: storedAppearance) ?? .system
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct BookmarkDetailView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     @State private var bookmark: Bookmark
     @State private var isSaving = false
     @State private var errorMessage: String?
@@ -15,60 +17,30 @@ struct BookmarkDetailView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                hero
+        GeometryReader { viewport in
+            let heroHeight = heroHeight(in: viewport.size)
 
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(bookmark.title)
-                        .font(.title.bold())
-                    Text(bookmark.creator)
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-                    metadata
-                }
+            ZStack {
+                Color(uiColor: .systemBackground)
+                    .ignoresSafeArea()
 
-                if let summary = bookmark.summary, !summary.isEmpty {
-                    Text(summary)
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                }
-
-                if !bookmark.tags.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack {
-                            ForEach(bookmark.tags) { tag in
-                                Text(tag.name)
-                                    .font(.caption)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 6)
-                                    .background(.secondary.opacity(0.12), in: .capsule)
-                            }
-                        }
+                ScrollView {
+                    VStack(spacing: 0) {
+                        parallaxHero(height: heroHeight)
+                        details
+                            .frame(
+                                minHeight: max(viewport.size.height - heroHeight, 0),
+                                alignment: .top
+                            )
                     }
                 }
-
-                Link(destination: bookmark.canonicalUrl) {
-                    Label("Open original", systemImage: "arrow.up.right.square")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-
-                Button {
-                    Task { await toggleFinished() }
-                } label: {
-                    Label(
-                        bookmark.isFinished ? "Mark unfinished" : "Mark finished",
-                        systemImage: bookmark.isFinished ? "arrow.uturn.backward.circle" : "checkmark.circle"
-                    )
-                    .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .disabled(isSaving)
+                .coordinateSpace(name: "bookmarkDetailScroll")
+                .ignoresSafeArea(edges: .top)
             }
-            .padding()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
             try? await client.markOpened(id: bookmark.id)
             if let refreshed = try? await client.getBookmark(id: bookmark.id) {
@@ -85,22 +57,113 @@ struct BookmarkDetailView: View {
         }
     }
 
-    private var hero: some View {
+    private var details: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(bookmark.title)
+                    .font(.title.bold())
+                Text(bookmark.creator)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                metadata
+            }
+
+            if let summary = bookmark.summary, !summary.isEmpty {
+                Text(summary)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !bookmark.tags.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        ForEach(bookmark.tags) { tag in
+                            Text(tag.name)
+                                .font(.caption)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(.secondary.opacity(0.12), in: .capsule)
+                        }
+                    }
+                }
+            }
+
+            Link(destination: bookmark.canonicalUrl) {
+                Label("Open original", systemImage: "arrow.up.right.square")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                Task { await toggleFinished() }
+            } label: {
+                Label(
+                    bookmark.isFinished ? "Mark unfinished" : "Mark finished",
+                    systemImage: bookmark.isFinished ? "arrow.uturn.backward.circle" : "checkmark.circle"
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .disabled(isSaving)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 28)
+        .padding(.bottom, 40)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func parallaxHero(height: CGFloat) -> some View {
+        GeometryReader { geometry in
+            let offset = geometry.frame(in: .named("bookmarkDetailScroll")).minY
+            let stretch = max(offset, 0)
+
+            heroImage
+                .frame(width: geometry.size.width, height: height + stretch)
+                .clipped()
+                .overlay(alignment: .bottom) {
+                    if colorScheme == .dark {
+                        LinearGradient(
+                            stops: heroFadeStops,
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 200)
+                    }
+                }
+                .offset(y: offset > 0 ? -offset : -offset * 0.35)
+        }
+        .frame(height: height)
+    }
+
+    private var heroFadeStops: [Gradient.Stop] {
+        let background = Color(uiColor: .systemBackground)
+
+        return [
+            .init(color: .clear, location: 0),
+            .init(color: background.opacity(0.28), location: 0.35),
+            .init(color: background.opacity(0.72), location: 0.72),
+            .init(color: background, location: 1),
+        ]
+    }
+
+    private var heroImage: some View {
         AsyncImage(url: bookmark.thumbnailUrl) { phase in
             switch phase {
-            case .success(let image): image.resizable().scaledToFill()
+            case .success(let image):
+                image.resizable().scaledToFill()
             default:
                 ZStack {
                     Color.secondary.opacity(0.12)
                     Image(systemName: bookmark.contentType.systemImage)
-                        .font(.largeTitle)
+                        .font(.system(size: 48))
                         .foregroundStyle(.secondary)
                 }
             }
         }
-        .frame(maxWidth: .infinity)
-        .aspectRatio(16 / 9, contentMode: .fit)
-        .clipShape(.rect(cornerRadius: 16))
+    }
+
+    private func heroHeight(in viewport: CGSize) -> CGFloat {
+        min(max(viewport.height * 0.33, 240), 320)
     }
 
     private var metadata: some View {

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -1,6 +1,10 @@
 import ClerkKitUI
 import SwiftUI
 
+private enum AccountRoute: Hashable {
+    case appearance
+}
+
 struct LibraryView: View {
     let client: APIClient
 
@@ -9,6 +13,7 @@ struct LibraryView: View {
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
+    @Namespace private var bookmarkTransition
 
     init(client: APIClient) {
         self.client = client
@@ -34,13 +39,16 @@ struct LibraryView: View {
                         filterMenu
                     }
                     ToolbarItem(placement: .topBarTrailing) {
-                        UserButton()
+                        accountButton
                     }
                 }
                 .navigationDestination(for: Bookmark.self) { bookmark in
                     BookmarkDetailView(bookmark: bookmark, client: client) { updated in
                         store.update(updated)
                     }
+                    .navigationTransition(
+                        .zoom(sourceID: bookmark.id, in: bookmarkTransition)
+                    )
                 }
         }
         .task(id: query) {
@@ -73,6 +81,7 @@ struct LibraryView: View {
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
+                .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)
                 }
@@ -118,5 +127,61 @@ struct LibraryView: View {
 
     private var hasFilters: Bool {
         showsFinished || provider != nil || contentType != nil
+    }
+
+    private var accountButton: some View {
+        UserButton()
+            .userProfileRows([
+                UserProfileCustomRow(
+                    route: AccountRoute.appearance,
+                    title: "Appearance",
+                    icon: .system(name: "circle.lefthalf.filled"),
+                    placement: .before(.signOut)
+                ),
+            ])
+            .userProfileDestination { route in
+                switch route {
+                case .appearance:
+                    AppearanceSettingsView()
+                }
+            }
+    }
+}
+
+private struct AppearanceSettingsView: View {
+    @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
+
+    private var selection: Binding<AppAppearance> {
+        Binding(
+            get: { AppAppearance(rawValue: storedAppearance) ?? .system },
+            set: { storedAppearance = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(AppAppearance.allCases) { appearance in
+                    Button {
+                        selection.wrappedValue = appearance
+                    } label: {
+                        Label(appearance.title, systemImage: appearance.systemImage)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(.rect)
+                            .overlay(alignment: .trailing) {
+                                if selection.wrappedValue == appearance {
+                                    Image(systemName: "checkmark")
+                                        .fontWeight(.semibold)
+                                }
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+            } footer: {
+                Text("System follows your iPhone’s appearance setting.")
+            }
+        }
+        .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
     }
 }


### PR DESCRIPTION
## Summary

- add the native iOS zoom transition from library rows into bookmark details
- add a consistent full-width parallax hero treatment with an adaptive dark-mode fade and a crisp light-mode edge
- add persisted System, Light, and Dark appearance options to the Clerk account profile

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- native simulator build and visual verification on `iPhone 17 — Zine` (iOS 26.2)