### PR TITLE
feat(ios): add native inbox navigation

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -10,22 +10,71 @@ struct AppRootView: View {
     var body: some View {
         Group {
             if let user = clerk.user {
-                LibraryView(
-                    client: APIClient(
-                        baseURL: configuration.apiBaseURL,
-                        tokenProvider: {
-                            guard let token = try await Clerk.shared.auth.getToken() else {
-                                throw APIError.missingSession
-                            }
-                            return token
-                        }
-                    ),
-                    cache: LibraryCache(userID: user.id)
+                AuthenticatedAppView(
+                    configuration: configuration,
+                    userID: user.id
                 )
             } else {
                 AuthView(isDismissible: false)
             }
         }
+    }
+}
+
+private struct AuthenticatedAppView: View {
+    private let client: APIClient
+    private let libraryCache: LibraryCache
+    private let inboxCache: InboxCache
+
+    @State private var search = ""
+    @State private var libraryRevision = 0
+
+    init(configuration: AppConfiguration, userID: String) {
+        client = APIClient(
+            baseURL: configuration.apiBaseURL,
+            tokenProvider: {
+                guard let token = try await Clerk.shared.auth.getToken() else {
+                    throw APIError.missingSession
+                }
+                return token
+            }
+        )
+        libraryCache = LibraryCache(userID: userID)
+        inboxCache = InboxCache(userID: userID)
+    }
+
+    var body: some View {
+        TabView {
+            Tab("Inbox", systemImage: "tray") {
+                InboxView(
+                    client: client,
+                    cache: inboxCache,
+                    onLibraryChanged: markLibraryChanged
+                )
+            }
+
+            Tab("Library", systemImage: "books.vertical") {
+                LibraryView(
+                    client: client,
+                    cache: libraryCache,
+                    refreshRevision: libraryRevision
+                )
+            }
+
+            Tab(role: .search) {
+                LibraryView(
+                    client: client,
+                    cache: libraryCache,
+                    searchText: $search,
+                    refreshRevision: libraryRevision
+                )
+                .searchable(text: $search, prompt: "Search your library")
+            }
+        }
+    }
+
+    private func markLibraryChanged() {
+        libraryRevision += 1
     }
 }
 

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -16,6 +16,18 @@ struct LibraryQuery: Hashable {
     }
 }
 
