### PR TITLE
feat(ios): add native home dashboard

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -2,6 +2,18 @@ import ClerkKit
 import ClerkKitUI
 import SwiftUI
 
+struct ExternalBookmarkOpenEvent: Equatable {
+    enum Change: Equatable {
+        case promote
+        case rollback
+    }
+
+    let id = UUID()
+    let bookmark: Bookmark
+    let openedAt: Date
+    let change: Change
+}
+
 struct AppRootView: View {
     let configuration: AppConfiguration
 
@@ -22,12 +34,18 @@ struct AppRootView: View {
 }
 
 private struct AuthenticatedAppView: View {
+    @Environment(\.scenePhase) private var scenePhase
+
     private let client: APIClient
+    private let homeCache: HomeCache
     private let libraryCache: LibraryCache
     private let inboxCache: InboxCache
 
     @State private var search = ""
+    @State private var homeRevision = 0
     @State private var libraryRevision = 0
+    @State private var externalOpenEvent: ExternalBookmarkOpenEvent?
+    @State private var externalOpenError: String?
 
     init(configuration: AppConfiguration, userID: String) {
         client = APIClient(
@@ -39,17 +57,32 @@ private struct AuthenticatedAppView: View {
                 return token
             }
         )
+        homeCache = HomeCache(userID: userID)
         libraryCache = LibraryCache(userID: userID)
         inboxCache = InboxCache(userID: userID)
     }
 
     var body: some View {
         TabView {
+            Tab("Home", systemImage: "house") {
+                HomeView(
+                    client: client,
+                    cache: homeCache,
+                    refreshRevision: homeRevision,
+                    externalOpenEvent: externalOpenEvent,
+                    onContentChanged: markBookmarkContentChanged,
+                    onExternalOpen: handleExternalOpen
+                )
+                .tint(Color.accentColor)
+            }
+
             Tab("Inbox", systemImage: "tray") {
                 InboxView(
                     client: client,
                     cache: inboxCache,
-                    onLibraryChanged: markLibraryChanged
+                    onLibraryChanged: markLibraryChanged,
+                    onInboxChanged: markHomeChanged,
+                    onExternalOpen: handleExternalOpen
                 )
                 .tint(Color.accentColor)
             }
@@ -58,7 +91,9 @@ private struct AuthenticatedAppView: View {
                 LibraryView(
                     client: client,
                     cache: libraryCache,
-                    refreshRevision: libraryRevision
+                    refreshRevision: libraryRevision,
+                    onContentChanged: markHomeChanged,
+                    onExternalOpen: handleExternalOpen
                 )
                 .tint(Color.accentColor)
             }
@@ -73,17 +108,81 @@ private struct AuthenticatedAppView: View {
                     client: client,
                     cache: libraryCache,
                     searchText: $search,
-                    refreshRevision: libraryRevision
+                    refreshRevision: libraryRevision,
+                    onContentChanged: markHomeChanged,
+                    onExternalOpen: handleExternalOpen
                 )
                 .searchable(text: $search, prompt: "Search your library")
                 .tint(Color.accentColor)
             }
         }
         .tint(Color.primary)
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active {
+                homeRevision += 1
+            }
+        }
+        .alert("Couldn’t update Jump Back In", isPresented: Binding(
+            get: { externalOpenError != nil },
+            set: { if !$0 { externalOpenError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(externalOpenError ?? "Please try again.")
+        }
     }
 
     private func markLibraryChanged() {
         libraryRevision += 1
+    }
+
+    private func markHomeChanged() {
+        homeRevision += 1
+    }
+
+    private func markBookmarkContentChanged() {
+        homeRevision += 1
+        libraryRevision += 1
+    }
+
+    private func handleExternalOpen(_ bookmark: Bookmark) {
+        guard bookmark.state == "BOOKMARKED", !bookmark.isFinished else { return }
+
+        let openedAt = Date()
+        externalOpenEvent = ExternalBookmarkOpenEvent(
+            bookmark: bookmark,
+            openedAt: openedAt,
+            change: .promote
+        )
+
+        Task {
+            await persistExternalOpen(bookmark, openedAt: openedAt)
+        }
+    }
+
+    private func persistExternalOpen(_ bookmark: Bookmark, openedAt: Date) async {
+        do {
+            try await client.markOpened(id: bookmark.id)
+        } catch is CancellationError {
+            return
+        } catch {
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+                try await client.markOpened(id: bookmark.id)
+            } catch is CancellationError {
+                return
+            } catch {
+                externalOpenEvent = ExternalBookmarkOpenEvent(
+                    bookmark: bookmark,
+                    openedAt: openedAt,
+                    change: .rollback
+                )
+                externalOpenError = "Zine couldn’t save that open after retrying. Your Home screen has been restored."
+                return
+            }
+        }
+
+        homeRevision += 1
     }
 }
 

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -60,7 +60,9 @@ struct ZineNativeApp: App {
     @ViewBuilder
     private var rootView: some View {
 #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("-screenshot-fixtures") {
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-home-fixtures") {
+            ScreenshotHomeView()
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-fixtures") {
             ScreenshotLibraryView()
         } else {
             configuredRootView

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -35,6 +35,10 @@ struct APIClient {
     let tokenProvider: TokenProvider
     var session: URLSession = .shared
 
+    func getHome() async throws -> HomeResponse {
+        try await request(url: baseURL.appending(path: "/api/v1/home"))
+    }
+
     func listBookmarks(
         query: LibraryQuery,
         cursor: String? = nil,
@@ -57,6 +61,55 @@ struct APIClient {
         if let contentType = query.contentType {
             items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
         }
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func listOpenedBookmarks(
+        cursor: String? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/bookmarks/opened"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func listQuickWinBookmarks(
+        cursor: String? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/bookmarks/quick-wins"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let cursor {
+            items.append(URLQueryItem(name: "cursor", value: cursor))
+        }
+        components.queryItems = items
+        return try await request(url: components.url!)
+    }
+
+    func listCollectionItems(
+        id: String,
+        cursor: String? = nil,
+        limit: Int = 30
+    ) async throws -> PaginatedBookmarksResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/collections/\(id)/items"),
+            resolvingAgainstBaseURL: false
+        )!
+        var items = [URLQueryItem(name: "limit", value: String(limit))]
         if let cursor {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }

--- a/apps/ios/ZineNative/Core/Models/Home.swift
+++ b/apps/ios/ZineNative/Core/Models/Home.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+struct HomeItem: Codable, Hashable, Identifiable {
+    let id: String
+    let itemId: String
+    let title: String
+    let thumbnailUrl: URL?
+    let canonicalUrl: URL
+    let contentType: ContentType
+    let provider: Provider
+    let creator: String
+    let creatorImageUrl: URL?
+    let creatorId: String?
+    let publisher: String?
+    let summary: String?
+    let duration: Int?
+    let publishedAt: String?
+    let readingTimeMinutes: Int?
+    let bookmarkedAt: String?
+    let lastOpenedAt: String?
+    let progress: BookmarkProgress?
+
+    init(bookmark: Bookmark, openedAt: Date) {
+        id = bookmark.id
+        itemId = bookmark.itemId
+        title = bookmark.title
+        thumbnailUrl = bookmark.thumbnailUrl
+        canonicalUrl = bookmark.canonicalUrl
+        contentType = bookmark.contentType
+        provider = bookmark.provider
+        creator = bookmark.creator
+        creatorImageUrl = bookmark.creatorImageUrl
+        creatorId = bookmark.creatorId
+        publisher = bookmark.publisher
+        summary = bookmark.summary
+        duration = bookmark.duration
+        publishedAt = bookmark.publishedAt
+        readingTimeMinutes = bookmark.readingTimeMinutes
+        bookmarkedAt = bookmark.bookmarkedAt
+        lastOpenedAt = openedAt.formatted(.iso8601)
+        progress = bookmark.progress
+    }
+
+    init(
+        id: String,
+        itemId: String,
+        title: String,
+        thumbnailUrl: URL?,
+        canonicalUrl: URL,
+        contentType: ContentType,
+        provider: Provider,
+        creator: String,
+        creatorImageUrl: URL?,
+        creatorId: String?,
+        publisher: String?,
+        summary: String?,
+        duration: Int?,
+        publishedAt: String?,
+        readingTimeMinutes: Int?,
+        bookmarkedAt: String?,
+        lastOpenedAt: String?,
+        progress: BookmarkProgress?
+    ) {
+        self.id = id
+        self.itemId = itemId
+        self.title = title
+        self.thumbnailUrl = thumbnailUrl
+        self.canonicalUrl = canonicalUrl
+        self.contentType = contentType
+        self.provider = provider
+        self.creator = creator
+        self.creatorImageUrl = creatorImageUrl
+        self.creatorId = creatorId
+        self.publisher = publisher
+        self.summary = summary
+        self.duration = duration
+        self.publishedAt = publishedAt
+        self.readingTimeMinutes = readingTimeMinutes
+        self.bookmarkedAt = bookmarkedAt
+        self.lastOpenedAt = lastOpenedAt
+        self.progress = progress
+    }
+
+    var consumptionLabel: String? {
+        if let readingTimeMinutes {
+            return "\(readingTimeMinutes) min read"
+        }
+        guard let duration else { return nil }
+        let minutes = max(1, duration / 60)
+        if minutes < 60 { return "\(minutes) min" }
+        return "\(minutes / 60) hr \(minutes % 60) min"
+    }
+
+    var isQuickWin: Bool {
+        if let readingTimeMinutes {
+            return readingTimeMinutes > 0 && readingTimeMinutes <= 10
+        }
+        if let duration {
+            return duration > 0 && duration <= 10 * 60
+        }
+        return false
+    }
+}
+
+enum HomeCollectionLayout: String, Codable, Hashable {
+    case stackRail = "STACK_RAIL"
+    case coverRail = "COVER_RAIL"
+    case rowGrid = "ROW_GRID"
+    case compactList = "COMPACT_LIST"
+}
+
+struct HomeCollection: Codable, Hashable, Identifiable {
+    let collectionId: String
+    let title: String
+    let layout: HomeCollectionLayout
+    let position: Int
+    let count: Int
+    let items: [HomeItem]
+
+    var id: String { collectionId }
+}
+
+enum HomeSectionKind: String, Codable, Hashable {
+    case builtIn = "BUILT_IN"
+    case collection = "COLLECTION"
+}
+
+enum HomeBuiltInSection: String, Codable, Hashable {
+    case jumpBackIn = "JUMP_BACK_IN"
+    case recentlyBookmarked = "RECENTLY_BOOKMARKED"
+    case inbox = "INBOX"
+    case podcasts = "PODCASTS"
+    case articles = "ARTICLES"
+    case videos = "VIDEOS"
+}
+
+struct HomeLayoutSection: Codable, Hashable {
+    let kind: HomeSectionKind
+    let builtInSection: HomeBuiltInSection?
+    let collectionId: String?
+}
+
+struct HomeContentTypeSections: Codable, Hashable {
+    let videos: [HomeItem]
+    let podcasts: [HomeItem]
+    let articles: [HomeItem]
+}
+
+struct HomeResponse: Codable, Hashable {
+    let recentBookmarks: [HomeItem]
+    let jumpBackIn: [HomeItem]
+    let byContentType: HomeContentTypeSections
+    let customCollections: [HomeCollection]
+    let sectionOrder: [HomeLayoutSection]
+    let requestId: String?
+    let traceId: String?
+}

--- a/apps/ios/ZineNative/Core/Persistence/HomeCache.swift
+++ b/apps/ios/ZineNative/Core/Persistence/HomeCache.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+struct HomeCacheSnapshot: Codable, Equatable {
+    let home: HomeResponse?
+    let inboxItems: [Bookmark]
+    let savedAt: Date
+}
+
+actor HomeCache {
+    private let fileURL: URL
+    private var snapshot: HomeCacheSnapshot?
+    private var didLoad = false
+
+    init(userID: String, baseDirectory: URL? = nil) {
+        let root = baseDirectory ?? FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        let safeUserID = userID.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+            ?? "unknown-user"
+        fileURL = root
+            .appending(path: "ZineNative/Home", directoryHint: .isDirectory)
+            .appending(path: "\(safeUserID).json")
+    }
+
+    func load() -> HomeCacheSnapshot? {
+        loadIfNeeded()
+        return snapshot
+    }
+
+    func save(home: HomeResponse?, inboxItems: [Bookmark]) {
+        loadIfNeeded()
+        snapshot = HomeCacheSnapshot(
+            home: home,
+            inboxItems: Array(inboxItems.prefix(4)),
+            savedAt: Date()
+        )
+        persist()
+    }
+
+    private func loadIfNeeded() {
+        guard !didLoad else { return }
+        didLoad = true
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        snapshot = try? JSONDecoder().decode(HomeCacheSnapshot.self, from: data)
+    }
+
+    private func persist() {
+        guard let snapshot,
+              let data = try? JSONEncoder().encode(snapshot)
+        else { return }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            // Home remains network-backed; this cache only improves launch behavior.
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Creators/CreatorView.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorView.swift
@@ -13,6 +13,7 @@ struct CreatorView: View {
     let onBookmarkUpdate: (Bookmark) -> Void
     let onBookmarkChange: (Bookmark, Bool, BookmarkChangePhase) -> Void
     let onBookmarkCommit: (Bookmark, Bool) -> Void
+    let onExternalOpen: (Bookmark) -> Void
 
     @State private var store: CreatorStore
     @State private var selectedSection: ContentSection = .bookmarked
@@ -26,7 +27,8 @@ struct CreatorView: View {
         client: APIClient,
         onBookmarkUpdate: @escaping (Bookmark) -> Void = { _ in },
         onBookmarkChange: @escaping (Bookmark, Bool, BookmarkChangePhase) -> Void = { _, _, _ in },
-        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in }
+        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in },
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
     ) {
         self.fallbackName = fallbackName
         self.fallbackImageUrl = fallbackImageUrl
@@ -35,6 +37,7 @@ struct CreatorView: View {
         self.onBookmarkUpdate = onBookmarkUpdate
         self.onBookmarkChange = onBookmarkChange
         self.onBookmarkCommit = onBookmarkCommit
+        self.onExternalOpen = onExternalOpen
         _store = State(initialValue: CreatorStore(creatorId: creatorId, client: client))
     }
 
@@ -242,7 +245,8 @@ struct CreatorView: View {
                         client: client,
                         onUpdate: onBookmarkUpdate,
                         onBookmarkChange: onBookmarkChange,
-                        onBookmarkCommit: onBookmarkCommit
+                        onBookmarkCommit: onBookmarkCommit,
+                        onExternalOpen: onExternalOpen
                     )
                 } label: {
                     creatorContentRow(

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class HomeSectionListStore {
+    private(set) var items: [Bookmark] = []
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var errorMessage: String?
+    private(set) var nextCursor: String?
+
+    private let route: HomeSectionRoute
+    private let client: APIClient
+    private var removedIndices: [String: Int] = [:]
+
+    init(route: HomeSectionRoute, client: APIClient) {
+        self.route = route
+        self.client = client
+    }
+
+    func reload() async {
+        errorMessage = nil
+        isLoading = items.isEmpty
+        defer { isLoading = false }
+
+        do {
+            let response = try await request()
+            guard !Task.isCancelled else { return }
+            items = response.items
+            nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadMoreIfNeeded(current item: Bookmark) async {
+        guard item.id == items.last?.id,
+              let nextCursor,
+              !isLoading,
+              !isLoadingMore
+        else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await request(cursor: nextCursor)
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(items.map(\.id))
+            items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
+            self.nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func update(_ bookmark: Bookmark) {
+        guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return }
+        if shouldKeep(bookmark) {
+            items[index] = bookmark
+        } else {
+            items.remove(at: index)
+        }
+    }
+
+    func setBookmarked(_ bookmark: Bookmark, isBookmarked: Bool) {
+        let shouldRemain = route == .inbox ? !isBookmarked : isBookmarked
+        if shouldRemain {
+            guard !items.contains(where: { $0.id == bookmark.id }) else { return }
+            let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
+            items.insert(bookmark, at: index)
+        } else if let index = items.firstIndex(where: { $0.id == bookmark.id }) {
+            removedIndices[bookmark.id] = index
+            items.remove(at: index)
+        }
+    }
+
+    private func request(cursor: String? = nil) async throws -> PaginatedBookmarksResponse {
+        switch route {
+        case .jumpBackIn:
+            return try await client.listOpenedBookmarks(cursor: cursor)
+        case .inbox:
+            return try await client.listInbox(query: InboxQuery(), cursor: cursor)
+        case .quickWins:
+            return try await client.listQuickWinBookmarks(cursor: cursor)
+        case .recentlySaved:
+            return try await client.listBookmarks(query: LibraryQuery(), cursor: cursor)
+        case .podcasts:
+            return try await client.listBookmarks(
+                query: LibraryQuery(contentType: .podcast),
+                cursor: cursor
+            )
+        case .articles:
+            return try await client.listBookmarks(
+                query: LibraryQuery(contentType: .article),
+                cursor: cursor
+            )
+        case .videos:
+            return try await client.listBookmarks(
+                query: LibraryQuery(contentType: .video),
+                cursor: cursor
+            )
+        case .collection(let id, _):
+            return try await client.listCollectionItems(id: id, cursor: cursor)
+        }
+    }
+
+    private func shouldKeep(_ bookmark: Bookmark) -> Bool {
+        switch route {
+        case .collection:
+            return bookmark.state == "BOOKMARKED"
+        case .inbox:
+            return bookmark.state == "INBOX" && !bookmark.isFinished
+        default:
+            return bookmark.state == "BOOKMARKED" && !bookmark.isFinished
+        }
+    }
+
+    private func prefetchImages(in bookmarks: [Bookmark]) {
+        let urls = bookmarks.flatMap { [$0.thumbnailUrl, $0.creatorImageUrl].compactMap { $0 } }
+        AppImagePipeline.prefetch(urls)
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct HomeSectionListView: View {
+    let route: HomeSectionRoute
+    let client: APIClient
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
+
+    @State private var store: HomeSectionListStore
+    @Namespace private var bookmarkTransition
+
+    init(
+        route: HomeSectionRoute,
+        client: APIClient,
+        onContentChanged: @escaping () -> Void = {},
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
+    ) {
+        self.route = route
+        self.client = client
+        self.onContentChanged = onContentChanged
+        self.onExternalOpen = onExternalOpen
+        _store = State(initialValue: HomeSectionListStore(route: route, client: client))
+    }
+
+    var body: some View {
+        content
+            .navigationTitle(route.title)
+            .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(for: Bookmark.self) { bookmark in
+                BookmarkDetailView(
+                    bookmark: bookmark,
+                    client: client,
+                    onUpdate: { updated in
+                        store.update(updated)
+                        onContentChanged()
+                    },
+                    onBookmarkChange: { changed, isBookmarked, _ in
+                        store.setBookmarked(changed, isBookmarked: isBookmarked)
+                        onContentChanged()
+                    },
+                    onBookmarkCommit: { _, _ in onContentChanged() },
+                    onExternalOpen: onExternalOpen
+                )
+                .navigationTransition(
+                    .zoom(sourceID: bookmark.id, in: bookmarkTransition)
+                )
+            }
+            .task {
+                await store.reload()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.items.isEmpty {
+            ProgressView("Loading \(route.title.lowercased())…")
+        } else if let error = store.errorMessage, store.items.isEmpty {
+            ContentUnavailableView {
+                Label("Section unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") {
+                    Task { await store.reload() }
+                }
+            }
+        } else if store.items.isEmpty {
+            ContentUnavailableView(
+                "Nothing here yet",
+                systemImage: "rectangle.stack",
+                description: Text("Items for this section will appear here.")
+            )
+        } else {
+            List(store.items) { bookmark in
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowSeparator(.hidden)
+                .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+                .task {
+                    await store.loadMoreIfNeeded(current: bookmark)
+                }
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload()
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -1,0 +1,640 @@
+import SwiftUI
+
+struct HomeNavigationRoute: Hashable {
+    enum Destination: Hashable {
+        case item(HomeItem)
+        case bookmark(Bookmark)
+    }
+
+    let destination: Destination
+    let sourceID: String
+
+    static func item(_ item: HomeItem, sectionID: String) -> HomeNavigationRoute {
+        HomeNavigationRoute(
+            destination: .item(item),
+            sourceID: "\(sectionID)-\(item.id)"
+        )
+    }
+
+    static func bookmark(_ bookmark: Bookmark, sectionID: String) -> HomeNavigationRoute {
+        HomeNavigationRoute(
+            destination: .bookmark(bookmark),
+            sourceID: "\(sectionID)-\(bookmark.id)"
+        )
+    }
+}
+
+enum HomeSectionRoute: Hashable {
+    case jumpBackIn
+    case inbox
+    case quickWins
+    case recentlySaved
+    case podcasts
+    case articles
+    case videos
+    case collection(id: String, title: String)
+
+    var title: String {
+        switch self {
+        case .jumpBackIn: "Jump Back In"
+        case .inbox: "Fresh in Your Inbox"
+        case .quickWins: "Quick Wins"
+        case .recentlySaved: "Recently Saved"
+        case .podcasts: "Listen Next"
+        case .articles: "Saved Reads"
+        case .videos: "Watch Later"
+        case .collection(_, let title): title
+        }
+    }
+}
+
+private struct HomeNavigationLink<Label: View>: View {
+    let route: HomeNavigationRoute
+    let transitionNamespace: Namespace.ID
+    @ViewBuilder let label: () -> Label
+
+    var body: some View {
+        NavigationLink(value: route, label: label)
+            .buttonStyle(.plain)
+            .matchedTransitionSource(id: route.sourceID, in: transitionNamespace)
+    }
+}
+
+struct HomeDashboardSectionView: View {
+    let section: HomeDashboardSection
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        switch section {
+        case .jumpBackIn(let items):
+            HomeJumpBackInSection(
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .inbox(let items):
+            HomeInboxSection(
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .quickWins(let items):
+            HomeItemGridSection(
+                title: "Quick Wins",
+                subtitle: "Ten minutes or less",
+                sectionRoute: .quickWins,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .recentlySaved(let items):
+            HomeLandscapeRail(
+                title: "Recently Saved",
+                subtitle: "Your latest bookmarks",
+                sectionRoute: .recentlySaved,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .podcasts(let items):
+            HomeCoverRail(
+                title: "Listen Next",
+                sectionRoute: .podcasts,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .articles(let items):
+            HomeLandscapeRail(
+                title: "Saved Reads",
+                sectionRoute: .articles,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .videos(let items):
+            HomeLandscapeRail(
+                title: "Watch Later",
+                sectionRoute: .videos,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .collection(let collection):
+            HomeCollectionSection(
+                collection: collection,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        }
+    }
+}
+
+private struct HomeSectionHeader: View {
+    let title: String
+    var subtitle: String?
+    let route: HomeSectionRoute
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            NavigationLink(value: route) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.title3.bold())
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .foregroundStyle(.primary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("View all \(title)")
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct HomeJumpBackInSection: View {
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(
+                title: "Jump Back In",
+                subtitle: "Pick up where you left off",
+                route: .jumpBackIn
+            )
+            .padding(.horizontal, 20)
+
+            if let first = items.first {
+                HomeNavigationLink(
+                    route: .item(first, sectionID: sectionID),
+                    transitionNamespace: transitionNamespace
+                ) {
+                    HomeResumeCard(item: first)
+                }
+                .padding(.horizontal, 20)
+            }
+
+            if items.count > 1 {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 14) {
+                        ForEach(items.dropFirst()) { item in
+                            HomeNavigationLink(
+                                route: .item(item, sectionID: sectionID),
+                                transitionNamespace: transitionNamespace
+                            ) {
+                                HomeJumpBackInCompactCard(item: item)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+            }
+        }
+    }
+}
+
+private struct HomeJumpBackInCompactCard: View {
+    let item: HomeItem
+
+    private enum Metrics {
+        static let cardWidth: CGFloat = 220
+        static let cardHeight: CGFloat = 72
+        static let imageWidth: CGFloat = 96
+        static let imageHeight: CGFloat = 54
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: Metrics.imageWidth, height: Metrics.imageHeight)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 20)
+            }
+            .frame(width: Metrics.imageWidth, height: Metrics.imageHeight)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 9))
+
+            Text(item.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(3)
+                .frame(maxHeight: .infinity, alignment: .leading)
+                .padding(.trailing, 10)
+        }
+        .padding(.leading, 9)
+        .frame(width: Metrics.cardWidth, height: Metrics.cardHeight, alignment: .leading)
+        .background(.secondary.opacity(0.08))
+        .clipShape(.rect(cornerRadius: 14))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeInboxSection: View {
+    let items: [Bookmark]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(
+                title: "Fresh in Your Inbox",
+                subtitle: "New items waiting for review",
+                route: .inbox
+            )
+
+            VStack(spacing: 0) {
+                ForEach(items) { bookmark in
+                    HomeNavigationLink(
+                        route: .bookmark(bookmark, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        BookmarkRow(bookmark: bookmark)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .contentShape(Rectangle())
+                    }
+
+                    if bookmark.id != items.last?.id {
+                        Divider()
+                            .padding(.leading, 88)
+                    }
+                }
+            }
+            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+private struct HomeCollectionSection: View {
+    let collection: HomeCollection
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        switch collection.layout {
+        case .stackRail:
+            HomeLandscapeRail(
+                title: collection.title,
+                sectionRoute: .collection(id: collection.id, title: collection.title),
+                items: collection.items,
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .coverRail:
+            HomeCoverRail(
+                title: collection.title,
+                sectionRoute: .collection(id: collection.id, title: collection.title),
+                items: collection.items,
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .rowGrid:
+            HomeItemGridSection(
+                title: collection.title,
+                sectionRoute: .collection(id: collection.id, title: collection.title),
+                items: Array(collection.items.prefix(4)),
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .compactList:
+            HomeCompactListSection(
+                title: collection.title,
+                sectionRoute: .collection(id: collection.id, title: collection.title),
+                items: Array(collection.items.prefix(4)),
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        }
+    }
+}
+
+private struct HomeLandscapeRail: View {
+    let title: String
+    var subtitle: String?
+    let sectionRoute: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(title: title, subtitle: subtitle, route: sectionRoute)
+                .padding(.horizontal, 20)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 14) {
+                    ForEach(items) { item in
+                        HomeNavigationLink(
+                            route: .item(item, sectionID: sectionID),
+                            transitionNamespace: transitionNamespace
+                        ) {
+                            HomeLandscapeCard(item: item)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+}
+
+private struct HomeCoverRail: View {
+    let title: String
+    let sectionRoute: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(title: title, route: sectionRoute)
+                .padding(.horizontal, 20)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 14) {
+                    ForEach(items) { item in
+                        HomeNavigationLink(
+                            route: .item(item, sectionID: sectionID),
+                            transitionNamespace: transitionNamespace
+                        ) {
+                            HomeCoverCard(item: item)
+                        }
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+}
+
+private struct HomeItemGridSection: View {
+    let title: String
+    var subtitle: String?
+    let sectionRoute: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(title: title, subtitle: subtitle, route: sectionRoute)
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+                ForEach(items) { item in
+                    HomeNavigationLink(
+                        route: .item(item, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        HomeGridCard(item: item)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+private struct HomeCompactListSection: View {
+    let title: String
+    let sectionRoute: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HomeSectionHeader(title: title, route: sectionRoute)
+
+            VStack(spacing: 0) {
+                ForEach(items) { item in
+                    HomeNavigationLink(
+                        route: .item(item, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        HomeItemRow(item: item)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .contentShape(Rectangle())
+                    }
+
+                    if item.id != items.last?.id {
+                        Divider()
+                            .padding(.leading, 88)
+                    }
+                }
+            }
+            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+private struct HomeResumeCard: View {
+    let item: HomeItem
+
+    var body: some View {
+        CachedRemoteImage(
+            url: item.thumbnailUrl,
+            targetSize: CGSize(width: 390, height: 220)
+        ) {
+            HomeImagePlaceholder(contentType: item.contentType, iconSize: 42)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 220)
+        .clipped()
+        .overlay {
+            LinearGradient(
+                colors: [.clear, .black.opacity(0.78)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+        .overlay(alignment: .bottomLeading) {
+            VStack(alignment: .leading, spacing: 7) {
+                Text("RESUME")
+                    .font(.caption2.bold())
+                    .tracking(0.8)
+                    .foregroundStyle(.white.opacity(0.8))
+                Text(item.title)
+                    .font(.title3.bold())
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                HStack(spacing: 5) {
+                    Text(item.creator)
+                    if let label = item.consumptionLabel {
+                        Text("·")
+                        Text(label)
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.82))
+
+                if let progress = item.progress, progress.percent > 0 {
+                    ProgressView(value: min(max(progress.percent / 100, 0), 1))
+                        .tint(Color.accentColor)
+                }
+            }
+            .padding(16)
+        }
+        .clipShape(.rect(cornerRadius: 18))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeLandscapeCard: View {
+    let item: HomeItem
+    var width: CGFloat = 244
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: width, height: 137)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 28)
+            }
+            .frame(width: width, height: 137)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 14))
+
+            Text(item.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            HomeItemMetadata(item: item)
+        }
+        .frame(width: width, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeCoverCard: View {
+    let item: HomeItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: 150, height: 190)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 30)
+            }
+            .frame(width: 150, height: 190)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 14))
+
+            Text(item.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+            HomeItemMetadata(item: item)
+        }
+        .frame(width: 150, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeGridCard: View {
+    let item: HomeItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: 180, height: 100)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 24)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 100)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 12))
+
+            Text(item.title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+            HomeItemMetadata(item: item)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeItemRow: View {
+    let item: HomeItem
+
+    var body: some View {
+        HStack(spacing: 10) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: 64, height: 48)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 15)
+            }
+            .frame(width: 64, height: 48)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 7))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                HomeItemMetadata(item: item)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomeItemMetadata: View {
+    let item: HomeItem
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(item.creator)
+                .lineLimit(1)
+            if let label = item.consumptionLabel {
+                Text("·")
+                Text(label)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+}
+
+private struct HomeImagePlaceholder: View {
+    let contentType: ContentType
+    let iconSize: CGFloat
+
+    var body: some View {
+        ZStack {
+            Color.secondary.opacity(0.12)
+            Image(systemName: contentType.systemImage)
+                .font(.system(size: iconSize))
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeStore.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Observation
+
+enum HomeDashboardSection: Identifiable {
+    case jumpBackIn([HomeItem])
+    case inbox([Bookmark])
+    case quickWins([HomeItem])
+    case recentlySaved([HomeItem])
+    case podcasts([HomeItem])
+    case articles([HomeItem])
+    case videos([HomeItem])
+    case collection(HomeCollection)
+
+    var id: String {
+        switch self {
+        case .jumpBackIn: "jump-back-in"
+        case .inbox: "inbox"
+        case .quickWins: "quick-wins"
+        case .recentlySaved: "recently-saved"
+        case .podcasts: "podcasts"
+        case .articles: "articles"
+        case .videos: "videos"
+        case .collection(let collection): "collection-\(collection.id)"
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class HomeStore {
+    private(set) var sections: [HomeDashboardSection] = []
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private let client: APIClient
+    private let cache: HomeCache
+    private var home: HomeResponse?
+    private var inboxItems: [Bookmark] = []
+    private var optimisticOpenedItems: [String: HomeItem] = [:]
+
+    init(client: APIClient, cache: HomeCache) {
+        self.client = client
+        self.cache = cache
+    }
+
+    func reload() async {
+        errorMessage = nil
+
+        if let snapshot = await cache.load() {
+            home = snapshot.home
+            inboxItems = snapshot.inboxItems
+            rebuildSections()
+        }
+
+        isLoading = sections.isEmpty
+        defer { isLoading = false }
+
+        var networkErrors: [Error] = []
+        var didUpdate = false
+
+        do {
+            home = try await client.getHome()
+            reconcileOptimisticOpenedItems()
+            didUpdate = true
+            rebuildSections()
+        } catch is CancellationError {
+            return
+        } catch {
+            networkErrors.append(error)
+        }
+
+        guard !Task.isCancelled else { return }
+
+        do {
+            let response = try await client.listInbox(query: InboxQuery(), limit: 4)
+            inboxItems = Array(response.items.prefix(4))
+            didUpdate = true
+            rebuildSections()
+        } catch is CancellationError {
+            return
+        } catch {
+            networkErrors.append(error)
+        }
+
+        if didUpdate {
+            await cache.save(home: home, inboxItems: inboxItems)
+        } else if sections.isEmpty {
+            errorMessage = networkErrors.first?.localizedDescription ?? "Please try again."
+        }
+    }
+
+    private func rebuildSections() {
+        sections = Self.makeSections(
+            home: home,
+            inboxItems: inboxItems,
+            optimisticOpenedItems: Array(optimisticOpenedItems.values)
+        )
+    }
+
+    func promoteOpened(_ bookmark: Bookmark, at openedAt: Date) {
+        guard bookmark.state == "BOOKMARKED", !bookmark.isFinished else { return }
+        optimisticOpenedItems[bookmark.id] = HomeItem(bookmark: bookmark, openedAt: openedAt)
+        rebuildSections()
+    }
+
+    func rollbackOpened(id: String, openedAt: Date) {
+        guard let optimistic = optimisticOpenedItems[id],
+              optimistic.lastOpenedAt == openedAt.formatted(.iso8601)
+        else { return }
+        optimisticOpenedItems[id] = nil
+        rebuildSections()
+    }
+
+    private func reconcileOptimisticOpenedItems() {
+        guard let home else { return }
+        let serverItems = Dictionary(uniqueKeysWithValues: home.jumpBackIn.map { ($0.id, $0) })
+
+        optimisticOpenedItems = optimisticOpenedItems.filter { id, optimistic in
+            guard let server = serverItems[id] else { return true }
+            return (server.lastOpenedAt ?? "") < (optimistic.lastOpenedAt ?? "")
+        }
+    }
+
+    static func makeSections(
+        home: HomeResponse?,
+        inboxItems: [Bookmark],
+        optimisticOpenedItems: [HomeItem] = []
+    ) -> [HomeDashboardSection] {
+        guard let home else {
+            return inboxItems.isEmpty ? [] : [.inbox(inboxItems)]
+        }
+
+        let jumpBackInCandidates: [HomeItem]
+        if optimisticOpenedItems.isEmpty {
+            jumpBackInCandidates = home.jumpBackIn
+        } else {
+            let optimisticIDs = Set(optimisticOpenedItems.map(\.id))
+            jumpBackInCandidates = (
+                optimisticOpenedItems + home.jumpBackIn.filter { !optimisticIDs.contains($0.id) }
+            ).sorted {
+                ($0.lastOpenedAt ?? "") > ($1.lastOpenedAt ?? "")
+            }
+        }
+        let jumpBackIn = Array(jumpBackInCandidates.prefix(6))
+        let jumpIDs = Set(jumpBackIn.map(\.id))
+        let quickWins = Array(
+            home.recentBookmarks
+                .filter { $0.isQuickWin && !jumpIDs.contains($0.id) }
+                .prefix(4)
+        )
+        let quickWinIDs = Set(quickWins.map(\.id))
+        let recentlySavedWithoutRepeats = home.recentBookmarks.filter {
+            !jumpIDs.contains($0.id) && !quickWinIDs.contains($0.id)
+        }
+        let recentlySaved = Array(
+            (recentlySavedWithoutRepeats.isEmpty
+                ? home.recentBookmarks.filter { !jumpIDs.contains($0.id) }
+                : recentlySavedWithoutRepeats)
+                .prefix(6)
+        )
+        let collectionsByID = Dictionary(
+            uniqueKeysWithValues: home.customCollections.map { ($0.id, $0) }
+        )
+        let order = home.sectionOrder.isEmpty ? Self.defaultOrder : home.sectionOrder
+        var result: [HomeDashboardSection] = []
+        var insertedQuickWins = false
+
+        for orderedSection in order {
+            switch orderedSection.kind {
+            case .builtIn:
+                guard let builtIn = orderedSection.builtInSection else { continue }
+                if let section = makeBuiltInSection(
+                    builtIn,
+                    home: home,
+                    inboxItems: inboxItems,
+                    jumpBackIn: jumpBackIn,
+                    recentlySaved: recentlySaved
+                ) {
+                    result.append(section)
+                }
+                if builtIn == .inbox, !quickWins.isEmpty {
+                    result.append(.quickWins(quickWins))
+                    insertedQuickWins = true
+                }
+            case .collection:
+                guard let collectionID = orderedSection.collectionId,
+                      let collection = collectionsByID[collectionID],
+                      !collection.items.isEmpty
+                else { continue }
+                result.append(.collection(collection))
+            }
+        }
+
+        if !quickWins.isEmpty, !insertedQuickWins {
+            let insertionIndex = min(1, result.endIndex)
+            result.insert(.quickWins(quickWins), at: insertionIndex)
+        }
+
+        return result
+    }
+
+    private static func makeBuiltInSection(
+        _ builtIn: HomeBuiltInSection,
+        home: HomeResponse,
+        inboxItems: [Bookmark],
+        jumpBackIn: [HomeItem],
+        recentlySaved: [HomeItem]
+    ) -> HomeDashboardSection? {
+        switch builtIn {
+        case .jumpBackIn:
+            return jumpBackIn.isEmpty ? nil : .jumpBackIn(jumpBackIn)
+        case .recentlyBookmarked:
+            return recentlySaved.isEmpty ? nil : .recentlySaved(recentlySaved)
+        case .inbox:
+            return inboxItems.isEmpty ? nil : .inbox(Array(inboxItems.prefix(4)))
+        case .podcasts:
+            return home.byContentType.podcasts.isEmpty
+                ? nil
+                : .podcasts(Array(home.byContentType.podcasts.prefix(8)))
+        case .articles:
+            return home.byContentType.articles.isEmpty
+                ? nil
+                : .articles(Array(home.byContentType.articles.prefix(8)))
+        case .videos:
+            return home.byContentType.videos.isEmpty
+                ? nil
+                : .videos(Array(home.byContentType.videos.prefix(8)))
+        }
+    }
+
+    private static let defaultOrder: [HomeLayoutSection] = [
+        HomeLayoutSection(kind: .builtIn, builtInSection: .jumpBackIn, collectionId: nil),
+        HomeLayoutSection(kind: .builtIn, builtInSection: .inbox, collectionId: nil),
+        HomeLayoutSection(kind: .builtIn, builtInSection: .recentlyBookmarked, collectionId: nil),
+        HomeLayoutSection(kind: .builtIn, builtInSection: .podcasts, collectionId: nil),
+        HomeLayoutSection(kind: .builtIn, builtInSection: .articles, collectionId: nil),
+        HomeLayoutSection(kind: .builtIn, builtInSection: .videos, collectionId: nil),
+    ]
+}

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct HomeView: View {
+    let client: APIClient
+    let refreshRevision: Int
+    let externalOpenEvent: ExternalBookmarkOpenEvent?
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
+
+    @State private var store: HomeStore
+    @Namespace private var bookmarkTransition
+
+    init(
+        client: APIClient,
+        cache: HomeCache,
+        refreshRevision: Int,
+        externalOpenEvent: ExternalBookmarkOpenEvent?,
+        onContentChanged: @escaping () -> Void,
+        onExternalOpen: @escaping (Bookmark) -> Void
+    ) {
+        self.client = client
+        self.refreshRevision = refreshRevision
+        self.externalOpenEvent = externalOpenEvent
+        self.onContentChanged = onContentChanged
+        self.onExternalOpen = onExternalOpen
+        _store = State(initialValue: HomeStore(client: client, cache: cache))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Home")
+                .navigationDestination(for: HomeNavigationRoute.self) { route in
+                    destination(for: route)
+                        .navigationTransition(
+                            .zoom(sourceID: route.sourceID, in: bookmarkTransition)
+                        )
+                }
+                .navigationDestination(for: HomeSectionRoute.self) { route in
+                    switch route {
+                    case .jumpBackIn:
+                        JumpBackInListView(
+                            client: client,
+                            onContentChanged: onContentChanged,
+                            onExternalOpen: onExternalOpen
+                        )
+                    default:
+                        HomeSectionListView(
+                            route: route,
+                            client: client,
+                            onContentChanged: onContentChanged,
+                            onExternalOpen: onExternalOpen
+                        )
+                    }
+                }
+        }
+        .task(id: refreshRevision) {
+            await store.reload()
+        }
+        .onChange(of: externalOpenEvent, initial: true) { _, event in
+            guard let event else { return }
+            switch event.change {
+            case .promote:
+                store.promoteOpened(event.bookmark, at: event.openedAt)
+            case .rollback:
+                store.rollbackOpened(id: event.bookmark.id, openedAt: event.openedAt)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.sections.isEmpty {
+            ProgressView("Loading Home…")
+        } else if let error = store.errorMessage, store.sections.isEmpty {
+            ContentUnavailableView {
+                Label("Home unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") {
+                    Task { await store.reload() }
+                }
+            }
+        } else if store.sections.isEmpty {
+            ContentUnavailableView(
+                "Nothing to pick up yet",
+                systemImage: "sparkles.rectangle.stack",
+                description: Text("New inbox items and saved content will appear here.")
+            )
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 30) {
+                    ForEach(store.sections) { section in
+                        HomeDashboardSectionView(
+                            section: section,
+                            transitionNamespace: bookmarkTransition
+                        )
+                    }
+                }
+                .padding(.vertical, 10)
+                .padding(.bottom, 24)
+            }
+            .refreshable {
+                await store.reload()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func destination(for route: HomeNavigationRoute) -> some View {
+        switch route.destination {
+        case .item(let item):
+            HomeItemDestination(
+                item: item,
+                client: client,
+                onContentChanged: onContentChanged,
+                onExternalOpen: onExternalOpen
+            )
+        case .bookmark(let bookmark):
+            BookmarkDetailView(
+                bookmark: bookmark,
+                client: client,
+                onUpdate: { _ in onContentChanged() },
+                onBookmarkCommit: { _, _ in onContentChanged() },
+                onExternalOpen: onExternalOpen
+            )
+        }
+    }
+}
+
+private struct HomeItemDestination: View {
+    let item: HomeItem
+    let client: APIClient
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
+
+    @State private var bookmark: Bookmark?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            if let bookmark {
+                BookmarkDetailView(
+                    bookmark: bookmark,
+                    client: client,
+                    onUpdate: { updated in
+                        self.bookmark = updated
+                        onContentChanged()
+                    },
+                    onBookmarkCommit: { _, _ in onContentChanged() },
+                    onExternalOpen: onExternalOpen
+                )
+            } else if let errorMessage {
+                ContentUnavailableView {
+                    Label("Item unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("Try again") {
+                        Task { await load() }
+                    }
+                }
+            } else {
+                ProgressView("Loading item…")
+            }
+        }
+        .task(id: item.id) {
+            await load()
+        }
+    }
+
+    private func load() async {
+        errorMessage = nil
+        do {
+            bookmark = try await client.getBookmark(id: item.id)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListStore.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListStore.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class JumpBackInListStore {
+    private(set) var items: [Bookmark] = []
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    private(set) var errorMessage: String?
+    private(set) var nextCursor: String?
+
+    private let client: APIClient
+    private var removedIndices: [String: Int] = [:]
+
+    init(client: APIClient) {
+        self.client = client
+    }
+
+    func reload() async {
+        errorMessage = nil
+        isLoading = items.isEmpty
+        defer { isLoading = false }
+
+        do {
+            let response = try await client.listOpenedBookmarks()
+            guard !Task.isCancelled else { return }
+            items = response.items
+            nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadMoreIfNeeded(current item: Bookmark) async {
+        guard item.id == items.last?.id,
+              let nextCursor,
+              !isLoading,
+              !isLoadingMore
+        else { return }
+
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await client.listOpenedBookmarks(cursor: nextCursor)
+            guard !Task.isCancelled else { return }
+            let existingIDs = Set(items.map(\.id))
+            items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
+            self.nextCursor = response.nextCursor
+            prefetchImages(in: response.items)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func update(_ bookmark: Bookmark) {
+        guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return }
+        if bookmark.isFinished || bookmark.state != "BOOKMARKED" {
+            items.remove(at: index)
+        } else {
+            items[index] = bookmark
+        }
+    }
+
+    func setBookmarked(_ bookmark: Bookmark, isBookmarked: Bool, phase: BookmarkChangePhase) {
+        if isBookmarked {
+            guard !items.contains(where: { $0.id == bookmark.id }) else { return }
+            let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
+            items.insert(bookmark, at: index)
+        } else if let index = items.firstIndex(where: { $0.id == bookmark.id }) {
+            removedIndices[bookmark.id] = index
+            items.remove(at: index)
+        } else if phase == .rollback {
+            let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
+            items.insert(bookmark, at: index)
+        }
+    }
+
+    func promote(_ bookmark: Bookmark) {
+        guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return }
+        let item = items.remove(at: index)
+        items.insert(item, at: 0)
+    }
+
+    private func prefetchImages(in bookmarks: [Bookmark]) {
+        let urls = bookmarks.flatMap { [$0.thumbnailUrl, $0.creatorImageUrl].compactMap { $0 } }
+        AppImagePipeline.prefetch(urls)
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct JumpBackInListView: View {
+    let client: APIClient
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
+
+    @State private var store: JumpBackInListStore
+    @Namespace private var bookmarkTransition
+
+    init(
+        client: APIClient,
+        onContentChanged: @escaping () -> Void = {},
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
+    ) {
+        self.client = client
+        self.onContentChanged = onContentChanged
+        self.onExternalOpen = onExternalOpen
+        _store = State(initialValue: JumpBackInListStore(client: client))
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Jump Back In")
+            .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(for: Bookmark.self) { bookmark in
+                BookmarkDetailView(
+                    bookmark: bookmark,
+                    client: client,
+                    onUpdate: { updated in
+                        store.update(updated)
+                        onContentChanged()
+                    },
+                    onBookmarkChange: { changed, isBookmarked, phase in
+                        store.setBookmarked(changed, isBookmarked: isBookmarked, phase: phase)
+                        onContentChanged()
+                    },
+                    onBookmarkCommit: { _, _ in onContentChanged() },
+                    onExternalOpen: { opened in
+                        store.promote(opened)
+                        onExternalOpen(opened)
+                    }
+                )
+                .navigationTransition(
+                    .zoom(sourceID: bookmark.id, in: bookmarkTransition)
+                )
+            }
+            .task {
+                await store.reload()
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading && store.items.isEmpty {
+            ProgressView("Loading history…")
+        } else if let error = store.errorMessage, store.items.isEmpty {
+            ContentUnavailableView {
+                Label("History unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") {
+                    Task { await store.reload() }
+                }
+            }
+        } else if store.items.isEmpty {
+            ContentUnavailableView(
+                "No opened bookmarks",
+                systemImage: "clock.arrow.circlepath",
+                description: Text("Bookmarks you open will appear here.")
+            )
+        } else {
+            List(store.items) { bookmark in
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowSeparator(.hidden)
+                .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+                .task {
+                    await store.loadMoreIfNeeded(current: bookmark)
+                }
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload()
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -1,0 +1,204 @@
+#if DEBUG
+import SwiftUI
+
+struct ScreenshotHomeView: View {
+    @Namespace private var bookmarkTransition
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack(spacing: 30) {
+                    ForEach(ScreenshotHomeFixtures.sections) { section in
+                        HomeDashboardSectionView(
+                            section: section,
+                            transitionNamespace: bookmarkTransition
+                        )
+                    }
+                }
+                .padding(.vertical, 10)
+                .padding(.bottom, 24)
+            }
+            .navigationTitle("Home")
+            .navigationDestination(for: HomeNavigationRoute.self) { route in
+                fixtureDestination(for: route)
+                    .navigationTransition(
+                        .zoom(sourceID: route.sourceID, in: bookmarkTransition)
+                    )
+            }
+            .navigationDestination(for: HomeSectionRoute.self) { route in
+                List(ScreenshotHomeFixtures.openedBookmarks) { bookmark in
+                    BookmarkRow(bookmark: bookmark)
+                }
+                .listStyle(.plain)
+                .navigationTitle(route.title)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func fixtureDestination(for route: HomeNavigationRoute) -> some View {
+        switch route.destination {
+        case .item(let item):
+            Text(item.title)
+                .navigationTitle(item.title)
+        case .bookmark(let bookmark):
+            Text(bookmark.title)
+                .navigationTitle(bookmark.title)
+        }
+    }
+}
+
+private enum ScreenshotHomeFixtures {
+    static let openedBookmarks = [
+        bookmark(id: "opened-1", title: "Building products that feel inevitable", creator: "Lenny’s Podcast"),
+        bookmark(id: "opened-2", title: "The hidden systems behind great teams", creator: "Acquired"),
+        bookmark(id: "opened-3", title: "A practical guide to product intuition", creator: "Every"),
+    ]
+
+    static let sections: [HomeDashboardSection] = [
+        .jumpBackIn([
+            homeItem(
+                id: "resume",
+                title: "Building products that feel inevitable",
+                creator: "Lenny’s Podcast",
+                contentType: .podcast,
+                provider: .spotify,
+                duration: 3_420,
+                minutes: nil,
+                progress: BookmarkProgress(position: 1_368, duration: 3_420, percent: 40)
+            ),
+            homeItem(
+                id: "resume-2",
+                title: "The hidden systems behind great teams",
+                creator: "Acquired",
+                contentType: .podcast,
+                provider: .spotify,
+                duration: 4_200,
+                minutes: nil,
+                progress: BookmarkProgress(position: 840, duration: 4_200, percent: 20)
+            ),
+            homeItem(
+                id: "resume-3",
+                title: "A practical guide to product intuition",
+                creator: "Every",
+                progress: BookmarkProgress(position: 3, duration: 12, percent: 25)
+            ),
+            homeItem(
+                id: "resume-4",
+                title: "Why small tools can have enormous leverage",
+                creator: "Works in Progress",
+                progress: BookmarkProgress(position: 5, duration: 18, percent: 28)
+            ),
+            homeItem(
+                id: "resume-5",
+                title: "The craft of making software feel calm",
+                creator: "Dense Discovery",
+                progress: BookmarkProgress(position: 4, duration: 10, percent: 40)
+            ),
+            homeItem(
+                id: "resume-6",
+                title: "Building an enduring creative practice",
+                creator: "The New Yorker",
+                progress: BookmarkProgress(position: 6, duration: 15, percent: 40)
+            ),
+        ]),
+        .inbox([
+            bookmark(id: "inbox-1", title: "What comes after the app?", creator: "Stratechery"),
+            bookmark(id: "inbox-2", title: "Designing tools for thought", creator: "Maggie Appleton"),
+            bookmark(id: "inbox-3", title: "The quiet craft of good software", creator: "Thorsten Ball"),
+        ]),
+        .quickWins([
+            homeItem(id: "quick-1", title: "Make room for better ideas", creator: "Dense Discovery"),
+            homeItem(id: "quick-2", title: "Small teams, sharp tools", creator: "Linear"),
+            homeItem(id: "quick-3", title: "A field guide to curiosity", creator: "Works in Progress"),
+            homeItem(id: "quick-4", title: "Notes on taste", creator: "Every"),
+        ]),
+        .recentlySaved([
+            homeItem(id: "saved-1", title: "The future of personal software", creator: "Ink & Switch"),
+            homeItem(id: "saved-2", title: "How great products compound", creator: "A Smart Bear"),
+            homeItem(id: "saved-3", title: "Interfaces for invisible systems", creator: "Rachel Been"),
+        ]),
+        .podcasts([
+            homeItem(
+                id: "podcast-1",
+                title: "The culture of building",
+                creator: "Acquired",
+                contentType: .podcast,
+                provider: .spotify,
+                duration: 4_200,
+                minutes: nil
+            ),
+            homeItem(
+                id: "podcast-2",
+                title: "Tools, taste, and technology",
+                creator: "Decoder",
+                contentType: .podcast,
+                provider: .spotify,
+                duration: 2_800,
+                minutes: nil
+            ),
+        ]),
+    ]
+
+    private static func homeItem(
+        id: String,
+        title: String,
+        creator: String,
+        contentType: ContentType = .article,
+        provider: Provider = .rss,
+        duration: Int? = nil,
+        minutes: Int? = 7,
+        progress: BookmarkProgress? = nil
+    ) -> HomeItem {
+        HomeItem(
+            id: id,
+            itemId: "item-\(id)",
+            title: title,
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/\(id)")!,
+            contentType: contentType,
+            provider: provider,
+            creator: creator,
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: nil,
+            summary: nil,
+            duration: duration,
+            publishedAt: "2026-07-18T12:00:00Z",
+            readingTimeMinutes: minutes,
+            bookmarkedAt: "2026-07-18T12:00:00Z",
+            lastOpenedAt: progress == nil ? nil : "2026-07-18T18:00:00Z",
+            progress: progress
+        )
+    }
+
+    private static func bookmark(id: String, title: String, creator: String) -> Bookmark {
+        Bookmark(
+            id: id,
+            itemId: "item-\(id)",
+            title: title,
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/\(id)")!,
+            contentType: .article,
+            provider: .rss,
+            creator: creator,
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: nil,
+            summary: nil,
+            duration: nil,
+            publishedAt: "2026-07-18T12:00:00Z",
+            wordCount: nil,
+            readingTimeMinutes: 6,
+            state: "INBOX",
+            ingestedAt: "2026-07-18T12:00:00Z",
+            bookmarkedAt: nil,
+            lastOpenedAt: nil,
+            progress: nil,
+            isFinished: false,
+            finishedAt: nil,
+            tags: []
+        )
+    }
+}
+#endif

--- a/apps/ios/ZineNative/Features/Inbox/InboxStore.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxStore.swift
@@ -14,6 +14,7 @@ final class InboxStore {
     private let client: APIClient
     private let cache: InboxCache
     private let onLibraryChanged: () -> Void
+    private let onInboxChanged: () -> Void
     private var activeQuery = InboxQuery()
     private var pendingItemIDs = Set<String>()
     private var detailRemovals: [String: InboxOptimisticRemoval] = [:]
@@ -21,11 +22,13 @@ final class InboxStore {
     init(
         client: APIClient,
         cache: InboxCache,
-        onLibraryChanged: @escaping () -> Void
+        onLibraryChanged: @escaping () -> Void,
+        onInboxChanged: @escaping () -> Void
     ) {
         self.client = client
         self.cache = cache
         self.onLibraryChanged = onLibraryChanged
+        self.onInboxChanged = onInboxChanged
     }
 
     func reload(query: InboxQuery) async {
@@ -98,6 +101,7 @@ final class InboxStore {
             await cache.remove(id: bookmark.id, query: removal.query)
             pendingItemIDs.remove(bookmark.id)
             onLibraryChanged()
+            onInboxChanged()
         } catch {
             restore(removal, message: "The item couldn’t be bookmarked. Please try again.")
         }
@@ -110,6 +114,7 @@ final class InboxStore {
             try await client.archiveInboxItem(id: bookmark.id)
             await cache.remove(id: bookmark.id, query: removal.query)
             pendingItemIDs.remove(bookmark.id)
+            onInboxChanged()
         } catch {
             restore(removal, message: "The item couldn’t be archived. Please try again.")
         }
@@ -141,6 +146,7 @@ final class InboxStore {
             Task { await cache.remove(id: id, query: removal.query) }
         }
         onLibraryChanged()
+        onInboxChanged()
     }
 
     func dismissActionError() {

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InboxView: View {
     let client: APIClient
+    let onExternalOpen: (Bookmark) -> Void
 
     @State private var store: InboxStore
     @State private var provider: Provider?
@@ -11,13 +12,17 @@ struct InboxView: View {
     init(
         client: APIClient,
         cache: InboxCache,
-        onLibraryChanged: @escaping () -> Void
+        onLibraryChanged: @escaping () -> Void,
+        onInboxChanged: @escaping () -> Void,
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
     ) {
         self.client = client
+        self.onExternalOpen = onExternalOpen
         _store = State(initialValue: InboxStore(
             client: client,
             cache: cache,
-            onLibraryChanged: onLibraryChanged
+            onLibraryChanged: onLibraryChanged,
+            onInboxChanged: onInboxChanged
         ))
     }
 
@@ -48,7 +53,8 @@ struct InboxView: View {
                         },
                         onBookmarkCommit: { changed, _ in
                             store.commitDetailBookmarkChange(id: changed.id)
-                        }
+                        },
+                        onExternalOpen: onExternalOpen
                     )
                     .navigationTransition(
                         .zoom(sourceID: bookmark.id, in: bookmarkTransition)

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -20,13 +20,15 @@ struct BookmarkDetailView: View {
     let onUpdate: (Bookmark) -> Void
     let onBookmarkChange: (Bookmark, Bool, BookmarkChangePhase) -> Void
     let onBookmarkCommit: (Bookmark, Bool) -> Void
+    let onExternalOpen: (Bookmark) -> Void
 
     init(
         bookmark: Bookmark,
         client: APIClient,
         onUpdate: @escaping (Bookmark) -> Void,
         onBookmarkChange: @escaping (Bookmark, Bool, BookmarkChangePhase) -> Void = { _, _, _ in },
-        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in }
+        onBookmarkCommit: @escaping (Bookmark, Bool) -> Void = { _, _ in },
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
     ) {
         _bookmark = State(initialValue: bookmark)
         _isBookmarked = State(initialValue: bookmark.state == "BOOKMARKED")
@@ -34,6 +36,7 @@ struct BookmarkDetailView: View {
         self.onUpdate = onUpdate
         self.onBookmarkChange = onBookmarkChange
         self.onBookmarkCommit = onBookmarkCommit
+        self.onExternalOpen = onExternalOpen
     }
 
     var body: some View {
@@ -62,7 +65,6 @@ struct BookmarkDetailView: View {
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
-            try? await client.markOpened(id: bookmark.id)
             if let refreshed = try? await client.getBookmark(id: bookmark.id) {
                 bookmark = refreshed
                 if !hasToggledBookmark {
@@ -140,7 +142,11 @@ struct BookmarkDetailView: View {
 
             Spacer(minLength: 0)
 
-            ProviderOpenButton(provider: bookmark.provider, destination: bookmark.canonicalUrl)
+            ProviderOpenButton(
+                provider: bookmark.provider,
+                destination: bookmark.canonicalUrl,
+                onOpen: { onExternalOpen(bookmark) }
+            )
                 .padding(.trailing, 8)
         }
     }
@@ -238,7 +244,8 @@ struct BookmarkDetailView: View {
                     client: client,
                     onBookmarkUpdate: onUpdate,
                     onBookmarkChange: onBookmarkChange,
-                    onBookmarkCommit: onBookmarkCommit
+                    onBookmarkCommit: onBookmarkCommit,
+                    onExternalOpen: onExternalOpen
                 )
             } label: {
                 creatorRowLabel(showsDisclosure: true)

--- a/apps/ios/ZineNative/Features/Library/LibraryStore.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryStore.swift
@@ -13,12 +13,18 @@ final class LibraryStore {
 
     private let client: APIClient
     private let cache: LibraryCache
+    private let onContentChanged: () -> Void
     private var activeQuery = LibraryQuery()
     private var unbookmarkedIndices: [String: Int] = [:]
 
-    init(client: APIClient, cache: LibraryCache) {
+    init(
+        client: APIClient,
+        cache: LibraryCache,
+        onContentChanged: @escaping () -> Void = {}
+    ) {
         self.client = client
         self.cache = cache
+        self.onContentChanged = onContentChanged
     }
 
     func reset() {
@@ -104,6 +110,7 @@ final class LibraryStore {
                 items.remove(at: index)
             }
             persistCurrentState()
+            onContentChanged()
         }
     }
 
@@ -123,6 +130,7 @@ final class LibraryStore {
         }
 
         persistCurrentState()
+        onContentChanged()
     }
 
     func complete(_ bookmark: Bookmark) async {
@@ -132,6 +140,7 @@ final class LibraryStore {
 
         do {
             _ = try await client.setFinished(id: bookmark.id, isFinished: true)
+            onContentChanged()
         } catch {
             restore(removal, message: "The bookmark couldn’t be completed. Please try again.")
         }
@@ -142,6 +151,7 @@ final class LibraryStore {
 
         do {
             try await client.archiveBookmark(id: bookmark.id)
+            onContentChanged()
         } catch {
             restore(removal, message: "The bookmark couldn’t be archived. Please try again.")
         }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -4,6 +4,8 @@ struct LibraryView: View {
     let client: APIClient
     let searchText: Binding<String>?
     let refreshRevision: Int
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
 
     @State private var store: LibraryStore
     @State private var showsFinished = false
@@ -15,12 +17,20 @@ struct LibraryView: View {
         client: APIClient,
         cache: LibraryCache,
         searchText: Binding<String>? = nil,
-        refreshRevision: Int = 0
+        refreshRevision: Int = 0,
+        onContentChanged: @escaping () -> Void = {},
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
     ) {
         self.client = client
         self.searchText = searchText
         self.refreshRevision = refreshRevision
-        _store = State(initialValue: LibraryStore(client: client, cache: cache))
+        self.onContentChanged = onContentChanged
+        self.onExternalOpen = onExternalOpen
+        _store = State(initialValue: LibraryStore(
+            client: client,
+            cache: cache,
+            onContentChanged: onContentChanged
+        ))
     }
 
     private var search: String {
@@ -56,7 +66,8 @@ struct LibraryView: View {
                         onUpdate: { updated in store.update(updated) },
                         onBookmarkChange: { changed, isBookmarked, _ in
                             store.setBookmarked(changed, isBookmarked: isBookmarked)
-                        }
+                        },
+                        onExternalOpen: onExternalOpen
                     )
                     .navigationTransition(
                         .zoom(sourceID: bookmark.id, in: bookmarkTransition)

--- a/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
+++ b/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
@@ -155,14 +155,29 @@ struct ProviderLinkButton: View {
 
 struct ProviderOpenButton: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.openURL) private var openURL
 
     let provider: Provider
     let destination: URL
+    let onOpen: () -> Void
+
+    init(
+        provider: Provider,
+        destination: URL,
+        onOpen: @escaping () -> Void = {}
+    ) {
+        self.provider = provider
+        self.destination = destination
+        self.onOpen = onOpen
+    }
 
     private var action: ProviderOpenAction { provider.openAction }
 
     var body: some View {
-        Link(destination: destination) {
+        Button {
+            onOpen()
+            openURL(destination)
+        } label: {
             providerLogo
                 .frame(width: 27, height: 27)
                 .frame(width: 56, height: 56)

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import XCTest
+@testable import ZineNative
+
+final class HomeTests: XCTestCase {
+    @MainActor
+    func testBuildsOrderedDashboardAndInsertsQuickWinsAfterInbox() {
+        let resume = makeHomeItem(id: "resume", minutes: 30, lastOpenedAt: "2026-07-18T10:00:00Z")
+        let quick = makeHomeItem(id: "quick", minutes: 5)
+        let recent = makeHomeItem(id: "recent", minutes: 20)
+        let collectionItem = makeHomeItem(id: "collection-item", minutes: 15)
+        let home = HomeResponse(
+            recentBookmarks: [quick, recent],
+            jumpBackIn: [resume],
+            byContentType: HomeContentTypeSections(videos: [], podcasts: [], articles: []),
+            customCollections: [
+                HomeCollection(
+                    collectionId: "collection-1",
+                    title: "Ideas",
+                    layout: .stackRail,
+                    position: 0,
+                    count: 1,
+                    items: [collectionItem]
+                ),
+            ],
+            sectionOrder: [
+                HomeLayoutSection(kind: .builtIn, builtInSection: .jumpBackIn, collectionId: nil),
+                HomeLayoutSection(kind: .builtIn, builtInSection: .inbox, collectionId: nil),
+                HomeLayoutSection(
+                    kind: .builtIn,
+                    builtInSection: .recentlyBookmarked,
+                    collectionId: nil
+                ),
+                HomeLayoutSection(
+                    kind: .collection,
+                    builtInSection: nil,
+                    collectionId: "collection-1"
+                ),
+            ],
+            requestId: nil,
+            traceId: nil
+        )
+
+        let sections = HomeStore.makeSections(home: home, inboxItems: [makeBookmark(index: 0)])
+
+        XCTAssertEqual(
+            sections.map(\.id),
+            ["jump-back-in", "inbox", "quick-wins", "recently-saved", "collection-collection-1"]
+        )
+    }
+
+    func testDecodesCompactHomeResponseWithProgress() throws {
+        let response = try JSONDecoder().decode(
+            HomeResponse.self,
+            from: Data(
+                """
+                {
+                  "recentBookmarks":[],
+                  "jumpBackIn":[{
+                    "id":"ui_1","itemId":"item_1","title":"Continue reading",
+                    "thumbnailUrl":null,"canonicalUrl":"https://example.com/item",
+                    "contentType":"ARTICLE","provider":"RSS","creator":"Example",
+                    "creatorImageUrl":null,"creatorId":"creator_1","publisher":null,
+                    "summary":null,"duration":null,"publishedAt":null,
+                    "readingTimeMinutes":8,"bookmarkedAt":"2026-07-18T00:00:00Z",
+                    "lastOpenedAt":"2026-07-18T01:00:00Z",
+                    "progress":{"position":4,"duration":8,"percent":50}
+                  }],
+                  "byContentType":{"videos":[],"podcasts":[],"articles":[]},
+                  "customCollections":[],
+                  "sectionOrder":[{"kind":"BUILT_IN","builtInSection":"JUMP_BACK_IN"}],
+                  "requestId":"request-1","traceId":"trace-1"
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(response.jumpBackIn.first?.progress?.percent, 50)
+        XCTAssertEqual(response.jumpBackIn.first?.creatorId, "creator_1")
+        XCTAssertTrue(response.jumpBackIn.first?.isQuickWin == true)
+    }
+
+    @MainActor
+    func testJumpBackInKeepsTheSixMostRecentItems() throws {
+        let home = HomeResponse(
+            recentBookmarks: [],
+            jumpBackIn: (0..<8).map {
+                makeHomeItem(
+                    id: "resume-\($0)",
+                    minutes: 20,
+                    lastOpenedAt: "2026-07-18T\(String(format: "%02d", $0)):00:00Z"
+                )
+            },
+            byContentType: HomeContentTypeSections(videos: [], podcasts: [], articles: []),
+            customCollections: [],
+            sectionOrder: [
+                HomeLayoutSection(kind: .builtIn, builtInSection: .jumpBackIn, collectionId: nil),
+            ],
+            requestId: nil,
+            traceId: nil
+        )
+
+        let sections = HomeStore.makeSections(home: home, inboxItems: [])
+        let jumpBackIn = try XCTUnwrap(sections.first)
+
+        guard case .jumpBackIn(let items) = jumpBackIn else {
+            return XCTFail("Expected Jump Back In to be the first section")
+        }
+
+        XCTAssertEqual(items.map(\.id), (0..<6).map { "resume-\($0)" })
+    }
+
+    @MainActor
+    func testOptimisticExternalOpenMovesBookmarkToFrontWithoutDuplicatingIt() throws {
+        let previouslyOpened = makeHomeItem(
+            id: "opened",
+            minutes: 20,
+            lastOpenedAt: "2026-07-18T10:00:00Z"
+        )
+        let bookmark = makeBookmark(index: 9, state: "BOOKMARKED")
+        let optimistic = HomeItem(
+            bookmark: bookmark,
+            openedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+        let home = HomeResponse(
+            recentBookmarks: [],
+            jumpBackIn: [previouslyOpened, optimistic],
+            byContentType: HomeContentTypeSections(videos: [], podcasts: [], articles: []),
+            customCollections: [],
+            sectionOrder: [
+                HomeLayoutSection(kind: .builtIn, builtInSection: .jumpBackIn, collectionId: nil),
+            ],
+            requestId: nil,
+            traceId: nil
+        )
+
+        let sections = HomeStore.makeSections(
+            home: home,
+            inboxItems: [],
+            optimisticOpenedItems: [optimistic]
+        )
+        let jumpBackIn = try XCTUnwrap(sections.first)
+
+        guard case .jumpBackIn(let items) = jumpBackIn else {
+            return XCTFail("Expected Jump Back In to be the first section")
+        }
+
+        XCTAssertEqual(items.map(\.id), [bookmark.id, previouslyOpened.id])
+    }
+
+    func testHomeTransitionSourceIDsAreStableAndSectionScoped() {
+        let item = makeHomeItem(id: "shared", minutes: 12)
+
+        XCTAssertEqual(
+            HomeNavigationRoute.item(item, sectionID: "jump-back-in").sourceID,
+            "jump-back-in-shared"
+        )
+        XCTAssertNotEqual(
+            HomeNavigationRoute.item(item, sectionID: "jump-back-in").sourceID,
+            HomeNavigationRoute.item(item, sectionID: "videos").sourceID
+        )
+    }
+
+    func testHomeCacheKeepsOnlyFourInboxItems() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = HomeCache(userID: "test-user", baseDirectory: directory)
+        await cache.save(home: nil, inboxItems: (0..<7).map { makeBookmark(index: $0) })
+
+        let snapshot = await cache.load()
+        XCTAssertEqual(snapshot?.inboxItems.count, 4)
+        XCTAssertEqual(snapshot?.inboxItems.first?.id, "inbox-0")
+    }
+
+    private func makeHomeItem(
+        id: String,
+        minutes: Int,
+        lastOpenedAt: String? = nil
+    ) -> HomeItem {
+        HomeItem(
+            id: id,
+            itemId: "item-\(id)",
+            title: "Item \(id)",
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/\(id)")!,
+            contentType: .article,
+            provider: .rss,
+            creator: "Creator",
+            creatorImageUrl: nil,
+            creatorId: "creator-1",
+            publisher: nil,
+            summary: nil,
+            duration: nil,
+            publishedAt: nil,
+            readingTimeMinutes: minutes,
+            bookmarkedAt: "2026-07-18T00:00:00Z",
+            lastOpenedAt: lastOpenedAt,
+            progress: nil
+        )
+    }
+
+    private func makeBookmark(index: Int, state: String = "INBOX") -> Bookmark {
+        Bookmark(
+            id: "inbox-\(index)",
+            itemId: "item-\(index)",
+            title: "Inbox item \(index)",
+            thumbnailUrl: nil,
+            canonicalUrl: URL(string: "https://example.com/items/\(index)")!,
+            contentType: .article,
+            provider: .rss,
+            creator: "Creator",
+            creatorImageUrl: nil,
+            creatorId: nil,
+            publisher: nil,
+            summary: nil,
+            duration: nil,
+            publishedAt: nil,
+            wordCount: nil,
+            readingTimeMinutes: 5,
+            state: state,
+            ingestedAt: "2026-07-18T00:00:00Z",
+            bookmarkedAt: nil,
+            lastOpenedAt: nil,
+            progress: nil,
+            isFinished: false,
+            finishedAt: nil,
+            tags: []
+        )
+    }
+}

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.6.0",
-    "description": "REST API for reading and managing Zine inbox items, bookmarks, creators, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
+    "version": "1.8.0",
+    "description": "REST API for reading and managing the Zine home dashboard, inbox items, bookmarks, creators, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
     {
@@ -19,6 +19,10 @@
     {
       "name": "Metadata",
       "description": "API metadata and machine-readable documentation."
+    },
+    {
+      "name": "Home",
+      "description": "Read the ordered, personalized dashboard shelves."
     },
     {
       "name": "Inbox",
@@ -152,6 +156,39 @@
                 "schema": { "$ref": "#/components/schemas/Error" }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/v1/home": {
+      "get": {
+        "tags": ["Home"],
+        "operationId": "getHome",
+        "summary": "Get the Home dashboard",
+        "description": "Returns recently opened and saved bookmarks, content-type shelves, custom collections, and the user's configured section order.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "responses": {
+          "200": {
+            "description": "Ordered Home dashboard content.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HomeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
           }
         }
       }
@@ -403,6 +440,94 @@
           "422": {
             "$ref": "#/components/responses/UnsupportedUrl"
           }
+        }
+      }
+    },
+    "/api/v1/bookmarks/opened": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "listOpenedBookmarks",
+        "summary": "List opened bookmarks",
+        "description": "Returns unfinished bookmarked items the user has opened, sorted by most recently opened first.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Opened bookmarked items.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedItems" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/bookmarks/quick-wins": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "listQuickWinBookmarks",
+        "summary": "List quick-win bookmarks",
+        "description": "Returns unfinished bookmarks that take ten minutes or less, sorted by most recently saved first.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quick-win bookmarked items.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedItems" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/collections/{id}/items": {
+      "get": {
+        "tags": ["Bookmarks"],
+        "operationId": "listCollectionItems",
+        "summary": "List collection items",
+        "description": "Returns all bookmarks in a custom collection using the collection's configured sort order.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/Limit" },
+          { "$ref": "#/components/parameters/Cursor" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bookmarks in the collection.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedItems" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
         }
       }
     },
@@ -2362,6 +2487,167 @@
             }
           }
         }
+      },
+      "HomeItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "itemId",
+          "title",
+          "thumbnailUrl",
+          "canonicalUrl",
+          "contentType",
+          "provider",
+          "creator",
+          "creatorImageUrl",
+          "creatorId",
+          "publisher",
+          "summary",
+          "duration",
+          "publishedAt",
+          "readingTimeMinutes",
+          "bookmarkedAt",
+          "lastOpenedAt",
+          "progress"
+        ],
+        "properties": {
+          "id": { "type": "string", "description": "User item ID." },
+          "itemId": { "type": "string", "description": "Canonical item ID." },
+          "title": { "type": "string" },
+          "thumbnailUrl": { "type": ["string", "null"], "format": "uri" },
+          "canonicalUrl": { "type": "string", "format": "uri" },
+          "contentType": {
+            "type": "string",
+            "enum": ["VIDEO", "PODCAST", "ARTICLE", "POST"]
+          },
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS", "SUBSTACK", "WEB", "X"]
+          },
+          "creator": { "type": "string" },
+          "creatorImageUrl": { "type": ["string", "null"], "format": "uri" },
+          "creatorId": { "type": ["string", "null"] },
+          "publisher": { "type": ["string", "null"] },
+          "summary": { "type": ["string", "null"] },
+          "duration": { "type": ["integer", "null"], "minimum": 0 },
+          "publishedAt": { "type": ["string", "null"], "format": "date-time" },
+          "readingTimeMinutes": { "type": ["integer", "null"], "minimum": 0 },
+          "bookmarkedAt": { "type": ["string", "null"], "format": "date-time" },
+          "lastOpenedAt": { "type": ["string", "null"], "format": "date-time" },
+          "progress": {
+            "oneOf": [
+              { "type": "null" },
+              {
+                "type": "object",
+                "required": ["position", "duration", "percent"],
+                "properties": {
+                  "position": { "type": "number", "minimum": 0 },
+                  "duration": { "type": "number", "minimum": 0 },
+                  "percent": { "type": "number", "minimum": 0, "maximum": 100 }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "HomeCollection": {
+        "type": "object",
+        "required": ["collectionId", "title", "layout", "position", "count", "items"],
+        "properties": {
+          "collectionId": { "type": "string" },
+          "title": { "type": "string" },
+          "layout": {
+            "type": "string",
+            "enum": ["STACK_RAIL", "COVER_RAIL", "ROW_GRID", "COMPACT_LIST"]
+          },
+          "position": { "type": "integer", "minimum": 0 },
+          "count": { "type": "integer", "minimum": 0 },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/HomeItem" }
+          }
+        }
+      },
+      "HomeLayoutSection": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["kind", "builtInSection"],
+            "properties": {
+              "kind": { "type": "string", "const": "BUILT_IN" },
+              "builtInSection": {
+                "type": "string",
+                "enum": [
+                  "JUMP_BACK_IN",
+                  "RECENTLY_BOOKMARKED",
+                  "INBOX",
+                  "PODCASTS",
+                  "ARTICLES",
+                  "VIDEOS"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": ["kind", "collectionId"],
+            "properties": {
+              "kind": { "type": "string", "const": "COLLECTION" },
+              "collectionId": { "type": "string" }
+            }
+          }
+        ]
+      },
+      "HomeResponse": {
+        "allOf": [
+          { "$ref": "#/components/schemas/RequestMetadata" },
+          {
+            "type": "object",
+            "required": [
+              "recentBookmarks",
+              "jumpBackIn",
+              "byContentType",
+              "customCollections",
+              "sectionOrder"
+            ],
+            "properties": {
+              "recentBookmarks": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/HomeItem" }
+              },
+              "jumpBackIn": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/HomeItem" }
+              },
+              "byContentType": {
+                "type": "object",
+                "required": ["videos", "podcasts", "articles"],
+                "properties": {
+                  "videos": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/HomeItem" }
+                  },
+                  "podcasts": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/HomeItem" }
+                  },
+                  "articles": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/HomeItem" }
+                  }
+                }
+              },
+              "customCollections": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/HomeCollection" }
+              },
+              "sectionOrder": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/HomeLayoutSection" }
+              }
+            }
+          }
+        ]
       },
       "PaginatedItems": {
         "allOf": [

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -13,7 +13,11 @@ const {
   mockCreateContext,
   mockCreateCaller,
   mockInbox,
+  mockHome,
   mockLibrary,
+  mockRecentlyOpened,
+  mockQuickWins,
+  mockCollectionItems,
   mockGetItem,
   mockBookmarkInboxItem,
   mockArchiveInboxItem,
@@ -69,7 +73,11 @@ const {
   })),
   mockCreateCaller: vi.fn(),
   mockInbox: vi.fn(),
+  mockHome: vi.fn(),
   mockLibrary: vi.fn(),
+  mockRecentlyOpened: vi.fn(),
+  mockQuickWins: vi.fn(),
+  mockCollectionItems: vi.fn(),
   mockGetItem: vi.fn(),
   mockBookmarkInboxItem: vi.fn(),
   mockArchiveInboxItem: vi.fn(),
@@ -293,7 +301,10 @@ describe('apiV1Routes', () => {
     mockCreateCaller.mockReturnValue({
       items: {
         inbox: mockInbox,
+        home: mockHome,
         library: mockLibrary,
+        recentlyOpened: mockRecentlyOpened,
+        quickWins: mockQuickWins,
         get: mockGetItem,
         bookmark: mockBookmarkInboxItem,
         archive: mockArchiveInboxItem,
@@ -303,6 +314,9 @@ describe('apiV1Routes', () => {
         updateProgress: mockUpdateProgress,
         getArticleContent: mockGetArticleContent,
         listTags: mockListTags,
+      },
+      collections: {
+        items: mockCollectionItems,
       },
       bookmarks: {
         preview: mockPreview,
@@ -360,6 +374,7 @@ describe('apiV1Routes', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as JsonBody;
     expect(body.openapi).toBe('3.1.0');
+    expect(body.paths).toHaveProperty('/api/v1/home');
     expect(body.paths).toHaveProperty('/api/v1/inbox');
     expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/bookmark');
     expect(body.paths).toHaveProperty('/api/v1/inbox/{id}/archive');
@@ -1360,6 +1375,38 @@ describe('apiV1Routes', () => {
     });
   });
 
+  it('returns the ordered Home dashboard for the token owner', async () => {
+    mockHome.mockResolvedValue({
+      recentBookmarks: [{ id: 'ui_recent', title: 'Recent bookmark' }],
+      jumpBackIn: [{ id: 'ui_opened', title: 'Opened bookmark' }],
+      byContentType: {
+        videos: [],
+        podcasts: [],
+        articles: [{ id: 'ui_recent', title: 'Recent bookmark' }],
+      },
+      customCollections: [],
+      sectionOrder: [{ kind: 'BUILT_IN', builtInSection: 'JUMP_BACK_IN' }],
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/home', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCreateCaller).toHaveBeenCalledWith({ userId: 'user_123' });
+    expect(mockHome).toHaveBeenCalledWith({});
+    expect((await res.json()) as JsonBody).toMatchObject({
+      recentBookmarks: [{ title: 'Recent bookmark' }],
+      jumpBackIn: [{ title: 'Opened bookmark' }],
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
   it('rejects invalid inbox filters', async () => {
     const app = createTestApp();
 
@@ -1436,6 +1483,85 @@ describe('apiV1Routes', () => {
         contentType: ContentType.ARTICLE,
         isFinished: true,
       },
+    });
+  });
+
+  it('lists opened bookmarks newest first through the history caller', async () => {
+    mockRecentlyOpened.mockResolvedValue({
+      items: [{ id: 'ui_opened', title: 'Opened bookmark' }],
+      nextCursor: 'older-opened',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/opened?limit=20&cursor=opened-cursor', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockRecentlyOpened).toHaveBeenCalledWith({
+      limit: 20,
+      cursor: 'opened-cursor',
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      items: [{ title: 'Opened bookmark' }],
+      nextCursor: 'older-opened',
+    });
+  });
+
+  it('lists quick-win bookmarks through the dedicated caller', async () => {
+    mockQuickWins.mockResolvedValue({
+      items: [{ id: 'ui_quick', title: 'Quick bookmark' }],
+      nextCursor: 'more-quick',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/quick-wins?limit=20&cursor=quick-cursor', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockQuickWins).toHaveBeenCalledWith({
+      limit: 20,
+      cursor: 'quick-cursor',
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      items: [{ title: 'Quick bookmark' }],
+      nextCursor: 'more-quick',
+    });
+  });
+
+  it('lists all items in a custom collection', async () => {
+    mockCollectionItems.mockResolvedValue({
+      items: [{ id: 'ui_collection', title: 'Collected bookmark' }],
+      nextCursor: 'more-collection',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request(
+        'http://localhost/api/v1/collections/collection_1/items?limit=20&cursor=collection-cursor',
+        {
+          headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+        }
+      ),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockCollectionItems).toHaveBeenCalledWith({
+      id: 'collection_1',
+      limit: 20,
+      cursor: 'collection-cursor',
+    });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      items: [{ title: 'Collected bookmark' }],
+      nextCursor: 'more-collection',
     });
   });
 

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1367,6 +1367,17 @@ apiV1Routes.get('/inbox', apiAuth('bookmarks:read'), async (c) => {
   });
 });
 
+apiV1Routes.get('/home', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const result = await caller.items.home({});
+
+  return c.json({
+    ...result,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
 apiV1Routes.get('/creators/:creatorId', apiAuth('bookmarks:read'), async (c) => {
   const caller = appRouter.createCaller(await createContext(c));
 
@@ -1484,6 +1495,55 @@ apiV1Routes.get('/bookmarks', apiAuth('bookmarks:read'), async (c) => {
       contentType: parsedQuery.data.contentType,
       isFinished,
     },
+  });
+
+  return c.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.get('/bookmarks/opened', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+  const result = await caller.items.recentlyOpened({
+    limit: parseLimit(c.req.query('limit')),
+    cursor: cursor && cursor.length > 0 ? cursor : undefined,
+  });
+
+  return c.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.get('/bookmarks/quick-wins', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+  const result = await caller.items.quickWins({
+    limit: parseLimit(c.req.query('limit')),
+    cursor: cursor && cursor.length > 0 ? cursor : undefined,
+  });
+
+  return c.json({
+    items: result.items,
+    nextCursor: result.nextCursor,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
+apiV1Routes.get('/collections/:id/items', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+  const cursor = c.req.query('cursor');
+  const result = await caller.collections.items({
+    id: c.req.param('id'),
+    limit: parseLimit(c.req.query('limit')),
+    cursor: cursor && cursor.length > 0 ? cursor : undefined,
   });
 
   return c.json({

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -10,6 +10,8 @@ import {
   ne,
   or,
   lt,
+  gt,
+  lte,
   isNotNull,
   sql,
   inArray,
@@ -127,6 +129,7 @@ export type ItemView = {
 type HomeItemView = Pick<
   ItemView,
   | 'id'
+  | 'itemId'
   | 'title'
   | 'thumbnailUrl'
   | 'canonicalUrl'
@@ -134,11 +137,15 @@ type HomeItemView = Pick<
   | 'provider'
   | 'creator'
   | 'creatorImageUrl'
+  | 'creatorId'
   | 'publisher'
   | 'summary'
   | 'duration'
+  | 'publishedAt'
   | 'readingTimeMinutes'
+  | 'bookmarkedAt'
   | 'lastOpenedAt'
+  | 'progress'
 >;
 
 // Helper Functions
@@ -391,6 +398,7 @@ function toHomeItemViews(
 
     return {
       id: itemView.id,
+      itemId: itemView.itemId,
       title: itemView.title,
       thumbnailUrl: itemView.thumbnailUrl,
       canonicalUrl: itemView.canonicalUrl,
@@ -398,11 +406,15 @@ function toHomeItemViews(
       provider: itemView.provider,
       creator: itemView.creator,
       creatorImageUrl: itemView.creatorImageUrl,
+      creatorId: itemView.creatorId,
       publisher: itemView.publisher,
       summary: itemView.summary,
       duration: itemView.duration,
+      publishedAt: itemView.publishedAt,
       readingTimeMinutes: itemView.readingTimeMinutes,
+      bookmarkedAt: itemView.bookmarkedAt,
       lastOpenedAt: itemView.lastOpenedAt,
+      progress: itemView.progress,
     };
   });
 }
@@ -727,6 +739,115 @@ export const itemsRouter = router({
       nextCursor,
     };
   }),
+
+  /**
+   * Get unfinished bookmarks that the user has opened, newest open first.
+   * Uses cursor-based pagination sorted by lastOpenedAt DESC.
+   */
+  recentlyOpened: protectedProcedure
+    .input(PaginationSchema.pick({ cursor: true, limit: true }).optional())
+    .query(async ({ input, ctx }) => {
+      const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
+      const cursor = input?.cursor ? decodeCursor(input.cursor) : null;
+      const conditions = [
+        eq(userItems.userId, ctx.userId),
+        eq(userItems.state, UserItemState.BOOKMARKED),
+        eq(userItems.isFinished, false),
+        isNotNull(userItems.lastOpenedAt),
+      ];
+
+      if (cursor) {
+        conditions.push(
+          or(
+            lt(userItems.lastOpenedAt, cursor.sortValue),
+            and(eq(userItems.lastOpenedAt, cursor.sortValue), lt(userItems.id, cursor.id))
+          )!
+        );
+      }
+
+      const results = await ctx.db
+        .select()
+        .from(userItems)
+        .innerJoin(items, eq(userItems.itemId, items.id))
+        .leftJoin(creators, eq(items.creatorId, creators.id))
+        .where(and(...conditions))
+        .orderBy(desc(userItems.lastOpenedAt), desc(userItems.id))
+        .limit(limit + 1);
+
+      const hasMore = results.length > limit;
+      const pageResults = hasMore ? results.slice(0, limit) : results;
+      const itemViews = await toItemViewsWithTags(ctx, pageResults);
+
+      let nextCursor: string | null = null;
+      if (hasMore && pageResults.length > 0) {
+        const lastResult = pageResults[pageResults.length - 1];
+        nextCursor = encodeCursor({
+          sortValue: lastResult.user_items.lastOpenedAt!,
+          id: lastResult.user_items.id,
+        });
+      }
+
+      return {
+        items: itemViews,
+        nextCursor,
+      };
+    }),
+
+  /**
+   * Get unfinished bookmarks that take ten minutes or less, newest save first.
+   */
+  quickWins: protectedProcedure
+    .input(PaginationSchema.pick({ cursor: true, limit: true }).optional())
+    .query(async ({ input, ctx }) => {
+      const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
+      const cursor = input?.cursor ? decodeCursor(input.cursor) : null;
+      const sortField = sql`COALESCE(${userItems.bookmarkedAt}, ${userItems.ingestedAt})`;
+      const conditions = [
+        eq(userItems.userId, ctx.userId),
+        eq(userItems.state, UserItemState.BOOKMARKED),
+        eq(userItems.isFinished, false),
+        or(
+          and(gt(items.readingTimeMinutes, 0), lte(items.readingTimeMinutes, 10)),
+          and(gt(items.duration, 0), lte(items.duration, 10 * 60))
+        )!,
+      ];
+
+      if (cursor) {
+        conditions.push(
+          or(
+            sql`${sortField} < ${cursor.sortValue}`,
+            and(sql`${sortField} = ${cursor.sortValue}`, lt(userItems.id, cursor.id))
+          )!
+        );
+      }
+
+      const results = await ctx.db
+        .select()
+        .from(userItems)
+        .innerJoin(items, eq(userItems.itemId, items.id))
+        .leftJoin(creators, eq(items.creatorId, creators.id))
+        .where(and(...conditions))
+        .orderBy(sql`${sortField} DESC`, desc(userItems.id))
+        .limit(limit + 1);
+
+      const hasMore = results.length > limit;
+      const pageResults = hasMore ? results.slice(0, limit) : results;
+      const itemViews = await toItemViewsWithTags(ctx, pageResults);
+
+      let nextCursor: string | null = null;
+      if (hasMore && pageResults.length > 0) {
+        const lastResult = pageResults[pageResults.length - 1];
+        nextCursor = encodeCursor({
+          sortValue: lastResult.user_items.bookmarkedAt ?? lastResult.user_items.ingestedAt,
+          id: lastResult.user_items.id,
+        });
+      }
+
+      return {
+        items: itemViews,
+        nextCursor,
+      };
+    }),
 
   /**
    * Get curated home sections.


### PR DESCRIPTION
## Summary

- add Home as the first native iOS tab with personalized dashboard shelves and cached loading
- track provider opens reliably and keep Jump Back In ordered by most recently opened
- add tappable section headers with complete paginated list destinations and consistent zoom transitions
- expose recently opened, quick-win, and custom collection REST pagination for the native app

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test` (mobile 1,125; worker 1,573; web 75)
- `bun run build`
- native Xcode tests (25 passed)
- signed Debug build installed and launched on Erik’s iPhone
- production API v1.8 deployed and health/OpenAPI readback verified