### PR TITLE
feat(ios): add optimistic library swipe actions

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -68,6 +68,12 @@ struct APIClient {
         return response.bookmark
     }
 
+    func archiveBookmark(id: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)"))
+        request.httpMethod = "DELETE"
+        let _: EmptyResponse = try await send(request)
+    }
+
     func markOpened(id: String) async throws {
         var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/opened"))
         request.httpMethod = "POST"

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -8,6 +8,7 @@ final class LibraryStore {
     private(set) var isLoading = false
     private(set) var isLoadingMore = false
     private(set) var errorMessage: String?
+    private(set) var actionErrorMessage: String?
     private(set) var nextCursor: String?
 
     private let client: APIClient
@@ -97,6 +98,32 @@ final class LibraryStore {
         }
     }
 
+    func complete(_ bookmark: Bookmark) async {
+        guard !bookmark.isFinished,
+              let removal = removeOptimistically(bookmark)
+        else { return }
+
+        do {
+            _ = try await client.setFinished(id: bookmark.id, isFinished: true)
+        } catch {
+            restore(removal, message: "The bookmark couldn’t be completed. Please try again.")
+        }
+    }
+
+    func archive(_ bookmark: Bookmark) async {
+        guard let removal = removeOptimistically(bookmark) else { return }
+
+        do {
+            try await client.archiveBookmark(id: bookmark.id)
+        } catch {
+            restore(removal, message: "The bookmark couldn’t be archived. Please try again.")
+        }
+    }
+
+    func dismissActionError() {
+        actionErrorMessage = nil
+    }
+
     private func prefetchImages(in bookmarks: [Bookmark]) {
         AppImagePipeline.prefetch(bookmarks.compactMap(\.thumbnailUrl))
     }
@@ -109,4 +136,27 @@ final class LibraryStore {
             await cache.save(items: items, nextCursor: nextCursor, query: query)
         }
     }
+
+    private func removeOptimistically(_ bookmark: Bookmark) -> OptimisticRemoval? {
+        guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return nil }
+        let removal = OptimisticRemoval(bookmark: items.remove(at: index), index: index, query: activeQuery)
+        persistCurrentState()
+        return removal
+    }
+
+    private func restore(_ removal: OptimisticRemoval, message: String) {
+        guard activeQuery == removal.query,
+              !items.contains(where: { $0.id == removal.bookmark.id })
+        else { return }
+
+        items.insert(removal.bookmark, at: min(removal.index, items.endIndex))
+        actionErrorMessage = message
+        persistCurrentState()
+    }
+}
+
+private struct OptimisticRemoval {
+    let bookmark: Bookmark
+    let index: Int
+    let query: LibraryQuery
 }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -58,6 +58,13 @@ struct LibraryView: View {
             guard !Task.isCancelled else { return }
             await store.reload(query: query)
         }
+        .alert("Couldn’t update bookmark", isPresented: actionErrorBinding) {
+            Button("OK", role: .cancel) {
+                store.dismissActionError()
+            }
+        } message: {
+            Text(store.actionErrorMessage ?? "Please try again.")
+        }
     }
 
     @ViewBuilder
@@ -82,6 +89,25 @@ struct LibraryView: View {
                     BookmarkRow(bookmark: bookmark)
                 }
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    if !bookmark.isFinished {
+                        Button {
+                            Task { await store.complete(bookmark) }
+                        } label: {
+                            Label("Complete", systemImage: "checkmark.circle.fill")
+                        }
+                        .tint(.green)
+                        .accessibilityLabel("Complete bookmark")
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        Task { await store.archive(bookmark) }
+                    } label: {
+                        Label("Archive", systemImage: "archivebox.fill")
+                    }
+                    .accessibilityLabel("Archive bookmark")
+                }
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)
                 }
@@ -97,6 +123,13 @@ struct LibraryView: View {
                 }
             }
         }
+    }
+
+    private var actionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionErrorMessage != nil },
+            set: { if !$0 { store.dismissActionError() } }
+        )
     }
 
     private var filterMenu: some View {


### PR DESCRIPTION
## Summary

- add native leading and trailing swipe actions to library rows
- complete bookmarks and archive bookmarks through the REST API
- optimistically remove acted-on rows, persist the updated cache, and restore individual rows if a request fails

## Validation

- `git diff --check`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination 'platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908' -derivedDataPath /tmp/zine-native-pr-derived test` (3 tests passed)
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -configuration Release -destination 'generic/platform=iOS' -derivedDataPath /tmp/zine-native-pr-release CODE_SIGNING_ALLOWED=NO build`
- pre-push checks: format, design-system, typecheck, web tests, and worker tests