### PR TITLE
feat(ios): refine native list experience

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -51,6 +51,7 @@ private struct AuthenticatedAppView: View {
                     cache: inboxCache,
                     onLibraryChanged: markLibraryChanged
                 )
+                .tint(Color.accentColor)
             }
 
             Tab("Library", systemImage: "books.vertical") {
@@ -59,6 +60,12 @@ private struct AuthenticatedAppView: View {
                     cache: libraryCache,
                     refreshRevision: libraryRevision
                 )
+                .tint(Color.accentColor)
+            }
+
+            Tab("Settings", systemImage: "gearshape") {
+                AppSettingsView(client: client)
+                    .tint(Color.accentColor)
             }
 
             Tab(role: .search) {
@@ -69,8 +76,10 @@ private struct AuthenticatedAppView: View {
                     refreshRevision: libraryRevision
                 )
                 .searchable(text: $search, prompt: "Search your library")
+                .tint(Color.accentColor)
             }
         }
+        .tint(Color.primary)
     }
 
     private func markLibraryChanged() {

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -92,16 +92,10 @@ struct InboxView: View {
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
+                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                    Button(role: .destructive) {
-                        Task { await store.archive(bookmark) }
-                    } label: {
-                        Label("Archive", systemImage: "archivebox.fill")
-                    }
-                    .accessibilityLabel("Archive inbox item")
-                }
-                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     Button {
                         Task { await store.bookmark(bookmark) }
                     } label: {
@@ -109,6 +103,14 @@ struct InboxView: View {
                     }
                     .tint(.green)
                     .accessibilityLabel("Bookmark inbox item")
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        Task { await store.archive(bookmark) }
+                    } label: {
+                        Label("Archive", systemImage: "archivebox.fill")
+                    }
+                    .accessibilityLabel("Archive inbox item")
                 }
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -4,33 +4,34 @@ struct BookmarkRow: View {
     let bookmark: Bookmark
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
+        HStack(alignment: .center, spacing: 10) {
             thumbnail
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 3) {
                 Text(bookmark.title)
-                    .font(.headline)
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
-                    .lineLimit(3)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
                 creatorLine
             }
         }
