### PR TITLE
feat(ios): add bookmark share extension

### DIFF
--- a/apps/ios/Configuration/Config.xcconfig
+++ b/apps/ios/Configuration/Config.xcconfig
@@ -4,5 +4,6 @@ ZINE_GOOGLE_CLIENT_ID = 973421703522-58dfb15bdqdhvhs2r9tt88ubgg45dkq1.apps.googl
 ZINE_GOOGLE_REVERSED_CLIENT_ID = com.googleusercontent.apps.973421703522-58dfb15bdqdhvhs2r9tt88ubgg45dkq1
 ZINE_SPOTIFY_CLIENT_ID = 4ce6c1f9fabe407ea4b2be0479dd63ff
 ZINE_X_CLIENT_ID = Vjd5eEktRTNoRDVZSm1aNGNvSWo6MTpjaQ
+ZINE_KEYCHAIN_ACCESS_GROUP = TRA7965NM5.app.zine.native
 
 #include? "Local.xcconfig"

--- a/apps/ios/Configuration/ShareExtension-Info.plist
+++ b/apps/ios/Configuration/ShareExtension-Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Zine</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>ZINEAPIBaseURL</key>
+	<string>$(ZINE_API_BASE_URL)</string>
+	<key>ZINEClerkPublishableKey</key>
+	<string>$(ZINE_CLERK_PUBLISHABLE_KEY)</string>
+	<key>ZINEKeychainAccessGroup</key>
+	<string>$(ZINE_KEYCHAIN_ACCESS_GROUP)</string>
+	<key>ZINEKeychainService</key>
+	<string>app.zine.native</string>
+</dict>
+</plist>

--- a/apps/ios/Configuration/ZineShareExtension.entitlements
+++ b/apps/ios/Configuration/ZineShareExtension.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>webcredentials:clerk.myzine.app</string>
-	</array>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)app.zine.native</string>

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -22,6 +22,16 @@ The API defaults to `https://api.myzine.app`. Override
 Open `ZineNative.xcodeproj`, select the `ZineNative` scheme, and run it on an
 iOS 18 or newer simulator or device.
 
-The first iteration intentionally contains only authentication and the Library
-vertical slice: list, pagination, refresh, search, filters, detail, and finished
-state. It does not replace or modify the React Native app.
+The native app is additive and does not replace or modify the React Native app.
+
+## Share extension
+
+The `ZineShareExtension` target appears as Zine in the iOS share sheet for web
+links. It loads a bookmark preview from the production REST API and lets the
+user save the link to their Zine library without opening the full app.
+
+The app and extension share the Clerk session through the
+`app.zine.native` keychain access group. A user who is not signed in is prompted
+to open Zine and sign in before trying the share action again. The share modal
+loads the user’s existing tags and supports selecting or creating tags before
+saving the bookmark.

--- a/apps/ios/ZineNative.xcodeproj/project.pbxproj
+++ b/apps/ios/ZineNative.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		A10000000000000000000002 /* ClerkKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000032 /* ClerkKitUI */; };
 		A10000000000000000000033 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000035 /* Nuke */; };
 		A10000000000000000000034 /* NukeUI in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000036 /* NukeUI */; };
+		B20000000000000000000001 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = A10000000000000000000031 /* ClerkKit */; };
+		B20000000000000000000002 /* ZineShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B20000000000000000000007 /* ZineShareExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B20000000000000000000003 /* BookmarkShareModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000000000000000000000A /* BookmarkShareModels.swift */; };
+		B20000000000000000000004 /* BookmarkShareClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000000000000000000000B /* BookmarkShareClient.swift */; };
+		B20000000000000000000005 /* BookmarkShareStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2000000000000000000000C /* BookmarkShareStore.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -21,7 +26,28 @@
 			remoteGlobalIDString = A10000000000000000000011;
 			remoteInfo = ZineNative;
 		};
+		B20000000000000000000006 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A10000000000000000000010 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B20000000000000000000011;
+			remoteInfo = ZineShareExtension;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		B20000000000000000000010 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				B20000000000000000000002 /* ZineShareExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		A10000000000000000000004 /* ZineNative.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZineNative.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -30,6 +56,12 @@
 		A10000000000000000000007 /* Local.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig.example; sourceTree = "<group>"; };
 		A10000000000000000000008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A10000000000000000000009 /* ZineNative.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ZineNative.entitlements; sourceTree = "<group>"; };
+		B20000000000000000000007 /* ZineShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ZineShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		B20000000000000000000008 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
+		B20000000000000000000009 /* ZineShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ZineShareExtension.entitlements; sourceTree = "<group>"; };
+		B2000000000000000000000A /* BookmarkShareModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZineNative/Core/Share/BookmarkShareModels.swift; sourceTree = SOURCE_ROOT; };
+		B2000000000000000000000B /* BookmarkShareClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZineNative/Core/Share/BookmarkShareClient.swift; sourceTree = SOURCE_ROOT; };
+		B2000000000000000000000C /* BookmarkShareStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZineNative/Core/Share/BookmarkShareStore.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -41,6 +73,11 @@
 		A1000000000000000000000B /* ZineNativeTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = ZineNativeTests;
+			sourceTree = "<group>";
+		};
+		B2000000000000000000000D /* ZineShareExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ZineShareExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -64,6 +101,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B2000000000000000000000E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B20000000000000000000001 /* ClerkKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -72,6 +117,8 @@
 			children = (
 				A1000000000000000000000A /* ZineNative */,
 				A1000000000000000000000B /* ZineNativeTests */,
+				B2000000000000000000000D /* ZineShareExtension */,
+				B2000000000000000000000F /* Shared Extension Sources */,
 				A1000000000000000000000F /* Configuration */,
 				A10000000000000000000012 /* Products */,
 			);
