### PR TITLE
fix(ios): remove bookmark hero image seam

### DIFF
--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -60,7 +60,9 @@ struct ZineNativeApp: App {
     @ViewBuilder
     private var rootView: some View {
 #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("-screenshot-today-story-fixture") {
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-bookmark-detail-fixture") {
+            ScreenshotBookmarkDetailView()
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-today-story-fixture") {
             ScreenshotTodayStoryView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-today-fixtures") {
             ScreenshotTodayView()

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -8,6 +8,7 @@ enum BookmarkChangePhase {
 
 struct BookmarkDetailView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.displayScale) private var displayScale
 
     @State private var bookmark: Bookmark
     @State private var isBookmarked: Bool
@@ -55,6 +56,7 @@ struct BookmarkDetailView: View {
                                 minHeight: max(viewport.size.height - heroHeight, 0),
                                 alignment: .top
                             )
+                            .background(Color(uiColor: .systemBackground))
                     }
                 }
                 .coordinateSpace(name: "bookmarkDetailScroll")
@@ -283,9 +285,13 @@ struct BookmarkDetailView: View {
         GeometryReader { geometry in
             let offset = geometry.frame(in: .named("bookmarkDetailScroll")).minY
             let stretch = max(offset, 0)
+            let renderedHeight = alignedToDisplayPixel(height + stretch)
+            let parallaxOffset = alignedToDisplayPixel(
+                offset > 0 ? -offset : -offset * 0.35
+            )
 
-            heroImage
-                .frame(width: geometry.size.width, height: height + stretch)
+            heroBase
+                .frame(width: geometry.size.width, height: renderedHeight)
                 .clipped()
                 .overlay(alignment: .bottom) {
                     if colorScheme == .dark {
@@ -294,22 +300,29 @@ struct BookmarkDetailView: View {
                             startPoint: .top,
                             endPoint: .bottom
                         )
-                        .frame(height: 200)
+                        .frame(height: 200 + displayPixel)
                     }
                 }
-                .offset(y: offset > 0 ? -offset : -offset * 0.35)
+                .offset(y: parallaxOffset)
         }
         .frame(height: height)
     }
 
-    private var heroFadeStops: [Gradient.Stop] {
-        let background = Color(uiColor: .systemBackground)
+    private var heroBase: some View {
+        ZStack {
+            Color(uiColor: .systemBackground)
 
+            heroImage
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var heroFadeStops: [Gradient.Stop] {
         return [
             .init(color: .clear, location: 0),
-            .init(color: background.opacity(0.28), location: 0.35),
-            .init(color: background.opacity(0.72), location: 0.72),
-            .init(color: background, location: 1),
+            .init(color: Color.black.opacity(0.28), location: 0.35),
+            .init(color: Color.black.opacity(0.72), location: 0.72),
+            .init(color: .black, location: 1),
         ]
     }
 
@@ -328,7 +341,16 @@ struct BookmarkDetailView: View {
     }
 
     private func heroHeight(in viewport: CGSize) -> CGFloat {
-        min(max(viewport.height * 0.33, 240), 320)
+        alignedToDisplayPixel(min(max(viewport.height * 0.33, 240), 320))
+    }
+
+    private func alignedToDisplayPixel(_ value: CGFloat) -> CGFloat {
+        guard displayScale > 0 else { return value }
+        return (value * displayScale).rounded() / displayScale
+    }
+
+    private var displayPixel: CGFloat {
+        displayScale > 0 ? 1 / displayScale : 1
     }
 
     private var metadata: some View {

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -33,16 +33,38 @@ struct ScreenshotLibraryView: View {
     }
 }
 
+struct ScreenshotBookmarkDetailView: View {
+    private let client = APIClient(
+        baseURL: URL(string: "https://example.invalid")!,
+        tokenProvider: { "screenshot-fixture" }
+    )
+
+    var body: some View {
+        NavigationStack {
+            BookmarkDetailView(
+                bookmark: ScreenshotFixtures.bookmarks[0],
+                client: client,
+                onUpdate: { _ in }
+            )
+        }
+        .environment(\.colorScheme, .dark)
+        .preferredColorScheme(.dark)
+    }
+}
+
 private enum ScreenshotFixtures {
     static let bookmarks: [Bookmark] = [
         make(
             id: "1",
-            title: "Joy & Curiosity #91",
-            creator: "Thorsten Ball",
-            provider: .substack,
-            contentType: .article,
-            readingTime: 8,
-            summary: "Notes on software, craft, curiosity, and the ideas worth returning to."
+            title: "True sight (Prompt responsibly)",
+            creator: "Notes On Work - by Caleb Porzio",
+            provider: .spotify,
+            contentType: .podcast,
+            thumbnailUrl: URL(
+                string: "https://i.scdn.co/image/ab6765630000ba8a116b917b6fbd4a810de9a368"
+            ),
+            duration: 2_846,
+            summary: "A conversation about building, taste, and using AI without losing the thread."
         ),
         make(
             id: "2",
@@ -88,6 +110,7 @@ private enum ScreenshotFixtures {
         creator: String,
         provider: Provider,
         contentType: ContentType,
+        thumbnailUrl: URL? = nil,
         duration: Int? = nil,
         readingTime: Int? = nil,
         summary: String
@@ -96,7 +119,7 @@ private enum ScreenshotFixtures {
             id: id,
             itemId: "item_\(id)",
             title: title,
-            thumbnailUrl: nil,
+            thumbnailUrl: thumbnailUrl,
             canonicalUrl: URL(string: "https://example.com/items/\(id)")!,
             contentType: contentType,
             provider: provider,


### PR DESCRIPTION
## Summary
- eliminate the transient dark-mode hero seam with opaque backing surfaces, explicit black fade stops, and display-pixel-aligned parallax geometry
- extend the fade by one physical pixel so the image-to-content boundary cannot expose a bright source row
- add a debug-only Notes On Work detail fixture for repeatable visual regression checks

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test` (1125 mobile, 1607 worker, and 75 web tests passed)
- `bun run build`
- Xcode simulator tests with parallel testing disabled (31 passed)
- dark-mode simulator verification with the exact Notes On Work artwork, including parallax scrolling