### PR TITLE
fix(ios): restore Home tab and inbox swipe actions

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -38,8 +38,8 @@ private struct AuthenticatedAppView: View {
 
     private let client: APIClient
     private let editorialCache: EditorialIssueCache
+    private let homeCache: HomeCache
     private let libraryCache: LibraryCache
-    private let inboxCache: InboxCache
 
     @State private var search = ""
     @State private var homeRevision = 0
@@ -58,8 +58,8 @@ private struct AuthenticatedAppView: View {
             }
         )
         editorialCache = EditorialIssueCache(userID: userID)
+        homeCache = HomeCache(userID: userID)
         libraryCache = LibraryCache(userID: userID)
-        inboxCache = InboxCache(userID: userID)
     }
 
     var body: some View {
@@ -75,12 +75,13 @@ private struct AuthenticatedAppView: View {
                 .tint(Color.accentColor)
             }
 
-            Tab("Inbox", systemImage: "tray") {
-                InboxView(
+            Tab("Home", systemImage: "house") {
+                HomeView(
                     client: client,
-                    cache: inboxCache,
-                    onLibraryChanged: markLibraryChanged,
-                    onInboxChanged: markHomeChanged,
+                    cache: homeCache,
+                    refreshRevision: homeRevision,
+                    externalOpenEvent: externalOpenEvent,
+                    onContentChanged: markBookmarkContentChanged,
                     onExternalOpen: handleExternalOpen
                 )
                 .tint(Color.accentColor)
@@ -129,10 +130,6 @@ private struct AuthenticatedAppView: View {
         } message: {
             Text(externalOpenError ?? "Please try again.")
         }
-    }
-
-    private func markLibraryChanged() {
-        libraryRevision += 1
     }
 
     private func markHomeChanged() {

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
@@ -13,6 +13,7 @@ final class HomeSectionListStore {
     private let route: HomeSectionRoute
     private let client: APIClient
     private var removedIndices: [String: Int] = [:]
+    private var pendingInboxItemIDs: Set<String> = []
 
     init(route: HomeSectionRoute, client: APIClient) {
         self.route = route
@@ -80,6 +81,59 @@ final class HomeSectionListStore {
             removedIndices[bookmark.id] = index
             items.remove(at: index)
         }
+    }
+
+    func bookmarkInboxItem(_ bookmark: Bookmark) async -> Bool {
+        await updateInboxItem(
+            bookmark,
+            request: { try await client.bookmarkItem(id: bookmark.id) },
+            errorMessage: "The item couldn’t be bookmarked. Please try again."
+        )
+    }
+
+    func archiveInboxItem(_ bookmark: Bookmark) async -> Bool {
+        await updateInboxItem(
+            bookmark,
+            request: { try await client.archiveInboxItem(id: bookmark.id) },
+            errorMessage: "The item couldn’t be archived. Please try again."
+        )
+    }
+
+    func dismissError() {
+        errorMessage = nil
+    }
+
+    private func updateInboxItem(
+        _ bookmark: Bookmark,
+        request: () async throws -> Void,
+        errorMessage: String
+    ) async -> Bool {
+        guard route == .inbox,
+              !pendingInboxItemIDs.contains(bookmark.id),
+              let index = items.firstIndex(where: { $0.id == bookmark.id })
+        else { return false }
+
+        pendingInboxItemIDs.insert(bookmark.id)
+        items.remove(at: index)
+
+        do {
+            try await request()
+            pendingInboxItemIDs.remove(bookmark.id)
+            return true
+        } catch is CancellationError {
+            restoreInboxItem(bookmark, at: index)
+            return false
+        } catch {
+            restoreInboxItem(bookmark, at: index)
+            self.errorMessage = errorMessage
+            return false
+        }
+    }
+
+    private func restoreInboxItem(_ bookmark: Bookmark, at index: Int) {
+        pendingInboxItemIDs.remove(bookmark.id)
+        guard !items.contains(where: { $0.id == bookmark.id }) else { return }
+        items.insert(bookmark, at: min(index, items.endIndex))
     }
 
     private func request(cursor: String? = nil) async throws -> PaginatedBookmarksResponse {

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -48,6 +48,13 @@ struct HomeSectionListView: View {
             .task {
                 await store.reload()
             }
+            .alert("Couldn’t update inbox", isPresented: actionErrorBinding) {
+                Button("OK", role: .cancel) {
+                    store.dismissError()
+                }
+            } message: {
+                Text(store.errorMessage ?? "Please try again.")
+            }
     }
 
     @ViewBuilder
@@ -78,6 +85,28 @@ struct HomeSectionListView: View {
                 .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
                 .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    if route == .inbox {
+                        Button {
+                            bookmarkInboxItem(bookmark)
+                        } label: {
+                            Label("Bookmark", systemImage: "bookmark.fill")
+                        }
+                        .tint(.green)
+                        .accessibilityLabel("Bookmark inbox item")
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    if route == .inbox {
+                        Button(role: .destructive) {
+                            archiveInboxItem(bookmark)
+                        } label: {
+                            Label("Archive", systemImage: "archivebox.fill")
+                        }
+                        .tint(.red)
+                        .accessibilityLabel("Archive inbox item")
+                    }
+                }
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)
                 }
@@ -91,6 +120,29 @@ struct HomeSectionListView: View {
                     ProgressView()
                         .padding()
                 }
+            }
+        }
+    }
+
+    private var actionErrorBinding: Binding<Bool> {
+        Binding(
+            get: { store.errorMessage != nil && !store.items.isEmpty },
+            set: { if !$0 { store.dismissError() } }
+        )
+    }
+
+    private func bookmarkInboxItem(_ bookmark: Bookmark) {
+        Task {
+            if await store.bookmarkInboxItem(bookmark) {
+                onContentChanged()
+            }
+        }
+    }
+
+    private func archiveInboxItem(_ bookmark: Bookmark) {
+        Task {
+            if await store.archiveInboxItem(bookmark) {
+                onContentChanged()
             }
         }
     }

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -116,6 +116,7 @@ struct InboxView: View {
                     } label: {
                         Label("Archive", systemImage: "archivebox.fill")
                     }
+                    .tint(.red)
                     .accessibilityLabel("Archive inbox item")
                 }
                 .task {

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -149,6 +149,7 @@ struct LibraryView: View {
                     } label: {
                         Label("Archive", systemImage: "archivebox.fill")
                     }
+                    .tint(.red)
                     .accessibilityLabel("Archive bookmark")
                 }
                 .task {


### PR DESCRIPTION
## Summary

- restore the native tab shell to Today, Home, Library, and Settings after the editorial merge
- add native leading Bookmark and trailing Archive actions to the expanded Fresh in Your Inbox list
- standardize Archive as a red action with the archive icon while keeping the compact four-item Home card static

## Validation

- bun run format:check
- bun run lint
- bun run design-system:check
- bun run typecheck
- bun run test
- bun run build
- xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS Simulator,id=F90D32E9-8533-4EF2-9B6F-40209BD7A067 -derivedDataPath /tmp/zine-pr-swipe-derived test (31 tests passed)
- signed physical-device build, install, and launch on Erik’s iPhone