### PR TITLE
perf(ios): make native library feel instant

### DIFF
--- a/apps/ios/ZineNative.xcodeproj/project.pbxproj
+++ b/apps/ios/ZineNative.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		A10000000000000000000001 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000031 /* ClerkKit */; };
 		A10000000000000000000002 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000032 /* ClerkKitUI */; };
+		A10000000000000000000033 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000035 /* Nuke */; };
+		A10000000000000000000034 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000036 /* NukeUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +52,8 @@
 			files = (
 				A10000000000000000000001 /* ClerkKit in Frameworks */,
 				A10000000000000000000002 /* ClerkKitUI in Frameworks */,
+				A10000000000000000000033 /* Nuke in Frameworks */,
+				A10000000000000000000034 /* NukeUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +119,8 @@
 			packageProductDependencies = (
 				A10000000000000000000031 /* ClerkKit */,
 				A10000000000000000000032 /* ClerkKitUI */,
+				A10000000000000000000035 /* Nuke */,
+				A10000000000000000000036 /* NukeUI */,
 			);
 			productName = ZineNative;
 			productReference = A10000000000000000000004 /* ZineNative.app */;
@@ -163,6 +169,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */,
+				A10000000000000000000037 /* XCRemoteSwiftPackageReference "Nuke" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = A10000000000000000000012 /* Products */;
@@ -318,11 +325,18 @@
 			repositoryURL = "https://github.com/clerk/clerk-ios";
 			requirement = { kind = upToNextMajorVersion; minimumVersion = 1.3.1; };
 		};
+		A10000000000000000000037 /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke.git";
+			requirement = { kind = upToNextMajorVersion; minimumVersion = 13.0.6; };
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		A10000000000000000000031 /* ClerkKit */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */; productName = ClerkKit; };
 		A10000000000000000000032 /* ClerkKitUI */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000030 /* XCRemoteSwiftPackageReference "clerk-ios" */; productName = ClerkKitUI; };