@@ -84,6 +131,8 @@
 				A10000000000000000000007 /* Local.xcconfig.example */,
 				A10000000000000000000008 /* Info.plist */,
 				A10000000000000000000009 /* ZineNative.entitlements */,
+				B20000000000000000000008 /* ShareExtension-Info.plist */,
+				B20000000000000000000009 /* ZineShareExtension.entitlements */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -93,8 +142,19 @@
 			children = (
 				A10000000000000000000004 /* ZineNative.app */,
 				A10000000000000000000005 /* ZineNativeTests.xctest */,
+				B20000000000000000000007 /* ZineShareExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B2000000000000000000000F /* Shared Extension Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B2000000000000000000000A /* BookmarkShareModels.swift */,
+				B2000000000000000000000B /* BookmarkShareClient.swift */,
+				B2000000000000000000000C /* BookmarkShareStore.swift */,
+			);
+			name = "Shared Extension Sources";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -107,10 +167,12 @@
 				A10000000000000000000013 /* Sources */,
 				A1000000000000000000000C /* Frameworks */,
 				A10000000000000000000014 /* Resources */,
+				B20000000000000000000010 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				B20000000000000000000014 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				A1000000000000000000000A /* ZineNative */,
@@ -125,6 +187,29 @@
 			productName = ZineNative;
 			productReference = A10000000000000000000004 /* ZineNative.app */;
 			productType = "com.apple.product-type.application";
+		};
+		B20000000000000000000011 /* ZineShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B20000000000000000000017 /* Build configuration list for PBXNativeTarget "ZineShareExtension" */;
+			buildPhases = (
+				B20000000000000000000013 /* Sources */,
+				B2000000000000000000000E /* Frameworks */,
+				B20000000000000000000012 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				B2000000000000000000000D /* ZineShareExtension */,
+			);
+			name = ZineShareExtension;
+			packageProductDependencies = (
+				A10000000000000000000031 /* ClerkKit */,
+			);
+			productName = ZineShareExtension;
+			productReference = B20000000000000000000007 /* ZineShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		A10000000000000000000015 /* ZineNativeTests */ = {
 			isa = PBXNativeTarget;
@@ -159,6 +244,7 @@
 				TargetAttributes = {
 					A10000000000000000000011 = { CreatedOnToolsVersion = 26.2; };
 					A10000000000000000000015 = { CreatedOnToolsVersion = 26.2; TestTargetID = A10000000000000000000011; };
+					B20000000000000000000011 = { CreatedOnToolsVersion = 26.2; };
 				};
 			};
 			buildConfigurationList = A10000000000000000000022 /* Build configuration list for PBXProject "ZineNative" */;
@@ -177,6 +263,7 @@
 			projectRoot = "";
 			targets = (
 				A10000000000000000000011 /* ZineNative */,
+				B20000000000000000000011 /* ZineShareExtension */,
 				A10000000000000000000015 /* ZineNativeTests */,
 			);
 		};
@@ -185,15 +272,27 @@
 /* Begin PBXResourcesBuildPhase section */
 		A10000000000000000000014 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 		A10000000000000000000017 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		B20000000000000000000012 /* Resources */ = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A10000000000000000000013 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
 		A10000000000000000000016 /* Sources */ = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		B20000000000000000000013 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B20000000000000000000003 /* BookmarkShareModels.swift in Sources */,
+				B20000000000000000000004 /* BookmarkShareClient.swift in Sources */,
+				B20000000000000000000005 /* BookmarkShareStore.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		A10000000000000000000018 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = A10000000000000000000011 /* ZineNative */; targetProxy = A10000000000000000000003 /* PBXContainerItemProxy */; };
+		B20000000000000000000014 /* PBXTargetDependency */ = {isa = PBXTargetDependency; target = B20000000000000000000011 /* ZineShareExtension */; targetProxy = B20000000000000000000006 /* PBXContainerItemProxy */; };
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -311,12 +410,75 @@
 			};
 			name = Release;
 		};