-        .padding(.vertical, 5)
+        .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
     }
 
     private var creatorLine: some View {
-        HStack(spacing: 7) {
+        HStack(spacing: 5) {
             CreatorAvatar(
                 imageUrl: bookmark.creatorImageUrl,
                 creator: bookmark.creator,
                 contentType: bookmark.contentType,
-                size: 22
+                size: 16
             )
 
             ViewThatFits(in: .horizontal) {
                 if let label = bookmark.consumptionLabel {
-                    HStack(spacing: 5) {
+                    HStack(spacing: 4) {
                         Text(bookmark.creator)
                         Text("·")
                         Text(label)
@@ -41,7 +42,7 @@ struct BookmarkRow: View {
                 Text(bookmark.creator)
                     .lineLimit(1)
             }
-            .font(.subheadline)
+            .font(.caption)
             .foregroundStyle(.secondary)
         }
     }
@@ -49,15 +50,16 @@ struct BookmarkRow: View {
     private var thumbnail: some View {
         CachedRemoteImage(
             url: bookmark.thumbnailUrl,
-            targetSize: CGSize(width: 96, height: 68)
+            targetSize: CGSize(width: 64, height: 48)
         ) {
             ZStack {
                 Color.secondary.opacity(0.12)
                 Image(systemName: bookmark.contentType.systemImage)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
-        .frame(width: 96, height: 68)
-        .clipShape(.rect(cornerRadius: 10))
+        .frame(width: 64, height: 48)
+        .clipShape(.rect(cornerRadius: 7))
     }
 }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -1,10 +1,4 @@
-import ClerkKitUI
 import SwiftUI
-
-private enum AccountRoute: Hashable {
-    case subscriptions
-    case appearance
-}
 
 struct LibraryView: View {
     let client: APIClient
@@ -53,9 +47,6 @@ struct LibraryView: View {
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         filterMenu
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        accountButton
                     }
                 }
                 .navigationDestination(for: Bookmark.self) { bookmark in
@@ -127,6 +118,8 @@ struct LibraryView: View {
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
+                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
                     if !bookmark.isFinished {
@@ -201,72 +194,9 @@ struct LibraryView: View {
         showsFinished || provider != nil || contentType != nil
     }
 
-    private var accountButton: some View {
-        UserButton()
-            .userProfileRows([
-                UserProfileCustomRow(
-                    route: AccountRoute.subscriptions,
-                    title: "Subscriptions",
-                    icon: .system(name: "rectangle.stack.badge.person.crop"),
-                    placement: .before(.signOut)
-                ),
-                UserProfileCustomRow(
-                    route: AccountRoute.appearance,
-                    title: "Appearance",
-                    icon: .system(name: "circle.lefthalf.filled"),
-                    placement: .before(.signOut)
-                ),
-            ])
-            .userProfileDestination { route in
-                switch route {
-                case .subscriptions:
-                    SubscriptionsView(client: client)
-                case .appearance:
-                    AppearanceSettingsView()
-                }
-            }
-    }
 }
 
 private struct LibraryReloadKey: Hashable {
     let query: LibraryQuery
     let revision: Int
-}
-
-private struct AppearanceSettingsView: View {
-    @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
-
-    private var selection: Binding<AppAppearance> {
-        Binding(
-            get: { AppAppearance(rawValue: storedAppearance) ?? .system },
-            set: { storedAppearance = $0.rawValue }
-        )
-    }
-
-    var body: some View {
-        List {
-            Section {
-                ForEach(AppAppearance.allCases) { appearance in
-                    Button {
-                        selection.wrappedValue = appearance
-                    } label: {
-                        Label(appearance.title, systemImage: appearance.systemImage)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .contentShape(.rect)
-                            .overlay(alignment: .trailing) {
-                                if selection.wrappedValue == appearance {
-                                    Image(systemName: "checkmark")
-                                        .fontWeight(.semibold)
-                                }
-                            }
-                    }
-                    .buttonStyle(.plain)
-                }
-            } footer: {
-                Text("System follows your iPhone’s appearance setting.")
-            }
-        }
-        .navigationTitle("Appearance")
-        .navigationBarTitleDisplayMode(.inline)
-    }
 }

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -13,6 +13,8 @@ struct ScreenshotLibraryView: View {
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
+                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowSeparator(.hidden)
             }
             .listStyle(.plain)
             .navigationTitle("Library")
@@ -22,11 +24,6 @@ struct ScreenshotLibraryView: View {
                     Button {} label: {
                         Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
                     }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Image(systemName: "person.crop.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(.secondary)
                 }
             }
             .navigationDestination(for: Bookmark.self) { bookmark in

--- a/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
+++ b/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
@@ -1,0 +1,82 @@
+import ClerkKit
+import ClerkKitUI
+import SwiftUI
+
+private enum SettingsRoute: Hashable {
+    case subscriptions
+    case appearance
+}
+
+struct AppSettingsView: View {
+    let client: APIClient
+
+    @Environment(Clerk.self) private var clerk
+
+    var body: some View {
+        if clerk.session?.tasks?.isEmpty == false {
+            AuthView(isDismissible: false)
+        } else {
+            UserProfileView(isDismissible: false)
+                .userProfileRows([
+                    UserProfileCustomRow(
+                        route: SettingsRoute.subscriptions,
+                        title: "Subscriptions",
+                        icon: .system(name: "rectangle.stack.badge.person.crop"),
+                        placement: .before(.signOut)
+                    ),
+                    UserProfileCustomRow(
+                        route: SettingsRoute.appearance,
+                        title: "Appearance",
+                        icon: .system(name: "circle.lefthalf.filled"),
+                        placement: .before(.signOut)
+                    ),
+                ])
+                .userProfileDestination { route in
+                    switch route {
+                    case .subscriptions:
+                        SubscriptionsView(client: client)
+                    case .appearance:
+                        AppearanceSettingsView()
+                    }
+                }
+        }
+    }
+}
+
+private struct AppearanceSettingsView: View {
+    @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
+
+    private var selection: Binding<AppAppearance> {
+        Binding(
+            get: { AppAppearance(rawValue: storedAppearance) ?? .system },
+            set: { storedAppearance = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(AppAppearance.allCases) { appearance in
+                    Button {
+                        selection.wrappedValue = appearance
+                    } label: {
+                        Label(appearance.title, systemImage: appearance.systemImage)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(.rect)
+                            .overlay(alignment: .trailing) {
+                                if selection.wrappedValue == appearance {
+                                    Image(systemName: "checkmark")
+                                        .fontWeight(.semibold)
+                                }
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+            } footer: {
+                Text("System follows your iPhone’s appearance setting.")
+            }
+        }
+        .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/apps/ios/ZineNative/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios/ZineNative/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors": [
     {
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "alpha": "1.000",
+          "blue": "0.122",
+          "green": "0.400",
+          "red": "0.937"
+        }
+      },
       "idiom": "universal"
     }
   ],


### PR DESCRIPTION
## Summary
- match the native app accent to the Expo orange while keeping the tab bar monochrome
- condense Inbox, Library, and Search rows with uniform thumbnails, single-line titles, and separator-free spacing
- correct Inbox swipe directions and move account settings into a dedicated bottom tab

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS\ Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908 -derivedDataPath /tmp/zine-native-pr-tests-20260718 test`
- signed Release build installed and launched on the physical iPhone as `app.zine.native`