+struct InboxQuery: Hashable {
+    var provider: Provider?
+    var contentType: ContentType?
+
+    var cacheKey: String {
+        [
+            provider?.rawValue ?? "all",
+            contentType?.rawValue ?? "all",
+        ].joined(separator: "|")
+    }
+}
+
 struct APIClient {
     typealias TokenProvider = () async throws -> String
 
@@ -39,6 +51,29 @@ struct APIClient {
         if !query.search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             items.append(URLQueryItem(name: "search", value: query.search))
         }
+        if let provider = query.provider {
+            items.append(URLQueryItem(name: "provider", value: provider.rawValue))
+        }
+        if let contentType = query.contentType {
+            items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
+        }
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func listInbox(
+        query: InboxQuery,
+        cursor: String? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/inbox"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
         if let provider = query.provider {
             items.append(URLQueryItem(name: "provider", value: provider.rawValue))
         }
@@ -76,6 +111,12 @@ struct APIClient {
 
     func bookmarkItem(id: String) async throws {
         var request = URLRequest(url: baseURL.appending(path: "/api/v1/inbox/\(id)/bookmark"))
+        request.httpMethod = "POST"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func archiveInboxItem(id: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/inbox/\(id)/archive"))
         request.httpMethod = "POST"
         let _: EmptyResponse = try await send(request)
     }

--- a/apps/ios/ZineNative/Core/Persistence/InboxCache.swift
+++ b/apps/ios/ZineNative/Core/Persistence/InboxCache.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+struct InboxCacheSnapshot: Codable, Equatable {
+    let items: [Bookmark]
+    let nextCursor: String?
+    let savedAt: Date
+}
+
+actor InboxCache {
+    private static let maximumSnapshots = 6
+
+    private let fileURL: URL
+    private var snapshots: [String: InboxCacheSnapshot]?
+
+    init(userID: String, baseDirectory: URL? = nil) {
+        let root = baseDirectory ?? FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        let safeUserID = userID.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+            ?? "unknown-user"
+        fileURL = root
+            .appending(path: "ZineNative/Inbox", directoryHint: .isDirectory)
+            .appending(path: "\(safeUserID).json")
+    }
+
+    func load(query: InboxQuery) -> InboxCacheSnapshot? {
+        loadSnapshotsIfNeeded()
+        return snapshots?[query.cacheKey]
+    }
+
+    func saveFirstPage(items: [Bookmark], nextCursor: String?, query: InboxQuery) {
+        loadSnapshotsIfNeeded()
+        snapshots?[query.cacheKey] = InboxCacheSnapshot(
+            items: Array(items.prefix(30)),
+            nextCursor: nextCursor,
+            savedAt: Date()
+        )
+        pruneSnapshots()
+        persistSnapshots()
+    }
+
+    func remove(id: String, query: InboxQuery) {
+        loadSnapshotsIfNeeded()
+        guard let snapshot = snapshots?[query.cacheKey] else { return }
+        snapshots?[query.cacheKey] = InboxCacheSnapshot(
+            items: snapshot.items.filter { $0.id != id },
+            nextCursor: snapshot.nextCursor,
+            savedAt: Date()
+        )
+        persistSnapshots()
+    }
+
+    func restore(_ bookmark: Bookmark, at index: Int, query: InboxQuery) {
+        loadSnapshotsIfNeeded()
+        guard let snapshot = snapshots?[query.cacheKey],
+              !snapshot.items.contains(where: { $0.id == bookmark.id })
+        else { return }
+
+        var items = snapshot.items
+        items.insert(bookmark, at: min(index, items.endIndex))
+        snapshots?[query.cacheKey] = InboxCacheSnapshot(
+            items: Array(items.prefix(30)),
+            nextCursor: snapshot.nextCursor,
+            savedAt: Date()
+        )
+        persistSnapshots()
+    }
+
+    private func loadSnapshotsIfNeeded() {
+        guard snapshots == nil else { return }
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode(
+                  [String: InboxCacheSnapshot].self,
+                  from: data
+              )
+        else {
+            snapshots = [:]
+            return
+        }
+        snapshots = decoded
+    }
+
+    private func pruneSnapshots() {
+        guard let snapshots, snapshots.count > Self.maximumSnapshots else { return }
+        let retainedKeys = snapshots
+            .sorted { $0.value.savedAt > $1.value.savedAt }
+            .prefix(Self.maximumSnapshots)
+            .map(\.key)
+        self.snapshots = snapshots.filter { retainedKeys.contains($0.key) }
+    }
+
+    private func persistSnapshots() {
+        guard let snapshots,
+              let data = try? JSONEncoder().encode(snapshots)
+        else { return }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // Inbox remains network-backed; this cache only improves launch behavior.
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Inbox/InboxStore.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxStore.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class InboxStore {
+    private(set) var items: [Bookmark] = []
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var errorMessage: String?
+    private(set) var actionErrorMessage: String?
+    private(set) var nextCursor: String?
+
+    private let client: APIClient
+    private let cache: InboxCache
+    private let onLibraryChanged: () -> Void
+    private var activeQuery = InboxQuery()
+    private var pendingItemIDs = Set<String>()
+    private var detailRemovals: [String: InboxOptimisticRemoval] = [:]
+
+    init(
+        client: APIClient,
+        cache: InboxCache,
+        onLibraryChanged: @escaping () -> Void
+    ) {
+        self.client = client
+        self.cache = cache
+        self.onLibraryChanged = onLibraryChanged
+    }
+
+    func reload(query: InboxQuery) async {
+        let queryChanged = activeQuery != query
+        activeQuery = query
+        errorMessage = nil
+
+        if queryChanged {
+            items = []
+            nextCursor = nil
+        }
+
+        if let snapshot = await cache.load(query: query) {
+            guard !Task.isCancelled, activeQuery == query else { return }
+            items = snapshot.items.filter { !pendingItemIDs.contains($0.id) }
+            nextCursor = snapshot.nextCursor
+        }
+
+        isLoading = items.isEmpty
+        defer { isLoading = false }
+
+        do {
+            let response = try await client.listInbox(query: query)
+            guard !Task.isCancelled, activeQuery == query else { return }
+            items = response.items.filter { !pendingItemIDs.contains($0.id) }
+            nextCursor = response.nextCursor
+            await cache.saveFirstPage(
+                items: response.items,
+                nextCursor: response.nextCursor,
+                query: query
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            guard activeQuery == query else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadMoreIfNeeded(current item: Bookmark) async {
+        guard item.id == items.last?.id,
+              let nextCursor,
+              !isLoading,
+              !isLoadingMore
+        else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await client.listInbox(query: activeQuery, cursor: nextCursor)
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(items.map(\.id))
+            items.append(contentsOf: response.items.filter {
+                !existingIDs.contains($0.id) && !pendingItemIDs.contains($0.id)
+            })
+            self.nextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func bookmark(_ bookmark: Bookmark) async {
+        guard let removal = removeOptimistically(bookmark) else { return }
+
+        do {
+            try await client.bookmarkItem(id: bookmark.id)
+            await cache.remove(id: bookmark.id, query: removal.query)
+            pendingItemIDs.remove(bookmark.id)
+            onLibraryChanged()
+        } catch {
+            restore(removal, message: "The item couldn’t be bookmarked. Please try again.")
+        }
+    }
+
+    func archive(_ bookmark: Bookmark) async {
+        guard let removal = removeOptimistically(bookmark) else { return }
+
+        do {
+            try await client.archiveInboxItem(id: bookmark.id)
+            await cache.remove(id: bookmark.id, query: removal.query)
+            pendingItemIDs.remove(bookmark.id)
+        } catch {
+            restore(removal, message: "The item couldn’t be archived. Please try again.")
+        }
+    }
+
+    func handleDetailBookmarkChange(
+        _ bookmark: Bookmark,
+        isBookmarked: Bool,
+        phase: BookmarkChangePhase
+    ) {
+        switch (isBookmarked, phase) {
+        case (true, .optimistic):
+            if let removal = removeOptimistically(bookmark) {
+                detailRemovals[bookmark.id] = removal
+            }
+        case (false, .rollback):
+            if let removal = detailRemovals.removeValue(forKey: bookmark.id) {
+                restore(removal, message: nil)
+            }
+        default:
+            break
+        }
+    }
+
+    func commitDetailBookmarkChange(id: String) {
+        let removal = detailRemovals.removeValue(forKey: id)
+        pendingItemIDs.remove(id)
+        if let removal {
+            Task { await cache.remove(id: id, query: removal.query) }
+        }
+        onLibraryChanged()
+    }
+
+    func dismissActionError() {
+        actionErrorMessage = nil
+    }
+
+    private func removeOptimistically(_ bookmark: Bookmark) -> InboxOptimisticRemoval? {
+        guard !pendingItemIDs.contains(bookmark.id),
+              let index = items.firstIndex(where: { $0.id == bookmark.id })
+        else { return nil }
+
+        pendingItemIDs.insert(bookmark.id)
+        let removal = InboxOptimisticRemoval(
+            bookmark: items.remove(at: index),
+            index: index,
+            query: activeQuery
+        )
+        Task { await cache.remove(id: bookmark.id, query: activeQuery) }
+        return removal
+    }
+
+    private func restore(_ removal: InboxOptimisticRemoval, message: String?) {
+        pendingItemIDs.remove(removal.bookmark.id)
+        guard activeQuery == removal.query,
+              !items.contains(where: { $0.id == removal.bookmark.id })
+        else { return }
+
+        items.insert(removal.bookmark, at: min(removal.index, items.endIndex))
+        actionErrorMessage = message
+        Task {
+            await cache.restore(removal.bookmark, at: removal.index, query: removal.query)
+        }
+    }
+}
+
+private struct InboxOptimisticRemoval {
+    let bookmark: Bookmark
+    let index: Int
+    let query: InboxQuery
+}

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+struct InboxView: View {
+    let client: APIClient
+
+    @State private var store: InboxStore
+    @State private var provider: Provider?
+    @State private var contentType: ContentType?
+    @Namespace private var bookmarkTransition
+
+    init(
+        client: APIClient,
+        cache: InboxCache,
+        onLibraryChanged: @escaping () -> Void
+    ) {
+        self.client = client
+        _store = State(initialValue: InboxStore(
+            client: client,
+            cache: cache,
+            onLibraryChanged: onLibraryChanged
+        ))
+    }
+
+    private var query: InboxQuery {
+        InboxQuery(provider: provider, contentType: contentType)
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Inbox")
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        filterMenu
+                    }
+                }
+                .navigationDestination(for: Bookmark.self) { bookmark in
+                    BookmarkDetailView(
+                        bookmark: bookmark,
+                        client: client,
+                        onUpdate: { _ in },
+                        onBookmarkChange: { changed, isBookmarked, phase in
+                            store.handleDetailBookmarkChange(
+                                changed,
+                                isBookmarked: isBookmarked,
+                                phase: phase
+                            )
+                        },
+                        onBookmarkCommit: { changed, _ in
+                            store.commitDetailBookmarkChange(id: changed.id)
+                        }
+                    )
+                    .navigationTransition(
+                        .zoom(sourceID: bookmark.id, in: bookmarkTransition)
+                    )
+                }
+        }
+        .task(id: query) {
+            await store.reload(query: query)
+        }
+        .alert("Couldn’t update inbox", isPresented: actionErrorBinding) {
+            Button("OK", role: .cancel) {
+                store.dismissActionError()
+            }
+        } message: {
+            Text(store.actionErrorMessage ?? "Please try again.")
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.items.isEmpty {
+            ProgressView("Loading inbox…")
+        } else if let error = store.errorMessage, store.items.isEmpty {
+            ContentUnavailableView {
+                Label("Inbox unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") {
+                    Task { await store.reload(query: query) }
+                }
+            }
+        } else if store.items.isEmpty {
+            ContentUnavailableView(
+                "Inbox is clear",
+                systemImage: "tray",
+                description: Text("New items from your sources will appear here.")
+            )
+        } else {
+            List(store.items) { bookmark in
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+                .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        Task { await store.archive(bookmark) }
+                    } label: {
+                        Label("Archive", systemImage: "archivebox.fill")
+                    }
+                    .accessibilityLabel("Archive inbox item")
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button {
+                        Task { await store.bookmark(bookmark) }
+                    } label: {
+                        Label("Bookmark", systemImage: "bookmark.fill")
+                    }
+                    .tint(.green)
+                    .accessibilityLabel("Bookmark inbox item")
+                }
+                .task {
+                    await store.loadMoreIfNeeded(current: bookmark)
+                }
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload(query: query)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+    }
+
+    private var actionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionErrorMessage != nil },
+            set: { if !$0 { store.dismissActionError() } }
+        )
+    }
+
+    private var filterMenu: some View {
+        Menu {
+            Picker("Provider", selection: $provider) {
+                Text("All providers").tag(Provider?.none)
+                ForEach(Provider.allCases) { value in
+                    Text(value.title).tag(Provider?.some(value))
+                }
+            }
+
+            Picker("Format", selection: $contentType) {
+                Text("All formats").tag(ContentType?.none)
+                ForEach(ContentType.allCases) { value in
+                    Text(value.title).tag(ContentType?.some(value))
+                }
+            }
+        } label: {
+            Label(
+                "Filter",
+                systemImage: hasFilters
+                    ? "line.3.horizontal.decrease.circle.fill"
+                    : "line.3.horizontal.decrease.circle"
+            )
+        }
+        .accessibilityLabel("Filter inbox")
+    }
+
+    private var hasFilters: Bool {
+        provider != nil || contentType != nil
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 import UIKit
 
+enum BookmarkChangePhase {
+    case optimistic
+    case rollback
+}
+
 struct BookmarkDetailView: View {
     @Environment(\.colorScheme) private var colorScheme
 
@@ -13,19 +18,22 @@ struct BookmarkDetailView: View {
 
     let client: APIClient
     let onUpdate: (Bookmark) -> Void
-    let onBookmarkChange: (Bookmark, Bool) -> Void
+    let onBookmarkChange: (Bookmark, Bool, BookmarkChangePhase) -> Void
+    let onBookmarkCommit: (Bookmark, Bool) -> Void
 
     init(
         bookmark: Bookmark,
         client: APIClient,
         onUpdate: @escaping (Bookmark) -> Void,
-        onBookmarkChange: @escaping (Bookmark, Bool) -> Void = { _, _ in }
+        onBookmarkChange: @escaping (Bookmark, Bool, BookmarkChangePhase) -> Void = { _, _, _ in },
+        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in }
     ) {
         _bookmark = State(initialValue: bookmark)
         _isBookmarked = State(initialValue: bookmark.state == "BOOKMARKED")
         self.client = client
         self.onUpdate = onUpdate
         self.onBookmarkChange = onBookmarkChange
+        self.onBookmarkCommit = onBookmarkCommit
     }
 
     var body: some View {
@@ -115,7 +123,9 @@ struct BookmarkDetailView: View {
             HStack(spacing: 5) {
                 bookmarkButton
 
-                completionButton
+                if isBookmarked {
+                    completionButton
+                }
                 tagsMenu
 
                 ShareLink(item: bookmark.canonicalUrl) {
@@ -320,7 +330,7 @@ struct BookmarkDetailView: View {
         hasToggledBookmark = true
         isSavingBookmark = true
         isBookmarked = newValue
-        onBookmarkChange(bookmark, newValue)
+        onBookmarkChange(bookmark, newValue, .optimistic)
 
         defer { isSavingBookmark = false }
 
@@ -330,9 +340,10 @@ struct BookmarkDetailView: View {
             } else {
                 try await client.archiveBookmark(id: bookmark.id)
             }
+            onBookmarkCommit(bookmark, newValue)
         } catch {
             isBookmarked = previousValue
-            onBookmarkChange(bookmark, previousValue)
+            onBookmarkChange(bookmark, previousValue, .rollback)
             errorMessage = error.localizedDescription
         }
     }

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -21,6 +21,14 @@ final class LibraryStore {
         self.cache = cache
     }
 
+    func reset() {
+        items = []
+        nextCursor = nil
+        errorMessage = nil
+        isLoading = false
+        isLoadingMore = false
+    }
+
     func reload(query: LibraryQuery) async {
         let queryChanged = activeQuery != query
         activeQuery = query

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -7,17 +7,33 @@ private enum AccountRoute: Hashable {
 
 struct LibraryView: View {
     let client: APIClient
+    let searchText: Binding<String>?
+    let refreshRevision: Int
 
     @State private var store: LibraryStore
-    @State private var search = ""
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
     @Namespace private var bookmarkTransition
 
-    init(client: APIClient, cache: LibraryCache) {
+    init(
+        client: APIClient,
+        cache: LibraryCache,
+        searchText: Binding<String>? = nil,
+        refreshRevision: Int = 0
+    ) {
         self.client = client
+        self.searchText = searchText
+        self.refreshRevision = refreshRevision
         _store = State(initialValue: LibraryStore(client: client, cache: cache))
+    }
+
+    private var search: String {
+        searchText?.wrappedValue ?? ""
+    }
+
+    private var isSearchMode: Bool {
+        searchText != nil
     }
 
     private var query: LibraryQuery {
@@ -32,8 +48,7 @@ struct LibraryView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle("Library")
-                .searchable(text: $search, prompt: "Search your library")
+                .navigationTitle(isSearchMode ? "Search" : "Library")
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         filterMenu
@@ -47,7 +62,7 @@ struct LibraryView: View {
                         bookmark: bookmark,
                         client: client,
                         onUpdate: { updated in store.update(updated) },
-                        onBookmarkChange: { changed, isBookmarked in
+                        onBookmarkChange: { changed, isBookmarked, _ in
                             store.setBookmarked(changed, isBookmarked: isBookmarked)
                         }
                     )
@@ -56,7 +71,11 @@ struct LibraryView: View {
                     )
                 }
         }
-        .task(id: query) {
+        .task(id: LibraryReloadKey(query: query, revision: refreshRevision)) {
+            if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                store.reset()
+                return
+            }
             if !search.isEmpty {
                 try? await Task.sleep(for: .milliseconds(250))
             }
@@ -87,7 +106,21 @@ struct LibraryView: View {
                 }
             }
         } else if store.items.isEmpty {
-            ContentUnavailableView.search(text: search)
+            if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ContentUnavailableView(
+                    "Search your library",
+                    systemImage: "magnifyingglass",
+                    description: Text("Find saved items by title or creator.")
+                )
+            } else if isSearchMode {
+                ContentUnavailableView.search(text: search)
+            } else {
+                ContentUnavailableView(
+                    "No bookmarks",
+                    systemImage: "bookmark",
+                    description: Text("Items you bookmark from Inbox will appear here.")
+                )
+            }
         } else {
             List(store.items) { bookmark in
                 NavigationLink(value: bookmark) {
@@ -184,6 +217,11 @@ struct LibraryView: View {
                 }
             }
     }
+}
+
+private struct LibraryReloadKey: Hashable {
+    let query: LibraryQuery
+    let revision: Int
 }
 
 private struct AppearanceSettingsView: View {

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -31,6 +31,17 @@ final class BookmarkTests: XCTestCase {
         XCTAssertNotEqual(first, second)
     }
 
+    func testInboxQueryIdentityIncludesEveryFilter() {
+        XCTAssertNotEqual(
+            InboxQuery(provider: .youtube, contentType: .video),
+            InboxQuery(provider: .youtube, contentType: .article)
+        )
+        XCTAssertNotEqual(
+            InboxQuery(provider: .youtube),
+            InboxQuery(provider: .spotify)
+        )
+    }
+
     func testProviderTitlesUseProductCapitalization() {
         XCTAssertEqual(Provider.youtube.title, "YouTube")
         XCTAssertEqual(Provider.x.title, "X")

--- a/apps/ios/ZineNativeTests/InboxCacheTests.swift
+++ b/apps/ios/ZineNativeTests/InboxCacheTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import ZineNative
+
+struct InboxCacheTests {
+    @Test func keepsOnlyFirstPageAndSupportsOptimisticRemovalRollback() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = InboxCache(userID: "test-user", baseDirectory: directory)
+        let query = InboxQuery(provider: .rss, contentType: .article)
+        let items = (0..<35).map(makeBookmark)
+
+        await cache.saveFirstPage(items: items, nextCursor: "next", query: query)
+        var snapshot = await cache.load(query: query)
+
+        #expect(snapshot?.items.count == 30)
+        #expect(snapshot?.nextCursor == "next")
+        #expect(await cache.load(query: InboxQuery()) == nil)
+
+        await cache.remove(id: items[4].id, query: query)
+        snapshot = await cache.load(query: query)
+        #expect(snapshot?.items.contains(where: { $0.id == items[4].id }) == false)
+
+        await cache.restore(items[4], at: 4, query: query)
+        snapshot = await cache.load(query: query)
+        #expect(snapshot?.items[4].id == items[4].id)
+        #expect(snapshot?.items.count == 30)
+    }
+
+    private func makeBookmark(index: Int) -> Bookmark {
+        Bookmark(
+            id: "inbox-\(index)",
+            itemId: "item-\(index)",
+            title: "Inbox item \(index)",
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/items/\(index)")!,
+            contentType: .article,
+            provider: .rss,
+            creator: "Creator",
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: nil,
+            summary: nil,
+            duration: nil,
+            publishedAt: nil,
+            wordCount: nil,
+            readingTimeMinutes: 5,
+            state: "INBOX",
+            ingestedAt: "2026-07-15T00:00:00Z",
+            bookmarkedAt: nil,
+            lastOpenedAt: nil,
+            progress: nil,
+            isFinished: false,
+            finishedAt: nil,
+            tags: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a native Inbox tab with pagination, filters, detail navigation, and optimistic bookmark/archive swipe actions
- add bounded Inbox metadata caching while avoiding eager media prefetch
- add native Inbox, Library, and Search tab navigation while keeping search scoped to the Search tab
- keep Library state synchronized when Inbox items are bookmarked

## Validation

- `xcodebuild -project ZineNative.xcodeproj -scheme ZineNative -configuration Debug -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -derivedDataPath /tmp/zine-native-tabs-build test`
- signed Release build, install, launch, and running-process verification on Erik’s iPhone
- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`