### PR TITLE
feat(subscriptions): add native source management

### DIFF
--- a/apps/ios/Configuration/Config.xcconfig
+++ b/apps/ios/Configuration/Config.xcconfig
@@ -1,4 +1,8 @@
 ZINE_API_BASE_URL = https:/$()/api.myzine.app
 ZINE_CLERK_PUBLISHABLE_KEY = pk_live_Y2xlcmsubXl6aW5lLmFwcCQ
+ZINE_GOOGLE_CLIENT_ID = 973421703522-58dfb15bdqdhvhs2r9tt88ubgg45dkq1.apps.googleusercontent.com
+ZINE_GOOGLE_REVERSED_CLIENT_ID = com.googleusercontent.apps.973421703522-58dfb15bdqdhvhs2r9tt88ubgg45dkq1
+ZINE_SPOTIFY_CLIENT_ID = 4ce6c1f9fabe407ea4b2be0479dd63ff
+ZINE_X_CLIENT_ID = Vjd5eEktRTNoRDVZSm1aNGNvSWo6MTpjaQ
 
 #include? "Local.xcconfig"

--- a/apps/ios/Configuration/Info.plist
+++ b/apps/ios/Configuration/Info.plist
@@ -28,6 +28,26 @@
 				<string>app.zine.native</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Zine provider OAuth callback</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>zine</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Google OAuth callback</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(ZINE_GOOGLE_REVERSED_CLIENT_ID)</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
@@ -50,5 +70,11 @@
 	<string>$(ZINE_API_BASE_URL)</string>
 	<key>ZINEClerkPublishableKey</key>
 	<string>$(ZINE_CLERK_PUBLISHABLE_KEY)</string>
+	<key>ZINEGoogleClientID</key>
+	<string>$(ZINE_GOOGLE_CLIENT_ID)</string>
+	<key>ZINESpotifyClientID</key>
+	<string>$(ZINE_SPOTIFY_CLIENT_ID)</string>
+	<key>ZINEXClientID</key>
+	<string>$(ZINE_X_CLIENT_ID)</string>
 </dict>
 </plist>

--- a/apps/ios/Configuration/Local.xcconfig.example
+++ b/apps/ios/Configuration/Local.xcconfig.example
@@ -2,5 +2,13 @@
 // Clerk instance. Local.xcconfig is ignored by the repository's *.local rule.
 ZINE_CLERK_PUBLISHABLE_KEY = pk_test_replace_me
 
+// Optional Google OAuth overrides for a development Google project.
+// ZINE_GOOGLE_CLIENT_ID = 123.apps.googleusercontent.com
+// ZINE_GOOGLE_REVERSED_CLIENT_ID = com.googleusercontent.apps.123
+
+// Optional OAuth overrides for development provider apps.
+// ZINE_SPOTIFY_CLIENT_ID = spotify_client_id
+// ZINE_X_CLIENT_ID = x_client_id
+
 // Optional for local worker development.
 // ZINE_API_BASE_URL = http:/$()/localhost:8787

--- a/apps/ios/ZineNative/App/AppConfiguration.swift
+++ b/apps/ios/ZineNative/App/AppConfiguration.swift
@@ -3,6 +3,9 @@ import Foundation
 struct AppConfiguration {
     let apiBaseURL: URL
     let clerkPublishableKey: String
+    let googleClientID: String
+    let spotifyClientID: String
+    let xClientID: String
 
     var isClerkConfigured: Bool {
         clerkPublishableKey.hasPrefix("pk_") && !clerkPublishableKey.contains("replace_me")
@@ -12,10 +15,16 @@ struct AppConfiguration {
         let values = Bundle.main.infoDictionary ?? [:]
         let apiURLString = values["ZINEAPIBaseURL"] as? String ?? "https://api.myzine.app"
         let key = values["ZINEClerkPublishableKey"] as? String ?? ""
+        let googleClientID = values["ZINEGoogleClientID"] as? String ?? ""
+        let spotifyClientID = values["ZINESpotifyClientID"] as? String ?? ""
+        let xClientID = values["ZINEXClientID"] as? String ?? ""
 
         return AppConfiguration(
             apiBaseURL: URL(string: apiURLString) ?? URL(string: "https://api.myzine.app")!,
-            clerkPublishableKey: key.trimmingCharacters(in: .whitespacesAndNewlines)
+            clerkPublishableKey: key.trimmingCharacters(in: .whitespacesAndNewlines),
+            googleClientID: googleClientID.trimmingCharacters(in: .whitespacesAndNewlines),
+            spotifyClientID: spotifyClientID.trimmingCharacters(in: .whitespacesAndNewlines),
+            xClientID: xClientID.trimmingCharacters(in: .whitespacesAndNewlines)
         )
     }()
 }

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -127,6 +127,207 @@ struct APIClient {
         let _: EmptyResponse = try await send(request)
     }
 
+    func listSubscriptionSources() async throws -> SubscriptionsHubResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/subscriptions"))
+    }
+
+    func listProviderSubscriptions(_ provider: SubscriptionSource) async throws -> ProviderSubscriptionsResponse {
+        try await request(
+            url: baseURL.appending(path: "/api/v1/subscriptions/\(provider.pathComponent)")
+        )
+    }
+
+    func registerOAuthState(_ state: String, provider: SubscriptionSource) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/connection/state"
+            )
+        )
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(RegisterOAuthStateRequest(state: state))
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func completeOAuth(
+        provider: SubscriptionSource,
+        code: String,
+        state: String,
+        codeVerifier: String,
+        redirectUri: String
+    ) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/connection/callback"
+            )
+        )
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(
+            CompleteOAuthRequest(
+                code: code,
+                state: state,
+                codeVerifier: codeVerifier,
+                redirectUri: redirectUri
+            )
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func disconnectProvider(_ provider: SubscriptionSource) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/connection"
+            )
+        )
+        request.httpMethod = "DELETE"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func addProviderSubscription(
+        _ item: ProviderSubscriptionItem,
+        provider: SubscriptionSource
+    ) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/subscriptions/\(provider.pathComponent)")
+        )
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(
+            AddProviderSubscriptionRequest(
+                channelId: item.channelId,
+                name: item.name,
+                imageUrl: item.imageUrl?.absoluteString
+            )
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func removeProviderSubscription(id: String, provider: SubscriptionSource) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/\(id)"
+            )
+        )
+        request.httpMethod = "DELETE"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func setProviderSubscriptionPaused(
+        id: String,
+        provider: SubscriptionSource,
+        isPaused: Bool
+    ) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/\(id)"
+            )
+        )
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(
+            UpdateProviderSubscriptionRequest(action: isPaused ? "pause" : "resume")
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func syncProviderSubscription(
+        id: String,
+        provider: SubscriptionSource
+    ) async throws -> SubscriptionSyncResponse {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/\(id)/sync"
+            )
+        )
+        request.httpMethod = "POST"
+        return try await send(request)
+    }
+
+    func listNewsletters() async throws -> NewsletterSubscriptionsResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/subscriptions/gmail"))
+    }
+
+    func updateNewsletter(id: String, action: String) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/subscriptions/gmail/\(id)")
+        )
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(ActionRequest(action: action))
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func unsubscribeNewsletter(id: String) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/subscriptions/gmail/\(id)")
+        )
+        request.httpMethod = "DELETE"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func syncNewsletters() async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/subscriptions/gmail/sync"))
+        request.httpMethod = "POST"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func listRssFeeds() async throws -> RssSubscriptionsResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/subscriptions/rss"))
+    }
+
+    func addRssFeed(url: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/subscriptions/rss"))
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(AddRssFeedRequest(feedUrl: url, seedMode: "latest"))
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func updateRssFeed(id: String, action: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/subscriptions/rss/\(id)"))
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(ActionRequest(action: action))
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func removeRssFeed(id: String) async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/subscriptions/rss/\(id)"))
+        request.httpMethod = "DELETE"
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func syncRssFeed(id: String) async throws -> SubscriptionSyncResponse {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/subscriptions/rss/\(id)/sync")
+        )
+        request.httpMethod = "POST"
+        return try await send(request)
+    }
+
+    func getXSubscriptions() async throws -> XSubscriptionsResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/subscriptions/x"))
+    }
+
+    func updateXBookmarkSettings(dailySyncEnabled: Bool) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/subscriptions/x/settings")
+        )
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(
+            UpdateXBookmarkSettingsRequest(dailySyncEnabled: dailySyncEnabled)
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func syncXBookmarks() async throws {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/subscriptions/x/sync"))
+        request.httpMethod = "POST"
+        let _: EmptyResponse = try await send(request)
+    }
+
     private func request<Response: Decodable>(url: URL) async throws -> Response {
         try await send(URLRequest(url: url))
     }
@@ -151,6 +352,40 @@ struct APIClient {
         }
         return try JSONDecoder().decode(Response.self, from: data)
     }
+}
+
+private struct AddProviderSubscriptionRequest: Encodable {
+    let channelId: String
+    let name: String
+    let imageUrl: String?
+}
+
+private struct RegisterOAuthStateRequest: Encodable {
+    let state: String
+}
+
+private struct CompleteOAuthRequest: Encodable {
+    let code: String
+    let state: String
+    let codeVerifier: String
+    let redirectUri: String
+}
+
+private struct UpdateProviderSubscriptionRequest: Encodable {
+    let action: String
+}
+
+private struct ActionRequest: Encodable {
+    let action: String
+}
+
+private struct AddRssFeedRequest: Encodable {
+    let feedUrl: String
+    let seedMode: String
+}
+
+private struct UpdateXBookmarkSettingsRequest: Encodable {
+    let dailySyncEnabled: Bool
 }
 
 private struct EmptyResponse: Decodable {}

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -2,6 +2,7 @@ import ClerkKitUI
 import SwiftUI
 
 private enum AccountRoute: Hashable {
+    case subscriptions
     case appearance
 }
 