+		A10000000000000000000035 /* Nuke */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000037 /* XCRemoteSwiftPackageReference "Nuke" */; productName = Nuke; };
+		A10000000000000000000036 /* NukeUI */ = {isa = XCSwiftPackageProductDependency; package = A10000000000000000000037 /* XCRemoteSwiftPackageReference "Nuke" */; productName = NukeUI; };
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = A10000000000000000000010 /* Project object */;

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -9,7 +9,7 @@ struct AppRootView: View {
 
     var body: some View {
         Group {
-            if clerk.user != nil {
+            if let user = clerk.user {
                 LibraryView(
                     client: APIClient(
                         baseURL: configuration.apiBaseURL,
@@ -19,7 +19,8 @@ struct AppRootView: View {
                             }
                             return token
                         }
-                    )
+                    ),
+                    cache: LibraryCache(userID: user.id)
                 )
             } else {
                 AuthView(isDismissible: false)

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -5,6 +5,15 @@ struct LibraryQuery: Hashable {
     var isFinished = false
     var provider: Provider?
     var contentType: ContentType?
+
+    var cacheKey: String {
+        [
+            search.trimmingCharacters(in: .whitespacesAndNewlines),
+            String(isFinished),
+            provider?.rawValue ?? "all",
+            contentType?.rawValue ?? "all",
+        ].joined(separator: "|")
+    }
 }
 
 struct APIClient {

--- a/apps/ios/ZineNative/Core/Images/AppImagePipeline.swift
+++ b/apps/ios/ZineNative/Core/Images/AppImagePipeline.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Nuke
+
+enum AppImagePipeline {
+    static let shared = ImagePipeline(
+        configuration: .withDataCache(
+            name: "app.zine.native.images",
+            sizeLimit: 300 * 1024 * 1024
+        )
+    )
+
+    private static let prefetcher = ImagePrefetcher(
+        pipeline: shared,
+        destination: .diskCache,
+        maxConcurrentRequestCount: 4
+    )
+
+    static func prefetch(_ urls: [URL]) {
+        prefetcher.startPrefetching(with: urls)
+    }
+}

--- a/apps/ios/ZineNative/Core/Images/CachedRemoteImage.swift
+++ b/apps/ios/ZineNative/Core/Images/CachedRemoteImage.swift
@@ -1,0 +1,50 @@
+import Nuke
+import NukeUI
+import SwiftUI
+
+struct CachedRemoteImage<Placeholder: View>: View {
+    let url: URL?
+    let targetSize: CGSize
+    let contentMode: SwiftUI.ContentMode
+    @ViewBuilder let placeholder: () -> Placeholder
+
+    init(
+        url: URL?,
+        targetSize: CGSize,
+        contentMode: SwiftUI.ContentMode = .fill,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.url = url
+        self.targetSize = targetSize
+        self.contentMode = contentMode
+        self.placeholder = placeholder
+    }
+
+    var body: some View {
+        LazyImage(request: request) { state in
+            if let image = state.image {
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: contentMode)
+            } else {
+                placeholder()
+            }
+        }
+        .pipeline(AppImagePipeline.shared)
+    }
+
+    private var request: ImageRequest? {
+        guard let url else { return nil }
+        return ImageRequest(
+            url: url,
+            processors: [
+                ImageProcessors.Resize(
+                    size: targetSize,
+                    unit: .points,
+                    contentMode: contentMode == .fill ? .aspectFill : .aspectFit,
+                    crop: contentMode == .fill
+                ),
+            ]
+        )
+    }
+}

--- a/apps/ios/ZineNative/Core/Persistence/LibraryCache.swift
+++ b/apps/ios/ZineNative/Core/Persistence/LibraryCache.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct LibraryCacheSnapshot: Codable, Equatable {
+    let items: [Bookmark]
+    let nextCursor: String?
+    let savedAt: Date
+}
+
+actor LibraryCache {
+    private static let maximumSnapshots = 12
+
+    private let fileURL: URL
+    private var snapshots: [String: LibraryCacheSnapshot]?
+
+    init(userID: String, baseDirectory: URL? = nil) {
+        let root = baseDirectory ?? FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        let safeUserID = userID.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+            ?? "unknown-user"
+        fileURL = root
+            .appending(path: "ZineNative/Library", directoryHint: .isDirectory)
+            .appending(path: "\(safeUserID).json")
+    }
+
+    func load(query: LibraryQuery) -> LibraryCacheSnapshot? {
+        loadSnapshotsIfNeeded()
+        return snapshots?[query.cacheKey]
+    }
+
+    func save(items: [Bookmark], nextCursor: String?, query: LibraryQuery) {
+        loadSnapshotsIfNeeded()
+        snapshots?[query.cacheKey] = LibraryCacheSnapshot(
+            items: items,
+            nextCursor: nextCursor,
+            savedAt: Date()
+        )
+        pruneSnapshots()
+        persistSnapshots()
+    }
+
+    private func loadSnapshotsIfNeeded() {
+        guard snapshots == nil else { return }
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode(
+                  [String: LibraryCacheSnapshot].self,
+                  from: data
+              )
+        else {
+            snapshots = [:]
+            return
+        }
+        snapshots = decoded
+    }
+
+    private func pruneSnapshots() {
+        guard let snapshots, snapshots.count > Self.maximumSnapshots else { return }
+        let retainedKeys = snapshots
+            .sorted { $0.value.savedAt > $1.value.savedAt }
+            .prefix(Self.maximumSnapshots)
+            .map(\.key)
+        self.snapshots = snapshots.filter { retainedKeys.contains($0.key) }
+    }
+
+    private func persistSnapshots() {
+        guard let snapshots,
+              let data = try? JSONEncoder().encode(snapshots)
+        else { return }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // The cache is an optimization; network loading remains the source of truth.
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -147,17 +147,15 @@ struct BookmarkDetailView: View {
     }
 
     private var heroImage: some View {
-        AsyncImage(url: bookmark.thumbnailUrl) { phase in
-            switch phase {
-            case .success(let image):
-                image.resizable().scaledToFill()
-            default:
-                ZStack {
-                    Color.secondary.opacity(0.12)
-                    Image(systemName: bookmark.contentType.systemImage)
-                        .font(.system(size: 48))
-                        .foregroundStyle(.secondary)
-                }
+        CachedRemoteImage(
+            url: bookmark.thumbnailUrl,
+            targetSize: CGSize(width: 430, height: 320)
+        ) {
+            ZStack {
+                Color.secondary.opacity(0.12)
+                Image(systemName: bookmark.contentType.systemImage)
+                    .font(.system(size: 48))
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -32,16 +32,14 @@ struct BookmarkRow: View {
     }
 
     private var thumbnail: some View {
-        AsyncImage(url: bookmark.thumbnailUrl) { phase in
-            switch phase {
-            case .success(let image):
-                image.resizable().scaledToFill()
-            default:
-                ZStack {
-                    Color.secondary.opacity(0.12)
-                    Image(systemName: bookmark.contentType.systemImage)
-                        .foregroundStyle(.secondary)
-                }
+        CachedRemoteImage(
+            url: bookmark.thumbnailUrl,
+            targetSize: CGSize(width: 96, height: 68)
+        ) {
+            ZStack {
+                Color.secondary.opacity(0.12)
+                Image(systemName: bookmark.contentType.systemImage)
+                    .foregroundStyle(.secondary)
             }
         }
         .frame(width: 96, height: 68)

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -11,16 +11,32 @@ final class LibraryStore {
     private(set) var nextCursor: String?
 
     private let client: APIClient
+    private let cache: LibraryCache
     private var activeQuery = LibraryQuery()
 
-    init(client: APIClient) {
+    init(client: APIClient, cache: LibraryCache) {
         self.client = client
+        self.cache = cache
     }
 
     func reload(query: LibraryQuery) async {
+        let queryChanged = activeQuery != query
         activeQuery = query
-        isLoading = true
         errorMessage = nil
+
+        if queryChanged {
+            items = []
+            nextCursor = nil
+        }
+
+        if let snapshot = await cache.load(query: query) {
+            guard !Task.isCancelled, activeQuery == query else { return }
+            items = snapshot.items
+            nextCursor = snapshot.nextCursor
+            prefetchImages(in: snapshot.items)
+        }
+
+        isLoading = items.isEmpty
         defer { isLoading = false }
 
         do {
@@ -28,6 +44,12 @@ final class LibraryStore {
             guard !Task.isCancelled, activeQuery == query else { return }
             items = response.items
             nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+            await cache.save(
+                items: response.items,
+                nextCursor: response.nextCursor,
+                query: query
+            )
         } catch is CancellationError {
             return
         } catch {
@@ -55,6 +77,8 @@ final class LibraryStore {
             let existingIDs = Set(items.map(\.id))
             items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
             self.nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+            await cache.save(items: items, nextCursor: response.nextCursor, query: activeQuery)
         } catch is CancellationError {
             return
         } catch {
@@ -69,6 +93,20 @@ final class LibraryStore {
             } else {
                 items.remove(at: index)
             }
+            persistCurrentState()
+        }
+    }
+
+    private func prefetchImages(in bookmarks: [Bookmark]) {
+        AppImagePipeline.prefetch(bookmarks.compactMap(\.thumbnailUrl))
+    }
+
+    private func persistCurrentState() {
+        let items = items
+        let nextCursor = nextCursor
+        let query = activeQuery
+        Task {
+            await cache.save(items: items, nextCursor: nextCursor, query: query)
         }
     }
 }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -15,9 +15,9 @@ struct LibraryView: View {
     @State private var contentType: ContentType?
     @Namespace private var bookmarkTransition
 
-    init(client: APIClient) {
+    init(client: APIClient, cache: LibraryCache) {
         self.client = client
-        _store = State(initialValue: LibraryStore(client: client))
+        _store = State(initialValue: LibraryStore(client: client, cache: cache))
     }
 
     private var query: LibraryQuery {

--- a/apps/ios/ZineNativeTests/LibraryCacheTests.swift
+++ b/apps/ios/ZineNativeTests/LibraryCacheTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import ZineNative
+
+struct LibraryCacheTests {
+    @Test func roundTripsSnapshotsByQuery() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = LibraryCache(userID: "test-user", baseDirectory: directory)
+        let query = LibraryQuery(provider: .youtube)
+        let bookmark = makeBookmark()
+
+        await cache.save(items: [bookmark], nextCursor: "next", query: query)
+        let snapshot = await cache.load(query: query)
+
+        #expect(snapshot?.items == [bookmark])
+        #expect(snapshot?.nextCursor == "next")
+        #expect(await cache.load(query: LibraryQuery()) == nil)
+    }
+
+    private func makeBookmark() -> Bookmark {
+        Bookmark(
+            id: "bookmark-1",
+            itemId: "item-1",
+            title: "Cached bookmark",
+            thumbnailUrl: URL(string: "https://example.com/image.jpg"),
+            canonicalUrl: URL(string: "https://example.com")!,
+            contentType: .video,
+            provider: .youtube,
+            creator: "Creator",
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: nil,
+            summary: nil,
+            duration: 60,
+            publishedAt: nil,
+            wordCount: nil,
+            readingTimeMinutes: nil,
+            state: "READY",
+            ingestedAt: "2026-07-12T00:00:00Z",
+            bookmarkedAt: nil,
+            lastOpenedAt: nil,
+            progress: nil,
+            isFinished: false,
+            finishedAt: nil,
+            tags: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- replace `AsyncImage` with a shared Nuke pipeline that provides memory and disk caching, request coalescing, downsampling, and library-page prefetching
- persist user-scoped library snapshots and render them immediately while fresh API data loads in the background
- keep cached pagination and bookmark mutations in sync and add native cache round-trip coverage

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (63 mobile suites / 1125 tests; 66 worker files / 1555 tests; 11 web files / 75 tests)
- `bun run build`
- Xcode native test suite (3 tests)
- Debug and Release builds on `iPhone 17 — Zine`
- signed Release device build and install on Erik’s iPhone