+		B20000000000000000000015 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A10000000000000000000006 /* Config.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Configuration/ZineShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TRA7965NM5;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Configuration/ShareExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native.share;
+				PRODUCT_MODULE_NAME = ZineShareExtension;
+				PRODUCT_NAME = Zine;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B20000000000000000000016 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A10000000000000000000006 /* Config.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Configuration/ZineShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TRA7965NM5;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Configuration/ShareExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = app.zine.native.share;
+				PRODUCT_MODULE_NAME = ZineShareExtension;
+				PRODUCT_NAME = Zine;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
 		A10000000000000000000020 /* Build configuration list for PBXNativeTarget "ZineNative" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000025 /* Debug */, A10000000000000000000026 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
 		A10000000000000000000021 /* Build configuration list for PBXNativeTarget "ZineNativeTests" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000027 /* Debug */, A10000000000000000000028 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
 		A10000000000000000000022 /* Build configuration list for PBXProject "ZineNative" */ = {isa = XCConfigurationList; buildConfigurations = (A10000000000000000000023 /* Debug */, A10000000000000000000024 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		B20000000000000000000017 /* Build configuration list for PBXNativeTarget "ZineShareExtension" */ = {isa = XCConfigurationList; buildConfigurations = (B20000000000000000000015 /* Debug */, B20000000000000000000016 /* Release */); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */

--- a/apps/ios/ZineNative/Core/Share/BookmarkShareClient.swift
+++ b/apps/ios/ZineNative/Core/Share/BookmarkShareClient.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+struct BookmarkShareClient: Sendable {
+    typealias TokenProvider = @MainActor @Sendable () async throws -> String
+
+    var preview: @Sendable (_ url: URL) async throws -> BookmarkSharePreview
+    var listTags: @Sendable () async throws -> [BookmarkShareTag]
+    var save: @Sendable (_ url: URL, _ tags: [String]) async throws -> BookmarkShareSaveResult
+
+    static func live(
+        baseURL: URL,
+        session: URLSession = .shared,
+        tokenProvider: @escaping TokenProvider
+    ) -> BookmarkShareClient {
+        let transport = BookmarkShareTransport(
+            baseURL: baseURL,
+            session: session,
+            tokenProvider: tokenProvider
+        )
+
+        return BookmarkShareClient(
+            preview: { url in
+                let response: PreviewResponse = try await transport.post(
+                    path: "/api/v1/bookmarks/preview",
+                    body: BookmarkURLBody(url: url.absoluteString)
+                )
+                return response.item
+            },
+            listTags: {
+                let response: TagsResponse = try await transport.get(path: "/api/v1/tags")
+                return response.tags
+            },
+            save: { url, tags in
+                let response: SaveResponse = try await transport.post(
+                    path: "/api/v1/bookmarks",
+                    body: SaveBookmarkBody(url: url.absoluteString, tags: tags)
+                )
+                return BookmarkShareSaveResult(
+                    status: response.bookmark.status,
+                    itemID: response.bookmark.itemId,
+                    userItemID: response.bookmark.userItemId,
+                    item: response.item
+                )
+            }
+        )
+    }
+}
+
+private struct BookmarkShareTransport: Sendable {
+    let baseURL: URL
+    let session: URLSession
+    let tokenProvider: BookmarkShareClient.TokenProvider
+
+    func get<Response: Decodable & Sendable>(path: String) async throws -> Response {
+        let request = try await authorizedRequest(path: path, method: "GET")
+        return try await execute(request)
+    }
+
+    func post<Body: Encodable & Sendable, Response: Decodable & Sendable>(
+        path: String,
+        body: Body
+    ) async throws -> Response {
+        var request = try await authorizedRequest(path: path, method: "POST")
+        request.httpBody = try JSONEncoder().encode(body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        return try await execute(request)
+    }
+
+    private func authorizedRequest(path: String, method: String) async throws -> URLRequest {
+        var request = URLRequest(url: baseURL.appending(path: path))
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let token = try await tokenProvider()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    private func execute<Response: Decodable & Sendable>(
+        _ request: URLRequest
+    ) async throws -> Response {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw BookmarkShareError.invalidResponse
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let payload = try? JSONDecoder().decode(ErrorResponse.self, from: data)
+            switch http.statusCode {
+            case 401, 403:
+                throw BookmarkShareError.signedOut
+            case 422:
+                throw BookmarkShareError.unsupportedURL
+            default:
+                throw BookmarkShareError.server(
+                    status: http.statusCode,
+                    message: payload?.error
+                        ?? HTTPURLResponse.localizedString(forStatusCode: http.statusCode)
+                )
+            }
+        }
+
+        do {
+            return try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            throw BookmarkShareError.invalidResponse
+        }
+    }
+}
+
+private struct BookmarkURLBody: Encodable, Sendable {
+    let url: String
+}
+
+private struct SaveBookmarkBody: Encodable, Sendable {
+    let url: String
+    let tags: [String]
+}
+
+private struct PreviewResponse: Decodable, Sendable {
+    let item: BookmarkSharePreview
+}
+
+private struct TagsResponse: Decodable, Sendable {
+    let tags: [BookmarkShareTag]
+}
+
+private struct SaveResponse: Decodable, Sendable {
+    struct BookmarkResult: Decodable, Sendable {
+        let itemId: String
+        let userItemId: String
+        let status: BookmarkShareSaveStatus
+    }
+
+    let bookmark: BookmarkResult
+    let item: BookmarkSharePreview
+}
+
+private struct ErrorResponse: Decodable {
+    let error: String
+}

--- a/apps/ios/ZineNative/Core/Share/BookmarkShareModels.swift
+++ b/apps/ios/ZineNative/Core/Share/BookmarkShareModels.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+struct BookmarkShareTag: Decodable, Equatable, Identifiable, Sendable {
+    let id: String
+    let name: String
+}
+
+struct BookmarkSharePreview: Decodable, Equatable, Sendable {
+    let provider: String
+    let contentType: String
+    let title: String
+    let creator: String
+    let creatorImageUrl: String?
+    let thumbnailUrl: String?
+    let canonicalUrl: String
+    let duration: Int?
+    let description: String?
+    let siteName: String?
+    let readingTimeMinutes: Int?
+
+    var thumbnailURL: URL? {
+        thumbnailUrl.flatMap(URL.init(string:))
+    }
+
+    var sourceLabel: String {
+        if let siteName, !siteName.isEmpty {
+            return siteName
+        }
+
+        if let host = URL(string: canonicalUrl)?.host(percentEncoded: false) {
+            return host.replacing(/^www\./, with: "")
+        }
+
+        return provider.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    var contentTypeLabel: String {
+        contentType.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    var lengthLabel: String? {
+        if let duration, duration > 0 {
+            let hours = duration / 3600
+            let minutes = (duration % 3600) / 60
+            if hours > 0 {
+                return minutes > 0 ? "\(hours) hr \(minutes) min" : "\(hours) hr"
+            }
+            return "\(max(1, minutes)) min"
+        }
+
+        if let readingTimeMinutes, readingTimeMinutes > 0 {
+            return "\(readingTimeMinutes) min read"
+        }
+
+        return nil
+    }
+}
+
+enum BookmarkShareSaveStatus: String, Decodable, Equatable, Sendable {
+    case created
+    case alreadyBookmarked = "already_bookmarked"
+    case rebookmarked
+
+    var confirmationTitle: String {
+        switch self {
+        case .created:
+            "Saved to Zine"
+        case .alreadyBookmarked:
+            "Already in your library"
+        case .rebookmarked:
+            "Added back to your library"
+        }
+    }
+}
+
+struct BookmarkShareSaveResult: Equatable, Sendable {
+    let status: BookmarkShareSaveStatus
+    let itemID: String
+    let userItemID: String
+    let item: BookmarkSharePreview
+}
+
+enum BookmarkShareError: LocalizedError, Equatable, Sendable {
+    case invalidConfiguration
+    case invalidResponse
+    case noSharedURL
+    case signedOut
+    case unsupportedURL
+    case server(status: Int, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration:
+            "Zine’s share extension isn’t configured correctly."
+        case .invalidResponse:
+            "Zine returned an unreadable response. Please try again."
+        case .noSharedURL:
+            "This item doesn’t contain a link Zine can save."
+        case .signedOut:
+            "Open Zine and sign in, then try sharing this link again."
+        case .unsupportedURL:
+            "Zine couldn’t create a preview for this link."
+        case let .server(_, message):
+            message
+        }
+    }
+}

--- a/apps/ios/ZineNative/Core/Share/BookmarkShareStore.swift
+++ b/apps/ios/ZineNative/Core/Share/BookmarkShareStore.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class BookmarkShareStore {
+    static let maximumTagCount = 20
+    static let maximumTagLength = 32
+
+    enum Phase: Equatable {
+        case loadingLink
+        case loadingPreview
+        case ready
+        case saving
+        case saved
+        case failed
+    }
+
+    private(set) var phase: Phase = .loadingLink
+    private(set) var url: URL?
+    private(set) var preview: BookmarkSharePreview?
+    private(set) var saveStatus: BookmarkShareSaveStatus?
+    private(set) var errorMessage: String?
+    private(set) var availableTags: [BookmarkShareTag] = []
+    private(set) var selectedTags: [String] = []
+    private(set) var isLoadingTags = false
+    private(set) var tagsErrorMessage: String?
+
+    private let loadURL: () async throws -> URL
+    private let client: BookmarkShareClient
+
+    init(
+        loadURL: @escaping () async throws -> URL,
+        client: BookmarkShareClient
+    ) {
+        self.loadURL = loadURL
+        self.client = client
+    }
+
+    func load() async {
+        guard phase == .loadingLink else { return }
+
+        do {
+            let sharedURL = try await loadURL()
+            guard Self.isSupported(sharedURL) else {
+                throw BookmarkShareError.unsupportedURL
+            }
+            url = sharedURL
+            await loadPreviewAndTags()
+        } catch is CancellationError {
+            return
+        } catch {
+            fail(with: error)
+        }
+    }
+
+    func retry() async {
+        errorMessage = nil
+        if url == nil {
+            phase = .loadingLink
+            await load()
+        } else {
+            await loadPreviewAndTags()
+        }
+    }
+
+    func tags(matching query: String) -> [BookmarkShareTag] {
+        let queryKey = Self.tagKey(query)
+        guard !queryKey.isEmpty else { return availableTags }
+        return availableTags.filter { Self.tagKey($0.name).contains(queryKey) }
+    }
+
+    func isTagSelected(_ name: String) -> Bool {
+        let key = Self.tagKey(name)
+        return selectedTags.contains { Self.tagKey($0) == key }
+    }
+
+    func canCreateTag(named name: String) -> Bool {
+        let normalizedName = Self.normalizedTagName(name)
+        guard !normalizedName.isEmpty, normalizedName.count <= Self.maximumTagLength else {
+            return false
+        }
+        let key = Self.tagKey(normalizedName)
+        return !availableTags.contains { Self.tagKey($0.name) == key }
+    }
+
+    @discardableResult
+    func selectTag(named name: String) -> Bool {
+        let normalizedName = Self.normalizedTagName(name)
+        guard !normalizedName.isEmpty,
+              normalizedName.count <= Self.maximumTagLength
+        else {
+            return false
+        }
+
+        let key = Self.tagKey(normalizedName)
+        if isTagSelected(normalizedName) {
+            return true
+        }
+        guard selectedTags.count < Self.maximumTagCount else { return false }
+
+        let canonicalName = availableTags.first { Self.tagKey($0.name) == key }?.name
+            ?? normalizedName
+        selectedTags.append(canonicalName)
+
+        if !availableTags.contains(where: { Self.tagKey($0.name) == key }) {
+            availableTags.append(
+                BookmarkShareTag(id: "local-\(key)", name: canonicalName)
+            )
+        }
+        return true
+    }
+
+    func toggleTag(named name: String) {
+        let key = Self.tagKey(name)
+        if isTagSelected(name) {
+            selectedTags.removeAll { Self.tagKey($0) == key }
+        } else {
+            _ = selectTag(named: name)
+        }
+    }
+
+    func retryTags() async {
+        await loadTags()
+    }
+
+    @discardableResult
+    func save() async -> Bool {
+        guard phase == .ready, let url else { return false }
+
+        phase = .saving
+        errorMessage = nil
+
+        do {
+            let result = try await client.save(url, selectedTags)
+            saveStatus = result.status
+            preview = result.item
+            phase = .saved
+            return true
+        } catch is CancellationError {
+            phase = .ready
+            return false
+        } catch {
+            fail(with: error)
+            return false
+        }
+    }
+
+    private func loadPreviewAndTags() async {
+        guard let url else { return }
+
+        phase = .loadingPreview
+        errorMessage = nil
+        isLoadingTags = true
+        tagsErrorMessage = nil
+
+        let client = self.client
+        let tagsTask = Task {
+            try await client.listTags()
+        }
+
+        do {
+            preview = try await client.preview(url)
+            phase = .ready
+        } catch is CancellationError {
+            tagsTask.cancel()
+            isLoadingTags = false
+            return
+        } catch {
+            tagsTask.cancel()
+            isLoadingTags = false
+            fail(with: error)
+            return
+        }
+
+        do {
+            mergeAvailableTags(try await tagsTask.value)
+        } catch is CancellationError {
+            isLoadingTags = false
+            return
+        } catch {
+            tagsErrorMessage = "Couldn’t load your tags. You can still add one manually."
+        }
+        isLoadingTags = false
+    }
+
+    private func loadTags() async {
+        isLoadingTags = true
+        tagsErrorMessage = nil
+
+        do {
+            mergeAvailableTags(try await client.listTags())
+        } catch is CancellationError {
+            isLoadingTags = false
+            return
+        } catch {
+            tagsErrorMessage = "Couldn’t load your tags. You can still add one manually."
+        }
+        isLoadingTags = false
+    }
+
+    private func mergeAvailableTags(_ tags: [BookmarkShareTag]) {
+        let selected = selectedTags.map {
+            BookmarkShareTag(id: "local-\(Self.tagKey($0))", name: $0)
+        }
+        availableTags = Self.uniqueTags(tags + selected)
+    }
+
+    private func fail(with error: Error) {
+        errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        phase = .failed
+    }
+
+    private static func isSupported(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+
+    static func normalizedTagName(_ value: String) -> String {
+        value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private static func tagKey(_ value: String) -> String {
+        normalizedTagName(value).lowercased()
+    }
+
+    private static func uniqueTags(_ tags: [BookmarkShareTag]) -> [BookmarkShareTag] {
+        var seen = Set<String>()
+        return tags.filter { seen.insert(tagKey($0.name)).inserted }
+    }
+}

--- a/apps/ios/ZineNativeTests/BookmarkShareTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkShareTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Testing
+@testable import ZineNative
+
+@MainActor
+struct BookmarkShareTests {
+    @Test
+    func loadsPreviewAndSavesCreatedBookmark() async throws {
+        let preview = makeBookmarkSharePreview()
+        let savedTags = TagRecorder()
+        let client = BookmarkShareClient(
+            preview: { url in
+                #expect(url.absoluteString == "https://example.com/story")
+                return preview
+            },
+            listTags: {
+                [
+                    BookmarkShareTag(id: "tag-1", name: "Design"),
+                    BookmarkShareTag(id: "tag-2", name: "Reading"),
+                ]
+            },
+            save: { _, tags in
+                await savedTags.record(tags)
+                return BookmarkShareSaveResult(
+                    status: .created,
+                    itemID: "item-1",
+                    userItemID: "user-item-1",
+                    item: preview
+                )
+            }
+        )
+        let store = BookmarkShareStore(
+            loadURL: { URL(string: "https://example.com/story")! },
+            client: client
+        )
+
+        await store.load()
+
+        #expect(store.phase == .ready)
+        #expect(store.preview == preview)
+        #expect(store.availableTags.map(\.name) == ["Design", "Reading"])
+        #expect(store.selectTag(named: " design "))
+        #expect(store.selectTag(named: "Product   Research"))
+        #expect(store.selectedTags == ["Design", "Product Research"])
+        #expect(await store.save())
+        #expect(store.phase == .saved)
+        #expect(store.saveStatus == .created)
+        #expect(await savedTags.tags == ["Design", "Product Research"])
+    }
+
+    @Test
+    func rejectsNonWebLinksBeforePreviewing() async {
+        let client = BookmarkShareClient(
+            preview: { _ in
+                Issue.record("Preview should not be requested for a non-web URL")
+                return makeBookmarkSharePreview()
+            },
+            listTags: {
+                Issue.record("Tags should not be requested for a non-web URL")
+                return []
+            },
+            save: { _, _ in
+                Issue.record("Save should not be requested for a non-web URL")
+                return BookmarkShareSaveResult(
+                    status: .created,
+                    itemID: "item-1",
+                    userItemID: "user-item-1",
+                    item: makeBookmarkSharePreview()
+                )
+            }
+        )
+        let store = BookmarkShareStore(
+            loadURL: { URL(string: "file:///tmp/story")! },
+            client: client
+        )
+
+        await store.load()
+
+        #expect(store.phase == .failed)
+        #expect(store.errorMessage == BookmarkShareError.unsupportedURL.errorDescription)
+    }
+
+    @Test
+    func tagLoadingFailureDoesNotBlockSaving() async {
+        let preview = makeBookmarkSharePreview()
+        let client = BookmarkShareClient(
+            preview: { _ in preview },
+            listTags: {
+                throw BookmarkShareError.server(status: 500, message: "Unavailable")
+            },
+            save: { _, _ in
+                BookmarkShareSaveResult(
+                    status: .created,
+                    itemID: "item-1",
+                    userItemID: "user-item-1",
+                    item: preview
+                )
+            }
+        )
+        let store = BookmarkShareStore(
+            loadURL: { URL(string: "https://example.com/story")! },
+            client: client
+        )
+
+        await store.load()
+
+        #expect(store.phase == .ready)
+        #expect(store.tagsErrorMessage != nil)
+        #expect(store.selectTag(named: "Manual Tag"))
+        #expect(await store.save())
+    }
+
+    @Test
+    func normalizesAndLimitsSelectedTags() {
+        let client = BookmarkShareClient(
+            preview: { _ in makeBookmarkSharePreview() },
+            listTags: { [] },
+            save: { _, _ in
+                BookmarkShareSaveResult(
+                    status: .created,
+                    itemID: "item-1",
+                    userItemID: "user-item-1",
+                    item: makeBookmarkSharePreview()
+                )
+            }
+        )
+        let store = BookmarkShareStore(
+            loadURL: { URL(string: "https://example.com/story")! },
+            client: client
+        )
+
+        #expect(store.selectTag(named: "  Design   Systems "))
+        #expect(store.selectTag(named: "design systems"))
+        #expect(store.selectedTags == ["Design Systems"])
+        #expect(!store.selectTag(named: String(repeating: "a", count: 33)))
+
+        for index in 1..<BookmarkShareStore.maximumTagCount {
+            #expect(store.selectTag(named: "Tag \(index)"))
+        }
+
+        #expect(store.selectedTags.count == BookmarkShareStore.maximumTagCount)
+        #expect(!store.selectTag(named: "One too many"))
+    }
+
+    @Test
+    func formatsSaveOutcomesForTheConfirmationState() {
+        #expect(BookmarkShareSaveStatus.created.confirmationTitle == "Saved to Zine")
+        #expect(
+            BookmarkShareSaveStatus.alreadyBookmarked.confirmationTitle
+                == "Already in your library"
+        )
+        #expect(
+            BookmarkShareSaveStatus.rebookmarked.confirmationTitle
+                == "Added back to your library"
+        )
+    }
+
+    @Test
+    func liveClientSendsBearerTokenAndDecodesShareRequests() async throws {
+        let recorder = RequestRecorder()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BookmarkShareURLProtocol.self]
+        BookmarkShareURLProtocol.handler = { request in
+            await recorder.record(request)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            let item =
+                """
+                {
+                  "provider": "WEB",
+                  "contentType": "ARTICLE",
+                  "title": "A useful story",
+                  "creator": "Example",
+                  "canonicalUrl": "https://example.com/story",
+                  "siteName": "Example"
+                }
+                """
+            let payload: String
+            switch request.url?.path {
+            case "/api/v1/tags":
+                payload = "{\"tags\":[{\"id\":\"tag-1\",\"name\":\"Design\"}]}"
+            case "/api/v1/bookmarks":
+                payload =
+                    """
+                    {
+                      "bookmark": {
+                        "itemId": "item-1",
+                        "userItemId": "user-item-1",
+                        "status": "created"
+                      },
+                      "item": \(item)
+                    }
+                    """
+            default:
+                payload = "{\"item\":\(item)}"
+            }
+            let data = Data(payload.utf8)
+            return (response, data)
+        }
+        let session = URLSession(configuration: configuration)
+        let client = BookmarkShareClient.live(
+            baseURL: URL(string: "https://api.myzine.app")!,
+            session: session,
+            tokenProvider: { "clerk-token" }
+        )
+
+        let preview = try await client.preview(URL(string: "https://example.com/story")!)
+        let tags = try await client.listTags()
+        let saved = try await client.save(
+            URL(string: "https://example.com/story")!,
+            ["Design", "Reading"]
+        )
+        let requests = await recorder.requests
+        let recordedSaveBody = await recorder.saveBody
+        let saveBody = try #require(recordedSaveBody)
+        let savePayload = try #require(
+            JSONSerialization.jsonObject(with: saveBody) as? [String: Any]
+        )
+
+        #expect(preview.title == "A useful story")
+        #expect(tags.map(\.name) == ["Design"])
+        #expect(saved.status == .created)
+        #expect(requests.map(\.url?.path) == [
+            "/api/v1/bookmarks/preview",
+            "/api/v1/tags",
+            "/api/v1/bookmarks",
+        ])
+        #expect(
+            requests.allSatisfy {
+                $0.value(forHTTPHeaderField: "Authorization") == "Bearer clerk-token"
+            }
+        )
+        #expect(savePayload["tags"] as? [String] == ["Design", "Reading"])
+    }
+
+}
+
+private func makeBookmarkSharePreview() -> BookmarkSharePreview {
+    BookmarkSharePreview(
+        provider: "WEB",
+        contentType: "ARTICLE",
+        title: "A useful story",
+        creator: "Example",
+        creatorImageUrl: nil,
+        thumbnailUrl: nil,
+        canonicalUrl: "https://example.com/story",
+        duration: nil,
+        description: "A story worth saving.",
+        siteName: "Example",
+        readingTimeMinutes: 5
+    )
+}
+
+private actor RequestRecorder {
+    private(set) var requests: [URLRequest] = []
+    private(set) var saveBody: Data?
+
+    func record(_ request: URLRequest) {
+        requests.append(request)
+        if request.url?.path == "/api/v1/bookmarks" {
+            saveBody = Self.bodyData(from: request)
+        }
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
+private actor TagRecorder {
+    private(set) var tags: [String] = []
+
+    func record(_ tags: [String]) {
+        self.tags = tags
+    }
+}
+
+private final class BookmarkShareURLProtocol: URLProtocol, @unchecked Sendable {
+    static var handler: (@Sendable (URLRequest) async throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Task {
+            do {
+                guard let handler = Self.handler else {
+                    throw BookmarkShareError.invalidResponse
+                }
+                let (response, data) = try await handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/apps/ios/ZineShareExtension/BookmarkShareView.swift
+++ b/apps/ios/ZineShareExtension/BookmarkShareView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+struct BookmarkShareView: View {
+    @State private var store: BookmarkShareStore
+    @State private var tagQuery = ""
+
+    let onCancel: () -> Void
+    let onComplete: () -> Void
+
+    init(
+        store: BookmarkShareStore,
+        onCancel: @escaping () -> Void,
+        onComplete: @escaping () -> Void
+    ) {
+        _store = State(initialValue: store)
+        self.onCancel = onCancel
+        self.onComplete = onComplete
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(.systemGroupedBackground))
+                .navigationTitle("Save to Zine")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(action: onCancel) {
+                            Image(systemName: "xmark")
+                        }
+                        .accessibilityLabel("Cancel")
+                        .disabled(store.phase == .saving)
+                    }
+                }
+                .safeAreaInset(edge: .bottom) {
+                    if store.phase == .ready || store.phase == .saving {
+                        saveButton
+                    }
+                }
+        }
+        .tint(Color(red: 0.937, green: 0.400, blue: 0.122))
+        .task {
+            await store.load()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch store.phase {
+        case .loadingLink:
+            LoadingView(title: "Reading link…")
+        case .loadingPreview:
+            LoadingView(title: "Fetching preview…")
+        case .ready, .saving:
+            if let preview = store.preview, let url = store.url {
+                ScrollView {
+                    VStack(spacing: 16) {
+                        BookmarkPreviewCard(preview: preview, originalURL: url)
+                        BookmarkTagSelector(store: store, query: $tagQuery)
+                    }
+                    .padding()
+                }
+            }
+        case .saved:
+            ConfirmationView(
+                title: store.saveStatus?.confirmationTitle ?? "Saved to Zine"
+            )
+        case .failed:
+            ErrorView(
+                message: store.errorMessage ?? "Something went wrong.",
+                onRetry: {
+                    Task { await store.retry() }
+                }
+            )
+        }
+    }
+
+    private var saveButton: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Button {
+                Task {
+                    guard await store.save() else { return }
+                    try? await Task.sleep(for: .milliseconds(700))
+                    guard !Task.isCancelled else { return }
+                    onComplete()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    if store.phase == .saving {
+                        ProgressView()
+                            .controlSize(.small)
+                            .tint(.white)
+                    }
+                    Text(store.phase == .saving ? "Saving…" : "Save Bookmark")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(store.phase == .saving)
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+        }
+        .background(.bar)
+    }
+}
+
+private struct BookmarkTagSelector: View {
+    let store: BookmarkShareStore
+    @Binding var query: String
+
+    private var normalizedQuery: String {
+        BookmarkShareStore.normalizedTagName(query)
+    }
+
+    private var visibleTags: [BookmarkShareTag] {
+        store.tags(matching: query)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Tags", systemImage: "tag")
+                    .font(.headline)
+
+                Spacer()
+
+                if !store.selectedTags.isEmpty {
+                    Text("\(store.selectedTags.count) selected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            TextField("Add or search tags", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.done)
+                .onSubmit(addQuery)
+                .accessibilityLabel("Tag input")
+
+            if normalizedQuery.count > BookmarkShareStore.maximumTagLength {
+                Text("Tags can be up to \(BookmarkShareStore.maximumTagLength) characters.")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if store.canCreateTag(named: query) {
+                Button(action: addQuery) {
+                    Label("Create \"\(normalizedQuery)\"", systemImage: "plus")
+                        .lineLimit(1)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.capsule)
+                .disabled(store.selectedTags.count >= BookmarkShareStore.maximumTagCount)
+            }
+
+            if store.isLoadingTags, store.availableTags.isEmpty {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading tags…")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            } else if let message = store.tagsErrorMessage {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Retry") {
+                        Task { await store.retryTags() }
+                    }
+                    .font(.caption.weight(.semibold))
+                }
+            }
+
+            if !visibleTags.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 8) {
+                        ForEach(visibleTags) { tag in
+                            TagChip(
+                                name: tag.name,
+                                isSelected: store.isTagSelected(tag.name),
+                                isDisabled: !store.isTagSelected(tag.name)
+                                    && store.selectedTags.count
+                                        >= BookmarkShareStore.maximumTagCount,
+                                onToggle: { store.toggleTag(named: tag.name) }
+                            )
+                        }
+                    }
+                }
+            } else if !store.isLoadingTags, normalizedQuery.isEmpty {
+                Text("No tags yet. Add one above.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if store.selectedTags.count >= BookmarkShareStore.maximumTagCount {
+                Text("You can add up to \(BookmarkShareStore.maximumTagCount) tags.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .disabled(store.phase == .saving)
+    }
+
+    private func addQuery() {
+        guard store.selectTag(named: query) else { return }
+        query = ""
+    }
+}
+
+private struct TagChip: View {
+    let name: String
+    let isSelected: Bool
+    let isDisabled: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 5) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.bold))
+                }
+                Text(name)
+                    .lineLimit(1)
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(isSelected ? Color.white : Color.primary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(isSelected ? Color.accentColor : Color(.tertiarySystemFill))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .accessibilityLabel("\(name) tag")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint(isSelected ? "Removes this tag" : "Adds this tag")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+private struct LoadingView: View {
+    let title: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            ProgressView()
+                .controlSize(.large)
+            Text(title)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ConfirmationView: View {
+    let title: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+            Text(title)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct ErrorView: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Couldn’t save this link", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Try Again", action: onRetry)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+
+private struct BookmarkPreviewCard: View {
+    let preview: BookmarkSharePreview
+    let originalURL: URL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            previewImage
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 6) {
+                    Label(preview.contentTypeLabel, systemImage: contentTypeIcon)
+                        .lineLimit(1)
+                    if let lengthLabel = preview.lengthLabel {
+                        Text("·")
+                        Text(lengthLabel)
+                            .lineLimit(1)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                Text(preview.title)
+                    .font(.headline)
+                    .lineLimit(3)
+
+                HStack(spacing: 4) {
+                    Text(preview.creator)
+                    Text("·")
+                    Text(preview.sourceLabel)
+                }
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+                Text(originalURL.absoluteString)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding()
+        }
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(.separator.opacity(0.35), lineWidth: 0.5)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var previewImage: some View {
+        ZStack {
+            Rectangle()
+                .fill(Color(.tertiarySystemFill))
+
+            if let thumbnailURL = preview.thumbnailURL {
+                AsyncImage(url: thumbnailURL) { phase in
+                    if let image = phase.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } else if phase.error != nil {
+                        imagePlaceholder
+                    } else {
+                        ProgressView()
+                    }
+                }
+            } else {
+                imagePlaceholder
+            }
+        }
+        .frame(height: 170)
+        .clipped()
+    }
+
+    private var imagePlaceholder: some View {
+        Image(systemName: contentTypeIcon)
+            .font(.system(size: 34))
+            .foregroundStyle(.secondary)
+    }
+
+    private var contentTypeIcon: String {
+        switch preview.contentType.uppercased() {
+        case "VIDEO": "play.rectangle"
+        case "PODCAST": "waveform"
+        case "POST": "text.bubble"
+        default: "doc.text"
+        }
+    }
+}

--- a/apps/ios/ZineShareExtension/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/ios/ZineShareExtension/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "alpha": "1.000",
+          "blue": "0.122",
+          "green": "0.400",
+          "red": "0.937"
+        }
+      },
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios/ZineShareExtension/Resources/Assets.xcassets/Contents.json
+++ b/apps/ios/ZineShareExtension/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/apps/ios/ZineShareExtension/ShareItemLoader.swift
+++ b/apps/ios/ZineShareExtension/ShareItemLoader.swift
@@ -1,0 +1,65 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum ShareItemLoader {
+    static func url(from context: NSExtensionContext?) async throws -> URL {
+        guard let items = context?.inputItems as? [NSExtensionItem] else {
+            throw BookmarkShareError.noSharedURL
+        }
+
+        let providers = items.flatMap { $0.attachments ?? [] }
+
+        for provider in providers where provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+            if let url = try await loadURL(from: provider) {
+                return url
+            }
+        }
+
+        for provider in providers where provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+            if let url = try await loadURLFromText(from: provider) {
+                return url
+            }
+        }
+
+        throw BookmarkShareError.noSharedURL
+    }
+
+    private static func loadURL(from provider: NSItemProvider) async throws -> URL? {
+        let item = try await provider.zineLoadItem(forTypeIdentifier: UTType.url.identifier)
+
+        if let url = item as? URL {
+            return url
+        }
+        if let url = item as? NSURL {
+            return url as URL
+        }
+        if let value = item as? String {
+            return URL(string: value.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        return nil
+    }
+
+    private static func loadURLFromText(from provider: NSItemProvider) async throws -> URL? {
+        let item = try await provider.zineLoadItem(forTypeIdentifier: UTType.plainText.identifier)
+        guard let text = item as? String else { return nil }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        return detector.firstMatch(in: text, options: [], range: range)?.url
+    }
+}
+
+private extension NSItemProvider {
+    func zineLoadItem(forTypeIdentifier typeIdentifier: String) async throws -> NSSecureCoding? {
+        try await withCheckedThrowingContinuation { continuation in
+            loadItem(forTypeIdentifier: typeIdentifier, options: nil) { item, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: item)
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/ZineShareExtension/ShareViewController.swift
+++ b/apps/ios/ZineShareExtension/ShareViewController.swift
@@ -1,0 +1,111 @@
+import ClerkKit
+import SwiftUI
+import UIKit
+
+final class ShareViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let configuration = ShareExtensionConfiguration.current
+        let client: BookmarkShareClient
+
+        if configuration.isValid {
+            Clerk.configure(
+                publishableKey: configuration.clerkPublishableKey,
+                options: Clerk.Options(
+                    telemetryEnabled: false,
+                    keychainConfig: .init(
+                        service: configuration.keychainService,
+                        accessGroup: configuration.keychainAccessGroup
+                    ),
+                    redirectConfig: .init(
+                        redirectUrl: "app.zine.native://callback",
+                        callbackUrlScheme: "app.zine.native"
+                    )
+                )
+            )
+
+            client = .live(
+                baseURL: configuration.apiBaseURL,
+                tokenProvider: {
+                    guard let token = try await Clerk.shared.auth.getToken() else {
+                        throw BookmarkShareError.signedOut
+                    }
+                    return token
+                }
+            )
+        } else {
+            client = BookmarkShareClient(
+                preview: { _ in throw BookmarkShareError.invalidConfiguration },
+                listTags: { throw BookmarkShareError.invalidConfiguration },
+                save: { _, _ in throw BookmarkShareError.invalidConfiguration }
+            )
+        }
+
+        let store = BookmarkShareStore(
+            loadURL: { [weak self] in
+                try await ShareItemLoader.url(from: self?.extensionContext)
+            },
+            client: client
+        )
+        let host = UIHostingController(
+            rootView: BookmarkShareView(
+                store: store,
+                onCancel: { [weak self] in self?.cancel() },
+                onComplete: { [weak self] in self?.complete() }
+            )
+        )
+
+        addChild(host)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(host.view)
+        NSLayoutConstraint.activate([
+            host.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            host.view.topAnchor.constraint(equalTo: view.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        host.didMove(toParent: self)
+
+        preferredContentSize = CGSize(width: 0, height: 640)
+    }
+
+    private func cancel() {
+        extensionContext?.cancelRequest(
+            withError: NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSUserCancelledError
+            )
+        )
+    }
+
+    private func complete() {
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+}
+
+private struct ShareExtensionConfiguration {
+    let apiBaseURL: URL
+    let clerkPublishableKey: String
+    let keychainService: String
+    let keychainAccessGroup: String
+
+    var isValid: Bool {
+        !clerkPublishableKey.isEmpty
+            && !clerkPublishableKey.contains("$(")
+            && !keychainService.isEmpty
+            && !keychainAccessGroup.isEmpty
+    }
+
+    static var current: ShareExtensionConfiguration {
+        let values = Bundle.main.infoDictionary ?? [:]
+        let baseURLString = values["ZINEAPIBaseURL"] as? String ?? "https://api.myzine.app"
+
+        return ShareExtensionConfiguration(
+            apiBaseURL: URL(string: baseURLString) ?? URL(string: "https://api.myzine.app")!,
+            clerkPublishableKey: values["ZINEClerkPublishableKey"] as? String ?? "",
+            keychainService: values["ZINEKeychainService"] as? String ?? "app.zine.native",
+            keychainAccessGroup: values["ZINEKeychainAccessGroup"] as? String ?? ""
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a native iOS share extension that accepts shared URLs and text from apps including Safari, YouTube, Spotify, and Substack
- reuse the signed-in Zine session to preview and save bookmarks, with clear loading, saved, signed-out, and error states plus an accessible X dismiss button
- load, search, select, and create tags directly in the share sheet before saving

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- native Xcode test suite: 18 passed, 0 failed (`-parallel-testing-enabled NO`)
- Release build installed and launched on a physical iPhone; embedded share extension validation passed