@@ -204,6 +205,12 @@ struct LibraryView: View {
         UserButton()
             .userProfileRows([
                 UserProfileCustomRow(
+                    route: AccountRoute.subscriptions,
+                    title: "Subscriptions",
+                    icon: .system(name: "rectangle.stack.badge.person.crop"),
+                    placement: .before(.signOut)
+                ),
+                UserProfileCustomRow(
                     route: AccountRoute.appearance,
                     title: "Appearance",
                     icon: .system(name: "circle.lefthalf.filled"),
@@ -212,6 +219,8 @@ struct LibraryView: View {
             ])
             .userProfileDestination { route in
                 switch route {
+                case .subscriptions:
+                    SubscriptionsView(client: client)
                 case .appearance:
                     AppearanceSettingsView()
                 }

--- a/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
@@ -1,0 +1,316 @@
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+private final class NewsletterSubscriptionsStore {
+    private(set) var response: NewsletterSubscriptionsResponse?
+    private(set) var isLoading = false
+    private(set) var isUpdatingConnection = false
+    private(set) var isSyncing = false
+    private(set) var pendingFeedIDs = Set<String>()
+    private(set) var errorMessage: String?
+    private(set) var actionMessage: String?
+
+    private let client: APIClient
+    private let oauth: ProviderOAuthSession
+
+    init(client: APIClient, configuration: AppConfiguration) {
+        self.client = client
+        oauth = ProviderOAuthSession(apiClient: client, configuration: configuration)
+    }
+
+    func reload() async {
+        isLoading = response == nil
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            response = try await client.listNewsletters()
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func connect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+        do {
+            try await oauth.connect(.gmail)
+            await reloadAfterMutation()
+        } catch is CancellationError {
+            return
+        } catch {
+            actionMessage = "Gmail couldn’t be connected. \(error.localizedDescription)"
+        }
+    }
+
+    func disconnect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+        do {
+            try await client.disconnectProvider(.gmail)
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "Gmail couldn’t be disconnected. \(error.localizedDescription)"
+        }
+    }
+
+    func sync() async {
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            try await client.syncNewsletters()
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "Newsletters couldn’t be synced. \(error.localizedDescription)"
+        }
+    }
+
+    func setActive(_ feed: NewsletterFeed, isActive: Bool) async {
+        await perform(feed) {
+            try await client.updateNewsletter(id: feed.id, action: isActive ? "activate" : "hide")
+        }
+    }
+
+    func unsubscribe(_ feed: NewsletterFeed) async {
+        await perform(feed) { try await client.unsubscribeNewsletter(id: feed.id) }
+    }
+
+    func dismissMessage() { actionMessage = nil }
+
+    private func perform(_ feed: NewsletterFeed, action: () async throws -> Void) async {
+        pendingFeedIDs.insert(feed.id)
+        defer { pendingFeedIDs.remove(feed.id) }
+        do {
+            try await action()
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "\(feed.displayName) couldn’t be updated. \(error.localizedDescription)"
+        }
+    }
+
+    private func reloadAfterMutation() async {
+        do {
+            response = try await client.listNewsletters()
+            errorMessage = nil
+        } catch {
+            actionMessage = "The change was saved, but the list couldn’t be refreshed."
+        }
+    }
+}
+
+struct NewsletterSubscriptionsView: View {
+    @State private var store: NewsletterSubscriptionsStore
+    @State private var searchText = ""
+    @State private var pendingUnsubscribe: NewsletterFeed?
+    @State private var showsDisconnectConfirmation = false
+
+    init(client: APIClient, configuration: AppConfiguration = .current) {
+        _store = State(
+            initialValue: NewsletterSubscriptionsStore(
+                client: client,
+                configuration: configuration
+            )
+        )
+    }
+
+    private var filteredFeeds: [NewsletterFeed] {
+        let items = store.response?.items.filter { $0.status != .unsubscribed } ?? []
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return items }
+        return items.filter {
+            $0.displayName.localizedStandardContains(query)
+                || ($0.fromAddress?.localizedStandardContains(query) == true)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.response == nil {
+                ProgressView("Loading newsletters…")
+            } else if let error = store.errorMessage, store.response == nil {
+                ContentUnavailableView {
+                    Label("Newsletters unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Try again") { Task { await store.reload() } }
+                }
+            } else {
+                newsletterList
+            }
+        }
+        .navigationTitle("Newsletters")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchText, prompt: "Search newsletters")
+        .task { await store.reload() }
+        .alert("Couldn’t update newsletters", isPresented: messageBinding) {
+            Button("OK", role: .cancel) { store.dismissMessage() }
+        } message: {
+            Text(store.actionMessage ?? "Please try again.")
+        }
+        .confirmationDialog(
+            "Unsubscribe from \(pendingUnsubscribe?.displayName ?? "this newsletter")?",
+            isPresented: unsubscribeBinding,
+            titleVisibility: .visible,
+            presenting: pendingUnsubscribe
+        ) { feed in
+            Button("Unsubscribe", role: .destructive) {
+                Task { await store.unsubscribe(feed) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("Zine will use the newsletter’s unsubscribe method when available and stop importing new issues.")
+        }
+        .confirmationDialog(
+            "Disconnect Gmail?",
+            isPresented: $showsDisconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Disconnect", role: .destructive) { Task { await store.disconnect() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Zine will stop reading newsletters from Gmail until you reconnect. Your Gmail account and messages will not be changed.")
+        }
+    }
+
+    private var newsletterList: some View {
+        List {
+            connectionSection
+
+            if store.response?.connection?.isActive != true {
+                Section {
+                    ContentUnavailableView(
+                        "Gmail isn’t connected",
+                        systemImage: SubscriptionSource.gmail.systemImage,
+                        description: Text("Connect Gmail with read-only access to detect and manage newsletters.")
+                    )
+                }
+            } else if filteredFeeds.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        searchText.isEmpty ? "No newsletters found" : "No matching newsletters",
+                        systemImage: searchText.isEmpty ? "envelope" : "magnifyingglass",
+                        description: Text(
+                            searchText.isEmpty
+                                ? "Sync Gmail to discover newsletters."
+                                : "Try another name or sender."
+                        )
+                    )
+                }
+            } else {
+                Section("Newsletters") {
+                    ForEach(filteredFeeds) { feed in newsletterRow(feed) }
+                }
+            }
+        }
+        .refreshable { await store.reload() }
+    }
+
+    private var connectionSection: some View {
+        Section("Account") {
+            LabeledContent("Gmail") {
+                Text(connectionLabel).foregroundStyle(connectionColor)
+            }
+
+            if store.isUpdatingConnection {
+                HStack { ProgressView(); Text("Updating connection…").foregroundStyle(.secondary) }
+            } else if store.response?.connection?.isActive == true {
+                Button {
+                    Task { await store.sync() }
+                } label: {
+                    Label(store.isSyncing ? "Syncing…" : "Sync Newsletters", systemImage: "arrow.clockwise")
+                }
+                .disabled(store.isSyncing)
+
+                Button("Disconnect Gmail", role: .destructive) {
+                    showsDisconnectConfirmation = true
+                }
+            } else {
+                Button {
+                    Task { await store.connect() }
+                } label: {
+                    Label(
+                        store.response?.connection?.needsAttention == true
+                            ? "Reconnect Gmail"
+                            : "Connect Gmail",
+                        systemImage: "person.crop.circle.badge.plus"
+                    )
+                }
+            }
+        }
+    }
+
+    private var connectionLabel: String {
+        if store.response?.connection?.isActive == true { return "Connected" }
+        if store.response?.connection?.needsAttention == true { return "Needs attention" }
+        return "Not connected"
+    }
+
+    private var connectionColor: Color {
+        if store.response?.connection?.isActive == true { return .green }
+        if store.response?.connection?.needsAttention == true { return .orange }
+        return .secondary
+    }
+
+    private func newsletterRow(_ feed: NewsletterFeed) -> some View {
+        HStack(spacing: 12) {
+            CachedRemoteImage(url: feed.imageUrl, targetSize: CGSize(width: 44, height: 44)) {
+                Image(systemName: "envelope.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(10)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(.circle)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(feed.displayName).lineLimit(2)
+                Text(feed.fromAddress ?? feed.status.title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+            if store.pendingFeedIDs.contains(feed.id) {
+                ProgressView()
+            } else {
+                Menu {
+                    if feed.status == .active {
+                        Button { Task { await store.setActive(feed, isActive: false) } } label: {
+                            Label("Hide", systemImage: "eye.slash")
+                        }
+                    } else {
+                        Button { Task { await store.setActive(feed, isActive: true) } } label: {
+                            Label("Activate", systemImage: "checkmark.circle")
+                        }
+                    }
+                    Button("Unsubscribe", systemImage: "envelope.badge", role: .destructive) {
+                        pendingUnsubscribe = feed
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle").font(.title3)
+                }
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    private var messageBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionMessage != nil },
+            set: { if !$0 { store.dismissMessage() } }
+        )
+    }
+
+    private var unsubscribeBinding: Binding<Bool> {
+        Binding(
+            get: { pendingUnsubscribe != nil },
+            set: { if !$0 { pendingUnsubscribe = nil } }
+        )
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderOAuthSession.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderOAuthSession.swift
@@ -1,0 +1,273 @@
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import Security
+import UIKit
+
+@MainActor
+final class ProviderOAuthSession: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private let apiClient: APIClient
+    private let configuration: AppConfiguration
+    private var activeSession: ASWebAuthenticationSession?
+
+    init(apiClient: APIClient, configuration: AppConfiguration) {
+        self.apiClient = apiClient
+        self.configuration = configuration
+    }
+
+    func connect(_ provider: SubscriptionSource) async throws {
+        let oauth = try ProviderOAuth.configuration(for: provider, app: configuration)
+        let pkce = try ProviderOAuth.generatePKCE()
+        let state = "\(provider.rawValue):\(UUID().uuidString)"
+        try await apiClient.registerOAuthState(state, provider: provider)
+
+        let authorizationURL = try ProviderOAuth.authorizationURL(
+            configuration: oauth,
+            state: state,
+            challenge: pkce.challenge
+        )
+        let callbackURL = try await authenticate(
+            authorizationURL: authorizationURL,
+            callbackScheme: oauth.redirectUri.scheme
+        )
+        let response = try ProviderOAuth.parseCallback(callbackURL, expectedState: state)
+
+        try await apiClient.completeOAuth(
+            provider: provider,
+            code: response.code,
+            state: response.state,
+            codeVerifier: pkce.verifier,
+            redirectUri: oauth.redirectUri.absoluteString
+        )
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        return scenes
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow) ?? scenes.flatMap(\.windows).first ?? ASPresentationAnchor()
+    }
+
+    private func authenticate(
+        authorizationURL: URL,
+        callbackScheme: String?
+    ) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: authorizationURL,
+                callbackURLScheme: callbackScheme
+            ) { [weak self] callbackURL, error in
+                self?.activeSession = nil
+
+                if let sessionError = error as? ASWebAuthenticationSessionError,
+                   sessionError.code == .canceledLogin {
+                    continuation.resume(throwing: CancellationError())
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: ProviderOAuthError.missingCallback)
+                }
+            }
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            activeSession = session
+
+            if !session.start() {
+                activeSession = nil
+                continuation.resume(throwing: ProviderOAuthError.couldNotStartSession)
+            }
+        }
+    }
+}
+
+enum ProviderOAuth {
+    struct PKCE: Equatable {
+        let verifier: String
+        let challenge: String
+    }
+
+    struct Callback: Equatable {
+        let code: String
+        let state: String
+    }
+
+    struct Configuration: Equatable {
+        let provider: SubscriptionSource
+        let clientID: String
+        let authorizationEndpoint: URL
+        let redirectUri: URL
+        let scopes: [String]
+        let requestsOfflineAccess: Bool
+    }
+
+    static func configuration(
+        for provider: SubscriptionSource,
+        app: AppConfiguration
+    ) throws -> Configuration {
+        let googleRedirect = googleRedirectUri(clientID: app.googleClientID)
+
+        let result: Configuration?
+        switch provider {
+        case .youtube:
+            result = googleRedirect.map {
+                Configuration(
+                    provider: provider,
+                    clientID: app.googleClientID,
+                    authorizationEndpoint: URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!,
+                    redirectUri: $0,
+                    scopes: [
+                        "https://www.googleapis.com/auth/youtube.readonly",
+                        "https://www.googleapis.com/auth/userinfo.email",
+                        "https://www.googleapis.com/auth/userinfo.profile",
+                    ],
+                    requestsOfflineAccess: true
+                )
+            }
+        case .gmail:
+            result = googleRedirect.map {
+                Configuration(
+                    provider: provider,
+                    clientID: app.googleClientID,
+                    authorizationEndpoint: URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!,
+                    redirectUri: $0,
+                    scopes: [
+                        "https://www.googleapis.com/auth/gmail.readonly",
+                        "https://www.googleapis.com/auth/userinfo.email",
+                        "https://www.googleapis.com/auth/userinfo.profile",
+                    ],
+                    requestsOfflineAccess: true
+                )
+            }
+        case .spotify:
+            result = Configuration(
+                provider: provider,
+                clientID: app.spotifyClientID,
+                authorizationEndpoint: URL(string: "https://accounts.spotify.com/authorize")!,
+                redirectUri: URL(string: "zine://oauth/callback")!,
+                scopes: ["user-library-read"],
+                requestsOfflineAccess: false
+            )
+        case .x:
+            result = Configuration(
+                provider: provider,
+                clientID: app.xClientID,
+                authorizationEndpoint: URL(string: "https://x.com/i/oauth2/authorize")!,
+                redirectUri: URL(string: "zine://oauth/callback")!,
+                scopes: ["tweet.read", "users.read", "bookmark.read", "offline.access"],
+                requestsOfflineAccess: false
+            )
+        case .rss:
+            result = nil
+        }
+
+        guard let result, !result.clientID.isEmpty else {
+            throw ProviderOAuthError.missingClientConfiguration(provider.providerTitle)
+        }
+        return result
+    }
+
+    static func googleRedirectUri(clientID: String) -> URL? {
+        let suffix = ".apps.googleusercontent.com"
+        guard clientID.hasSuffix(suffix), clientID.count > suffix.count else { return nil }
+        let identifier = clientID.dropLast(suffix.count)
+        return URL(string: "com.googleusercontent.apps.\(identifier):/oauth2redirect")
+    }
+
+    static func generatePKCE() throws -> PKCE {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            throw ProviderOAuthError.randomGenerationFailed
+        }
+
+        let verifier = Data(bytes).base64URLEncodedString()
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        let challenge = Data(digest).base64URLEncodedString()
+        return PKCE(verifier: verifier, challenge: challenge)
+    }
+
+    static func authorizationURL(
+        configuration: Configuration,
+        state: String,
+        challenge: String
+    ) throws -> URL {
+        var components = URLComponents(
+            url: configuration.authorizationEndpoint,
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [
+            URLQueryItem(name: "client_id", value: configuration.clientID),
+            URLQueryItem(name: "redirect_uri", value: configuration.redirectUri.absoluteString),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: configuration.scopes.joined(separator: " ")),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        if configuration.requestsOfflineAccess {
+            items.append(URLQueryItem(name: "access_type", value: "offline"))
+            items.append(URLQueryItem(name: "prompt", value: "consent"))
+        }
+        components.queryItems = items
+        guard let url = components.url else { throw ProviderOAuthError.invalidAuthorizationURL }
+        return url
+    }
+
+    static func parseCallback(_ url: URL, expectedState: String) throws -> Callback {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let value = { (name: String) in items.first(where: { $0.name == name })?.value }
+
+        if let oauthError = value("error") {
+            throw ProviderOAuthError.providerError(value("error_description") ?? oauthError)
+        }
+        guard let state = value("state"), state == expectedState else {
+            throw ProviderOAuthError.stateMismatch
+        }
+        guard let code = value("code"), !code.isEmpty else {
+            throw ProviderOAuthError.missingAuthorizationCode
+        }
+        return Callback(code: code, state: state)
+    }
+}
+
+enum ProviderOAuthError: LocalizedError {
+    case missingClientConfiguration(String)
+    case randomGenerationFailed
+    case invalidAuthorizationURL
+    case couldNotStartSession
+    case missingCallback
+    case stateMismatch
+    case missingAuthorizationCode
+    case providerError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingClientConfiguration(let provider):
+            "\(provider) sign-in is not configured for this build."
+        case .randomGenerationFailed:
+            "A secure sign-in request couldn’t be created."
+        case .invalidAuthorizationURL:
+            "The provider sign-in address is invalid."
+        case .couldNotStartSession:
+            "Provider sign-in couldn’t be opened."
+        case .missingCallback:
+            "Provider sign-in did not return to Zine."
+        case .stateMismatch:
+            "Provider sign-in could not be verified. Please try again."
+        case .missingAuthorizationCode:
+            "The provider did not return an authorization code."
+        case .providerError(let message):
+            message
+        }
+    }
+}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsClient.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsClient.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct ProviderSubscriptionsClient {
+    var load: () async throws -> ProviderSubscriptionsResponse
+    var add: (ProviderSubscriptionItem) async throws -> Void
+    var remove: (String) async throws -> Void
+    var setPaused: (String, Bool) async throws -> Void
+    var sync: (String) async throws -> SubscriptionSyncResponse
+    var connect: () async throws -> Void
+    var disconnect: () async throws -> Void
+
+    @MainActor
+    static func live(
+        provider: SubscriptionSource,
+        apiClient: APIClient,
+        configuration: AppConfiguration
+    ) -> Self {
+        let oauthSession = ProviderOAuthSession(apiClient: apiClient, configuration: configuration)
+        return Self(
+            load: { try await apiClient.listProviderSubscriptions(provider) },
+            add: { try await apiClient.addProviderSubscription($0, provider: provider) },
+            remove: { try await apiClient.removeProviderSubscription(id: $0, provider: provider) },
+            setPaused: {
+                try await apiClient.setProviderSubscriptionPaused(
+                    id: $0,
+                    provider: provider,
+                    isPaused: $1
+                )
+            },
+            sync: { try await apiClient.syncProviderSubscription(id: $0, provider: provider) },
+            connect: { try await oauthSession.connect(provider) },
+            disconnect: { try await apiClient.disconnectProvider(provider) }
+        )
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsStore.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsStore.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProviderSubscriptionsStore {
+    private(set) var items: [ProviderSubscriptionItem] = []
+    private(set) var connection: ProviderConnection?
+    private(set) var connectionRequired = false
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+    private(set) var actionErrorMessage: String?
+    private(set) var pendingItemIDs = Set<String>()
+    private(set) var syncMessage: String?
+    private(set) var isUpdatingConnection = false
+
+    let provider: SubscriptionSource
+    private let client: ProviderSubscriptionsClient
+
+    init(provider: SubscriptionSource, client: ProviderSubscriptionsClient) {
+        self.provider = provider
+        self.client = client
+    }
+
+    func reload() async {
+        errorMessage = nil
+        isLoading = items.isEmpty
+        defer { isLoading = false }
+
+        do {
+            let response = try await client.load()
+            guard !Task.isCancelled else { return }
+            items = response.items
+            connection = response.connection
+            connectionRequired = response.connectionRequired
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func add(_ item: ProviderSubscriptionItem) async {
+        await perform(item: item, failureMessage: "The \(provider.itemNoun) couldn’t be added.") {
+            try await client.add(item)
+        }
+    }
+
+    func connect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+
+        do {
+            try await client.connect()
+            await refreshAfterMutation()
+        } catch is CancellationError {
+            return
+        } catch {
+            actionErrorMessage = "\(provider.providerTitle) couldn’t be connected. \(error.localizedDescription)"
+        }
+    }
+
+    func disconnect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+
+        do {
+            try await client.disconnect()
+            await refreshAfterMutation()
+        } catch {
+            actionErrorMessage = "\(provider.providerTitle) couldn’t be disconnected. \(error.localizedDescription)"
+        }
+    }
+
+    func remove(_ item: ProviderSubscriptionItem) async {
+        guard let subscriptionId = item.subscriptionId else { return }
+        await perform(item: item, failureMessage: "The subscription couldn’t be removed.") {
+            try await client.remove(subscriptionId)
+        }
+    }
+
+    func setPaused(_ item: ProviderSubscriptionItem, isPaused: Bool) async {
+        guard let subscriptionId = item.subscriptionId else { return }
+        let failure = isPaused
+            ? "The subscription couldn’t be paused."
+            : "The subscription couldn’t be resumed."
+        await perform(item: item, failureMessage: failure) {
+            try await client.setPaused(subscriptionId, isPaused)
+        }
+    }
+
+    func sync(_ item: ProviderSubscriptionItem) async {
+        guard let subscriptionId = item.subscriptionId else { return }
+        pendingItemIDs.insert(item.channelId)
+        syncMessage = nil
+        defer { pendingItemIDs.remove(item.channelId) }
+
+        do {
+            let result = try await client.sync(subscriptionId)
+            let noun = provider == .youtube ? "video" : "episode"
+            syncMessage = result.itemsFound == 1
+                ? "Fetched 1 new \(noun) from \(item.name)."
+                : "Fetched \(result.itemsFound) new \(noun)s from \(item.name)."
+            await refreshAfterMutation()
+        } catch {
+            actionErrorMessage = "The subscription couldn’t be synced. \(error.localizedDescription)"
+        }
+    }
+
+    func dismissActionError() { actionErrorMessage = nil }
+    func dismissSyncMessage() { syncMessage = nil }
+
+    private func perform(
+        item: ProviderSubscriptionItem,
+        failureMessage: String,
+        action: () async throws -> Void
+    ) async {
+        pendingItemIDs.insert(item.channelId)
+        defer { pendingItemIDs.remove(item.channelId) }
+
+        do {
+            try await action()
+            await refreshAfterMutation()
+        } catch {
+            actionErrorMessage = "\(failureMessage) \(error.localizedDescription)"
+        }
+    }
+
+    private func refreshAfterMutation() async {
+        do {
+            let response = try await client.load()
+            items = response.items
+            connection = response.connection
+            connectionRequired = response.connectionRequired
+        } catch {
+            actionErrorMessage = "The change was saved, but the list couldn’t be refreshed. Pull to refresh."
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
@@ -1,0 +1,263 @@
+import SwiftUI
+
+struct ProviderSubscriptionsView: View {
+    @State private var store: ProviderSubscriptionsStore
+    @State private var searchText = ""
+    @State private var pendingRemoval: ProviderSubscriptionItem?
+    @State private var showsDisconnectConfirmation = false
+
+    private let provider: SubscriptionSource
+
+    init(
+        provider: SubscriptionSource,
+        client: APIClient,
+        configuration: AppConfiguration = .current
+    ) {
+        self.provider = provider
+        _store = State(
+            initialValue: ProviderSubscriptionsStore(
+                provider: provider,
+                client: .live(
+                    provider: provider,
+                    apiClient: client,
+                    configuration: configuration
+                )
+            )
+        )
+    }
+
+    init(provider: SubscriptionSource, client: ProviderSubscriptionsClient) {
+        self.provider = provider
+        _store = State(
+            initialValue: ProviderSubscriptionsStore(provider: provider, client: client)
+        )
+    }
+
+    private var filteredItems: [ProviderSubscriptionItem] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return store.items }
+        return store.items.filter { $0.name.localizedStandardContains(query) }
+    }
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.items.isEmpty {
+                ProgressView("Loading \(provider.title)…")
+            } else if let error = store.errorMessage, store.items.isEmpty {
+                ContentUnavailableView {
+                    Label("\(provider.title) unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Try again") { Task { await store.reload() } }
+                }
+            } else {
+                subscriptionList
+            }
+        }
+        .navigationTitle(provider.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchText, prompt: searchPrompt)
+        .task { await store.reload() }
+        .alert("Couldn’t update \(provider.title)", isPresented: actionErrorBinding) {
+            Button("OK", role: .cancel) { store.dismissActionError() }
+        } message: {
+            Text(store.actionErrorMessage ?? "Please try again.")
+        }
+        .alert("\(provider.title) synced", isPresented: syncMessageBinding) {
+            Button("OK", role: .cancel) { store.dismissSyncMessage() }
+        } message: {
+            Text(store.syncMessage ?? "The subscription is up to date.")
+        }
+        .confirmationDialog(
+            "Remove \(pendingRemoval?.name ?? "this subscription")?",
+            isPresented: removalBinding,
+            titleVisibility: .visible,
+            presenting: pendingRemoval
+        ) { item in
+            Button("Remove Subscription", role: .destructive) {
+                Task { await store.remove(item) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("New items will stop arriving. Existing inbox items are removed; bookmarks are kept.")
+        }
+        .confirmationDialog(
+            "Disconnect \(provider.providerTitle)?",
+            isPresented: $showsDisconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Disconnect", role: .destructive) { Task { await store.disconnect() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "Zine will stop reading your \(provider.providerTitle) subscriptions until you reconnect. Your account will not be changed."
+            )
+        }
+    }
+
+    private var searchPrompt: String {
+        provider == .youtube ? "Search channels" : "Search shows"
+    }
+
+    private var subscriptionList: some View {
+        List {
+            connectionSection
+
+            if store.connectionRequired || store.connection?.isActive != true {
+                Section {
+                    ContentUnavailableView(
+                        "\(provider.providerTitle) isn’t connected",
+                        systemImage: provider.systemImage,
+                        description: Text(
+                            "Sign in to \(provider.providerTitle) to import and manage \(provider.itemNoun)s in Zine."
+                        )
+                    )
+                }
+            } else if filteredItems.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        searchText.isEmpty ? "No \(provider.itemNoun)s" : "No matches",
+                        systemImage: searchText.isEmpty ? provider.systemImage : "magnifyingglass",
+                        description: Text(
+                            searchText.isEmpty
+                                ? "The \(provider.itemNoun)s you follow will appear here."
+                                : "Try another name."
+                        )
+                    )
+                }
+            } else {
+                Section(provider == .youtube ? "Channels" : "Shows") {
+                    ForEach(filteredItems) { item in itemRow(item) }
+                }
+            }
+        }
+        .refreshable { await store.reload() }
+    }
+
+    private var connectionSection: some View {
+        Section("Account") {
+            LabeledContent {
+                Text(connectionLabel)
+                    .foregroundStyle(connectionColor)
+            } label: {
+                Label(provider.providerTitle, systemImage: provider.systemImage)
+            }
+
+            if store.isUpdatingConnection {
+                HStack {
+                    ProgressView()
+                    Text(store.connection?.isActive == true ? "Disconnecting…" : "Connecting…")
+                        .foregroundStyle(.secondary)
+                }
+            } else if store.connection?.isActive == true {
+                Button("Disconnect \(provider.providerTitle)", role: .destructive) {
+                    showsDisconnectConfirmation = true
+                }
+            } else {
+                Button {
+                    Task { await store.connect() }
+                } label: {
+                    Label(
+                        store.connection?.needsAttention == true
+                            ? "Reconnect \(provider.providerTitle)"
+                            : "Connect \(provider.providerTitle)",
+                        systemImage: "person.crop.circle.badge.plus"
+                    )
+                }
+            }
+        }
+    }
+
+    private var connectionLabel: String {
+        if store.connection?.isActive == true { return "Connected" }
+        if store.connection?.needsAttention == true { return "Needs attention" }
+        return "Not connected"
+    }
+
+    private var connectionColor: Color {
+        if store.connection?.isActive == true { return .green }
+        if store.connection?.needsAttention == true { return .orange }
+        return .secondary
+    }
+
+    private func itemRow(_ item: ProviderSubscriptionItem) -> some View {
+        HStack(spacing: 12) {
+            CachedRemoteImage(url: item.imageUrl, targetSize: CGSize(width: 44, height: 44)) {
+                Image(systemName: provider.systemImage)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(8)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(.circle)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.name).lineLimit(2)
+                Text(item.status?.title ?? "Available to add")
+                    .font(.caption)
+                    .foregroundStyle(
+                        item.status == .active || item.status == nil ? Color.secondary : Color.orange
+                    )
+            }
+
+            Spacer()
+
+            if store.pendingItemIDs.contains(item.channelId) {
+                ProgressView()
+            } else if item.isSubscribed {
+                subscriptionMenu(item)
+            } else {
+                Button("Add") { Task { await store.add(item) } }
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    private func subscriptionMenu(_ item: ProviderSubscriptionItem) -> some View {
+        Menu {
+            if item.status == .active {
+                Button { Task { await store.sync(item) } } label: {
+                    Label("Sync Now", systemImage: "arrow.clockwise")
+                }
+                Button { Task { await store.setPaused(item, isPaused: true) } } label: {
+                    Label("Pause", systemImage: "pause.circle")
+                }
+            } else if item.status == .paused {
+                Button { Task { await store.setPaused(item, isPaused: false) } } label: {
+                    Label("Resume", systemImage: "play.circle")
+                }
+            }
+
+            Button("Remove", systemImage: "trash", role: .destructive) {
+                pendingRemoval = item
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle").font(.title3)
+        }
+        .accessibilityLabel("Manage \(item.name)")
+    }
+
+    private var actionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionErrorMessage != nil },
+            set: { if !$0 { store.dismissActionError() } }
+        )
+    }
+
+    private var syncMessageBinding: Binding<Bool> {
+        Binding(
+            get: { store.syncMessage != nil },
+            set: { if !$0 { store.dismissSyncMessage() } }
+        )
+    }
+
+    private var removalBinding: Binding<Bool> {
+        Binding(
+            get: { pendingRemoval != nil },
+            set: { if !$0 { pendingRemoval = nil } }
+        )
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
@@ -1,0 +1,266 @@
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+private final class RssSubscriptionsStore {
+    private(set) var response: RssSubscriptionsResponse?
+    private(set) var isLoading = false
+    private(set) var isAdding = false
+    private(set) var pendingFeedIDs = Set<String>()
+    private(set) var errorMessage: String?
+    private(set) var actionMessage: String?
+
+    private let client: APIClient
+
+    init(client: APIClient) {
+        self.client = client
+    }
+
+    func reload() async {
+        isLoading = response == nil
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            response = try await client.listRssFeeds()
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func add(url: String) async -> Bool {
+        let value = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let candidate = URL(string: value),
+              let scheme = candidate.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            actionMessage = "Enter a complete http or https feed URL."
+            return false
+        }
+
+        isAdding = true
+        defer { isAdding = false }
+        do {
+            try await client.addRssFeed(url: value)
+            await reloadAfterMutation()
+            return true
+        } catch {
+            actionMessage = "The RSS feed couldn’t be added. \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    func setPaused(_ feed: RssFeed, isPaused: Bool) async {
+        await perform(feed) {
+            try await client.updateRssFeed(id: feed.id, action: isPaused ? "pause" : "resume")
+        }
+    }
+
+    func remove(_ feed: RssFeed) async {
+        await perform(feed) { try await client.removeRssFeed(id: feed.id) }
+    }
+
+    func sync(_ feed: RssFeed) async {
+        pendingFeedIDs.insert(feed.id)
+        defer { pendingFeedIDs.remove(feed.id) }
+        do {
+            let result = try await client.syncRssFeed(id: feed.id)
+            actionMessage = result.itemsFound == 1
+                ? "Fetched 1 new item from \(feed.title)."
+                : "Fetched \(result.itemsFound) new items from \(feed.title)."
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "The RSS feed couldn’t be synced. \(error.localizedDescription)"
+        }
+    }
+
+    func dismissMessage() { actionMessage = nil }
+
+    private func perform(_ feed: RssFeed, action: () async throws -> Void) async {
+        pendingFeedIDs.insert(feed.id)
+        defer { pendingFeedIDs.remove(feed.id) }
+        do {
+            try await action()
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "\(feed.title) couldn’t be updated. \(error.localizedDescription)"
+        }
+    }
+
+    private func reloadAfterMutation() async {
+        do {
+            response = try await client.listRssFeeds()
+            errorMessage = nil
+        } catch {
+            actionMessage = "The change was saved, but the feed list couldn’t be refreshed."
+        }
+    }
+}
+
+struct RssSubscriptionsView: View {
+    @State private var store: RssSubscriptionsStore
+    @State private var searchText = ""
+    @State private var feedURL = ""
+    @State private var pendingRemoval: RssFeed?
+
+    init(client: APIClient) {
+        _store = State(initialValue: RssSubscriptionsStore(client: client))
+    }
+
+    private var filteredFeeds: [RssFeed] {
+        let items = store.response?.items.filter { $0.status != .unsubscribed } ?? []
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return items }
+        return items.filter {
+            $0.title.localizedStandardContains(query)
+                || $0.feedUrl.absoluteString.localizedStandardContains(query)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.response == nil {
+                ProgressView("Loading RSS feeds…")
+            } else if let error = store.errorMessage, store.response == nil {
+                ContentUnavailableView {
+                    Label("RSS unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Try again") { Task { await store.reload() } }
+                }
+            } else {
+                feedList
+            }
+        }
+        .navigationTitle("RSS")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchText, prompt: "Search feeds")
+        .task { await store.reload() }
+        .alert("RSS", isPresented: messageBinding) {
+            Button("OK", role: .cancel) { store.dismissMessage() }
+        } message: {
+            Text(store.actionMessage ?? "Please try again.")
+        }
+        .confirmationDialog(
+            "Remove \(pendingRemoval?.title ?? "this feed")?",
+            isPresented: removalBinding,
+            titleVisibility: .visible,
+            presenting: pendingRemoval
+        ) { feed in
+            Button("Remove Feed", role: .destructive) { Task { await store.remove(feed) } }
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("New articles will stop arriving. Existing bookmarks are kept.")
+        }
+    }
+
+    private var feedList: some View {
+        List {
+            Section {
+                HStack {
+                    TextField("https://example.com/feed.xml", text: $feedURL)
+                        .keyboardType(.URL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .accessibilityLabel("RSS feed URL")
+                    if store.isAdding {
+                        ProgressView()
+                    } else {
+                        Button("Add") {
+                            Task {
+                                if await store.add(url: feedURL) { feedURL = "" }
+                            }
+                        }
+                        .disabled(feedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            } header: {
+                Text("Add a Feed")
+            } footer: {
+                Text("RSS connects directly—no external account is required.")
+            }
+
+            if filteredFeeds.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        searchText.isEmpty ? "No RSS feeds" : "No matching feeds",
+                        systemImage: searchText.isEmpty ? SubscriptionSource.rss.systemImage : "magnifyingglass",
+                        description: Text(
+                            searchText.isEmpty
+                                ? "Paste a feed URL above to start syncing articles."
+                                : "Try another title or URL."
+                        )
+                    )
+                }
+            } else {
+                Section("Feeds") {
+                    ForEach(filteredFeeds) { feed in feedRow(feed) }
+                }
+            }
+        }
+        .refreshable { await store.reload() }
+    }
+
+    private func feedRow(_ feed: RssFeed) -> some View {
+        HStack(spacing: 12) {
+            CachedRemoteImage(url: feed.imageUrl, targetSize: CGSize(width: 44, height: 44)) {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .resizable()
+                    .scaledToFit()
+                    .padding(10)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(width: 44, height: 44)
+            .clipShape(.circle)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(feed.title).lineLimit(2)
+                Text(feed.status.title)
+                    .font(.caption)
+                    .foregroundStyle(feed.status == .active ? Color.secondary : Color.orange)
+            }
+
+            Spacer()
+            if store.pendingFeedIDs.contains(feed.id) {
+                ProgressView()
+            } else {
+                Menu {
+                    Button { Task { await store.sync(feed) } } label: {
+                        Label("Sync Now", systemImage: "arrow.clockwise")
+                    }
+                    if feed.status == .active {
+                        Button { Task { await store.setPaused(feed, isPaused: true) } } label: {
+                            Label("Pause", systemImage: "pause.circle")
+                        }
+                    } else {
+                        Button { Task { await store.setPaused(feed, isPaused: false) } } label: {
+                            Label("Resume", systemImage: "play.circle")
+                        }
+                    }
+                    Button("Remove", systemImage: "trash", role: .destructive) {
+                        pendingRemoval = feed
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle").font(.title3)
+                }
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    private var messageBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionMessage != nil },
+            set: { if !$0 { store.dismissMessage() } }
+        )
+    }
+
+    private var removalBinding: Binding<Bool> {
+        Binding(
+            get: { pendingRemoval != nil },
+            set: { if !$0 { pendingRemoval = nil } }
+        )
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+enum SubscriptionSource: String, CaseIterable, Decodable, Hashable, Identifiable {
+    case youtube = "YOUTUBE"
+    case spotify = "SPOTIFY"
+    case gmail = "GMAIL"
+    case x = "X"
+    case rss = "RSS"
+
+    var id: Self { self }
+
+    var pathComponent: String { rawValue.lowercased() }
+
+    var title: String {
+        switch self {
+        case .youtube: "YouTube"
+        case .spotify: "Spotify"
+        case .gmail: "Newsletters"
+        case .x: "X Bookmarks"
+        case .rss: "RSS"
+        }
+    }
+
+    var providerTitle: String {
+        switch self {
+        case .gmail: "Gmail"
+        case .x: "X"
+        default: title
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .youtube: "play.rectangle.fill"
+        case .spotify: "waveform.circle.fill"
+        case .gmail: "envelope.fill"
+        case .x: "bookmark.square.fill"
+        case .rss: "dot.radiowaves.left.and.right"
+        }
+    }
+
+    var itemNoun: String {
+        switch self {
+        case .youtube: "channel"
+        case .spotify: "show"
+        case .gmail: "newsletter"
+        case .x: "bookmark"
+        case .rss: "feed"
+        }
+    }
+
+    var connectedDescription: String {
+        switch self {
+        case .youtube: "Videos from your selected channels appear in Inbox after sync."
+        case .spotify: "New episodes from your selected shows appear in Inbox."
+        case .gmail: "Active newsletters from Gmail appear in Inbox as articles."
+        case .x: "Your X bookmarks are imported into your Zine library."
+        case .rss: "RSS feeds sync directly without an external account."
+        }
+    }
+}
+
+enum ProviderSubscriptionStatus: String, Decodable {
+    case active = "ACTIVE"
+    case paused = "PAUSED"
+    case disconnected = "DISCONNECTED"
+
+    var title: String {
+        switch self {
+        case .active: "Active"
+        case .paused: "Paused"
+        case .disconnected: "Needs attention"
+        }
+    }
+}
+
+struct ProviderConnection: Decodable, Equatable {
+    let status: String
+    let providerUserId: String?
+    let connectedAt: Int?
+    let lastRefreshedAt: Int?
+
+    var isActive: Bool { status == "ACTIVE" }
+    var needsAttention: Bool { status == "EXPIRED" || status == "REVOKED" }
+}
+
+struct SubscriptionSourceSummary: Decodable, Equatable, Identifiable {
+    let provider: SubscriptionSource
+    let connectionStatus: String?
+    let activeCount: Int
+
+    var id: SubscriptionSource { provider }
+    var isConnected: Bool { connectionStatus == "ACTIVE" }
+    var needsAttention: Bool { connectionStatus == "EXPIRED" || connectionStatus == "REVOKED" }
+
+    var statusText: String {
+        let count = "\(activeCount) \(provider.itemNoun)\(activeCount == 1 ? "" : "s")"
+        if provider == .rss { return activeCount > 0 ? count : "No account required" }
+        if needsAttention { return "Needs attention · \(count)" }
+        if isConnected { return "Connected · \(count)" }
+        return activeCount > 0 ? "Not connected · \(count)" : "Not connected"
+    }
+}
+
+struct SubscriptionsHubResponse: Decodable, Equatable {
+    let sources: [SubscriptionSourceSummary]
+}
+
+struct ProviderSubscriptionItem: Decodable, Equatable, Identifiable {
+    let subscriptionId: String?
+    let channelId: String
+    let name: String
+    let imageUrl: URL?
+    let status: ProviderSubscriptionStatus?
+    let isSubscribed: Bool
+    let lastPolledAt: Int?
+
+    var id: String { channelId }
+}
+
+struct ProviderSubscriptionsResponse: Decodable, Equatable {
+    let connection: ProviderConnection?
+    let connectionRequired: Bool
+    let items: [ProviderSubscriptionItem]
+}
+
+struct SubscriptionSyncResponse: Decodable, Equatable {
+    let itemsFound: Int
+}
+
+enum NewsletterStatus: String, Decodable {
+    case active = "ACTIVE"
+    case hidden = "HIDDEN"
+    case unsubscribed = "UNSUBSCRIBED"
+
+    var title: String {
+        switch self {
+        case .active: "Active"
+        case .hidden: "Hidden"
+        case .unsubscribed: "Unsubscribed"
+        }
+    }
+}
+
+struct NewsletterFeed: Decodable, Equatable, Identifiable {
+    let id: String
+    let displayName: String
+    let fromAddress: String?
+    let imageUrl: URL?
+    let status: NewsletterStatus
+    let lastSeenAt: Int?
+}
+
+struct NewsletterStats: Decodable, Equatable {
+    let total: Int
+    let active: Int
+    let hidden: Int
+    let unsubscribed: Int
+    let lastSyncAt: Int?
+    let lastSyncStatus: String
+    let lastSyncError: String?
+}
+
+struct NewsletterSubscriptionsResponse: Decodable, Equatable {
+    let connection: ProviderConnection?
+    let items: [NewsletterFeed]
+    let stats: NewsletterStats
+}
+
+enum RssFeedStatus: String, Decodable {
+    case active = "ACTIVE"
+    case paused = "PAUSED"
+    case unsubscribed = "UNSUBSCRIBED"
+    case error = "ERROR"
+
+    var title: String {
+        switch self {
+        case .active: "Active"
+        case .paused: "Paused"
+        case .unsubscribed: "Removed"
+        case .error: "Needs attention"
+        }
+    }
+}
+
+struct RssFeed: Decodable, Equatable, Identifiable {
+    let id: String
+    let feedUrl: URL
+    let title: String
+    let description: String?
+    let siteUrl: URL?
+    let imageUrl: URL?
+    let status: RssFeedStatus
+    let errorCount: Int
+    let lastError: String?
+    let lastPolledAt: Int?
+    let lastSuccessAt: Int?
+}
+
+struct RssStats: Decodable, Equatable {
+    let total: Int
+    let active: Int
+    let paused: Int
+    let unsubscribed: Int
+    let error: Int
+    let lastSuccessAt: Int?
+}
+
+struct RssSubscriptionsResponse: Decodable, Equatable {
+    let items: [RssFeed]
+    let stats: RssStats
+}
+
+struct XBookmarkSyncState: Decodable, Equatable {
+    let status: String
+    let dailySyncEnabled: Bool
+    let lastSyncAt: Int?
+    let lastSuccessAt: Int?
+    let lastError: String?
+    let rateLimitedUntil: Int?
+    let lastEstimatedBillableReads: Int
+}
+
+struct XSubscriptionsResponse: Decodable, Equatable {
+    let connection: ProviderConnection?
+    let connected: Bool
+    let connectionStatus: String?
+    let importedCount: Int
+    let sync: XBookmarkSyncState?
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
@@ -1,0 +1,122 @@
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+private final class SubscriptionsHubStore {
+    private(set) var sources: [SubscriptionSourceSummary] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private let loadSources: () async throws -> SubscriptionsHubResponse
+
+    init(loadSources: @escaping () async throws -> SubscriptionsHubResponse) {
+        self.loadSources = loadSources
+    }
+
+    func reload() async {
+        isLoading = sources.isEmpty
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let response = try await loadSources()
+            guard !Task.isCancelled else { return }
+            sources = response.sources
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct SubscriptionsView: View {
+    let client: APIClient
+    let configuration: AppConfiguration
+
+    @State private var store: SubscriptionsHubStore
+
+    init(client: APIClient, configuration: AppConfiguration = .current) {
+        self.client = client
+        self.configuration = configuration
+        _store = State(
+            initialValue: SubscriptionsHubStore(loadSources: client.listSubscriptionSources)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.sources.isEmpty {
+                ProgressView("Loading subscriptions…")
+            } else if let error = store.errorMessage, store.sources.isEmpty {
+                ContentUnavailableView {
+                    Label("Subscriptions unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Try again") { Task { await store.reload() } }
+                }
+            } else {
+                List {
+                    Section {
+                        ForEach(orderedSources) { summary in
+                            NavigationLink(value: summary.provider) {
+                                subscriptionSourceRow(summary)
+                            }
+                        }
+                    } footer: {
+                        Text("Connect accounts and choose what Zine should sync from each source.")
+                    }
+                }
+                .refreshable { await store.reload() }
+            }
+        }
+        .navigationTitle("Subscriptions")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationDestination(for: SubscriptionSource.self) { source in
+            destination(for: source)
+        }
+        .task { await store.reload() }
+    }
+
+    private var orderedSources: [SubscriptionSourceSummary] {
+        let byProvider = Dictionary(uniqueKeysWithValues: store.sources.map { ($0.provider, $0) })
+        return SubscriptionSource.allCases.compactMap { byProvider[$0] }
+    }
+
+    private func subscriptionSourceRow(_ summary: SubscriptionSourceSummary) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: summary.provider.systemImage)
+                .font(.title3)
+                .foregroundStyle(summary.needsAttention ? .orange : .primary)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(summary.provider.title)
+                Text(summary.statusText)
+                    .font(.caption)
+                    .foregroundStyle(summary.needsAttention ? .orange : .secondary)
+            }
+        }
+        .padding(.vertical, 3)
+    }
+
+    @ViewBuilder
+    private func destination(for source: SubscriptionSource) -> some View {
+        switch source {
+        case .youtube, .spotify:
+            ProviderSubscriptionsView(
+                provider: source,
+                client: client,
+                configuration: configuration
+            )
+        case .gmail:
+            NewsletterSubscriptionsView(client: client, configuration: configuration)
+        case .x:
+            XSubscriptionsView(client: client, configuration: configuration)
+        case .rss:
+            RssSubscriptionsView(client: client)
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
@@ -1,0 +1,251 @@
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+private final class XSubscriptionsStore {
+    private(set) var response: XSubscriptionsResponse?
+    private(set) var isLoading = false
+    private(set) var isUpdatingConnection = false
+    private(set) var isSyncing = false
+    private(set) var isUpdatingSettings = false
+    private(set) var errorMessage: String?
+    private(set) var actionMessage: String?
+
+    private let client: APIClient
+    private let oauth: ProviderOAuthSession
+
+    init(client: APIClient, configuration: AppConfiguration) {
+        self.client = client
+        oauth = ProviderOAuthSession(apiClient: client, configuration: configuration)
+    }
+
+    func reload() async {
+        isLoading = response == nil
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            response = try await client.getXSubscriptions()
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func connect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+        do {
+            try await oauth.connect(.x)
+            await reloadAfterMutation()
+        } catch is CancellationError {
+            return
+        } catch {
+            actionMessage = "X couldn’t be connected. \(error.localizedDescription)"
+        }
+    }
+
+    func disconnect() async {
+        isUpdatingConnection = true
+        defer { isUpdatingConnection = false }
+        do {
+            try await client.disconnectProvider(.x)
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "X couldn’t be disconnected. \(error.localizedDescription)"
+        }
+    }
+
+    func sync() async {
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            try await client.syncXBookmarks()
+            await reloadAfterMutation()
+        } catch {
+            actionMessage = "X bookmarks couldn’t be synced. \(error.localizedDescription)"
+        }
+    }
+
+    func setDailySyncEnabled(_ enabled: Bool) async {
+        guard let current = response, current.sync?.dailySyncEnabled != enabled else { return }
+        isUpdatingSettings = true
+        response = XSubscriptionsResponse(
+            connection: current.connection,
+            connected: current.connected,
+            connectionStatus: current.connectionStatus,
+            importedCount: current.importedCount,
+            sync: current.sync.map {
+                XBookmarkSyncState(
+                    status: $0.status,
+                    dailySyncEnabled: enabled,
+                    lastSyncAt: $0.lastSyncAt,
+                    lastSuccessAt: $0.lastSuccessAt,
+                    lastError: $0.lastError,
+                    rateLimitedUntil: $0.rateLimitedUntil,
+                    lastEstimatedBillableReads: $0.lastEstimatedBillableReads
+                )
+            }
+        )
+        defer { isUpdatingSettings = false }
+
+        do {
+            try await client.updateXBookmarkSettings(dailySyncEnabled: enabled)
+            await reloadAfterMutation()
+        } catch {
+            response = current
+            actionMessage = "Daily sync couldn’t be updated. \(error.localizedDescription)"
+        }
+    }
+
+    func dismissMessage() { actionMessage = nil }
+
+    private func reloadAfterMutation() async {
+        do {
+            response = try await client.getXSubscriptions()
+            errorMessage = nil
+        } catch {
+            actionMessage = "The change was saved, but X status couldn’t be refreshed."
+        }
+    }
+}
+
+struct XSubscriptionsView: View {
+    @State private var store: XSubscriptionsStore
+    @State private var showsDisconnectConfirmation = false
+
+    init(client: APIClient, configuration: AppConfiguration = .current) {
+        _store = State(
+            initialValue: XSubscriptionsStore(client: client, configuration: configuration)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if store.isLoading && store.response == nil {
+                ProgressView("Loading X bookmarks…")
+            } else if let error = store.errorMessage, store.response == nil {
+                ContentUnavailableView {
+                    Label("X bookmarks unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(error)
+                } actions: {
+                    Button("Try again") { Task { await store.reload() } }
+                }
+            } else {
+                settingsList
+            }
+        }
+        .navigationTitle("X Bookmarks")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await store.reload() }
+        .alert("Couldn’t update X bookmarks", isPresented: messageBinding) {
+            Button("OK", role: .cancel) { store.dismissMessage() }
+        } message: {
+            Text(store.actionMessage ?? "Please try again.")
+        }
+        .confirmationDialog(
+            "Disconnect X?",
+            isPresented: $showsDisconnectConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Disconnect", role: .destructive) { Task { await store.disconnect() } }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Zine will stop importing bookmarks from X. Existing items in your library are kept.")
+        }
+    }
+
+    private var settingsList: some View {
+        List {
+            Section("Account") {
+                LabeledContent("X") {
+                    Text(connectionLabel).foregroundStyle(connectionColor)
+                }
+
+                if store.isUpdatingConnection {
+                    HStack { ProgressView(); Text("Updating connection…").foregroundStyle(.secondary) }
+                } else if store.response?.connection?.isActive == true {
+                    Button("Disconnect X", role: .destructive) {
+                        showsDisconnectConfirmation = true
+                    }
+                } else {
+                    Button {
+                        Task { await store.connect() }
+                    } label: {
+                        Label(
+                            store.response?.connection?.needsAttention == true ? "Reconnect X" : "Connect X",
+                            systemImage: "person.crop.circle.badge.plus"
+                        )
+                    }
+                }
+            }
+
+            if store.response?.connection?.isActive == true {
+                Section {
+                    LabeledContent("Imported") {
+                        Text("\(store.response?.importedCount ?? 0)")
+                    }
+
+                    Toggle(
+                        "Daily sync",
+                        isOn: Binding(
+                            get: { store.response?.sync?.dailySyncEnabled ?? false },
+                            set: { enabled in Task { await store.setDailySyncEnabled(enabled) } }
+                        )
+                    )
+                    .disabled(store.isUpdatingSettings)
+
+                    Button {
+                        Task { await store.sync() }
+                    } label: {
+                        Label(store.isSyncing ? "Syncing…" : "Sync Now", systemImage: "arrow.clockwise")
+                    }
+                    .disabled(store.isSyncing)
+
+                    if let lastSyncAt = store.response?.sync?.lastSuccessAt {
+                        LabeledContent("Last successful sync") {
+                            Text(Date(timeIntervalSince1970: TimeInterval(lastSyncAt) / 1_000), style: .relative)
+                        }
+                    }
+                    if let error = store.response?.sync?.lastError, !error.isEmpty {
+                        Text(error).font(.caption).foregroundStyle(.orange)
+                    }
+                } header: {
+                    Text("Bookmark Sync")
+                } footer: {
+                    Text("X applies API limits and Zine enforces a cooldown between manual syncs.")
+                }
+            } else {
+                Section {
+                    ContentUnavailableView(
+                        "X isn’t connected",
+                        systemImage: SubscriptionSource.x.systemImage,
+                        description: Text("Connect X to import bookmarks into your Zine library.")
+                    )
+                }
+            }
+        }
+        .refreshable { await store.reload() }
+    }
+
+    private var connectionLabel: String {
+        if store.response?.connection?.isActive == true { return "Connected" }
+        if store.response?.connection?.needsAttention == true { return "Needs attention" }
+        return "Not connected"
+    }
+
+    private var connectionColor: Color {
+        if store.response?.connection?.isActive == true { return .green }
+        if store.response?.connection?.needsAttention == true { return .orange }
+        return .secondary
+    }
+
+    private var messageBinding: Binding<Bool> {
+        Binding(
+            get: { store.actionMessage != nil },
+            set: { if !$0 { store.dismissMessage() } }
+        )
+    }
+}

--- a/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
+++ b/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+@testable import ZineNative
+
+struct SubscriptionSourcesTests {
+    @Test func buildsOAuthRequestsForEveryConnectedProvider() throws {
+        let app = AppConfiguration(
+            apiBaseURL: URL(string: "https://api.example.com")!,
+            clerkPublishableKey: "pk_test_value",
+            googleClientID: "12345.apps.googleusercontent.com",
+            spotifyClientID: "spotify-client",
+            xClientID: "x-client"
+        )
+        let pkce = try ProviderOAuth.generatePKCE()
+
+        for provider in [
+            SubscriptionSource.youtube,
+            .spotify,
+            .gmail,
+            .x,
+        ] {
+            let configuration = try ProviderOAuth.configuration(for: provider, app: app)
+            let url = try ProviderOAuth.authorizationURL(
+                configuration: configuration,
+                state: "\(provider.rawValue):12345678-1234-1234-1234-123456789012",
+                challenge: pkce.challenge
+            )
+            let values = queryValues(url)
+
+            #expect(values["client_id"] == configuration.clientID)
+            #expect(values["redirect_uri"] == configuration.redirectUri.absoluteString)
+            #expect(values["code_challenge_method"] == "S256")
+            #expect(values["scope"] == configuration.scopes.joined(separator: " "))
+        }
+
+        #expect(pkce.verifier.count == 43)
+        #expect(!pkce.verifier.contains("="))
+    }
+
+    @Test func usesProviderSpecificScopesAndRedirects() throws {
+        let app = AppConfiguration(
+            apiBaseURL: URL(string: "https://api.example.com")!,
+            clerkPublishableKey: "pk_test_value",
+            googleClientID: "12345.apps.googleusercontent.com",
+            spotifyClientID: "spotify-client",
+            xClientID: "x-client"
+        )
+
+        let youtube = try ProviderOAuth.configuration(for: .youtube, app: app)
+        let gmail = try ProviderOAuth.configuration(for: .gmail, app: app)
+        let spotify = try ProviderOAuth.configuration(for: .spotify, app: app)
+        let x = try ProviderOAuth.configuration(for: .x, app: app)
+
+        #expect(youtube.redirectUri.absoluteString == "com.googleusercontent.apps.12345:/oauth2redirect")
+        #expect(youtube.scopes.contains { $0.contains("youtube.readonly") })
+        #expect(gmail.scopes.contains { $0.contains("gmail.readonly") })
+        #expect(spotify.redirectUri.absoluteString == "zine://oauth/callback")
+        #expect(spotify.scopes == ["user-library-read"])
+        #expect(x.scopes.contains("bookmark.read"))
+        #expect(x.scopes.contains("offline.access"))
+    }
+
+    @Test func validatesOAuthCallbackState() throws {
+        let callback = URL(string: "zine://oauth/callback?code=auth-code&state=expected")!
+
+        #expect(
+            try ProviderOAuth.parseCallback(callback, expectedState: "expected")
+                == ProviderOAuth.Callback(code: "auth-code", state: "expected")
+        )
+        #expect(throws: ProviderOAuthError.self) {
+            try ProviderOAuth.parseCallback(callback, expectedState: "different")
+        }
+    }
+
+    @Test func decodesSubscriptionHubAndProviderItems() throws {
+        let hub = try JSONDecoder().decode(
+            SubscriptionsHubResponse.self,
+            from: Data(
+                """
+                {"sources":[
+                  {"provider":"YOUTUBE","connectionStatus":"ACTIVE","activeCount":2},
+                  {"provider":"RSS","connectionStatus":null,"activeCount":1}
+                ]}
+                """.utf8
+            )
+        )
+        let provider = try JSONDecoder().decode(
+            ProviderSubscriptionsResponse.self,
+            from: Data(
+                """
+                {
+                  "connection":{"status":"ACTIVE","providerUserId":"user","connectedAt":100,"lastRefreshedAt":200},
+                  "connectionRequired":false,
+                  "items":[{
+                    "subscriptionId":"sub-1","channelId":"source-1","name":"Active Source",
+                    "imageUrl":null,"status":"ACTIVE","isSubscribed":true,"lastPolledAt":300
+                  }]
+                }
+                """.utf8
+            )
+        )
+
+        #expect(hub.sources[0].provider == .youtube)
+        #expect(hub.sources[0].statusText == "Connected · 2 channels")
+        #expect(hub.sources[1].statusText == "1 feed")
+        #expect(provider.connection?.isActive == true)
+        #expect(provider.items[0].status == .active)
+    }
+
+    @MainActor
+    @Test func providerStoreReloadsAfterAddingAnItem() async {
+        let item = ProviderSubscriptionItem(
+            subscriptionId: nil,
+            channelId: "show-1",
+            name: "Show One",
+            imageUrl: nil,
+            status: nil,
+            isSubscribed: false,
+            lastPolledAt: nil
+        )
+        let subscribed = ProviderSubscriptionItem(
+            subscriptionId: "sub-1",
+            channelId: item.channelId,
+            name: item.name,
+            imageUrl: nil,
+            status: .active,
+            isSubscribed: true,
+            lastPolledAt: nil
+        )
+        let recorder = SubscriptionClientRecorder(
+            responses: [response(items: [item]), response(items: [subscribed])]
+        )
+        let store = ProviderSubscriptionsStore(provider: .spotify, client: recorder.client)
+
+        await store.reload()
+        await store.add(item)
+
+        #expect(store.items == [subscribed])
+        #expect(await recorder.addedIDs == [item.channelId])
+    }
+
+    private func response(items: [ProviderSubscriptionItem]) -> ProviderSubscriptionsResponse {
+        ProviderSubscriptionsResponse(
+            connection: ProviderConnection(
+                status: "ACTIVE",
+                providerUserId: "provider-user",
+                connectedAt: 100,
+                lastRefreshedAt: 200
+            ),
+            connectionRequired: false,
+            items: items
+        )
+    }
+
+    private func queryValues(_ url: URL) -> [String: String] {
+        let query = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        return Dictionary(uniqueKeysWithValues: (query?.queryItems ?? []).compactMap {
+            item in item.value.map { (item.name, $0) }
+        })
+    }
+}
+
+private actor SubscriptionClientRecorder {
+    private var responses: [ProviderSubscriptionsResponse]
+    private(set) var addedIDs: [String] = []
+
+    init(responses: [ProviderSubscriptionsResponse]) {
+        self.responses = responses
+    }
+
+    nonisolated var client: ProviderSubscriptionsClient {
+        ProviderSubscriptionsClient(
+            load: { [self] in await nextResponse() },
+            add: { [self] item in await recordAdd(item.channelId) },
+            remove: { _ in },
+            setPaused: { _, _ in },
+            sync: { _ in SubscriptionSyncResponse(itemsFound: 0) },
+            connect: {},
+            disconnect: {}
+        )
+    }
+
+    private func nextResponse() -> ProviderSubscriptionsResponse { responses.removeFirst() }
+    private func recordAdd(_ id: String) { addedIDs.append(id) }
+}

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.2.0",
-    "description": "REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, and subscription sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
+    "version": "1.5.0",
+    "description": "REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
     {
@@ -35,6 +35,10 @@
     {
       "name": "Reading",
       "description": "Article content, opened events, and reading/playback progress."
+    },
+    {
+      "name": "Subscriptions",
+      "description": "Manage provider subscriptions. The current REST surface is scoped to YouTube."
     },
     {
       "name": "Sync",
@@ -901,6 +905,671 @@
         }
       }
     },
+    "/api/v1/subscriptions": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "listSubscriptionSources",
+        "summary": "List subscription sources and status summaries",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": { "description": "YouTube, Spotify, Gmail, X, and RSS source summaries." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify/connection/state": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "registerSpotifyOAuthState",
+        "summary": "Register Spotify OAuth state",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthState" },
+        "responses": {
+          "200": { "description": "OAuth state registered." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify/connection/callback": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "completeSpotifyOAuth",
+        "summary": "Complete Spotify OAuth",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthCallback" },
+        "responses": {
+          "200": { "description": "Spotify connected." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify/connection": {
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "disconnectSpotify",
+        "summary": "Disconnect Spotify",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "Spotify disconnected." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "listSpotifySubscriptions",
+        "summary": "List current and available Spotify shows",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "responses": {
+          "200": { "description": "Spotify connection and show subscription state." },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      },
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "addSpotifySubscription",
+        "summary": "Add a Spotify show",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/ProviderSubscription" },
+        "responses": {
+          "201": { "description": "Spotify show added." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify/{subscriptionId}": {
+      "parameters": [{ "$ref": "#/components/parameters/SubscriptionId" }],
+      "patch": {
+        "tags": ["Subscriptions"],
+        "operationId": "updateSpotifySubscription",
+        "summary": "Pause or resume a Spotify show",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/PauseResume" },
+        "responses": {
+          "200": { "description": "Subscription updated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "removeSpotifySubscription",
+        "summary": "Remove a Spotify show",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "Subscription removed." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/spotify/{subscriptionId}/sync": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "syncSpotifySubscription",
+        "summary": "Sync a Spotify show now",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "parameters": [{ "$ref": "#/components/parameters/SubscriptionId" }],
+        "responses": {
+          "200": { "description": "Subscription synced." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail/connection/state": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "registerGmailOAuthState",
+        "summary": "Register Gmail OAuth state",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthState" },
+        "responses": {
+          "200": { "description": "OAuth state registered." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail/connection/callback": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "completeGmailOAuth",
+        "summary": "Complete Gmail OAuth",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthCallback" },
+        "responses": {
+          "200": { "description": "Gmail connected and newsletter discovery started." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail/connection": {
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "disconnectGmail",
+        "summary": "Disconnect Gmail",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "Gmail disconnected." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "listNewsletters",
+        "summary": "List Gmail newsletters",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "responses": {
+          "200": { "description": "Gmail connection, newsletter list, and statistics." },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail/{feedId}": {
+      "parameters": [{ "$ref": "#/components/parameters/FeedId" }],
+      "patch": {
+        "tags": ["Subscriptions"],
+        "operationId": "updateNewsletter",
+        "summary": "Activate or hide a newsletter",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/NewsletterAction" },
+        "responses": {
+          "200": { "description": "Newsletter updated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "unsubscribeNewsletter",
+        "summary": "Unsubscribe from a newsletter",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "Unsubscribe requested." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/gmail/sync": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "syncNewsletters",
+        "summary": "Sync Gmail newsletters now",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "Newsletter sync completed." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "412": { "description": "Gmail is not connected." }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x/connection/state": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "registerXOAuthState",
+        "summary": "Register X OAuth state",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthState" },
+        "responses": {
+          "200": { "description": "OAuth state registered." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x/connection/callback": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "completeXOAuth",
+        "summary": "Complete X OAuth",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/OAuthCallback" },
+        "responses": {
+          "200": { "description": "X connected." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x/connection": {
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "disconnectX",
+        "summary": "Disconnect X",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "X disconnected." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "getXBookmarkStatus",
+        "summary": "Get X bookmark sync status",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "responses": {
+          "200": { "description": "X connection, imported count, and sync state." },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x/settings": {
+      "patch": {
+        "tags": ["Subscriptions"],
+        "operationId": "updateXBookmarkSettings",
+        "summary": "Enable or disable daily X bookmark sync",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["dailySyncEnabled"],
+                "additionalProperties": false,
+                "properties": { "dailySyncEnabled": { "type": "boolean" } }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "X bookmark settings updated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/x/sync": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "syncXBookmarks",
+        "summary": "Sync X bookmarks now",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "X bookmark sync completed." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "412": { "description": "X is not connected." },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/rss": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "listRssSubscriptions",
+        "summary": "List RSS feeds",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "responses": {
+          "200": { "description": "RSS feed list and statistics." },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      },
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "addRssSubscription",
+        "summary": "Add an RSS feed",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["feedUrl"],
+                "additionalProperties": false,
+                "properties": {
+                  "feedUrl": { "type": "string", "minLength": 1 },
+                  "seedMode": { "type": "string", "enum": ["latest", "none"] }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "RSS feed added and validated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "412": { "description": "Feed validation failed." }
+        }
+      }
+    },
+    "/api/v1/subscriptions/rss/{feedId}": {
+      "parameters": [{ "$ref": "#/components/parameters/FeedId" }],
+      "patch": {
+        "tags": ["Subscriptions"],
+        "operationId": "updateRssSubscription",
+        "summary": "Pause or resume an RSS feed",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "requestBody": { "$ref": "#/components/requestBodies/PauseResume" },
+        "responses": {
+          "200": { "description": "RSS feed updated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "removeRssSubscription",
+        "summary": "Remove an RSS feed",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "responses": {
+          "200": { "description": "RSS feed removed." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/rss/{feedId}/sync": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "syncRssSubscription",
+        "summary": "Sync an RSS feed now",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "parameters": [{ "$ref": "#/components/parameters/FeedId" }],
+        "responses": {
+          "200": { "description": "RSS feed synced." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube/connection/state": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "registerYouTubeOAuthState",
+        "summary": "Register a YouTube OAuth state value",
+        "description": "Stores a one-time CSRF state value before the native client opens Google authorization.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["state"],
+                "additionalProperties": false,
+                "properties": {
+                  "state": { "type": "string", "minLength": 32, "maxLength": 128 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "OAuth state registered." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube/connection/callback": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "completeYouTubeOAuth",
+        "summary": "Complete YouTube OAuth",
+        "description": "Validates state, exchanges the authorization code using PKCE, and stores the encrypted provider connection.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["code", "state", "codeVerifier", "redirectUri"],
+                "additionalProperties": false,
+                "properties": {
+                  "code": { "type": "string", "minLength": 1 },
+                  "state": { "type": "string", "minLength": 32, "maxLength": 128 },
+                  "codeVerifier": { "type": "string", "minLength": 43, "maxLength": 128 },
+                  "redirectUri": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "YouTube connected." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube/connection": {
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "disconnectYouTube",
+        "summary": "Disconnect YouTube",
+        "description": "Revokes the provider token when possible, removes the encrypted connection, and marks YouTube subscriptions disconnected.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "responses": {
+          "200": { "description": "YouTube disconnected." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube": {
+      "get": {
+        "tags": ["Subscriptions"],
+        "operationId": "listYouTubeSubscriptions",
+        "summary": "List current and available YouTube channels",
+        "description": "Returns Zine's current YouTube subscriptions together with followed YouTube channels that can be added.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "YouTube connection and subscription state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["connection", "connectionRequired", "items", "requestId", "traceId"],
+                  "properties": {
+                    "connection": {
+                      "oneOf": [
+                        { "type": "null" },
+                        {
+                          "type": "object",
+                          "required": ["status", "connectedAt"],
+                          "properties": {
+                            "status": { "type": "string" },
+                            "providerUserId": { "type": ["string", "null"] },
+                            "connectedAt": { "type": "integer" },
+                            "lastRefreshedAt": { "type": ["integer", "null"] }
+                          }
+                        }
+                      ]
+                    },
+                    "connectionRequired": { "type": "boolean" },
+                    "items": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/YouTubeSubscription" }
+                    },
+                    "requestId": { "type": "string" },
+                    "traceId": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      },
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "addYouTubeSubscription",
+        "summary": "Add a YouTube channel",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["channelId"],
+                "additionalProperties": false,
+                "properties": {
+                  "channelId": { "type": "string", "minLength": 1 },
+                  "name": { "type": "string", "minLength": 1 },
+                  "imageUrl": { "type": "string", "format": "uri" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "Subscription added." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "412": { "description": "YouTube is not connected." }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube/{subscriptionId}": {
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "patch": {
+        "tags": ["Subscriptions"],
+        "operationId": "updateYouTubeSubscription",
+        "summary": "Pause or resume a YouTube subscription",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["action"],
+                "additionalProperties": false,
+                "properties": {
+                  "action": { "type": "string", "enum": ["pause", "resume"] }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Subscription updated." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "412": { "description": "YouTube is not connected." }
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "operationId": "removeYouTubeSubscription",
+        "summary": "Remove a YouTube subscription",
+        "description": "Stops future ingestion, removes subscription-created inbox items, and preserves bookmarks.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "responses": {
+          "200": { "description": "Subscription removed." },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/subscriptions/youtube/{subscriptionId}/sync": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "operationId": "syncYouTubeSubscription",
+        "summary": "Sync one YouTube subscription now",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["sync:write"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Subscription synced." },
+          "400": { "$ref": "#/components/responses/ValidationError" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "412": { "description": "YouTube is not connected." },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
     "/api/v1/sync-jobs": {
       "post": {
         "tags": ["Sync"],
@@ -1040,7 +1709,101 @@
         "description": "Use a Clerk session JWT for a signed-in Zine user, or a Zine personal access token with the required operation scope."
       }
     },
+    "requestBodies": {
+      "OAuthState": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["state"],
+              "additionalProperties": false,
+              "properties": {
+                "state": { "type": "string", "minLength": 32, "maxLength": 128 }
+              }
+            }
+          }
+        }
+      },
+      "OAuthCallback": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["code", "state", "codeVerifier", "redirectUri"],
+              "additionalProperties": false,
+              "properties": {
+                "code": { "type": "string", "minLength": 1 },
+                "state": { "type": "string", "minLength": 32, "maxLength": 128 },
+                "codeVerifier": { "type": "string", "minLength": 43, "maxLength": 128 },
+                "redirectUri": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        }
+      },
+      "ProviderSubscription": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["channelId"],
+              "additionalProperties": false,
+              "properties": {
+                "channelId": { "type": "string", "minLength": 1 },
+                "name": { "type": "string", "minLength": 1 },
+                "imageUrl": { "type": "string", "format": "uri" }
+              }
+            }
+          }
+        }
+      },
+      "PauseResume": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["action"],
+              "additionalProperties": false,
+              "properties": {
+                "action": { "type": "string", "enum": ["pause", "resume"] }
+              }
+            }
+          }
+        }
+      },
+      "NewsletterAction": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": ["action"],
+              "additionalProperties": false,
+              "properties": {
+                "action": { "type": "string", "enum": ["activate", "hide"] }
+              }
+            }
+          }
+        }
+      }
+    },
     "parameters": {
+      "SubscriptionId": {
+        "name": "subscriptionId",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string" }
+      },
+      "FeedId": {
+        "name": "feedId",
+        "in": "path",
+        "required": true,
+        "schema": { "type": "string" }
+      },
       "Limit": {
         "name": "limit",
         "in": "query",
@@ -1786,6 +2549,30 @@
             }
           }
         ]
+      },
+      "YouTubeSubscription": {
+        "type": "object",
+        "required": [
+          "subscriptionId",
+          "channelId",
+          "name",
+          "imageUrl",
+          "status",
+          "isSubscribed",
+          "lastPolledAt"
+        ],
+        "properties": {
+          "subscriptionId": { "type": ["string", "null"] },
+          "channelId": { "type": "string" },
+          "name": { "type": "string" },
+          "imageUrl": { "type": ["string", "null"], "format": "uri" },
+          "status": {
+            "type": ["string", "null"],
+            "enum": ["ACTIVE", "PAUSED", "DISCONNECTED", null]
+          },
+          "isSubscribed": { "type": "boolean" },
+          "lastPolledAt": { "type": ["integer", "null"] }
+        }
       },
       "CreateSyncJobRequest": {
         "type": "object",

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -25,6 +25,32 @@ const {
   mockListTags,
   mockPreview,
   mockSave,
+  mockConnectionsList,
+  mockConnectionsRegisterState,
+  mockConnectionsCallback,
+  mockConnectionsDisconnect,
+  mockSubscriptionsList,
+  mockSubscriptionsDiscover,
+  mockSubscriptionsAdd,
+  mockSubscriptionsRemove,
+  mockSubscriptionsPause,
+  mockSubscriptionsResume,
+  mockSubscriptionsSyncNow,
+  mockNewslettersList,
+  mockNewslettersStats,
+  mockNewslettersUpdateStatus,
+  mockNewslettersUnsubscribe,
+  mockNewslettersSyncNow,
+  mockRssList,
+  mockRssStats,
+  mockRssAdd,
+  mockRssRemove,
+  mockRssPause,
+  mockRssResume,
+  mockRssSyncNow,
+  mockXBookmarksStatus,
+  mockXBookmarksUpdateSettings,
+  mockXBookmarksSyncNow,
   mockInitiateSyncJob,
   mockGetActiveSyncJob,
   mockGetJobStatus,
@@ -52,6 +78,32 @@ const {
   mockListTags: vi.fn(),
   mockPreview: vi.fn(),
   mockSave: vi.fn(),
+  mockConnectionsList: vi.fn(),
+  mockConnectionsRegisterState: vi.fn(),
+  mockConnectionsCallback: vi.fn(),
+  mockConnectionsDisconnect: vi.fn(),
+  mockSubscriptionsList: vi.fn(),
+  mockSubscriptionsDiscover: vi.fn(),
+  mockSubscriptionsAdd: vi.fn(),
+  mockSubscriptionsRemove: vi.fn(),
+  mockSubscriptionsPause: vi.fn(),
+  mockSubscriptionsResume: vi.fn(),
+  mockSubscriptionsSyncNow: vi.fn(),
+  mockNewslettersList: vi.fn(),
+  mockNewslettersStats: vi.fn(),
+  mockNewslettersUpdateStatus: vi.fn(),
+  mockNewslettersUnsubscribe: vi.fn(),
+  mockNewslettersSyncNow: vi.fn(),
+  mockRssList: vi.fn(),
+  mockRssStats: vi.fn(),
+  mockRssAdd: vi.fn(),
+  mockRssRemove: vi.fn(),
+  mockRssPause: vi.fn(),
+  mockRssResume: vi.fn(),
+  mockRssSyncNow: vi.fn(),
+  mockXBookmarksStatus: vi.fn(),
+  mockXBookmarksUpdateSettings: vi.fn(),
+  mockXBookmarksSyncNow: vi.fn(),
   mockInitiateSyncJob: vi.fn(),
   mockGetActiveSyncJob: vi.fn(),
   mockGetJobStatus: vi.fn(),
@@ -199,6 +251,39 @@ describe('apiV1Routes', () => {
       userId: 'clerk_user_123',
       payload: { sub: 'clerk_user_123' },
     });
+    mockConnectionsList.mockResolvedValue({
+      YOUTUBE: null,
+      SPOTIFY: null,
+      GMAIL: null,
+      X: null,
+    });
+    mockSubscriptionsList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    mockSubscriptionsDiscover.mockResolvedValue({ items: [], connectionRequired: true });
+    mockNewslettersList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    mockNewslettersStats.mockResolvedValue({
+      total: 0,
+      active: 0,
+      hidden: 0,
+      unsubscribed: 0,
+      lastSyncAt: null,
+      lastSyncStatus: 'IDLE',
+      lastSyncError: null,
+    });
+    mockRssList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
+    mockRssStats.mockResolvedValue({
+      total: 0,
+      active: 0,
+      paused: 0,
+      unsubscribed: 0,
+      error: 0,
+      lastSuccessAt: null,
+    });
+    mockXBookmarksStatus.mockResolvedValue({
+      connected: false,
+      connectionStatus: null,
+      importedCount: 0,
+      sync: null,
+    });
     mockCreateCaller.mockReturnValue({
       items: {
         inbox: mockInbox,
@@ -216,6 +301,42 @@ describe('apiV1Routes', () => {
       bookmarks: {
         preview: mockPreview,
         save: mockSave,
+      },
+      subscriptions: {
+        connections: {
+          list: mockConnectionsList,
+          registerState: mockConnectionsRegisterState,
+          callback: mockConnectionsCallback,
+          disconnect: mockConnectionsDisconnect,
+        },
+        list: mockSubscriptionsList,
+        discover: { available: mockSubscriptionsDiscover },
+        add: mockSubscriptionsAdd,
+        remove: mockSubscriptionsRemove,
+        pause: mockSubscriptionsPause,
+        resume: mockSubscriptionsResume,
+        syncNow: mockSubscriptionsSyncNow,
+        newsletters: {
+          list: mockNewslettersList,
+          stats: mockNewslettersStats,
+          updateStatus: mockNewslettersUpdateStatus,
+          unsubscribe: mockNewslettersUnsubscribe,
+          syncNow: mockNewslettersSyncNow,
+        },
+        rss: {
+          list: mockRssList,
+          stats: mockRssStats,
+          add: mockRssAdd,
+          remove: mockRssRemove,
+          pause: mockRssPause,
+          resume: mockRssResume,
+          syncNow: mockRssSyncNow,
+        },
+        xBookmarks: {
+          status: mockXBookmarksStatus,
+          updateSettings: mockXBookmarksUpdateSettings,
+          syncNow: mockXBookmarksSyncNow,
+        },
       },
     });
   });
@@ -246,6 +367,532 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/sync-jobs');
     expect(body.paths).toHaveProperty('/api/v1/sync-jobs/{jobId}');
     expect(body.paths).toHaveProperty('/api/v1/sync-jobs/active');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/connection');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/spotify');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/spotify/connection/callback');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/gmail');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/gmail/connection/callback');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/x');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/x/connection/callback');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/rss');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/connection/state');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/connection/callback');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}');
+    expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}/sync');
+  });
+
+  it('lists current and available YouTube subscriptions for a Clerk session', async () => {
+    mockConnectionsList.mockResolvedValue({
+      YOUTUBE: {
+        status: 'ACTIVE',
+        providerUserId: 'youtube_user',
+        connectedAt: 100,
+        lastRefreshedAt: 200,
+      },
+    });
+    mockSubscriptionsList.mockResolvedValue({
+      items: [
+        {
+          id: 'sub_1',
+          providerChannelId: 'channel_1',
+          name: 'Subscribed Channel',
+          imageUrl: 'https://example.com/subscribed.jpg',
+          status: 'ACTIVE',
+          lastPolledAt: 300,
+        },
+        {
+          id: 'sub_old',
+          providerChannelId: 'channel_old',
+          name: 'Old Channel',
+          imageUrl: null,
+          status: 'UNSUBSCRIBED',
+          lastPolledAt: null,
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
+    mockSubscriptionsDiscover.mockResolvedValue({
+      items: [
+        {
+          id: 'channel_2',
+          name: 'Available Channel',
+          imageUrl: 'https://example.com/available.jpg',
+          isSubscribed: false,
+        },
+      ],
+      connectionRequired: false,
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube', {
+        headers: { Authorization: 'Bearer clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      connection: { status: 'ACTIVE', providerUserId: 'youtube_user' },
+      connectionRequired: false,
+      items: [
+        { channelId: 'channel_2', isSubscribed: false },
+        { subscriptionId: 'sub_1', channelId: 'channel_1', isSubscribed: true },
+      ],
+    });
+    expect(mockSubscriptionsList).toHaveBeenCalledWith({
+      provider: Provider.YOUTUBE,
+      limit: 100,
+      cursor: undefined,
+    });
+    expect(mockSubscriptionsDiscover).toHaveBeenCalledWith({ provider: Provider.YOUTUBE });
+  });
+
+  it('registers and completes a YouTube OAuth connection', async () => {
+    mockConnectionsRegisterState.mockResolvedValue({ success: true });
+    mockConnectionsCallback.mockResolvedValue({ success: true });
+    const app = createTestApp();
+    const state = `YOUTUBE:${'a'.repeat(36)}`;
+    const headers = {
+      Authorization: 'Bearer clerk-session-jwt',
+      'Content-Type': 'application/json',
+    };
+
+    const stateResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube/connection/state', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ state }),
+      }),
+      createMockEnv()
+    );
+    const callbackResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube/connection/callback', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          code: 'authorization-code',
+          state,
+          codeVerifier: 'v'.repeat(43),
+          redirectUri: 'com.googleusercontent.apps.test:/oauth2redirect',
+        }),
+      }),
+      createMockEnv()
+    );
+
+    expect(stateResponse.status).toBe(200);
+    expect(callbackResponse.status).toBe(200);
+    expect(mockConnectionsRegisterState).toHaveBeenCalledWith({
+      provider: Provider.YOUTUBE,
+      state,
+    });
+    expect(mockConnectionsCallback).toHaveBeenCalledWith({
+      provider: Provider.YOUTUBE,
+      code: 'authorization-code',
+      state,
+      codeVerifier: 'v'.repeat(43),
+      redirectUri: 'com.googleusercontent.apps.test:/oauth2redirect',
+    });
+  });
+
+  it('disconnects YouTube without accepting a provider from the client', async () => {
+    mockConnectionsDisconnect.mockResolvedValue({ success: true });
+    const app = createTestApp();
+
+    const response = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube/connection', {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockConnectionsDisconnect).toHaveBeenCalledWith({ provider: Provider.YOUTUBE });
+  });
+
+  it('returns one subscription hub summary across all supported sources', async () => {
+    mockConnectionsList.mockResolvedValue({
+      YOUTUBE: { status: 'ACTIVE' },
+      SPOTIFY: null,
+      GMAIL: { status: 'EXPIRED' },
+      X: { status: 'ACTIVE' },
+    });
+    mockSubscriptionsList.mockImplementation(async (input: { provider: Provider }) => ({
+      items: input.provider === Provider.YOUTUBE ? [{ id: 'youtube-1' }] : [],
+      nextCursor: null,
+      hasMore: false,
+    }));
+    mockNewslettersStats.mockResolvedValue({ active: 3 });
+    mockRssStats.mockResolvedValue({ active: 2 });
+    mockXBookmarksStatus.mockResolvedValue({ importedCount: 7 });
+    const app = createTestApp();
+
+    const response = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions', {
+        headers: { Authorization: 'Bearer clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sources: [
+        { provider: 'YOUTUBE', connectionStatus: 'ACTIVE', activeCount: 1 },
+        { provider: 'SPOTIFY', connectionStatus: null, activeCount: 0 },
+        { provider: 'GMAIL', connectionStatus: 'EXPIRED', activeCount: 3 },
+        { provider: 'X', connectionStatus: 'ACTIVE', activeCount: 7 },
+        { provider: 'RSS', connectionStatus: null, activeCount: 2 },
+      ],
+    });
+  });
+
+  it('registers, completes, and disconnects Spotify OAuth using a server-owned provider', async () => {
+    mockConnectionsRegisterState.mockResolvedValue({ success: true });
+    mockConnectionsCallback.mockResolvedValue({ success: true });
+    mockConnectionsDisconnect.mockResolvedValue({ success: true });
+    const app = createTestApp();
+    const state = `SPOTIFY:${'a'.repeat(36)}`;
+    const headers = {
+      Authorization: 'Bearer clerk-session-jwt',
+      'Content-Type': 'application/json',
+    };
+
+    const stateResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/spotify/connection/state', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ state }),
+      }),
+      createMockEnv()
+    );
+    const callbackResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/spotify/connection/callback', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          code: 'spotify-code',
+          state,
+          codeVerifier: 'v'.repeat(43),
+          redirectUri: 'zine://oauth/callback',
+        }),
+      }),
+      createMockEnv()
+    );
+    const disconnectResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/spotify/connection', {
+        method: 'DELETE',
+        headers,
+      }),
+      createMockEnv()
+    );
+
+    expect(stateResponse.status).toBe(200);
+    expect(callbackResponse.status).toBe(200);
+    expect(disconnectResponse.status).toBe(200);
+    expect(mockConnectionsRegisterState).toHaveBeenCalledWith({
+      provider: Provider.SPOTIFY,
+      state,
+    });
+    expect(mockConnectionsCallback).toHaveBeenCalledWith({
+      provider: Provider.SPOTIFY,
+      code: 'spotify-code',
+      state,
+      codeVerifier: 'v'.repeat(43),
+      redirectUri: 'zine://oauth/callback',
+    });
+    expect(mockConnectionsDisconnect).toHaveBeenCalledWith({ provider: Provider.SPOTIFY });
+  });
+
+  it('manages Spotify shows through the shared subscription procedures', async () => {
+    mockConnectionsList.mockResolvedValue({
+      YOUTUBE: null,
+      SPOTIFY: { status: 'ACTIVE', providerUserId: 'spotify-user' },
+      GMAIL: null,
+      X: null,
+    });
+    mockSubscriptionsDiscover.mockResolvedValue({
+      items: [{ id: 'show-1', name: 'A Show', imageUrl: null }],
+      connectionRequired: false,
+    });
+    mockSubscriptionsAdd.mockResolvedValue({ subscriptionId: 'sub-1' });
+    const app = createTestApp();
+    const auth = { Authorization: 'Bearer clerk-session-jwt' };
+
+    const listResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/spotify', { headers: auth }),
+      createMockEnv()
+    );
+    const addResponse = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/spotify', {
+        method: 'POST',
+        headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ channelId: 'show-1', name: 'A Show' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(await listResponse.json()).toMatchObject({
+      connection: { status: 'ACTIVE' },
+      items: [{ channelId: 'show-1', isSubscribed: false }],
+    });
+    expect(addResponse.status).toBe(201);
+    expect(mockSubscriptionsAdd).toHaveBeenCalledWith({
+      provider: Provider.SPOTIFY,
+      providerChannelId: 'show-1',
+      name: 'A Show',
+      imageUrl: undefined,
+    });
+  });
+
+  it('manages Gmail newsletters through REST', async () => {
+    mockNewslettersList.mockResolvedValue({
+      items: [{ id: 'feed-1', displayName: 'Daily Letter', status: 'ACTIVE' }],
+      nextCursor: null,
+      hasMore: false,
+    });
+    mockNewslettersUpdateStatus.mockResolvedValue({ success: true });
+    mockNewslettersUnsubscribe.mockResolvedValue({ success: true });
+    mockNewslettersSyncNow.mockResolvedValue({ success: true });
+    const app = createTestApp();
+    const auth = { Authorization: 'Bearer clerk-session-jwt' };
+
+    const list = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/gmail', { headers: auth }),
+      createMockEnv()
+    );
+    const hide = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/gmail/feed-1', {
+        method: 'PATCH',
+        headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'hide' }),
+      }),
+      createMockEnv()
+    );
+    const unsubscribe = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/gmail/feed-1', {
+        method: 'DELETE',
+        headers: auth,
+      }),
+      createMockEnv()
+    );
+    const sync = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/gmail/sync', {
+        method: 'POST',
+        headers: auth,
+      }),
+      createMockEnv()
+    );
+
+    expect([list.status, hide.status, unsubscribe.status, sync.status]).toEqual([
+      200, 200, 200, 200,
+    ]);
+    expect(mockNewslettersUpdateStatus).toHaveBeenCalledWith({
+      feedId: 'feed-1',
+      status: 'HIDDEN',
+    });
+    expect(mockNewslettersUnsubscribe).toHaveBeenCalledWith({ feedId: 'feed-1' });
+    expect(mockNewslettersSyncNow).toHaveBeenCalled();
+  });
+
+  it('manages RSS feeds through REST', async () => {
+    mockRssAdd.mockResolvedValue({ id: 'rss-1', created: true });
+    mockRssPause.mockResolvedValue({ success: true });
+    mockRssRemove.mockResolvedValue({ success: true });
+    mockRssSyncNow.mockResolvedValue({ success: true, itemsFound: 2 });
+    const app = createTestApp();
+    const auth = { Authorization: 'Bearer clerk-session-jwt' };
+
+    const add = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/rss', {
+        method: 'POST',
+        headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ feedUrl: 'https://example.com/feed.xml', seedMode: 'latest' }),
+      }),
+      createMockEnv()
+    );
+    const pause = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/rss/rss-1', {
+        method: 'PATCH',
+        headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'pause' }),
+      }),
+      createMockEnv()
+    );
+    const sync = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/rss/rss-1/sync', {
+        method: 'POST',
+        headers: auth,
+      }),
+      createMockEnv()
+    );
+    const remove = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/rss/rss-1', {
+        method: 'DELETE',
+        headers: auth,
+      }),
+      createMockEnv()
+    );
+
+    expect([add.status, pause.status, sync.status, remove.status]).toEqual([201, 200, 200, 200]);
+    expect(mockRssAdd).toHaveBeenCalledWith({
+      feedUrl: 'https://example.com/feed.xml',
+      seedMode: 'latest',
+    });
+    expect(mockRssPause).toHaveBeenCalledWith({ feedId: 'rss-1' });
+    expect(mockRssSyncNow).toHaveBeenCalledWith({ feedId: 'rss-1' });
+    expect(mockRssRemove).toHaveBeenCalledWith({ feedId: 'rss-1' });
+  });
+
+  it('manages X bookmark sync through REST', async () => {
+    mockXBookmarksStatus.mockResolvedValue({
+      connected: true,
+      connectionStatus: 'ACTIVE',
+      importedCount: 4,
+      sync: { dailySyncEnabled: false },
+    });
+    mockXBookmarksUpdateSettings.mockResolvedValue({ success: true, dailySyncEnabled: true });
+    mockXBookmarksSyncNow.mockResolvedValue({ success: true });
+    const app = createTestApp();
+    const auth = { Authorization: 'Bearer clerk-session-jwt' };
+
+    const status = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/x', { headers: auth }),
+      createMockEnv()
+    );
+    const update = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/x/settings', {
+        method: 'PATCH',
+        headers: { ...auth, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dailySyncEnabled: true }),
+      }),
+      createMockEnv()
+    );
+    const sync = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/x/sync', {
+        method: 'POST',
+        headers: auth,
+      }),
+      createMockEnv()
+    );
+
+    expect([status.status, update.status, sync.status]).toEqual([200, 200, 200]);
+    expect(mockXBookmarksUpdateSettings).toHaveBeenCalledWith({ dailySyncEnabled: true });
+    expect(mockXBookmarksSyncNow).toHaveBeenCalled();
+  });
+
+  it('adds a YouTube subscription', async () => {
+    mockSubscriptionsAdd.mockResolvedValue({ id: 'sub_1', status: 'ACTIVE' });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer clerk-session-jwt',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          channelId: 'channel_1',
+          name: 'Channel One',
+          imageUrl: 'https://example.com/channel.jpg',
+        }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(201);
+    expect(mockSubscriptionsAdd).toHaveBeenCalledWith({
+      provider: Provider.YOUTUBE,
+      providerChannelId: 'channel_1',
+      name: 'Channel One',
+      imageUrl: 'https://example.com/channel.jpg',
+    });
+  });
+
+  it('explains when YouTube must be connected before adding a subscription', async () => {
+    mockSubscriptionsAdd.mockRejectedValue(
+      new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Not connected to YOUTUBE. Please connect your YOUTUBE account first.',
+      })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer clerk-session-jwt',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ channelId: 'channel_1' }),
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(412);
+    expect(await res.json()).toMatchObject({ code: 'PRECONDITION_FAILED' });
+  });
+
+  it('pauses, resumes, removes, and syncs a YouTube subscription', async () => {
+    mockSubscriptionsPause.mockResolvedValue({ success: true });
+    mockSubscriptionsResume.mockResolvedValue({ success: true });
+    mockSubscriptionsRemove.mockResolvedValue({ success: true });
+    mockSubscriptionsSyncNow.mockResolvedValue({ success: true, itemsFound: 2 });
+    const app = createTestApp();
+    const request = (path: string, method: string, body?: unknown) =>
+      app.fetch(
+        new Request(`http://localhost${path}`, {
+          method,
+          headers: {
+            Authorization: 'Bearer clerk-session-jwt',
+            ...(body ? { 'Content-Type': 'application/json' } : {}),
+          },
+          body: body ? JSON.stringify(body) : undefined,
+        }),
+        createMockEnv()
+      );
+
+    expect(
+      (await request('/api/v1/subscriptions/youtube/sub_1', 'PATCH', { action: 'pause' })).status
+    ).toBe(200);
+    expect(
+      (await request('/api/v1/subscriptions/youtube/sub_1', 'PATCH', { action: 'resume' })).status
+    ).toBe(200);
+    expect((await request('/api/v1/subscriptions/youtube/sub_1', 'DELETE')).status).toBe(200);
+    const sync = await request('/api/v1/subscriptions/youtube/sub_1/sync', 'POST');
+    expect(sync.status).toBe(200);
+    expect(await sync.json()).toMatchObject({ itemsFound: 2 });
+    expect(mockSubscriptionsPause).toHaveBeenCalledWith({ subscriptionId: 'sub_1' });
+    expect(mockSubscriptionsResume).toHaveBeenCalledWith({ subscriptionId: 'sub_1' });
+    expect(mockSubscriptionsRemove).toHaveBeenCalledWith({ subscriptionId: 'sub_1' });
+    expect(mockSubscriptionsSyncNow).toHaveBeenCalledWith({ subscriptionId: 'sub_1' });
+  });
+
+  it('returns a rate-limit response for repeated manual YouTube syncs', async () => {
+    mockSubscriptionsSyncNow.mockRejectedValue(
+      new TRPCError({
+        code: 'TOO_MANY_REQUESTS',
+        message: 'Please wait 5 minutes between manual syncs',
+      })
+    );
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/subscriptions/youtube/sub_1/sync', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer clerk-session-jwt' },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({ code: 'RATE_LIMITED' });
   });
 
   it('returns 401 for missing and invalid tokens', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -4,7 +4,13 @@ import { TRPCError } from '@trpc/server';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { ulid } from 'ulid';
-import { ContentTypeSchema, ProviderSchema, UserItemState } from '@zine/shared';
+import {
+  ContentTypeSchema,
+  Provider,
+  ProviderSchema,
+  SubscriptionStatus,
+  UserItemState,
+} from '@zine/shared';
 import { PublishEditorialEditionSchema } from '@zine/editorial-schema';
 import type { Env } from '../types';
 import { createDb } from '../db';
@@ -59,6 +65,60 @@ const BookmarkQuerySchema = z.object({
 });
 
 const SyncJobBodySchema = z.object({}).strict().optional();
+
+const AddProviderSubscriptionBodySchema = z
+  .object({
+    channelId: z.string().min(1),
+    name: z.string().min(1).optional(),
+    imageUrl: z.string().url().optional(),
+  })
+  .strict();
+
+const UpdateProviderSubscriptionBodySchema = z
+  .object({
+    action: z.enum(['pause', 'resume']),
+  })
+  .strict();
+
+const RegisterOAuthStateBodySchema = z
+  .object({
+    state: z.string().min(32).max(128),
+  })
+  .strict();
+
+const CompleteOAuthBodySchema = z
+  .object({
+    code: z.string().min(1),
+    state: z.string().min(32).max(128),
+    codeVerifier: z.string().min(43).max(128),
+    redirectUri: z.string().min(1),
+  })
+  .strict();
+
+const UpdateNewsletterBodySchema = z
+  .object({
+    action: z.enum(['activate', 'hide']),
+  })
+  .strict();
+
+const AddRssFeedBodySchema = z
+  .object({
+    feedUrl: z.string().min(1),
+    seedMode: z.enum(['latest', 'none']).optional(),
+  })
+  .strict();
+
+const UpdateRssFeedBodySchema = z
+  .object({
+    action: z.enum(['pause', 'resume']),
+  })
+  .strict();
+
+const UpdateXBookmarkSettingsBodySchema = z
+  .object({
+    dailySyncEnabled: z.boolean(),
+  })
+  .strict();
 
 const SetTagsBodySchema = z
   .object({
@@ -216,6 +276,30 @@ function trpcErrorResponse(c: Context<Env>, error: unknown) {
         401
       );
     }
+
+    if (error.code === 'PRECONDITION_FAILED') {
+      return c.json(
+        {
+          error: error.message,
+          code: 'PRECONDITION_FAILED',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        412
+      );
+    }
+
+    if (error.code === 'TOO_MANY_REQUESTS') {
+      return c.json(
+        {
+          error: error.message,
+          code: 'RATE_LIMITED',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        429
+      );
+    }
   }
 
   throw error;
@@ -304,6 +388,793 @@ function apiAuth(requiredPatScope: ApiTokenScope) {
 const apiV1Routes = new Hono<Env>();
 
 apiV1Routes.get('/openapi.json', (c) => c.json(openApiSpec));
+
+apiV1Routes.get('/subscriptions', apiAuth('sync:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const [connections, youtube, spotify, newsletters, rss, xBookmarks] = await Promise.all([
+      caller.subscriptions.connections.list(),
+      caller.subscriptions.list({
+        provider: Provider.YOUTUBE,
+        status: SubscriptionStatus.ACTIVE,
+        limit: 100,
+      }),
+      caller.subscriptions.list({
+        provider: Provider.SPOTIFY,
+        status: SubscriptionStatus.ACTIVE,
+        limit: 100,
+      }),
+      caller.subscriptions.newsletters.stats(),
+      caller.subscriptions.rss.stats(),
+      caller.subscriptions.xBookmarks.status(),
+    ]);
+
+    return c.json({
+      sources: [
+        {
+          provider: Provider.YOUTUBE,
+          connectionStatus: connections.YOUTUBE?.status ?? null,
+          activeCount: youtube.items.length,
+        },
+        {
+          provider: Provider.SPOTIFY,
+          connectionStatus: connections.SPOTIFY?.status ?? null,
+          activeCount: spotify.items.length,
+        },
+        {
+          provider: Provider.GMAIL,
+          connectionStatus: connections.GMAIL?.status ?? null,
+          activeCount: newsletters.active,
+        },
+        {
+          provider: Provider.X,
+          connectionStatus: connections.X?.status ?? null,
+          activeCount: xBookmarks.importedCount,
+        },
+        {
+          provider: Provider.RSS,
+          connectionStatus: null,
+          activeCount: rss.active,
+        },
+      ],
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/subscriptions/youtube', apiAuth('sync:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const connections = await caller.subscriptions.connections.list();
+    const subscriptionItems = [];
+    let cursor: string | undefined;
+
+    do {
+      const page = await caller.subscriptions.list({
+        provider: Provider.YOUTUBE,
+        limit: 100,
+        cursor,
+      });
+      subscriptionItems.push(...page.items);
+      cursor = page.hasMore && page.nextCursor ? page.nextCursor : undefined;
+    } while (cursor);
+
+    const discovery = await caller.subscriptions.discover.available({
+      provider: Provider.YOUTUBE,
+    });
+    const activeSubscriptions = subscriptionItems.filter(
+      (subscription) => subscription.status !== 'UNSUBSCRIBED'
+    );
+    const items = [
+      ...activeSubscriptions.map((subscription) => ({
+        subscriptionId: subscription.id,
+        channelId: subscription.providerChannelId,
+        name: subscription.name,
+        imageUrl: subscription.imageUrl,
+        status: subscription.status,
+        isSubscribed: true,
+        lastPolledAt: subscription.lastPolledAt,
+      })),
+      ...discovery.items.map((channel) => ({
+        subscriptionId: null,
+        channelId: channel.id,
+        name: channel.name,
+        imageUrl: channel.imageUrl ?? null,
+        status: null,
+        isSubscribed: false,
+        lastPolledAt: null,
+      })),
+    ].sort((left, right) => left.name.localeCompare(right.name));
+
+    return c.json({
+      connection: connections.YOUTUBE
+        ? {
+            status: connections.YOUTUBE.status,
+            providerUserId: connections.YOUTUBE.providerUserId,
+            connectedAt: connections.YOUTUBE.connectedAt,
+            lastRefreshedAt: connections.YOUTUBE.lastRefreshedAt,
+          }
+        : null,
+      connectionRequired: discovery.connectionRequired,
+      items,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/youtube/connection/state', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = RegisterOAuthStateBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.connections.registerState({
+      provider: Provider.YOUTUBE,
+      state: parsedBody.data.state,
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/youtube/connection/callback', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = CompleteOAuthBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.connections.callback({
+      provider: Provider.YOUTUBE,
+      ...parsedBody.data,
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.delete('/subscriptions/youtube/connection', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.connections.disconnect({
+      provider: Provider.YOUTUBE,
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/youtube', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = AddProviderSubscriptionBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.add({
+      provider: Provider.YOUTUBE,
+      providerChannelId: parsedBody.data.channelId,
+      name: parsedBody.data.name,
+      imageUrl: parsedBody.data.imageUrl,
+    });
+    return c.json(
+      {
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      201
+    );
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.patch('/subscriptions/youtube/:subscriptionId', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = UpdateProviderSubscriptionBodySchema.safeParse(body);
+
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  const input = { subscriptionId: c.req.param('subscriptionId') };
+  try {
+    const result =
+      parsedBody.data.action === 'pause'
+        ? await caller.subscriptions.pause(input)
+        : await caller.subscriptions.resume(input);
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.delete('/subscriptions/youtube/:subscriptionId', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.remove({
+      subscriptionId: c.req.param('subscriptionId'),
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post(
+  '/subscriptions/youtube/:subscriptionId/sync',
+  apiAuth('sync:write'),
+  async (c) => {
+    const caller = appRouter.createCaller(await createContext(c));
+    try {
+      const result = await caller.subscriptions.syncNow({
+        subscriptionId: c.req.param('subscriptionId'),
+      });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  }
+);
+
+type OAuthConnectionProvider = typeof Provider.SPOTIFY | typeof Provider.GMAIL | typeof Provider.X;
+
+function registerOAuthConnectionRoutes(slug: string, provider: OAuthConnectionProvider) {
+  apiV1Routes.post(`/subscriptions/${slug}/connection/state`, apiAuth('sync:write'), async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsedBody = RegisterOAuthStateBodySchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json(
+        {
+          error: 'Invalid request body',
+          code: 'INVALID_REQUEST_BODY',
+          issues: parsedBody.error.issues,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+
+    const caller = appRouter.createCaller(await createContext(c));
+    try {
+      const result = await caller.subscriptions.connections.registerState({
+        provider,
+        state: parsedBody.data.state,
+      });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+
+  apiV1Routes.post(
+    `/subscriptions/${slug}/connection/callback`,
+    apiAuth('sync:write'),
+    async (c) => {
+      const body = await c.req.json().catch(() => null);
+      const parsedBody = CompleteOAuthBodySchema.safeParse(body);
+
+      if (!parsedBody.success) {
+        return c.json(
+          {
+            error: 'Invalid request body',
+            code: 'INVALID_REQUEST_BODY',
+            issues: parsedBody.error.issues,
+            requestId: c.get('requestId'),
+            traceId: c.get('traceId'),
+          },
+          400
+        );
+      }
+
+      const caller = appRouter.createCaller(await createContext(c));
+      try {
+        const result = await caller.subscriptions.connections.callback({
+          provider,
+          ...parsedBody.data,
+        });
+        return c.json({
+          ...result,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        });
+      } catch (error) {
+        return trpcErrorResponse(c, error);
+      }
+    }
+  );
+
+  apiV1Routes.delete(`/subscriptions/${slug}/connection`, apiAuth('sync:write'), async (c) => {
+    const caller = appRouter.createCaller(await createContext(c));
+    try {
+      const result = await caller.subscriptions.connections.disconnect({ provider });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+}
+
+function registerManagedProviderRoutes(slug: string, provider: typeof Provider.SPOTIFY) {
+  apiV1Routes.get(`/subscriptions/${slug}`, apiAuth('sync:read'), async (c) => {
+    const caller = appRouter.createCaller(await createContext(c));
+
+    try {
+      const connections = await caller.subscriptions.connections.list();
+      const subscriptionItems = [];
+      let cursor: string | undefined;
+
+      do {
+        const page = await caller.subscriptions.list({ provider, limit: 100, cursor });
+        subscriptionItems.push(...page.items);
+        cursor = page.hasMore && page.nextCursor ? page.nextCursor : undefined;
+      } while (cursor);
+
+      const discovery = await caller.subscriptions.discover.available({ provider });
+      const activeSubscriptions = subscriptionItems.filter(
+        (subscription) => subscription.status !== 'UNSUBSCRIBED'
+      );
+      const items = [
+        ...activeSubscriptions.map((subscription) => ({
+          subscriptionId: subscription.id,
+          channelId: subscription.providerChannelId,
+          name: subscription.name,
+          imageUrl: subscription.imageUrl,
+          status: subscription.status,
+          isSubscribed: true,
+          lastPolledAt: subscription.lastPolledAt,
+        })),
+        ...discovery.items.map((item) => ({
+          subscriptionId: null,
+          channelId: item.id,
+          name: item.name,
+          imageUrl: item.imageUrl ?? null,
+          status: null,
+          isSubscribed: false,
+          lastPolledAt: null,
+        })),
+      ].sort((left, right) => left.name.localeCompare(right.name));
+
+      return c.json({
+        connection: connections.SPOTIFY
+          ? {
+              status: connections.SPOTIFY.status,
+              providerUserId: connections.SPOTIFY.providerUserId,
+              connectedAt: connections.SPOTIFY.connectedAt,
+              lastRefreshedAt: connections.SPOTIFY.lastRefreshedAt,
+            }
+          : null,
+        connectionRequired: discovery.connectionRequired,
+        items,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+
+  apiV1Routes.post(`/subscriptions/${slug}`, apiAuth('sync:write'), async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsedBody = AddProviderSubscriptionBodySchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json(
+        {
+          error: 'Invalid request body',
+          code: 'INVALID_REQUEST_BODY',
+          issues: parsedBody.error.issues,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+
+    const caller = appRouter.createCaller(await createContext(c));
+    try {
+      const result = await caller.subscriptions.add({
+        provider,
+        providerChannelId: parsedBody.data.channelId,
+        name: parsedBody.data.name,
+        imageUrl: parsedBody.data.imageUrl,
+      });
+      return c.json(
+        {
+          ...result,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        201
+      );
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+
+  apiV1Routes.patch(`/subscriptions/${slug}/:subscriptionId`, apiAuth('sync:write'), async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsedBody = UpdateProviderSubscriptionBodySchema.safeParse(body);
+
+    if (!parsedBody.success) {
+      return c.json(
+        {
+          error: 'Invalid request body',
+          code: 'INVALID_REQUEST_BODY',
+          issues: parsedBody.error.issues,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        400
+      );
+    }
+
+    const caller = appRouter.createCaller(await createContext(c));
+    const input = { subscriptionId: c.req.param('subscriptionId') };
+    try {
+      const result =
+        parsedBody.data.action === 'pause'
+          ? await caller.subscriptions.pause(input)
+          : await caller.subscriptions.resume(input);
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+
+  apiV1Routes.delete(`/subscriptions/${slug}/:subscriptionId`, apiAuth('sync:write'), async (c) => {
+    const caller = appRouter.createCaller(await createContext(c));
+    try {
+      const result = await caller.subscriptions.remove({
+        subscriptionId: c.req.param('subscriptionId'),
+      });
+      return c.json({
+        ...result,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      });
+    } catch (error) {
+      return trpcErrorResponse(c, error);
+    }
+  });
+
+  apiV1Routes.post(
+    `/subscriptions/${slug}/:subscriptionId/sync`,
+    apiAuth('sync:write'),
+    async (c) => {
+      const caller = appRouter.createCaller(await createContext(c));
+      try {
+        const result = await caller.subscriptions.syncNow({
+          subscriptionId: c.req.param('subscriptionId'),
+        });
+        return c.json({
+          ...result,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        });
+      } catch (error) {
+        return trpcErrorResponse(c, error);
+      }
+    }
+  );
+}
+
+registerOAuthConnectionRoutes('spotify', Provider.SPOTIFY);
+registerOAuthConnectionRoutes('gmail', Provider.GMAIL);
+registerOAuthConnectionRoutes('x', Provider.X);
+registerManagedProviderRoutes('spotify', Provider.SPOTIFY);
+
+apiV1Routes.get('/subscriptions/gmail', apiAuth('sync:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const [connections, newsletters, stats] = await Promise.all([
+      caller.subscriptions.connections.list(),
+      caller.subscriptions.newsletters.list({ limit: 100 }),
+      caller.subscriptions.newsletters.stats(),
+    ]);
+    return c.json({
+      connection: connections.GMAIL,
+      items: newsletters.items,
+      stats,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.patch('/subscriptions/gmail/:feedId', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = UpdateNewsletterBodySchema.safeParse(body);
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.newsletters.updateStatus({
+      feedId: c.req.param('feedId'),
+      status: parsedBody.data.action === 'activate' ? 'ACTIVE' : 'HIDDEN',
+    });
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.delete('/subscriptions/gmail/:feedId', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.newsletters.unsubscribe({
+      feedId: c.req.param('feedId'),
+    });
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/gmail/sync', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.newsletters.syncNow();
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/subscriptions/rss', apiAuth('sync:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const [feeds, stats] = await Promise.all([
+      caller.subscriptions.rss.list({ limit: 100 }),
+      caller.subscriptions.rss.stats(),
+    ]);
+    return c.json({
+      items: feeds.items,
+      stats,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/rss', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = AddRssFeedBodySchema.safeParse(body);
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.rss.add(parsedBody.data);
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') }, 201);
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.patch('/subscriptions/rss/:feedId', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = UpdateRssFeedBodySchema.safeParse(body);
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  const input = { feedId: c.req.param('feedId') };
+  try {
+    const result =
+      parsedBody.data.action === 'pause'
+        ? await caller.subscriptions.rss.pause(input)
+        : await caller.subscriptions.rss.resume(input);
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.delete('/subscriptions/rss/:feedId', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.rss.remove({ feedId: c.req.param('feedId') });
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/rss/:feedId/sync', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.rss.syncNow({ feedId: c.req.param('feedId') });
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/subscriptions/x', apiAuth('sync:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const [connections, status] = await Promise.all([
+      caller.subscriptions.connections.list(),
+      caller.subscriptions.xBookmarks.status(),
+    ]);
+    return c.json({
+      connection: connections.X,
+      ...status,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.patch('/subscriptions/x/settings', apiAuth('sync:write'), async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsedBody = UpdateXBookmarkSettingsBodySchema.safeParse(body);
+  if (!parsedBody.success) {
+    return c.json(
+      {
+        error: 'Invalid request body',
+        code: 'INVALID_REQUEST_BODY',
+        issues: parsedBody.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.xBookmarks.updateSettings(parsedBody.data);
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/subscriptions/x/sync', apiAuth('sync:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  try {
+    const result = await caller.subscriptions.xBookmarks.syncNow();
+    return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
 
 apiV1Routes.post('/sync-jobs', apiAuth('sync:write'), async (c) => {
   let body: unknown;


### PR DESCRIPTION
## Summary

- add a single Account → Subscriptions hub for YouTube, Spotify, Gmail newsletters, X bookmarks, and RSS
- add native provider connection, sync, pause, resume, remove, and source-specific management flows
- expose Clerk-authenticated REST endpoints and OpenAPI coverage for every subscription source
- add native OAuth configuration plus worker and Swift test coverage

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test` (mobile: 1,125 tests; worker: 1,568 tests; web: 75 tests)
- `bun run build`
- `xcodebuild -quiet -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination 'platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908' -derivedDataPath /tmp/zine-native-all-subscriptions-sim-derived -clonedSourcePackagesDirPath /tmp/zine-native-youtube-oauth-source-packages test` (12 tests)