### PR TITLE
feat(ios): add creator avatars to library

### DIFF
--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -61,10 +61,8 @@ struct BookmarkDetailView: View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 10) {
                 Text(bookmark.title)
-                    .font(.title.bold())
-                Text(bookmark.creator)
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
+                    .font(.title2.bold())
+                creatorRow
                 metadata
             }
 
@@ -110,6 +108,22 @@ struct BookmarkDetailView: View {
         .padding(.top, 28)
         .padding(.bottom, 40)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var creatorRow: some View {
+        HStack(spacing: 10) {
+            CreatorAvatar(
+                imageUrl: bookmark.creatorImageUrl,
+                creator: bookmark.creator,
+                contentType: bookmark.contentType,
+                size: 32
+            )
+
+            Text(bookmark.creator)
+                .font(.headline)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
     }
 
     private func parallaxHero(height: CGFloat) -> some View {

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -12,23 +12,38 @@ struct BookmarkRow: View {
                     .foregroundStyle(.primary)
                     .lineLimit(3)
 
-                Text(bookmark.creator)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-
-                HStack(spacing: 8) {
-                    Label(bookmark.provider.title, systemImage: bookmark.contentType.systemImage)
-                    if let label = bookmark.consumptionLabel {
-                        Text(label)
-                    }
-                }
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+                creatorLine
             }
         }
         .padding(.vertical, 5)
         .accessibilityElement(children: .combine)
+    }
+
+    private var creatorLine: some View {
+        HStack(spacing: 7) {
+            CreatorAvatar(
+                imageUrl: bookmark.creatorImageUrl,
+                creator: bookmark.creator,
+                contentType: bookmark.contentType,
+                size: 22
+            )
+
+            ViewThatFits(in: .horizontal) {
+                if let label = bookmark.consumptionLabel {
+                    HStack(spacing: 5) {
+                        Text(bookmark.creator)
+                        Text("·")
+                        Text(label)
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                }
+
+                Text(bookmark.creator)
+                    .lineLimit(1)
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
     }
 
     private var thumbnail: some View {

--- a/apps/ios/ZineNative/Features/Library/CreatorAvatar.swift
+++ b/apps/ios/ZineNative/Features/Library/CreatorAvatar.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct CreatorAvatar: View {
+    let imageUrl: URL?
+    let creator: String
+    let contentType: ContentType
+    let size: CGFloat
+
+    var body: some View {
+        CachedRemoteImage(
+            url: imageUrl,
+            targetSize: CGSize(width: size, height: size)
+        ) {
+            fallback
+        }
+        .frame(width: size, height: size)
+        .clipShape(.circle)
+        .accessibilityHidden(true)
+    }
+
+    private var fallback: some View {
+        ZStack {
+            Circle()
+                .fill(.secondary.opacity(0.12))
+
+            if let initial {
+                Text(initial)
+                    .font(.system(size: size * 0.45, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            } else {
+                Image(systemName: contentType.systemImage)
+                    .font(.system(size: size * 0.38, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var initial: String? {
+        creator
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .first
+            .map { String($0).uppercased() }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -125,7 +125,12 @@ final class LibraryStore {
     }
 
     private func prefetchImages(in bookmarks: [Bookmark]) {
-        AppImagePipeline.prefetch(bookmarks.compactMap(\.thumbnailUrl))
+        var seenURLs = Set<URL>()
+        let urls = bookmarks
+            .flatMap { [$0.thumbnailUrl, $0.creatorImageUrl].compactMap { $0 } }
+            .filter { seenURLs.insert($0).inserted }
+
+        AppImagePipeline.prefetch(urls)
     }
 
     private func persistCurrentState() {


### PR DESCRIPTION
## Summary

- add a shared cached creator-avatar component with initial and content-type fallbacks
- show creator avatars in library rows and bookmark details, with a slightly smaller detail title
- simplify list metadata to creator plus duration when it fits
- prefetch and deduplicate creator-avatar URLs alongside bookmark covers

## Validation

- `git diff --check`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination 'platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908' -derivedDataPath /tmp/zine-native-pr-avatar test` (3 tests passed)
- signed Release device build for Erik's iPhone
- installed and launched `app.zine.native` on Erik's iPhone
- pre-push checks: format, design-system, typecheck, 75 web tests, and 1,534 worker tests