### PR TITLE
feat(creators): add native creator pages

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -94,6 +94,37 @@ struct APIClient {
         return response.item
     }
 
+    func getCreator(id: String) async throws -> CreatorResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/creators/\(id)"))
+    }
+
+    func listCreatorBookmarks(
+        creatorId: String,
+        cursor: String? = nil,
+        isFinished: Bool? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/creators/\(creatorId)/bookmarks"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        if let isFinished {
+            items.append(URLQueryItem(name: "isFinished", value: String(isFinished)))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func getCreatorLatestContent(id: String) async throws -> CreatorLatestContentResponse {
+        try await request(
+            url: baseURL.appending(path: "/api/v1/creators/\(id)/latest-content")
+        )
+    }
+
     func setFinished(id: String, isFinished: Bool) async throws -> FinishedStateResponse.FinishedBookmark {
         var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)"))
         request.httpMethod = "PATCH"

--- a/apps/ios/ZineNative/Core/API/APIResponses.swift
+++ b/apps/ios/ZineNative/Core/API/APIResponses.swift
@@ -9,6 +9,16 @@ struct BookmarkResponse: Decodable {
     let item: Bookmark
 }
 
+struct CreatorResponse: Decodable {
+    let creator: CreatorProfile
+}
+
+struct CreatorLatestContentResponse: Decodable {
+    let items: [CreatorContentItem]
+    let provider: Provider
+    let reason: String?
+}
+
 struct FinishedStateResponse: Decodable {
     struct FinishedBookmark: Decodable {
         let id: String

--- a/apps/ios/ZineNative/Core/Models/Creator.swift
+++ b/apps/ios/ZineNative/Core/Models/Creator.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct CreatorProfile: Codable, Hashable, Identifiable {
+    let id: String
+    let name: String
+    let imageUrl: URL?
+    let provider: Provider
+    let providerCreatorId: String
+    let description: String?
+    let handle: String?
+    let externalUrl: URL?
+    let createdAt: Int64
+    let updatedAt: Int64
+}
+
+struct CreatorContentItem: Codable, Hashable, Identifiable {
+    let id: String
+    let title: String
+    let description: String?
+    let thumbnailUrl: URL?
+    let publishedAt: Int64
+    let externalUrl: URL
+    let duration: Int?
+    let itemId: String?
+    let isBookmarked: Bool
+
+    var metadataLabel: String {
+        var parts = [
+            Date(timeIntervalSince1970: Double(publishedAt) / 1_000)
+                .formatted(date: .abbreviated, time: .omitted),
+        ]
+
+        if let duration {
+            let minutes = max(1, duration / 60)
+            parts.append(minutes < 60 ? "\(minutes) min" : "\(minutes / 60) hr \(minutes % 60) min")
+        }
+
+        return parts.joined(separator: " · ")
+    }
+}
+

--- a/apps/ios/ZineNative/Features/Creators/CreatorStore.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorStore.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CreatorStore {
+    private(set) var profile: CreatorProfile?
+    private(set) var bookmarks: [Bookmark] = []
+    private(set) var completedBookmarks: [Bookmark] = []
+    private(set) var latestContent: [CreatorContentItem] = []
+    private(set) var latestProvider: Provider?
+    private(set) var latestReason: String?
+    private(set) var isLoading = false
+    private(set) var isLoadingBookmarks = false
+    private(set) var isLoadingCompletedBookmarks = false
+    private(set) var isLoadingMore = false
+    private(set) var isLoadingMoreCompleted = false
+    private(set) var isLoadingLatest = false
+    private(set) var profileErrorMessage: String?
+    private(set) var bookmarksErrorMessage: String?
+    private(set) var completedBookmarksErrorMessage: String?
+    private(set) var latestErrorMessage: String?
+    private(set) var nextCursor: String?
+    private(set) var completedNextCursor: String?
+
+    let creatorId: String
+    private let client: APIClient
+
+    init(creatorId: String, client: APIClient) {
+        self.creatorId = creatorId
+        self.client = client
+    }
+
+    func reload() async {
+        profileErrorMessage = nil
+        bookmarksErrorMessage = nil
+        completedBookmarksErrorMessage = nil
+        latestErrorMessage = nil
+        isLoading = profile == nil && bookmarks.isEmpty && completedBookmarks.isEmpty
+
+        async let profileLoad: Void = loadProfile()
+        async let bookmarksLoad: Void = loadBookmarks(reset: true)
+        async let completedBookmarksLoad: Void = loadCompletedBookmarks(reset: true)
+        async let latestLoad: Void = loadLatestContent()
+        _ = await (profileLoad, bookmarksLoad, completedBookmarksLoad, latestLoad)
+
+        isLoading = false
+    }
+
+    func loadMoreIfNeeded(current bookmark: Bookmark) async {
+        guard bookmark.id == bookmarks.last?.id,
+            let nextCursor,
+            !isLoadingBookmarks,
+            !isLoadingMore
+        else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await client.listCreatorBookmarks(
+                creatorId: creatorId,
+                cursor: nextCursor,
+                isFinished: false
+            )
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(bookmarks.map(\.id))
+            bookmarks.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
+            self.nextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            bookmarksErrorMessage = error.localizedDescription
+        }
+    }
+
+    func loadMoreCompletedIfNeeded(current bookmark: Bookmark) async {
+        guard bookmark.id == completedBookmarks.last?.id,
+            let completedNextCursor,
+            !isLoadingCompletedBookmarks,
+            !isLoadingMoreCompleted
+        else { return }
+
+        isLoadingMoreCompleted = true
+        defer { isLoadingMoreCompleted = false }
+
+        do {
+            let response = try await client.listCreatorBookmarks(
+                creatorId: creatorId,
+                cursor: completedNextCursor,
+                isFinished: true
+            )
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(completedBookmarks.map(\.id))
+            completedBookmarks.append(
+                contentsOf: response.items.filter { !existingIDs.contains($0.id) }
+            )
+            self.completedNextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            completedBookmarksErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadProfile() async {
+        do {
+            profile = try await client.getCreator(id: creatorId).creator
+        } catch is CancellationError {
+            return
+        } catch {
+            profileErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadBookmarks(reset: Bool) async {
+        isLoadingBookmarks = reset && bookmarks.isEmpty
+        defer { isLoadingBookmarks = false }
+
+        do {
+            let response = try await client.listCreatorBookmarks(
+                creatorId: creatorId,
+                isFinished: false
+            )
+            guard !Task.isCancelled else { return }
+            bookmarks = response.items
+            nextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            bookmarksErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadCompletedBookmarks(reset: Bool) async {
+        isLoadingCompletedBookmarks = reset && completedBookmarks.isEmpty
+        defer { isLoadingCompletedBookmarks = false }
+
+        do {
+            let response = try await client.listCreatorBookmarks(
+                creatorId: creatorId,
+                isFinished: true
+            )
+            guard !Task.isCancelled else { return }
+            completedBookmarks = response.items
+            completedNextCursor = response.nextCursor
+        } catch is CancellationError {
+            return
+        } catch {
+            completedBookmarksErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadLatestContent() async {
+        isLoadingLatest = latestContent.isEmpty
+        defer { isLoadingLatest = false }
+
+        do {
+            let response = try await client.getCreatorLatestContent(id: creatorId)
+            guard !Task.isCancelled else { return }
+            latestContent = response.items
+            latestProvider = response.provider
+            latestReason = response.reason
+        } catch is CancellationError {
+            return
+        } catch {
+            latestErrorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Creators/CreatorView.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorView.swift
@@ -15,6 +15,7 @@ struct CreatorView: View {
 
     @State private var store: CreatorStore
     @State private var selectedSection: ContentSection = .bookmarked
+    @State private var renderedSection: ContentSection = .bookmarked
 
     init(
         creatorId: String,
@@ -106,7 +107,7 @@ struct CreatorView: View {
 
     private var contentSwitcher: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Picker("Creator content", selection: $selectedSection) {
+            Picker("Creator content", selection: sectionSelection) {
                 Text("Bookmarked")
                     .tag(ContentSection.bookmarked)
                 Text(latestSectionTitle)
@@ -115,7 +116,7 @@ struct CreatorView: View {
             .pickerStyle(.segmented)
             .sensoryFeedback(.selection, trigger: selectedSection)
 
-            switch selectedSection {
+            switch renderedSection {
             case .bookmarked:
                 savedSection
             case .latest:
@@ -126,6 +127,22 @@ struct CreatorView: View {
 
     private var latestSectionTitle: String {
         store.latestProvider.map { "Latest on \($0.title)" } ?? "Latest"
+    }
+
+    private var sectionSelection: Binding<ContentSection> {
+        Binding(
+            get: { selectedSection },
+            set: { newSelection in
+                guard newSelection != selectedSection else { return }
+                selectedSection = newSelection
+
+                Task { @MainActor in
+                    await Task.yield()
+                    guard selectedSection == newSelection else { return }
+                    renderedSection = newSelection
+                }
+            }
+        )
     }
 
     private var savedSection: some View {
@@ -214,7 +231,7 @@ struct CreatorView: View {
     }
 
     private func bookmarkRows(_ bookmarks: [Bookmark], isCompleted: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(bookmarks) { bookmark in
                 NavigationLink {
                     BookmarkDetailView(
@@ -267,7 +284,7 @@ struct CreatorView: View {
                     message: "This creator’s feed doesn’t have any recent content to show."
                 )
             } else {
-                VStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
                     ForEach(store.latestContent) { item in
                         Link(destination: item.externalUrl) {
                             creatorContentRow(

--- a/apps/ios/ZineNative/Features/Creators/CreatorView.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorView.swift
@@ -1,0 +1,363 @@
+import SwiftUI
+
+struct CreatorView: View {
+    private enum ContentSection: Hashable {
+        case bookmarked
+        case latest
+    }
+
+    let fallbackName: String
+    let fallbackImageUrl: URL?
+    let client: APIClient
+    let onBookmarkUpdate: (Bookmark) -> Void
+    let onBookmarkChange: (Bookmark, Bool, BookmarkChangePhase) -> Void
+    let onBookmarkCommit: (Bookmark, Bool) -> Void
+
+    @State private var store: CreatorStore
+    @State private var selectedSection: ContentSection = .bookmarked
+
+    init(
+        creatorId: String,
+        fallbackName: String,
+        fallbackImageUrl: URL?,
+        client: APIClient,
+        onBookmarkUpdate: @escaping (Bookmark) -> Void = { _ in },
+        onBookmarkChange: @escaping (Bookmark, Bool, BookmarkChangePhase) -> Void = { _, _, _ in },
+        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in }
+    ) {
+        self.fallbackName = fallbackName
+        self.fallbackImageUrl = fallbackImageUrl
+        self.client = client
+        self.onBookmarkUpdate = onBookmarkUpdate
+        self.onBookmarkChange = onBookmarkChange
+        self.onBookmarkCommit = onBookmarkCommit
+        _store = State(initialValue: CreatorStore(creatorId: creatorId, client: client))
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 20) {
+                creatorHeader
+                contentSwitcher
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 16)
+            .padding(.bottom, 40)
+        }
+        .navigationTitle(store.profile?.name ?? fallbackName)
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await store.reload() }
+        .refreshable { await store.reload() }
+    }
+
+    private var creatorHeader: some View {
+        VStack(spacing: 12) {
+            CreatorAvatar(
+                imageUrl: store.profile?.imageUrl ?? fallbackImageUrl,
+                creator: store.profile?.name ?? fallbackName,
+                contentType: .article,
+                size: 88
+            )
+
+            VStack(spacing: 5) {
+                Text(store.profile?.name ?? fallbackName)
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+
+                if let handle = store.profile?.handle, !handle.isEmpty {
+                    Text(handle)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let description = store.profile?.description, !description.isEmpty {
+                Text(description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(5)
+            }
+
+            if let externalUrl = store.profile?.externalUrl,
+                let provider = store.profile?.provider
+            {
+                ProviderLinkButton(
+                    provider: provider,
+                    destination: externalUrl,
+                    title: provider.creatorActionTitle
+                )
+                .padding(.top, 8)
+            } else if let externalUrl = store.profile?.externalUrl {
+                Link("View creator", destination: externalUrl)
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.top, 8)
+            }
+
+            if let error = store.profileErrorMessage {
+                Text("Some profile details couldn’t be loaded. \(error)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var contentSwitcher: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Picker("Creator content", selection: $selectedSection) {
+                Text("Bookmarked")
+                    .tag(ContentSection.bookmarked)
+                Text(latestSectionTitle)
+                    .tag(ContentSection.latest)
+            }
+            .pickerStyle(.segmented)
+            .sensoryFeedback(.selection, trigger: selectedSection)
+
+            switch selectedSection {
+            case .bookmarked:
+                savedSection
+            case .latest:
+                latestSection
+            }
+        }
+    }
+
+    private var latestSectionTitle: String {
+        store.latestProvider.map { "Latest on \($0.title)" } ?? "Latest"
+    }
+
+    private var savedSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            if (store.isLoadingBookmarks || store.isLoadingCompletedBookmarks)
+                && store.bookmarks.isEmpty
+                && store.completedBookmarks.isEmpty
+            {
+                ProgressView("Loading bookmarks…")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+            } else if store.bookmarks.isEmpty && store.completedBookmarks.isEmpty {
+                sectionMessage(
+                    title: "No saved content",
+                    message: "Bookmarks from this creator will appear here."
+                )
+            } else {
+                bookmarkSection(
+                    title: "Up Next",
+                    bookmarks: store.bookmarks,
+                    isCompleted: false,
+                    isLoading: store.isLoadingBookmarks,
+                    isLoadingMore: store.isLoadingMore,
+                    emptyMessage: "Nothing unfinished from this creator."
+                )
+
+                bookmarkSection(
+                    title: "Completed",
+                    bookmarks: store.completedBookmarks,
+                    isCompleted: true,
+                    isLoading: store.isLoadingCompletedBookmarks,
+                    isLoadingMore: store.isLoadingMoreCompleted,
+                    emptyMessage: "No completed bookmarks from this creator yet."
+                )
+            }
+
+            if let error = store.bookmarksErrorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if let error = store.completedBookmarksErrorMessage {
+                Text("Completed bookmarks couldn’t be loaded. \(error)")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func bookmarkSection(
+        title: String,
+        bookmarks: [Bookmark],
+        isCompleted: Bool,
+        isLoading: Bool,
+        isLoadingMore: Bool,
+        emptyMessage: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+                Text("\(bookmarks.count)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if isLoading && bookmarks.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            } else if bookmarks.isEmpty {
+                Text(emptyMessage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            } else {
+                bookmarkRows(bookmarks, isCompleted: isCompleted)
+
+                if isLoadingMore {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private func bookmarkRows(_ bookmarks: [Bookmark], isCompleted: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(bookmarks) { bookmark in
+                NavigationLink {
+                    BookmarkDetailView(
+                        bookmark: bookmark,
+                        client: client,
+                        onUpdate: onBookmarkUpdate,
+                        onBookmarkChange: onBookmarkChange,
+                        onBookmarkCommit: onBookmarkCommit
+                    )
+                } label: {
+                    creatorContentRow(
+                        thumbnailUrl: bookmark.thumbnailUrl,
+                        title: bookmark.title,
+                        metadataLabel: bookmarkMetadataLabel(bookmark),
+                        placeholderSystemImage: bookmark.contentType.systemImage,
+                        accessorySystemImage: "chevron.right"
+                    )
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.plain)
+                .task {
+                    if isCompleted {
+                        await store.loadMoreCompletedIfNeeded(current: bookmark)
+                    } else {
+                        await store.loadMoreIfNeeded(current: bookmark)
+                    }
+                }
+
+                if bookmark.id != bookmarks.last?.id {
+                    Divider().padding(.leading, 106)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var latestSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if store.isLoadingLatest && store.latestContent.isEmpty {
+                ProgressView("Checking for recent content…")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 24)
+            } else if let error = store.latestErrorMessage {
+                sectionMessage(title: "Latest content unavailable", message: error)
+            } else if let reason = store.latestReason {
+                sectionMessage(title: "Latest content unavailable", message: latestReasonMessage(reason))
+            } else if store.latestContent.isEmpty {
+                sectionMessage(
+                    title: "Nothing recent found",
+                    message: "This creator’s feed doesn’t have any recent content to show."
+                )
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(store.latestContent) { item in
+                        Link(destination: item.externalUrl) {
+                            creatorContentRow(
+                                thumbnailUrl: item.thumbnailUrl,
+                                title: item.title,
+                                metadataLabel: item.metadataLabel,
+                                placeholderSystemImage: "doc.richtext",
+                                accessorySystemImage: "arrow.up.right"
+                            )
+                                .padding(.vertical, 8)
+                        }
+                        .buttonStyle(.plain)
+
+                        if item.id != store.latestContent.last?.id {
+                            Divider().padding(.leading, 106)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func sectionMessage(title: String, message: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.subheadline.weight(.semibold))
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 12))
+    }
+
+    private func creatorContentRow(
+        thumbnailUrl: URL?,
+        title: String,
+        metadataLabel: String,
+        placeholderSystemImage: String,
+        accessorySystemImage: String
+    ) -> some View {
+        HStack(spacing: 12) {
+            CachedRemoteImage(
+                url: thumbnailUrl,
+                targetSize: CGSize(width: 94, height: 60)
+            ) {
+                ZStack {
+                    Color.secondary.opacity(0.12)
+                    Image(systemName: placeholderSystemImage)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 94, height: 60)
+            .clipShape(.rect(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(metadataLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+            Image(systemName: accessorySystemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .contentShape(Rectangle())
+    }
+
+    private func bookmarkMetadataLabel(_ bookmark: Bookmark) -> String {
+        [bookmark.creator, bookmark.consumptionLabel]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+    }
+
+    private func latestReasonMessage(_ reason: String) -> String {
+        switch reason {
+        case "NOT_CONNECTED":
+            "Connect this provider in Subscriptions to load the creator’s latest content."
+        case "TOKEN_EXPIRED":
+            "Reconnect this provider in Subscriptions to refresh the creator’s feed."
+        case "RATE_LIMITED":
+            "The provider is temporarily rate limited. Pull to refresh in a few minutes."
+        default:
+            "A latest-content feed isn’t available for this source yet."
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Creators/CreatorView.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorView.swift
@@ -8,6 +8,7 @@ struct CreatorView: View {
 
     let fallbackName: String
     let fallbackImageUrl: URL?
+    let fallbackProvider: Provider
     let client: APIClient
     let onBookmarkUpdate: (Bookmark) -> Void
     let onBookmarkChange: (Bookmark, Bool, BookmarkChangePhase) -> Void
@@ -21,6 +22,7 @@ struct CreatorView: View {
         creatorId: String,
         fallbackName: String,
         fallbackImageUrl: URL?,
+        fallbackProvider: Provider,
         client: APIClient,
         onBookmarkUpdate: @escaping (Bookmark) -> Void = { _ in },
         onBookmarkChange: @escaping (Bookmark, Bool, BookmarkChangePhase) -> Void = { _, _, _ in },
@@ -28,6 +30,7 @@ struct CreatorView: View {
     ) {
         self.fallbackName = fallbackName
         self.fallbackImageUrl = fallbackImageUrl
+        self.fallbackProvider = fallbackProvider
         self.client = client
         self.onBookmarkUpdate = onBookmarkUpdate
         self.onBookmarkChange = onBookmarkChange
@@ -126,7 +129,7 @@ struct CreatorView: View {
     }
 
     private var latestSectionTitle: String {
-        store.latestProvider.map { "Latest on \($0.title)" } ?? "Latest"
+        "Latest on \((store.latestProvider ?? fallbackProvider).title)"
     }
 
     private var sectionSelection: Binding<ContentSection> {

--- a/apps/ios/ZineNative/Features/Library/ActionRowHaptic.swift
+++ b/apps/ios/ZineNative/Features/Library/ActionRowHaptic.swift
@@ -1,14 +1,20 @@
 import SwiftUI
 import UIKit
 
+enum ActionRowHaptics {
+    static func play() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+}
+
 private struct ActionRowHapticModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.simultaneousGesture(
             TapGesture()
                 .onEnded {
-                    let generator = UIImpactFeedbackGenerator(style: .light)
-                    generator.prepare()
-                    generator.impactOccurred()
+                    ActionRowHaptics.play()
                 }
         )
     }

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -234,6 +234,7 @@ struct BookmarkDetailView: View {
                     creatorId: creatorId,
                     fallbackName: bookmark.creator,
                     fallbackImageUrl: bookmark.creatorImageUrl,
+                    fallbackProvider: bookmark.provider,
                     client: client,
                     onBookmarkUpdate: onUpdate,
                     onBookmarkChange: onBookmarkChange,

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -226,7 +226,30 @@ struct BookmarkDetailView: View {
             .contentShape(Rectangle())
     }
 
+    @ViewBuilder
     private var creatorRow: some View {
+        if let creatorId = bookmark.creatorId {
+            NavigationLink {
+                CreatorView(
+                    creatorId: creatorId,
+                    fallbackName: bookmark.creator,
+                    fallbackImageUrl: bookmark.creatorImageUrl,
+                    client: client,
+                    onBookmarkUpdate: onUpdate,
+                    onBookmarkChange: onBookmarkChange,
+                    onBookmarkCommit: onBookmarkCommit
+                )
+            } label: {
+                creatorRowLabel(showsDisclosure: true)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("View \(bookmark.creator)")
+        } else {
+            creatorRowLabel(showsDisclosure: false)
+        }
+    }
+
+    private func creatorRowLabel(showsDisclosure: Bool) -> some View {
         HStack(spacing: 10) {
             CreatorAvatar(
                 imageUrl: bookmark.creatorImageUrl,
@@ -237,7 +260,13 @@ struct BookmarkDetailView: View {
 
             Text(bookmark.creator)
                 .font(.headline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
+
+            if showsDisclosure {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
         }
         .accessibilityElement(children: .combine)
     }
@@ -302,7 +331,7 @@ struct BookmarkDetailView: View {
             }
         }
         .font(.subheadline)
-        .foregroundStyle(.tertiary)
+        .foregroundStyle(Color.primary.opacity(0.72))
     }
 
     private func toggleFinished() async {

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -16,6 +16,7 @@ struct BookmarkRow: View {
                 creatorLine
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 2)
         .accessibilityElement(children: .combine)
     }

--- a/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
+++ b/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
@@ -15,6 +15,17 @@ struct ProviderOpenAction {
 }
 
 extension Provider {
+    var creatorActionTitle: String {
+        switch self {
+        case .youtube, .spotify, .substack, .x, .web:
+            "View on \(title)"
+        case .gmail:
+            "View in Gmail"
+        case .rss:
+            "View feed"
+        }
+    }
+
     var openAction: ProviderOpenAction {
         switch self {
         case .youtube:
@@ -80,6 +91,64 @@ extension Provider {
                 logo: .system("dot.radiowaves.left.and.right"),
                 needsDarkModeBorder: false
             )
+        }
+    }
+}
+
+struct ProviderLinkButton: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.openURL) private var openURL
+
+    let provider: Provider
+    let destination: URL
+    let title: String
+
+    private var action: ProviderOpenAction { provider.openAction }
+
+    var body: some View {
+        Button {
+            ActionRowHaptics.play()
+            openURL(destination)
+        } label: {
+            HStack(spacing: 8) {
+                providerLogo
+                    .frame(width: 18, height: 18)
+
+                Text(title)
+
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.bold))
+            }
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(action.foregroundColor)
+            .padding(.horizontal, 15)
+            .frame(minHeight: 44)
+            .background(action.backgroundColor, in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .overlay {
+            if action.needsDarkModeBorder && colorScheme == .dark {
+                Capsule()
+                    .stroke(.white.opacity(0.22), lineWidth: 1)
+                    .allowsHitTesting(false)
+            }
+        }
+        .accessibilityLabel(title)
+    }
+
+    @ViewBuilder
+    private var providerLogo: some View {
+        switch action.logo {
+        case let .asset(name):
+            Image(name)
+                .resizable()
+                .scaledToFit()
+        case let .system(name):
+            Image(systemName: name)
+                .resizable()
+                .scaledToFit()
+                .symbolRenderingMode(.monochrome)
         }
     }
 }

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -48,6 +48,35 @@ final class BookmarkTests: XCTestCase {
         XCTAssertEqual(Provider.rss.title, "RSS")
     }
 
+    func testDecodesCreatorProfileAndLatestContent() throws {
+        let creator = try JSONDecoder().decode(
+            CreatorResponse.self,
+            from: Data(
+                """
+                {"creator":{"id":"creator_1","name":"Creator One","imageUrl":null,
+                "provider":"YOUTUBE","providerCreatorId":"channel_1","description":"Videos",
+                "handle":"@creator","externalUrl":"https://youtube.com/@creator",
+                "createdAt":1,"updatedAt":2}}
+                """.utf8
+            )
+        )
+        let latest = try JSONDecoder().decode(
+            CreatorLatestContentResponse.self,
+            from: Data(
+                """
+                {"items":[{"id":"video_1","title":"New video","description":null,
+                "thumbnailUrl":null,"publishedAt":1752797600000,
+                "externalUrl":"https://youtube.com/watch?v=video_1","duration":600,
+                "itemId":null,"isBookmarked":false}],"provider":"YOUTUBE"}
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(creator.creator.provider, .youtube)
+        XCTAssertEqual(latest.items.first?.duration, 600)
+        XCTAssertEqual(latest.reason, nil)
+    }
+
     func testProviderOpenActionsMatchDestinationsAndBrandLogos() {
         XCTAssertEqual(Provider.youtube.openAction.title, "Open in YouTube")
         XCTAssertEqual(Provider.youtube.openAction.logo, .asset("YouTubeLogo"))
@@ -59,5 +88,9 @@ final class BookmarkTests: XCTestCase {
         XCTAssertEqual(Provider.web.openAction.logo, .system("safari.fill"))
         XCTAssertEqual(Provider.x.openAction.title, "Open in X")
         XCTAssertEqual(Provider.x.openAction.logo, .asset("XLogo"))
+        XCTAssertEqual(Provider.youtube.creatorActionTitle, "View on YouTube")
+        XCTAssertEqual(Provider.spotify.creatorActionTitle, "View on Spotify")
+        XCTAssertEqual(Provider.substack.creatorActionTitle, "View on Substack")
+        XCTAssertEqual(Provider.x.creatorActionTitle, "View on X")
     }
 }

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.5.0",
-    "description": "REST API for reading and managing Zine inbox items, bookmarks, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
+    "version": "1.6.0",
+    "description": "REST API for reading and managing Zine inbox items, bookmarks, creators, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
     {
@@ -27,6 +27,10 @@
     {
       "name": "Bookmarks",
       "description": "Read, save, update, and remove bookmarked items."
+    },
+    {
+      "name": "Creators",
+      "description": "Read creator profiles, bookmarked content, and provider-backed latest content."
     },
     {
       "name": "Tags",
@@ -56,6 +60,98 @@
         "responses": {
           "200": {
             "description": "OpenAPI document for the Zine REST API."
+          }
+        }
+      }
+    },
+    "/api/v1/creators/{creatorId}": {
+      "get": {
+        "tags": ["Creators"],
+        "operationId": "getCreator",
+        "summary": "Get a creator profile",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [{ "$ref": "#/components/parameters/CreatorId" }],
+        "responses": {
+          "200": {
+            "description": "Creator profile.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CreatorResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/creators/{creatorId}/bookmarks": {
+      "get": {
+        "tags": ["Creators"],
+        "operationId": "listCreatorBookmarks",
+        "summary": "List bookmarks from a creator",
+        "description": "Returns all content the authenticated user has bookmarked from this creator, newest bookmark first.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          { "$ref": "#/components/parameters/CreatorId" },
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" },
+          {
+            "name": "isFinished",
+            "in": "query",
+            "description": "Filter creator bookmarks by completion state. Omit to return all bookmarks.",
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmarked content from the creator.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedItems" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/api/v1/creators/{creatorId}/latest-content": {
+      "get": {
+        "tags": ["Creators"],
+        "operationId": "getCreatorLatestContent",
+        "summary": "Get a creator's latest content",
+        "description": "Returns recent content from the creator's provider or discoverable feed when that source is supported.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [{ "$ref": "#/components/parameters/CreatorId" }],
+        "responses": {
+          "200": {
+            "description": "Latest provider-backed content, or a reason it is unavailable.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CreatorLatestContentResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": {
+            "description": "The provider is temporarily rate limited.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
           }
         }
       }
@@ -1859,6 +1955,15 @@
         "schema": {
           "type": "string"
         }
+      },
+      "CreatorId": {
+        "name": "creatorId",
+        "in": "path",
+        "required": true,
+        "description": "Stable creator ID attached to an item.",
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "responses": {
@@ -2012,6 +2117,94 @@
             "type": "string"
           }
         }
+      },
+      "Creator": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "imageUrl",
+          "provider",
+          "providerCreatorId",
+          "description",
+          "handle",
+          "externalUrl",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "imageUrl": { "type": ["string", "null"], "format": "uri" },
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "providerCreatorId": { "type": "string" },
+          "description": { "type": ["string", "null"] },
+          "handle": { "type": ["string", "null"] },
+          "externalUrl": { "type": ["string", "null"], "format": "uri" },
+          "createdAt": { "type": "integer" },
+          "updatedAt": { "type": "integer" }
+        }
+      },
+      "CreatorResponse": {
+        "allOf": [
+          { "$ref": "#/components/schemas/RequestMetadata" },
+          {
+            "type": "object",
+            "required": ["creator"],
+            "properties": {
+              "creator": { "$ref": "#/components/schemas/Creator" }
+            }
+          }
+        ]
+      },
+      "CreatorLatestContentItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "description",
+          "thumbnailUrl",
+          "publishedAt",
+          "externalUrl",
+          "duration",
+          "isBookmarked"
+        ],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": ["string", "null"] },
+          "thumbnailUrl": { "type": ["string", "null"], "format": "uri" },
+          "publishedAt": { "type": "integer", "description": "Unix time in milliseconds." },
+          "externalUrl": { "type": "string", "format": "uri" },
+          "duration": { "type": ["integer", "null"], "minimum": 0 },
+          "itemId": { "type": ["string", "null"] },
+          "isBookmarked": { "type": "boolean" }
+        }
+      },
+      "CreatorLatestContentResponse": {
+        "allOf": [
+          { "$ref": "#/components/schemas/RequestMetadata" },
+          {
+            "type": "object",
+            "required": ["items", "provider"],
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/CreatorLatestContentItem" }
+              },
+              "provider": { "type": "string" },
+              "cacheStatus": { "type": "string", "enum": ["HIT", "MISS"] },
+              "reason": {
+                "type": "string",
+                "enum": ["PROVIDER_NOT_SUPPORTED", "NOT_CONNECTED", "TOKEN_EXPIRED", "RATE_LIMITED"]
+              },
+              "connectUrl": { "type": "string", "format": "uri" }
+            }
+          }
+        ]
       },
       "Tag": {
         "type": "object",

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -17,6 +17,9 @@ const {
   mockGetItem,
   mockBookmarkInboxItem,
   mockArchiveInboxItem,
+  mockGetCreator,
+  mockCreatorBookmarks,
+  mockCreatorLatestContent,
   mockUnbookmark,
   mockSetTags,
   mockMarkOpened,
@@ -70,6 +73,9 @@ const {
   mockGetItem: vi.fn(),
   mockBookmarkInboxItem: vi.fn(),
   mockArchiveInboxItem: vi.fn(),
+  mockGetCreator: vi.fn(),
+  mockCreatorBookmarks: vi.fn(),
+  mockCreatorLatestContent: vi.fn(),
   mockUnbookmark: vi.fn(),
   mockSetTags: vi.fn(),
   mockMarkOpened: vi.fn(),
@@ -302,6 +308,11 @@ describe('apiV1Routes', () => {
         preview: mockPreview,
         save: mockSave,
       },
+      creators: {
+        get: mockGetCreator,
+        listBookmarks: mockCreatorBookmarks,
+        fetchLatestContent: mockCreatorLatestContent,
+      },
       subscriptions: {
         connections: {
           list: mockConnectionsList,
@@ -352,6 +363,9 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/inbox');
     expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/bookmark');
     expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/archive');
+    expect(body.paths).toHaveProperty('/api/v1/creators/{creatorId}');
+    expect(body.paths).toHaveProperty('/api/v1/creators/{creatorId}/bookmarks');
+    expect(body.paths).toHaveProperty('/api/v1/creators/{creatorId}/latest-content');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/preview');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}');
@@ -381,6 +395,79 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/connection/callback');
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}');
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}/sync');
+  });
+
+  it('returns creator profile, bookmarks, and latest content for a Clerk session', async () => {
+    const app = createTestApp();
+    mockVerifyClerkRequestToken.mockResolvedValue({
+      success: true,
+      userId: 'user_123',
+    });
+    mockGetCreator.mockResolvedValue({
+      id: 'creator_1',
+      name: 'Creator One',
+      imageUrl: null,
+      provider: Provider.YOUTUBE,
+      providerCreatorId: 'channel_1',
+      description: 'Makes thoughtful videos.',
+      handle: '@creatorone',
+      externalUrl: 'https://youtube.com/@creatorone',
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    mockCreatorBookmarks.mockResolvedValue({
+      items: [{ id: 'ui_1', title: 'Saved video' }],
+      nextCursor: 'next-page',
+      hasMore: true,
+    });
+    mockCreatorLatestContent.mockResolvedValue({
+      provider: Provider.YOUTUBE,
+      items: [
+        {
+          id: 'video_1',
+          title: 'A new video',
+          description: null,
+          thumbnailUrl: null,
+          publishedAt: 1_752_797_600_000,
+          externalUrl: 'https://youtube.com/watch?v=video_1',
+          duration: 600,
+          itemId: null,
+          isBookmarked: false,
+        },
+      ],
+      cacheStatus: 'MISS',
+    });
+
+    const headers = { Authorization: 'Bearer clerk-session-token' };
+    const creator = await app.fetch(
+      new Request('http://localhost/api/v1/creators/creator_1', { headers }),
+      createMockEnv()
+    );
+    const bookmarks = await app.fetch(
+      new Request(
+        'http://localhost/api/v1/creators/creator_1/bookmarks?limit=20&cursor=page-1&isFinished=false',
+        { headers }
+      ),
+      createMockEnv()
+    );
+    const latest = await app.fetch(
+      new Request('http://localhost/api/v1/creators/creator_1/latest-content', { headers }),
+      createMockEnv()
+    );
+
+    expect(creator.status).toBe(200);
+    expect(bookmarks.status).toBe(200);
+    expect(latest.status).toBe(200);
+    expect(mockGetCreator).toHaveBeenCalledWith({ creatorId: 'creator_1' });
+    expect(mockCreatorBookmarks).toHaveBeenCalledWith({
+      creatorId: 'creator_1',
+      limit: 20,
+      cursor: 'page-1',
+      isFinished: false,
+    });
+    expect(mockCreatorLatestContent).toHaveBeenCalledWith({ creatorId: 'creator_1' });
+    expect(await bookmarks.json()).toMatchObject({ nextCursor: 'next-page' });
+    expect(await latest.json()).toMatchObject({ provider: Provider.YOUTUBE });
   });
 
   it('lists current and available YouTube subscriptions for a Clerk session', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1367,6 +1367,60 @@ apiV1Routes.get('/inbox', apiAuth('bookmarks:read'), async (c) => {
   });
 });
 
+apiV1Routes.get('/creators/:creatorId', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const creator = await caller.creators.get({ creatorId: c.req.param('creatorId') });
+    return c.json({
+      creator,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/creators/:creatorId/bookmarks', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+
+  try {
+    const result = await caller.creators.listBookmarks({
+      creatorId: c.req.param('creatorId'),
+      limit: parseLimit(c.req.query('limit')),
+      cursor: cursor && cursor.length > 0 ? cursor : undefined,
+      isFinished: parseBoolean(c.req.query('isFinished')),
+    });
+    return c.json({
+      items: result.items,
+      nextCursor: result.nextCursor,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.get('/creators/:creatorId/latest-content', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.creators.fetchLatestContent({
+      creatorId: c.req.param('creatorId'),
+    });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
 apiV1Routes.post('/inbox/:id/bookmark', apiAuth('bookmarks:write'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 

--- a/apps/worker/src/trpc/routers/creators.ts
+++ b/apps/worker/src/trpc/routers/creators.ts
@@ -147,6 +147,7 @@ const ListBookmarksInputSchema = z.object({
   creatorId: z.string().min(1, 'Creator ID is required'),
   cursor: z.string().optional(),
   limit: z.number().int().min(1).max(50).default(20),
+  isFinished: z.boolean().optional(),
 });
 
 const ListPublicationsInputSchema = z.object({
@@ -370,6 +371,10 @@ export const creatorsRouter = router({
           eq(userItems.userId, ctx.userId),
           eq(userItems.state, UserItemState.BOOKMARKED),
         ];
+
+        if (input.isFinished !== undefined) {
+          conditions.push(eq(userItems.isFinished, input.isFinished));
+        }
 
         // Use COALESCE to handle NULL bookmarkedAt - falls back to ingestedAt
         const sortField = sql`COALESCE(${userItems.bookmarkedAt}, ${userItems.ingestedAt})`;


### PR DESCRIPTION
## Summary

- expose creator profiles, creator bookmarks, completion filtering, and provider-backed latest content through the Clerk-authenticated REST API and OpenAPI contract
- add the native SwiftUI creator page with Bookmarked and Latest sections, provider-branded creator actions, shared content rows, and haptic feedback
- preserve bookmark update callbacks and use explicit detail routing so creator bookmark taps stay on the selected content

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test` (1,125 mobile, 1,569 worker, and 75 web tests passed)
- `bun run build`
- `xcodebuild test -project ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS Simulator` (native suite passed)
- signed Release builds installed and exercised on a physical iPhone