### PR TITLE
feat(worker): add dependable article body pipeline

### DIFF
--- a/apps/worker/src/admin/article-body-backfill.test.ts
+++ b/apps/worker/src/admin/article-body-backfill.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createDb, enqueueArticleBody } = vi.hoisted(() => ({
+  createDb: vi.fn(),
+  enqueueArticleBody: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ createDb }));
+vi.mock('../article-body/service', () => ({ enqueueArticleBody }));
+
+import { backfillArticleBodies } from './article-body-backfill';
+
+const rows = [
+  {
+    item_id: 'item_001',
+    provider: 'RSS',
+    pipeline_status: null,
+    extractor_version: null,
+  },
+  {
+    item_id: 'item_002',
+    provider: 'WEB',
+    pipeline_status: 'UNAVAILABLE',
+    extractor_version: null,
+  },
+];
+
+function createEnv(resultRows = rows) {
+  const all = vi.fn().mockResolvedValue({ results: resultRows });
+  const bind = vi.fn().mockReturnValue({ all });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  return {
+    env: { DB: { prepare }, ARTICLE_BODY_PIPELINE_ENABLED: 'false' },
+    prepare,
+    bind,
+  };
+}
+
+describe('article-body backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDb.mockReturnValue({});
+  });
+
+  it('is dry-run-first and returns a bounded canonical-item cohort', async () => {
+    const { env } = createEnv();
+    const result = await backfillArticleBodies(env as never, { limit: 2 });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      extractorVersion: 1,
+      limit: 2,
+      nextCursor: 'item_002',
+      scanned: 2,
+      enqueued: 0,
+      skipped: 0,
+    });
+    expect(enqueueArticleBody).not.toHaveBeenCalled();
+  });
+
+  it('routes execution through the guarded idempotent enqueue service', async () => {
+    const { env } = createEnv([rows[0]]);
+    enqueueArticleBody.mockResolvedValue({ queued: false, reason: 'disabled' });
+
+    const result = await backfillArticleBodies(env as never, {
+      dryRun: false,
+      traceId: 'trace_1',
+    });
+
+    expect(enqueueArticleBody).toHaveBeenCalledWith(
+      expect.anything(),
+      env,
+      expect.objectContaining({ itemId: 'item_001', trigger: 'backfill', traceId: 'trace_1' })
+    );
+    expect(result).toMatchObject({
+      enqueued: 0,
+      skipped: 1,
+      skipReasons: { disabled: 1 },
+    });
+  });
+
+  it('paginates by canonical item id and selects only eligible non-current items', async () => {
+    const { env, bind, prepare } = createEnv([]);
+    await backfillArticleBodies(env as never, { cursor: 'item_099', limit: 7 });
+
+    expect(bind).toHaveBeenCalledWith(1, 'item_099', 7);
+    const query = prepare.mock.calls[0][0] as string;
+    expect(query).toContain("i.content_type = 'ARTICLE'");
+    expect(query).toContain("abs.status NOT IN ('PENDING', 'PROCESSING')");
+    expect(query).toContain('EXISTS (SELECT 1 FROM user_items');
+  });
+});

--- a/apps/worker/src/admin/article-body-backfill.ts
+++ b/apps/worker/src/admin/article-body-backfill.ts
@@ -1,0 +1,147 @@
+import { createDb } from '../db';
+import { enqueueArticleBody } from '../article-body/service';
+import { ARTICLE_BODY_EXTRACTOR_VERSION } from '../article-body/types';
+import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
+
+const backfillLogger = logger.child('admin:article-body-backfill');
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+interface BackfillRow {
+  item_id: string;
+  provider: string;
+  pipeline_status: string | null;
+  extractor_version: number | null;
+}
+
+export interface ArticleBodyBackfillOptions {
+  dryRun?: boolean;
+  limit?: number;
+  cursor?: string | null;
+  traceId?: string;
+}
+
+export interface ArticleBodyBackfillCandidate {
+  itemId: string;
+  provider: string;
+  pipelineStatus: string | null;
+  extractorVersion: number | null;
+}
+
+export interface ArticleBodyBackfillResult {
+  dryRun: boolean;
+  extractorVersion: number;
+  limit: number;
+  cursor: string | null;
+  nextCursor: string | null;
+  scanned: number;
+  enqueued: number;
+  skipped: number;
+  skipReasons: Record<string, number>;
+  candidates: ArticleBodyBackfillCandidate[];
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(value)));
+}
+
+async function loadCandidates(
+  db: D1Database,
+  options: { limit: number; cursor: string | null }
+): Promise<ArticleBodyBackfillCandidate[]> {
+  const cursorClause = options.cursor ? 'AND i.id > ?' : '';
+  const statement = db.prepare(`
+    SELECT
+      i.id AS item_id,
+      i.provider,
+      abs.status AS pipeline_status,
+      abv.extractor_version
+    FROM items i
+    LEFT JOIN article_body_states abs ON abs.item_id = i.id
+    LEFT JOIN article_body_versions abv ON abv.id = abs.current_version_id
+    WHERE i.content_type = 'ARTICLE'
+      AND (i.canonical_url LIKE 'https://%' OR i.canonical_url LIKE 'http://%')
+      AND EXISTS (SELECT 1 FROM user_items ui WHERE ui.item_id = i.id)
+      AND (abs.status IS NULL OR abs.status NOT IN ('PENDING', 'PROCESSING'))
+      AND (
+        abs.status IS NULL
+        OR abv.extractor_version IS NULL
+        OR abs.status NOT IN ('AVAILABLE', 'DEGRADED')
+        OR abv.extractor_version < ?
+      )
+      ${cursorClause}
+    ORDER BY i.id
+    LIMIT ?
+  `);
+  const bound = options.cursor
+    ? statement.bind(ARTICLE_BODY_EXTRACTOR_VERSION, options.cursor, options.limit)
+    : statement.bind(ARTICLE_BODY_EXTRACTOR_VERSION, options.limit);
+  const result = await bound.all<BackfillRow>();
+  return (result.results ?? []).map((row) => ({
+    itemId: row.item_id,
+    provider: row.provider,
+    pipelineStatus: row.pipeline_status,
+    extractorVersion: row.extractor_version,
+  }));
+}
+
+export async function backfillArticleBodies(
+  env: Pick<Bindings, 'DB' | 'ARTICLE_BODY_PIPELINE_ENABLED' | 'ARTICLE_BODY_QUEUE'>,
+  options: ArticleBodyBackfillOptions = {}
+): Promise<ArticleBodyBackfillResult> {
+  const dryRun = options.dryRun ?? true;
+  const limit = normalizeLimit(options.limit);
+  const cursor = options.cursor ?? null;
+  const candidates = await loadCandidates(env.DB, { limit, cursor });
+  let enqueued = 0;
+  let skipped = 0;
+  const skipReasons: Record<string, number> = {};
+
+  if (!dryRun) {
+    const db = createDb(env.DB);
+    for (const candidate of candidates) {
+      const result = await enqueueArticleBody(db, env, {
+        itemId: candidate.itemId,
+        trigger: 'backfill',
+        traceId: options.traceId,
+      });
+      if (result.queued) {
+        enqueued += 1;
+      } else {
+        skipped += 1;
+        const reason = result.reason ?? 'unknown';
+        skipReasons[reason] = (skipReasons[reason] ?? 0) + 1;
+      }
+    }
+  }
+
+  const nextCursor =
+    candidates.length === limit ? (candidates[candidates.length - 1]?.itemId ?? null) : null;
+  backfillLogger.info('Article-body backfill page processed', {
+    dryRun,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: candidates.length,
+    enqueued,
+    skipped,
+    skipReasons,
+  });
+
+  return {
+    dryRun,
+    extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+    limit,
+    cursor,
+    nextCursor,
+    scanned: candidates.length,
+    enqueued,
+    skipped,
+    skipReasons,
+    candidates,
+  };
+}
+
+export const articleBodyBackfillInternals = { normalizeLimit, loadCandidates };

--- a/apps/worker/src/article-body/acquisition.test.ts
+++ b/apps/worker/src/article-body/acquisition.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { acquireArticleBody, isSafePublicArticleUrl } from './acquisition';
+import {
+  acquireArticleBody,
+  articleBodyAcquisitionInternals,
+  isSafePublicArticleUrl,
+} from './acquisition';
 
 function articleText(sentences = 40): string {
   return 'This reporting provides evidence, context, analysis, and useful conclusions. '.repeat(
@@ -133,6 +137,30 @@ describe('acquireArticleBody', () => {
       expect.objectContaining({ redirect: 'manual' })
     );
   });
+
+  it('fetches stable Substack publication URLs instead of rate-limited share redirects', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(page('Text is king'), {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    );
+
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        canonicalUrl:
+          'https://open.substack.com/pub/experimentalhistory/p/text-is-king?r=share-token',
+        title: 'Text is king',
+      },
+      { fetch: fetch as never }
+    );
+
+    expect(result.status).toBe('AVAILABLE');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://experimentalhistory.substack.com/p/text-is-king',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
 });
 
 describe('isSafePublicArticleUrl', () => {
@@ -142,5 +170,20 @@ describe('isSafePublicArticleUrl', () => {
     expect(isSafePublicArticleUrl('http://192.168.1.2/story')).toBe(false);
     expect(isSafePublicArticleUrl('https://user:pass@example.com/story')).toBe(false);
     expect(isSafePublicArticleUrl('file:///etc/passwd')).toBe(false);
+  });
+});
+
+describe('article-body public URL resolution', () => {
+  it('rewrites only recognized open.substack.com publication share paths', () => {
+    expect(
+      articleBodyAcquisitionInternals.resolvePublicArticleFetchUrl(
+        'https://open.substack.com/pub/experimentalhistory/p/text-is-king?r=share-token'
+      )
+    ).toBe('https://experimentalhistory.substack.com/p/text-is-king');
+    expect(
+      articleBodyAcquisitionInternals.resolvePublicArticleFetchUrl(
+        'https://open.substack.com/redirect?url=https://example.com'
+      )
+    ).toBe('https://open.substack.com/redirect?url=https://example.com');
   });
 });

--- a/apps/worker/src/article-body/acquisition.test.ts
+++ b/apps/worker/src/article-body/acquisition.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { acquireArticleBody, isSafePublicArticleUrl } from './acquisition';
+
+function articleText(sentences = 40): string {
+  return 'This reporting provides evidence, context, analysis, and useful conclusions. '.repeat(
+    sentences
+  );
+}
+
+function page(title = 'A dependable article', sentences = 40): string {
+  return `<!doctype html><html><head><title>${title}</title></head><body><article><h1>${title}</h1><p>${articleText(sentences)}</p><p>${articleText(sentences)}</p></article></body></html>`;
+}
+
+function input() {
+  return {
+    itemId: 'item_1',
+    canonicalUrl: 'https://example.com/story',
+    title: 'A dependable article',
+    publisher: 'Example',
+  };
+}
+
+describe('acquireArticleBody', () => {
+  it('uses a high-quality embedded feed body without a public fetch', async () => {
+    const fetch = vi.fn();
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        embeddedCandidates: [
+          {
+            html: `<p>${articleText(40)}</p><p>${articleText(40)}</p>`,
+            sourceKind: 'RSS_FULL',
+            sourceUrl: 'https://example.com/feed.xml',
+          },
+        ],
+      },
+      { fetch: fetch as never, now: () => 1_700_000_000_000 }
+    );
+
+    expect(result.status).toBe('AVAILABLE');
+    expect(result.artifact).toMatchObject({ sourceKind: 'RSS_FULL', qualityScore: 1 });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to public Readability when the feed only exposes a teaser', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(page(), { headers: { 'content-type': 'text/html; charset=utf-8' } })
+      );
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        embeddedCandidates: [
+          {
+            html: '<p>A short teaser. Read more</p>',
+            sourceKind: 'RSS_FULL',
+            sourceUrl: 'https://example.com/feed.xml',
+          },
+        ],
+      },
+      { fetch: fetch as never }
+    );
+
+    expect(result.status).toBe('AVAILABLE');
+    expect(result.artifact?.sourceKind).toBe('PUBLIC_WEB');
+    expect(result.attempts).toMatchObject([
+      { sourceKind: 'RSS_FULL', disposition: 'UNAVAILABLE' },
+      { sourceKind: 'PUBLIC_WEB', disposition: 'AVAILABLE', httpStatus: 200 },
+    ]);
+  });
+
+  it('retains a readable degraded feed body when public fallback fails', async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response('blocked', { status: 403 }));
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        embeddedCandidates: [
+          {
+            html: `<p>${articleText(7)}</p>`,
+            sourceKind: 'ATOM_FULL',
+            sourceUrl: 'https://example.com/feed.atom',
+          },
+        ],
+      },
+      { fetch: fetch as never }
+    );
+
+    expect(result.status).toBe('DEGRADED');
+    expect(result.artifact?.sourceKind).toBe('ATOM_FULL');
+    expect(result.attempts[1]).toMatchObject({ errorCode: 'HTTP_403' });
+  });
+
+  it('rejects unsafe public destinations before fetch', async () => {
+    const fetch = vi.fn();
+    const result = await acquireArticleBody(
+      { ...input(), canonicalUrl: 'http://127.0.0.1/admin' },
+      { fetch: fetch as never }
+    );
+
+    expect(result).toMatchObject({ status: 'UNAVAILABLE', errorCode: 'UNSAFE_URL' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-HTML responses explicitly', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { headers: { 'content-type': 'application/json' } }));
+    const result = await acquireArticleBody(input(), { fetch: fetch as never });
+
+    expect(result).toMatchObject({
+      status: 'UNAVAILABLE',
+      errorCode: 'UNSUPPORTED_CONTENT_TYPE',
+      lastHttpStatus: 200,
+    });
+  });
+
+  it('rejects a public redirect to a private destination before following it', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://169.254.169.254/latest/meta-data' },
+      })
+    );
+
+    const result = await acquireArticleBody(input(), { fetch: fetch as never });
+
+    expect(result).toMatchObject({ status: 'UNAVAILABLE', errorCode: 'UNSAFE_REDIRECT' });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com/story',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+});
+
+describe('isSafePublicArticleUrl', () => {
+  it('permits public HTTP URLs and rejects local or credentialed URLs', () => {
+    expect(isSafePublicArticleUrl('https://example.com/story')).toBe(true);
+    expect(isSafePublicArticleUrl('http://localhost/story')).toBe(false);
+    expect(isSafePublicArticleUrl('http://192.168.1.2/story')).toBe(false);
+    expect(isSafePublicArticleUrl('https://user:pass@example.com/story')).toBe(false);
+    expect(isSafePublicArticleUrl('file:///etc/passwd')).toBe(false);
+  });
+});

--- a/apps/worker/src/article-body/acquisition.ts
+++ b/apps/worker/src/article-body/acquisition.ts
@@ -20,6 +20,15 @@ const ARTICLE_FETCH_TIMEOUT_MS = 12_000;
 const MAX_ARTICLE_HTML_BYTES = 5 * 1024 * 1024;
 const MAX_ARTICLE_REDIRECTS = 5;
 
+function resolvePublicArticleFetchUrl(canonicalUrl: string): string {
+  const url = new URL(canonicalUrl);
+  if (url.hostname.toLowerCase() !== 'open.substack.com') return canonicalUrl;
+
+  const match = /^\/pub\/([a-z0-9-]+)\/p\/([a-z0-9-]+)\/?$/i.exec(url.pathname);
+  if (!match) return canonicalUrl;
+  return `https://${match[1]}.substack.com/p/${match[2]}`;
+}
+
 export interface ArticleBodyAcquisitionInput {
   itemId: string;
   canonicalUrl: string;
@@ -152,7 +161,7 @@ async function fetchPublicCandidate(
   const timeout = setTimeout(() => controller.abort(), ARTICLE_FETCH_TIMEOUT_MS);
   try {
     let response: Response | null = null;
-    let responseUrl = input.canonicalUrl;
+    let responseUrl = resolvePublicArticleFetchUrl(input.canonicalUrl);
     for (let redirects = 0; redirects <= MAX_ARTICLE_REDIRECTS; redirects += 1) {
       response = await fetchImplementation(responseUrl, {
         redirect: 'manual',
@@ -367,4 +376,8 @@ export const articleBodyAcquisitionLimits = {
   fetchTimeoutMs: ARTICLE_FETCH_TIMEOUT_MS,
   maxHtmlBytes: MAX_ARTICLE_HTML_BYTES,
   maxRedirects: MAX_ARTICLE_REDIRECTS,
+};
+
+export const articleBodyAcquisitionInternals = {
+  resolvePublicArticleFetchUrl,
 };

--- a/apps/worker/src/article-body/acquisition.ts
+++ b/apps/worker/src/article-body/acquisition.ts
@@ -1,0 +1,370 @@
+import { extractArticleFromHtml } from '../lib/article-extractor';
+import { buildArticleBodyArtifact } from './artifact';
+import { normalizeArticleBodyHtml, type NormalizedArticleBody } from './normalization';
+import {
+  assessArticleBodyQuality,
+  type ArticleBodyQualityAssessment,
+  type ArticleBodyQualityDisposition,
+} from './quality';
+import {
+  ARTICLE_BODY_EXTRACTOR_VERSION,
+  type ArticleBodyArtifact,
+  type ArticleBodyEmbeddedCandidate,
+  type ArticleBodySourceKind,
+} from './types';
+import { isSafePublicArticleUrl } from './url-safety';
+
+export { isSafePublicArticleUrl } from './url-safety';
+
+const ARTICLE_FETCH_TIMEOUT_MS = 12_000;
+const MAX_ARTICLE_HTML_BYTES = 5 * 1024 * 1024;
+const MAX_ARTICLE_REDIRECTS = 5;
+
+export interface ArticleBodyAcquisitionInput {
+  itemId: string;
+  canonicalUrl: string;
+  title: string;
+  byline?: string | null;
+  publisher?: string | null;
+  publishedAt?: string | null;
+  language?: string | null;
+  embeddedCandidates?: ArticleBodyEmbeddedCandidate[];
+}
+
+export interface ArticleBodyAcquisitionAttempt {
+  sourceKind: ArticleBodySourceKind;
+  sourceUrl: string;
+  disposition: ArticleBodyQualityDisposition;
+  qualityScore: number;
+  qualityWarnings: string[];
+  wordCount: number;
+  httpStatus: number | null;
+  errorCode: string | null;
+}
+
+export interface ArticleBodyAcquisitionResult {
+  status: ArticleBodyQualityDisposition;
+  artifact: ArticleBodyArtifact | null;
+  attempts: ArticleBodyAcquisitionAttempt[];
+  errorCode: string | null;
+  lastHttpStatus: number | null;
+}
+
+export interface ArticleBodyAcquisitionDependencies {
+  fetch?: typeof fetch;
+  now?: () => number;
+  extractorVersion?: number;
+}
+
+interface EvaluatedCandidate {
+  artifact: ArticleBodyArtifact | null;
+  assessment: ArticleBodyQualityAssessment;
+  normalized: NormalizedArticleBody;
+  attempt: ArticleBodyAcquisitionAttempt;
+}
+
+async function evaluateCandidate(
+  input: ArticleBodyAcquisitionInput,
+  candidate: {
+    html: string;
+    sourceKind: ArticleBodySourceKind;
+    sourceUrl: string;
+    extractedTitle?: string | null;
+    byline?: string | null;
+    publisher?: string | null;
+    publishedAt?: string | null;
+    httpStatus?: number | null;
+  },
+  extractedAt: number,
+  extractorVersion: number
+): Promise<EvaluatedCandidate> {
+  const normalized = normalizeArticleBodyHtml(candidate.html, input.canonicalUrl);
+  const assessment = assessArticleBodyQuality(normalized, {
+    expectedTitle: input.title,
+    extractedTitle: candidate.extractedTitle ?? input.title,
+  });
+  const attempt: ArticleBodyAcquisitionAttempt = {
+    sourceKind: candidate.sourceKind,
+    sourceUrl: candidate.sourceUrl,
+    disposition: assessment.disposition,
+    qualityScore: assessment.score,
+    qualityWarnings: assessment.warnings,
+    wordCount: normalized.wordCount,
+    httpStatus: candidate.httpStatus ?? null,
+    errorCode: assessment.disposition === 'UNAVAILABLE' ? 'QUALITY_REJECTED' : null,
+  };
+
+  const artifact =
+    assessment.disposition === 'UNAVAILABLE'
+      ? null
+      : await buildArticleBodyArtifact({
+          extractorVersion,
+          itemId: input.itemId,
+          canonicalUrl: input.canonicalUrl,
+          title: input.title,
+          byline: candidate.byline ?? input.byline ?? null,
+          publisher: candidate.publisher ?? input.publisher ?? null,
+          publishedAt: candidate.publishedAt ?? input.publishedAt ?? null,
+          language: input.language ?? null,
+          sourceKind: candidate.sourceKind,
+          sourceUrl: candidate.sourceUrl,
+          extractedAt,
+          wordCount: normalized.wordCount,
+          readingTimeMinutes: normalized.readingTimeMinutes,
+          qualityScore: assessment.score,
+          qualityWarnings: assessment.warnings,
+          sanitizedHtml: normalized.sanitizedHtml,
+          plainText: normalized.plainText,
+          blocks: normalized.blocks,
+        });
+
+  return { artifact, assessment, normalized, attempt };
+}
+
+function failedAttempt(
+  input: ArticleBodyAcquisitionInput,
+  errorCode: string,
+  options: { httpStatus?: number | null; sourceUrl?: string } = {}
+): ArticleBodyAcquisitionAttempt {
+  return {
+    sourceKind: 'PUBLIC_WEB',
+    sourceUrl: options.sourceUrl ?? input.canonicalUrl,
+    disposition: 'UNAVAILABLE',
+    qualityScore: 0,
+    qualityWarnings: [],
+    wordCount: 0,
+    httpStatus: options.httpStatus ?? null,
+    errorCode,
+  };
+}
+
+async function fetchPublicCandidate(
+  input: ArticleBodyAcquisitionInput,
+  fetchImplementation: typeof fetch,
+  extractedAt: number,
+  extractorVersion: number
+): Promise<{ evaluated: EvaluatedCandidate | null; attempt: ArticleBodyAcquisitionAttempt }> {
+  if (!isSafePublicArticleUrl(input.canonicalUrl)) {
+    return { evaluated: null, attempt: failedAttempt(input, 'UNSAFE_URL') };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ARTICLE_FETCH_TIMEOUT_MS);
+  try {
+    let response: Response | null = null;
+    let responseUrl = input.canonicalUrl;
+    for (let redirects = 0; redirects <= MAX_ARTICLE_REDIRECTS; redirects += 1) {
+      response = await fetchImplementation(responseUrl, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'ZineBot/2.0 (+https://zine.app/bot)',
+          Accept: 'text/html,application/xhtml+xml',
+        },
+      });
+      if (response.status < 300 || response.status >= 400) break;
+
+      const location = response.headers.get('location');
+      if (!location) {
+        return {
+          evaluated: null,
+          attempt: failedAttempt(input, 'REDIRECT_WITHOUT_LOCATION', {
+            httpStatus: response.status,
+            sourceUrl: responseUrl,
+          }),
+        };
+      }
+      const nextUrl = new URL(location, responseUrl).href;
+      if (!isSafePublicArticleUrl(nextUrl)) {
+        return {
+          evaluated: null,
+          attempt: failedAttempt(input, 'UNSAFE_REDIRECT', {
+            httpStatus: response.status,
+            sourceUrl: nextUrl,
+          }),
+        };
+      }
+      if (redirects === MAX_ARTICLE_REDIRECTS) {
+        return {
+          evaluated: null,
+          attempt: failedAttempt(input, 'TOO_MANY_REDIRECTS', {
+            httpStatus: response.status,
+            sourceUrl: responseUrl,
+          }),
+        };
+      }
+      responseUrl = nextUrl;
+    }
+    if (!response) throw new Error('Article fetch returned no response');
+    if (!response.ok) {
+      return {
+        evaluated: null,
+        attempt: failedAttempt(input, `HTTP_${response.status}`, {
+          httpStatus: response.status,
+          sourceUrl: responseUrl,
+        }),
+      };
+    }
+
+    const contentType = response.headers.get('content-type')?.toLocaleLowerCase() ?? '';
+    if (contentType && !contentType.includes('text/html') && !contentType.includes('xhtml')) {
+      return {
+        evaluated: null,
+        attempt: failedAttempt(input, 'UNSUPPORTED_CONTENT_TYPE', {
+          httpStatus: response.status,
+          sourceUrl: responseUrl,
+        }),
+      };
+    }
+    const contentLength = Number(response.headers.get('content-length') ?? 0);
+    if (Number.isFinite(contentLength) && contentLength > MAX_ARTICLE_HTML_BYTES) {
+      return {
+        evaluated: null,
+        attempt: failedAttempt(input, 'BODY_TOO_LARGE', {
+          httpStatus: response.status,
+          sourceUrl: responseUrl,
+        }),
+      };
+    }
+
+    const html = await response.text();
+    if (new TextEncoder().encode(html).byteLength > MAX_ARTICLE_HTML_BYTES) {
+      return {
+        evaluated: null,
+        attempt: failedAttempt(input, 'BODY_TOO_LARGE', {
+          httpStatus: response.status,
+          sourceUrl: responseUrl,
+        }),
+      };
+    }
+    const extracted = extractArticleFromHtml(html, responseUrl);
+    if (!extracted?.isArticle || !extracted.content) {
+      return {
+        evaluated: null,
+        attempt: failedAttempt(input, 'NOT_READERABLE', {
+          httpStatus: response.status,
+          sourceUrl: responseUrl,
+        }),
+      };
+    }
+
+    const evaluated = await evaluateCandidate(
+      input,
+      {
+        html: extracted.content,
+        sourceKind: 'PUBLIC_WEB',
+        sourceUrl: responseUrl,
+        extractedTitle: extracted.title,
+        byline: extracted.author,
+        publisher: extracted.siteName,
+        publishedAt: extracted.publishedAt,
+        httpStatus: response.status,
+      },
+      extractedAt,
+      extractorVersion
+    );
+    return { evaluated, attempt: evaluated.attempt };
+  } catch {
+    const errorCode = controller.signal.aborted ? 'FETCH_TIMEOUT' : 'FETCH_FAILED';
+    return { evaluated: null, attempt: failedAttempt(input, errorCode) };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function betterCandidate(
+  current: EvaluatedCandidate | null,
+  candidate: EvaluatedCandidate
+): EvaluatedCandidate {
+  if (!current) return candidate;
+  if (candidate.assessment.score !== current.assessment.score) {
+    return candidate.assessment.score > current.assessment.score ? candidate : current;
+  }
+  return candidate.normalized.wordCount > current.normalized.wordCount ? candidate : current;
+}
+
+export async function acquireArticleBody(
+  input: ArticleBodyAcquisitionInput,
+  dependencies: ArticleBodyAcquisitionDependencies = {}
+): Promise<ArticleBodyAcquisitionResult> {
+  const fetchImplementation = dependencies.fetch ?? fetch;
+  const extractedAt = dependencies.now?.() ?? Date.now();
+  const extractorVersion = dependencies.extractorVersion ?? ARTICLE_BODY_EXTRACTOR_VERSION;
+  const attempts: ArticleBodyAcquisitionAttempt[] = [];
+  let bestDegraded: EvaluatedCandidate | null = null;
+
+  for (const candidate of input.embeddedCandidates ?? []) {
+    let evaluated: EvaluatedCandidate;
+    try {
+      evaluated = await evaluateCandidate(input, candidate, extractedAt, extractorVersion);
+    } catch {
+      attempts.push({
+        sourceKind: candidate.sourceKind,
+        sourceUrl: candidate.sourceUrl,
+        disposition: 'UNAVAILABLE',
+        qualityScore: 0,
+        qualityWarnings: [],
+        wordCount: 0,
+        httpStatus: null,
+        errorCode: 'NORMALIZATION_FAILED',
+      });
+      continue;
+    }
+    attempts.push(evaluated.attempt);
+    if (evaluated.assessment.disposition === 'AVAILABLE') {
+      return {
+        status: 'AVAILABLE',
+        artifact: evaluated.artifact,
+        attempts,
+        errorCode: null,
+        lastHttpStatus: null,
+      };
+    }
+    if (evaluated.assessment.disposition === 'DEGRADED') {
+      bestDegraded = betterCandidate(bestDegraded, evaluated);
+    }
+  }
+
+  const publicResult = await fetchPublicCandidate(
+    input,
+    fetchImplementation,
+    extractedAt,
+    extractorVersion
+  );
+  attempts.push(publicResult.attempt);
+  if (publicResult.evaluated?.assessment.disposition === 'AVAILABLE') {
+    return {
+      status: 'AVAILABLE',
+      artifact: publicResult.evaluated.artifact,
+      attempts,
+      errorCode: null,
+      lastHttpStatus: publicResult.attempt.httpStatus,
+    };
+  }
+  if (publicResult.evaluated?.assessment.disposition === 'DEGRADED') {
+    bestDegraded = betterCandidate(bestDegraded, publicResult.evaluated);
+  }
+  if (bestDegraded) {
+    return {
+      status: 'DEGRADED',
+      artifact: bestDegraded.artifact,
+      attempts,
+      errorCode: null,
+      lastHttpStatus: publicResult.attempt.httpStatus,
+    };
+  }
+
+  return {
+    status: 'UNAVAILABLE',
+    artifact: null,
+    attempts,
+    errorCode: publicResult.attempt.errorCode ?? 'NO_ACCEPTABLE_BODY',
+    lastHttpStatus: publicResult.attempt.httpStatus,
+  };
+}
+
+export const articleBodyAcquisitionLimits = {
+  fetchTimeoutMs: ARTICLE_FETCH_TIMEOUT_MS,
+  maxHtmlBytes: MAX_ARTICLE_HTML_BYTES,
+  maxRedirects: MAX_ARTICLE_REDIRECTS,
+};

--- a/apps/worker/src/article-body/artifact.test.ts
+++ b/apps/worker/src/article-body/artifact.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildArticleBodyArtifact,
+  verifyArticleBodyArtifactIntegrity,
+  type BuildArticleBodyArtifactInput,
+} from './artifact';
+
+function input(
+  overrides: Partial<BuildArticleBodyArtifactInput> = {}
+): BuildArticleBodyArtifactInput {
+  return {
+    extractorVersion: 1,
+    itemId: 'item_1',
+    canonicalUrl: 'https://example.com/story',
+    title: 'A dependable body',
+    byline: 'A. Writer',
+    publisher: 'Example',
+    publishedAt: '2026-07-23T12:00:00.000Z',
+    language: 'en',
+    sourceKind: 'RSS_FULL',
+    sourceUrl: 'https://example.com/feed.xml',
+    extractedAt: 1_700_000_000_000,
+    wordCount: 2,
+    readingTimeMinutes: 1,
+    qualityScore: 0.98,
+    sanitizedHtml: '<p>Hello world</p>',
+    plainText: 'Hello world',
+    blocks: [{ id: 'p1', kind: 'paragraph', text: 'Hello world' }],
+    ...overrides,
+  };
+}
+
+describe('article-body artifacts', () => {
+  it('uses a deterministic content identity independent of extraction time', async () => {
+    const first = await buildArticleBodyArtifact(input());
+    const replay = await buildArticleBodyArtifact(
+      input({ extractedAt: first.extractedAt + 1_000 })
+    );
+
+    expect(replay.contentHash).toBe(first.contentHash);
+    expect(await verifyArticleBodyArtifactIntegrity(first)).toBe(true);
+  });
+
+  it('changes identity when normalized body content changes', async () => {
+    const first = await buildArticleBodyArtifact(input());
+    const changed = await buildArticleBodyArtifact(
+      input({ sanitizedHtml: '<p>Changed</p>', plainText: 'Changed' })
+    );
+
+    expect(changed.contentHash).not.toBe(first.contentHash);
+  });
+
+  it('detects a modified artifact', async () => {
+    const artifact = await buildArticleBodyArtifact(input());
+
+    expect(await verifyArticleBodyArtifactIntegrity({ ...artifact, plainText: 'tampered' })).toBe(
+      false
+    );
+  });
+});

--- a/apps/worker/src/article-body/artifact.ts
+++ b/apps/worker/src/article-body/artifact.ts
@@ -1,0 +1,121 @@
+import { ArticleBodyArtifactSchema } from './schema';
+import {
+  ARTICLE_BODY_SCHEMA_VERSION,
+  type ArticleBodyArtifact,
+  type ArticleBodyBlock,
+  type ArticleBodySourceKind,
+} from './types';
+
+export interface BuildArticleBodyArtifactInput {
+  extractorVersion: number;
+  itemId: string;
+  canonicalUrl: string;
+  title: string;
+  byline?: string | null;
+  publisher?: string | null;
+  publishedAt?: string | null;
+  language?: string | null;
+  sourceKind: ArticleBodySourceKind;
+  sourceUrl: string;
+  extractedAt: number;
+  wordCount: number;
+  readingTimeMinutes: number;
+  qualityScore: number;
+  qualityWarnings?: string[];
+  sanitizedHtml: string;
+  plainText: string;
+  blocks?: ArticleBodyBlock[];
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function contentIdentityPayload(input: BuildArticleBodyArtifactInput): string {
+  return JSON.stringify({
+    schemaVersion: ARTICLE_BODY_SCHEMA_VERSION,
+    extractorVersion: input.extractorVersion,
+    itemId: input.itemId,
+    canonicalUrl: input.canonicalUrl,
+    title: input.title,
+    byline: input.byline ?? null,
+    publisher: input.publisher ?? null,
+    publishedAt: input.publishedAt ?? null,
+    language: input.language ?? null,
+    sourceKind: input.sourceKind,
+    sourceUrl: input.sourceUrl,
+    wordCount: input.wordCount,
+    readingTimeMinutes: input.readingTimeMinutes,
+    qualityScore: input.qualityScore,
+    qualityWarnings: input.qualityWarnings ?? [],
+    sanitizedHtml: input.sanitizedHtml,
+    plainText: input.plainText,
+    blocks: input.blocks ?? [],
+  });
+}
+
+export async function computeArticleBodyContentHash(
+  input: BuildArticleBodyArtifactInput
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(contentIdentityPayload(input))
+  );
+  return `sha256:${bytesToHex(new Uint8Array(digest))}`;
+}
+
+export async function buildArticleBodyArtifact(
+  input: BuildArticleBodyArtifactInput
+): Promise<ArticleBodyArtifact> {
+  const artifact: ArticleBodyArtifact = {
+    schemaVersion: ARTICLE_BODY_SCHEMA_VERSION,
+    extractorVersion: input.extractorVersion,
+    itemId: input.itemId,
+    canonicalUrl: input.canonicalUrl,
+    title: input.title,
+    byline: input.byline ?? null,
+    publisher: input.publisher ?? null,
+    publishedAt: input.publishedAt ?? null,
+    language: input.language ?? null,
+    sourceKind: input.sourceKind,
+    sourceUrl: input.sourceUrl,
+    extractedAt: input.extractedAt,
+    contentHash: await computeArticleBodyContentHash(input),
+    wordCount: input.wordCount,
+    readingTimeMinutes: input.readingTimeMinutes,
+    qualityScore: input.qualityScore,
+    qualityWarnings: input.qualityWarnings ?? [],
+    sanitizedHtml: input.sanitizedHtml,
+    plainText: input.plainText,
+    blocks: input.blocks ?? [],
+  };
+
+  return ArticleBodyArtifactSchema.parse(artifact);
+}
+
+export async function verifyArticleBodyArtifactIntegrity(
+  artifact: ArticleBodyArtifact
+): Promise<boolean> {
+  const parsed = ArticleBodyArtifactSchema.parse(artifact);
+  const expected = await computeArticleBodyContentHash({
+    extractorVersion: parsed.extractorVersion,
+    itemId: parsed.itemId,
+    canonicalUrl: parsed.canonicalUrl,
+    title: parsed.title,
+    byline: parsed.byline,
+    publisher: parsed.publisher,
+    publishedAt: parsed.publishedAt,
+    language: parsed.language,
+    sourceKind: parsed.sourceKind,
+    sourceUrl: parsed.sourceUrl,
+    extractedAt: parsed.extractedAt,
+    wordCount: parsed.wordCount,
+    readingTimeMinutes: parsed.readingTimeMinutes,
+    qualityScore: parsed.qualityScore,
+    qualityWarnings: parsed.qualityWarnings,
+    sanitizedHtml: parsed.sanitizedHtml,
+    plainText: parsed.plainText,
+    blocks: parsed.blocks,
+  });
+  return expected === parsed.contentHash;
+}

--- a/apps/worker/src/article-body/consumer.test.ts
+++ b/apps/worker/src/article-body/consumer.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { expectLoggerErrorCalls } from '../test/mock-logger';
+import type { ArticleBodyQueueMessage } from './types';
+
+const {
+  createDb,
+  markArticleBodyProcessing,
+  markArticleBodyRetryScheduled,
+  markArticleBodyUnavailable,
+  dlqValues,
+  findItem,
+} = vi.hoisted(() => ({
+  createDb: vi.fn(),
+  markArticleBodyProcessing: vi.fn(),
+  markArticleBodyRetryScheduled: vi.fn(),
+  markArticleBodyUnavailable: vi.fn(),
+  dlqValues: vi.fn(),
+  findItem: vi.fn(),
+}));
+
+vi.mock('../db', () => ({ createDb }));
+vi.mock('./service', () => ({
+  isArticleBodyPipelineEnabled: (env: { ARTICLE_BODY_PIPELINE_ENABLED?: string }) =>
+    env.ARTICLE_BODY_PIPELINE_ENABLED?.trim().toLowerCase() === 'true',
+  markArticleBodyProcessing,
+  markArticleBodyRetryScheduled,
+  markArticleBodyUnavailable,
+}));
+
+import { handleArticleBodyDLQ, handleArticleBodyQueue } from './consumer';
+import { RetryableArticleBodyError } from './processor';
+
+function body(): ArticleBodyQueueMessage {
+  return {
+    itemId: 'item_1',
+    extractorVersion: 1,
+    trigger: 'bookmark',
+    enqueuedAt: 1_700_000_000_000,
+  };
+}
+
+function queueMessage(value: unknown = body(), attempts = 1) {
+  return {
+    id: 'message_1',
+    timestamp: new Date(),
+    body: value,
+    attempts,
+    ack: vi.fn(),
+    retry: vi.fn(),
+  };
+}
+
+function batch(message: ReturnType<typeof queueMessage>, queue = 'zine-article-body-queue-dev') {
+  return {
+    queue,
+    messages: [message],
+    ackAll: vi.fn(),
+    retryAll: vi.fn(),
+  } as never;
+}
+
+describe('article-body queue consumers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDb.mockReturnValue({
+      query: { items: { findFirst: findItem } },
+      insert: vi.fn().mockReturnValue({ values: dlqValues }),
+    });
+  });
+
+  it('acks without processing while the foundation flag is disabled', async () => {
+    const message = queueMessage();
+    const processor = vi.fn();
+
+    await handleArticleBodyQueue(batch(message), { DB: {} } as never, processor);
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(processor).not.toHaveBeenCalled();
+    expect(markArticleBodyProcessing).not.toHaveBeenCalled();
+    expect(markArticleBodyUnavailable).toHaveBeenCalledWith(
+      expect.anything(),
+      'item_1',
+      'PIPELINE_DISABLED',
+      { attemptCount: 1 }
+    );
+  });
+
+  it('acks invalid messages instead of retrying poison input', async () => {
+    const message = queueMessage({ itemId: '' });
+
+    await handleArticleBodyQueue(batch(message), { DB: {} } as never);
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+    expectLoggerErrorCalls([
+      [
+        'Invalid article-body queue message',
+        expect.objectContaining({ event: 'article_body.queue.invalid', messageId: 'message_1' }),
+      ],
+    ]);
+  });
+
+  it('processes a valid enabled message and acknowledges success', async () => {
+    const message = queueMessage();
+    const processor = vi.fn().mockResolvedValue(undefined);
+    const env = { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never;
+
+    await handleArticleBodyQueue(batch(message), env, processor);
+
+    expect(markArticleBodyProcessing).toHaveBeenCalledWith(expect.anything(), 'item_1', 1);
+    expect(processor).toHaveBeenCalledWith(body(), expect.anything(), env);
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('retries processor failures with bounded backoff', async () => {
+    const message = queueMessage(body(), 2);
+    const processor = vi.fn().mockRejectedValue(new Error('not installed'));
+
+    await handleArticleBodyQueue(
+      batch(message),
+      { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never,
+      processor
+    );
+
+    expect(message.ack).not.toHaveBeenCalled();
+    expect(message.retry).toHaveBeenCalledWith({ delaySeconds: 300 });
+    expect(markArticleBodyRetryScheduled).toHaveBeenCalledWith(
+      expect.anything(),
+      'item_1',
+      'PROCESSOR_FAILED',
+      2,
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  it('preserves typed acquisition error codes in retry diagnostics', async () => {
+    const message = queueMessage();
+    const processor = vi
+      .fn()
+      .mockRejectedValue(new RetryableArticleBodyError('HTTP_503', 'upstream unavailable', 503));
+
+    await handleArticleBodyQueue(
+      batch(message),
+      { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never,
+      processor
+    );
+
+    expect(markArticleBodyRetryScheduled).toHaveBeenCalledWith(
+      expect.anything(),
+      'item_1',
+      'HTTP_503',
+      1,
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  it('persists an aggregate-safe DLQ event and makes item state unavailable', async () => {
+    const message = queueMessage(body(), 4);
+    findItem.mockResolvedValue({ id: 'item_1' });
+
+    await handleArticleBodyDLQ(batch(message, 'zine-article-body-dlq-dev'), { DB: {} } as never);
+
+    expect(markArticleBodyUnavailable).toHaveBeenCalledWith(
+      expect.anything(),
+      'item_1',
+      'QUEUE_RETRIES_EXHAUSTED',
+      expect.objectContaining({ attemptCount: 4 })
+    );
+    expect(dlqValues).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: 'item_1', attempts: 4 })
+    );
+    expect(message.ack).toHaveBeenCalledOnce();
+    expectLoggerErrorCalls([
+      [
+        'Article-body message reached DLQ',
+        expect.objectContaining({
+          event: 'article_body.dlq.message_failed',
+          itemId: 'item_1',
+          attempts: 4,
+        }),
+      ],
+    ]);
+  });
+});

--- a/apps/worker/src/article-body/consumer.ts
+++ b/apps/worker/src/article-body/consumer.ts
@@ -1,0 +1,136 @@
+import { ulid } from 'ulid';
+
+import { createDb, type Database } from '../db';
+import { articleBodyDlqEvents } from '../db/schema';
+import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
+import { processArticleBodyQueueMessage, RetryableArticleBodyError } from './processor';
+import { ArticleBodyQueueMessageSchema } from './schema';
+import {
+  isArticleBodyPipelineEnabled,
+  markArticleBodyProcessing,
+  markArticleBodyRetryScheduled,
+  markArticleBodyUnavailable,
+} from './service';
+import type { ArticleBodyQueueMessage } from './types';
+
+const articleBodyLogger = logger.child('article-body-consumer');
+
+export type ArticleBodyProcessor = (
+  message: ArticleBodyQueueMessage,
+  db: Database,
+  env: Bindings
+) => Promise<void>;
+
+export async function handleArticleBodyQueue(
+  batch: MessageBatch<ArticleBodyQueueMessage>,
+  env: Bindings,
+  processor: ArticleBodyProcessor = processArticleBodyQueueMessage
+): Promise<void> {
+  const enabled = isArticleBodyPipelineEnabled(env);
+  const db = createDb(env.DB);
+
+  for (const message of batch.messages) {
+    const parsed = ArticleBodyQueueMessageSchema.safeParse(message.body);
+    if (!parsed.success) {
+      articleBodyLogger.error('Invalid article-body queue message', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.invalid',
+        messageId: message.id,
+        error: parsed.error.message,
+      });
+      message.ack();
+      continue;
+    }
+
+    if (!enabled) {
+      await markArticleBodyUnavailable(db, parsed.data.itemId, 'PIPELINE_DISABLED', {
+        attemptCount: message.attempts,
+      });
+      articleBodyLogger.info('Article-body pipeline disabled; acknowledging queued message', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.disabled',
+        messageId: message.id,
+        itemId: parsed.data.itemId,
+      });
+      message.ack();
+      continue;
+    }
+
+    try {
+      await markArticleBodyProcessing(db, parsed.data.itemId, message.attempts);
+      await processor(parsed.data, db, env);
+      message.ack();
+    } catch (error) {
+      const delaySeconds = Math.min(60 * 60, 60 * 5 ** Math.max(0, message.attempts - 1));
+      const errorCode =
+        error instanceof RetryableArticleBodyError ? error.errorCode : 'PROCESSOR_FAILED';
+      const now = Date.now();
+      await markArticleBodyRetryScheduled(
+        db,
+        parsed.data.itemId,
+        errorCode,
+        message.attempts,
+        now + delaySeconds * 1_000,
+        now
+      );
+      articleBodyLogger.warn('Article-body queue message will retry', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.retry',
+        messageId: message.id,
+        itemId: parsed.data.itemId,
+        attempts: message.attempts,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      message.retry({ delaySeconds });
+    }
+  }
+}
+
+export async function handleArticleBodyDLQ(
+  batch: MessageBatch<ArticleBodyQueueMessage>,
+  env: Bindings
+): Promise<void> {
+  const db = createDb(env.DB);
+  const now = Date.now();
+
+  for (const message of batch.messages) {
+    const parsed = ArticleBodyQueueMessageSchema.safeParse(message.body);
+    let itemId: string | null = null;
+
+    if (parsed.success) {
+      const item = await db.query.items.findFirst({
+        where: (table, { eq }) => eq(table.id, parsed.data.itemId),
+        columns: { id: true },
+      });
+      itemId = item?.id ?? null;
+
+      if (itemId) {
+        await markArticleBodyUnavailable(db, itemId, 'QUEUE_RETRIES_EXHAUSTED', {
+          attemptCount: message.attempts,
+          now,
+        });
+      }
+    }
+
+    await db.insert(articleBodyDlqEvents).values({
+      id: ulid(),
+      itemId,
+      extractorVersion: parsed.success ? parsed.data.extractorVersion : null,
+      trigger: parsed.success ? parsed.data.trigger : null,
+      attempts: message.attempts,
+      errorCode: parsed.success ? 'QUEUE_RETRIES_EXHAUSTED' : 'INVALID_MESSAGE',
+      deadLetteredAt: now,
+    });
+
+    articleBodyLogger.error('Article-body message reached DLQ', {
+      operation: 'article_body.dlq',
+      event: 'article_body.dlq.message_failed',
+      messageId: message.id,
+      itemId,
+      attempts: message.attempts,
+      errorCode: parsed.success ? 'QUEUE_RETRIES_EXHAUSTED' : 'INVALID_MESSAGE',
+    });
+    message.ack();
+  }
+}

--- a/apps/worker/src/article-body/diagnostics.test.ts
+++ b/apps/worker/src/article-body/diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getArticleBodyHealth } from './diagnostics';
+
+describe('article-body diagnostics', () => {
+  it('returns aggregate lifecycle and DLQ counts without item identifiers', async () => {
+    const all = vi.fn().mockResolvedValue({
+      results: [
+        { status: 'AVAILABLE', count: 12 },
+        { status: 'UNAVAILABLE', count: 2 },
+        { status: 'UNKNOWN', count: 99 },
+      ],
+    });
+    const first = vi.fn().mockResolvedValue({ count: 1 });
+    const prepare = vi.fn().mockReturnValueOnce({ all }).mockReturnValueOnce({ first });
+
+    const result = await getArticleBodyHealth({
+      DB: { prepare },
+      ARTICLE_BODY_QUEUE: {},
+      ARTICLE_BODY_PIPELINE_ENABLED: 'false',
+    } as never);
+
+    expect(result).toEqual({
+      status: 'ok',
+      enabled: false,
+      configured: true,
+      states: {
+        PENDING: 0,
+        PROCESSING: 0,
+        AVAILABLE: 12,
+        DEGRADED: 0,
+        UNAVAILABLE: 2,
+      },
+      dlqCount: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain('item_');
+  });
+
+  it('reports migration or query failures without throwing the health route', async () => {
+    const prepare = vi.fn().mockReturnValue({
+      all: vi.fn().mockRejectedValue(new Error('no such table')),
+      first: vi.fn().mockRejectedValue(new Error('no such table')),
+    });
+
+    await expect(getArticleBodyHealth({ DB: { prepare } } as never)).resolves.toMatchObject({
+      status: 'error',
+      enabled: false,
+      configured: false,
+      error: 'no such table',
+    });
+  });
+});

--- a/apps/worker/src/article-body/diagnostics.ts
+++ b/apps/worker/src/article-body/diagnostics.ts
@@ -1,0 +1,63 @@
+import type { Bindings } from '../types';
+import { isArticleBodyPipelineEnabled } from './service';
+import type { ArticleBodyStatus } from './types';
+
+const STATUSES: ArticleBodyStatus[] = [
+  'PENDING',
+  'PROCESSING',
+  'AVAILABLE',
+  'DEGRADED',
+  'UNAVAILABLE',
+];
+
+export interface ArticleBodyHealth {
+  status: 'ok' | 'error';
+  enabled: boolean;
+  configured: boolean;
+  states: Record<ArticleBodyStatus, number>;
+  dlqCount: number;
+  error?: string;
+}
+
+function emptyStateCounts(): Record<ArticleBodyStatus, number> {
+  return Object.fromEntries(STATUSES.map((status) => [status, 0])) as Record<
+    ArticleBodyStatus,
+    number
+  >;
+}
+
+export async function getArticleBodyHealth(env: Bindings): Promise<ArticleBodyHealth> {
+  const base = {
+    enabled: isArticleBodyPipelineEnabled(env),
+    configured: Boolean(env.ARTICLE_BODY_QUEUE),
+    states: emptyStateCounts(),
+    dlqCount: 0,
+  };
+
+  try {
+    const [statesResult, dlqResult] = await Promise.all([
+      env.DB.prepare(
+        'SELECT status, COUNT(*) AS count FROM article_body_states GROUP BY status'
+      ).all<{ status: ArticleBodyStatus; count: number }>(),
+      env.DB.prepare('SELECT COUNT(*) AS count FROM article_body_dlq_events').first<{
+        count: number;
+      }>(),
+    ]);
+
+    for (const row of statesResult.results) {
+      if (STATUSES.includes(row.status)) base.states[row.status] = Number(row.count);
+    }
+
+    return {
+      status: 'ok',
+      ...base,
+      dlqCount: Number(dlqResult?.count ?? 0),
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      ...base,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeArticleBodyHtml } from './normalization';
+
+describe('normalizeArticleBodyHtml', () => {
+  it('sanitizes active content, attributes, and unsafe URLs', () => {
+    const normalized = normalizeArticleBodyHtml(
+      `<div onclick="steal()"><script>alert(1)</script><p>Hello <a href="/story" onclick="x()">world</a>. <a href="http://127.0.0.1/admin">Local</a></p><img src="javascript:bad" onerror="x()"><img src="http://192.168.1.2/private.jpg"><iframe src="https://bad.example"></iframe></div>`,
+      'https://example.com/base/'
+    );
+
+    expect(normalized.sanitizedHtml).toContain('href="https://example.com/story"');
+    expect(normalized.sanitizedHtml).toContain('>Local</a>');
+    expect(normalized.sanitizedHtml).not.toContain('127.0.0.1');
+    expect(normalized.sanitizedHtml).not.toMatch(/script|iframe|onclick|onerror|javascript:/);
+    expect(normalized.plainText).toBe('Hello world. Local');
+    expect(normalized.diagnostics.droppedElements).toBeGreaterThanOrEqual(2);
+    expect(normalized.diagnostics.blockedUrls).toBe(3);
+  });
+
+  it('creates stable semantic blocks and exact word metrics', () => {
+    const normalized = normalizeArticleBodyHtml(
+      '<h2>A heading</h2><p>One two three.</p><blockquote>Four five.</blockquote>',
+      'https://example.com/story'
+    );
+
+    expect(normalized.blocks).toEqual([
+      { id: 'b1', kind: 'heading', text: 'A heading' },
+      { id: 'b2', kind: 'paragraph', text: 'One two three.' },
+      { id: 'b3', kind: 'quote', text: 'Four five.' },
+    ]);
+    expect(normalized.wordCount).toBe(7);
+    expect(normalized.readingTimeMinutes).toBe(1);
+  });
+});

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -1,0 +1,209 @@
+import { parseHTML } from 'linkedom/worker';
+
+import type { ArticleBodyBlock } from './types';
+import { isSafePublicArticleUrl } from './url-safety';
+
+const DROP_WITH_CONTENT = new Set([
+  'script',
+  'style',
+  'noscript',
+  'iframe',
+  'object',
+  'embed',
+  'form',
+  'input',
+  'button',
+  'select',
+  'textarea',
+  'nav',
+  'footer',
+  'aside',
+  'svg',
+  'canvas',
+]);
+
+const ALLOWED_TAGS = new Set([
+  'article',
+  'section',
+  'div',
+  'p',
+  'br',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'pre',
+  'code',
+  'ul',
+  'ol',
+  'li',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'a',
+  'img',
+  'figure',
+  'figcaption',
+  'hr',
+  'time',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+]);
+
+const BLOCK_SELECTOR = 'h1,h2,h3,h4,h5,h6,p,blockquote,pre,li,figcaption,th,td';
+const WORD_PATTERN = /[\p{L}\p{N}]+(?:[’'-][\p{L}\p{N}]+)*/gu;
+
+export interface ArticleBodyNormalizationDiagnostics {
+  droppedElements: number;
+  strippedAttributes: number;
+  blockedUrls: number;
+  linkTextCharacters: number;
+  totalTextCharacters: number;
+}
+
+export interface NormalizedArticleBody {
+  sanitizedHtml: string;
+  plainText: string;
+  blocks: ArticleBodyBlock[];
+  wordCount: number;
+  readingTimeMinutes: number;
+  diagnostics: ArticleBodyNormalizationDiagnostics;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value
+    .replace(/\u00a0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function safeAbsoluteUrl(value: string, baseUrl: string): string | null {
+  try {
+    const url = new URL(value, baseUrl);
+    return isSafePublicArticleUrl(url.href) ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function unwrap(element: Element): void {
+  const parent = element.parentNode;
+  if (!parent) return;
+  while (element.firstChild) parent.insertBefore(element.firstChild, element);
+  element.remove();
+}
+
+function blockKind(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  if (/^h[1-6]$/.test(tag)) return 'heading';
+  if (tag === 'li') return 'list_item';
+  if (tag === 'blockquote') return 'quote';
+  if (tag === 'pre') return 'code';
+  if (tag === 'figcaption') return 'caption';
+  if (tag === 'th' || tag === 'td') return 'table_cell';
+  return 'paragraph';
+}
+
+export function normalizeArticleBodyHtml(rawHtml: string, baseUrl: string): NormalizedArticleBody {
+  const { document } = parseHTML(`<html><body><article>${rawHtml}</article></body></html>`);
+  const root = document.querySelector('article');
+  if (!root) throw new Error('Unable to create article normalization root');
+
+  const diagnostics: ArticleBodyNormalizationDiagnostics = {
+    droppedElements: 0,
+    strippedAttributes: 0,
+    blockedUrls: 0,
+    linkTextCharacters: 0,
+    totalTextCharacters: 0,
+  };
+
+  for (const element of Array.from(root.querySelectorAll('*'))) {
+    const tag = element.tagName.toLowerCase();
+    if (DROP_WITH_CONTENT.has(tag)) {
+      diagnostics.droppedElements += 1;
+      element.remove();
+      continue;
+    }
+    if (!ALLOWED_TAGS.has(tag)) {
+      diagnostics.droppedElements += 1;
+      unwrap(element);
+    }
+  }
+
+  for (const element of Array.from(root.querySelectorAll('*'))) {
+    const tag = element.tagName.toLowerCase();
+    const originalAttributes = Array.from(element.attributes).map((attribute) => attribute.name);
+    const allowed =
+      tag === 'a'
+        ? new Set(['href', 'title'])
+        : tag === 'img'
+          ? new Set(['src', 'alt', 'title', 'width', 'height'])
+          : tag === 'time'
+            ? new Set(['datetime'])
+            : new Set<string>();
+
+    for (const attribute of originalAttributes) {
+      if (!allowed.has(attribute.toLowerCase())) {
+        element.removeAttribute(attribute);
+        diagnostics.strippedAttributes += 1;
+      }
+    }
+
+    if (tag === 'a') {
+      diagnostics.linkTextCharacters += normalizeWhitespace(element.textContent ?? '').length;
+      const href = element.getAttribute('href');
+      if (href) {
+        const resolved = safeAbsoluteUrl(href, baseUrl);
+        if (resolved) {
+          element.setAttribute('href', resolved);
+        } else {
+          element.removeAttribute('href');
+          diagnostics.blockedUrls += 1;
+        }
+      }
+    }
+
+    if (tag === 'img') {
+      const src = element.getAttribute('src');
+      const resolved = src ? safeAbsoluteUrl(src, baseUrl) : null;
+      if (resolved) {
+        element.setAttribute('src', resolved);
+      } else {
+        diagnostics.blockedUrls += 1;
+        element.remove();
+      }
+    }
+  }
+
+  const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR))
+    .map((element, index) => ({
+      id: `b${index + 1}`,
+      kind: blockKind(element),
+      text: normalizeWhitespace(element.textContent ?? ''),
+    }))
+    .filter((block) => block.text.length > 0);
+
+  const plainText =
+    blocks.length > 0
+      ? blocks.map((block) => block.text).join('\n\n')
+      : normalizeWhitespace(root.textContent ?? '');
+  const words = plainText.match(WORD_PATTERN) ?? [];
+  diagnostics.totalTextCharacters = plainText.length;
+
+  return {
+    sanitizedHtml: root.innerHTML.trim(),
+    plainText,
+    blocks,
+    wordCount: words.length,
+    readingTimeMinutes: words.length === 0 ? 0 : Math.max(1, Math.ceil(words.length / 200)),
+    diagnostics,
+  };
+}

--- a/apps/worker/src/article-body/processor.test.ts
+++ b/apps/worker/src/article-body/processor.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { acquireArticleBody, markArticleBodyUnavailable, publishArticleBodyArtifact } = vi.hoisted(
+  () => ({
+    acquireArticleBody: vi.fn(),
+    markArticleBodyUnavailable: vi.fn(),
+    publishArticleBodyArtifact: vi.fn(),
+  })
+);
+
+vi.mock('./acquisition', () => ({ acquireArticleBody }));
+vi.mock('./service', () => ({ markArticleBodyUnavailable, publishArticleBodyArtifact }));
+
+import { articleBodyProcessorInternals, processArticleBodyQueueMessage } from './processor';
+import type { RetryableArticleBodyError } from './processor';
+import type { ArticleBodyArtifact, ArticleBodyQueueMessage } from './types';
+
+const message: ArticleBodyQueueMessage = {
+  itemId: 'item_1',
+  extractorVersion: 1,
+  trigger: 'backfill',
+  enqueuedAt: 1_700_000_000_000,
+};
+
+const artifact: ArticleBodyArtifact = {
+  schemaVersion: 1,
+  extractorVersion: 1,
+  itemId: 'item_1',
+  canonicalUrl: 'https://example.com/story',
+  title: 'A dependable story',
+  byline: 'Author',
+  publisher: 'Example',
+  publishedAt: '2026-07-23T00:00:00.000Z',
+  language: 'en',
+  sourceKind: 'PUBLIC_WEB',
+  sourceUrl: 'https://example.com/story',
+  extractedAt: 1_700_000_000_000,
+  contentHash: `sha256:${'a'.repeat(64)}`,
+  wordCount: 700,
+  readingTimeMinutes: 4,
+  qualityScore: 0.94,
+  qualityWarnings: [],
+  sanitizedHtml: '<p>Story</p>',
+  plainText: 'Story',
+  blocks: [{ id: 'block_1', kind: 'paragraph', text: 'Story' }],
+};
+
+function createDb(item: Record<string, unknown> | undefined = {}) {
+  const row = {
+    id: 'item_1',
+    contentType: 'ARTICLE',
+    canonicalUrl: 'https://example.com/story',
+    title: 'A dependable story',
+    publisher: 'Example',
+    publishedAt: '2026-07-23T00:00:00.000Z',
+    byline: 'Author',
+    ...item,
+  };
+  const limit = vi.fn().mockResolvedValue(item === undefined ? [] : [row]);
+  const whereSelect = vi.fn().mockReturnValue({ limit });
+  const leftJoin = vi.fn().mockReturnValue({ where: whereSelect });
+  const from = vi.fn().mockReturnValue({ leftJoin });
+  const select = vi.fn().mockReturnValue({ from });
+  const whereUpdate = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where: whereUpdate });
+  const update = vi.fn().mockReturnValue({ set });
+  return { db: { select, update }, set };
+}
+
+describe('article-body processor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('publishes a successful artifact and mirrors reading metrics onto the item', async () => {
+    const { db, set } = createDb();
+    acquireArticleBody.mockResolvedValue({
+      status: 'AVAILABLE',
+      artifact,
+      attempts: [],
+      errorCode: null,
+      lastHttpStatus: 200,
+    });
+
+    await processArticleBodyQueueMessage(
+      message,
+      db as never,
+      {
+        ARTICLE_CONTENT: {},
+      } as never
+    );
+
+    expect(acquireArticleBody).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: 'item_1', canonicalUrl: artifact.canonicalUrl }),
+      { extractorVersion: 1 }
+    );
+    expect(publishArticleBodyArtifact).toHaveBeenCalledWith(
+      db,
+      expect.anything(),
+      artifact,
+      'AVAILABLE'
+    );
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ wordCount: 700, readingTimeMinutes: 4 })
+    );
+  });
+
+  it('records terminal acquisition failures without retrying', async () => {
+    const { db } = createDb();
+    acquireArticleBody.mockResolvedValue({
+      status: 'UNAVAILABLE',
+      artifact: null,
+      attempts: [],
+      errorCode: 'NOT_READERABLE',
+      lastHttpStatus: 200,
+    });
+
+    await processArticleBodyQueueMessage(message, db as never, {} as never);
+
+    expect(markArticleBodyUnavailable).toHaveBeenCalledWith(db, 'item_1', 'NOT_READERABLE', {
+      httpStatus: 200,
+    });
+  });
+
+  it('throws a typed error for transient acquisition failures', async () => {
+    const { db } = createDb();
+    acquireArticleBody.mockResolvedValue({
+      status: 'UNAVAILABLE',
+      artifact: null,
+      attempts: [],
+      errorCode: 'HTTP_503',
+      lastHttpStatus: 503,
+    });
+
+    await expect(processArticleBodyQueueMessage(message, db as never, {} as never)).rejects.toEqual(
+      expect.objectContaining<Partial<RetryableArticleBodyError>>({
+        errorCode: 'HTTP_503',
+        httpStatus: 503,
+      })
+    );
+  });
+
+  it('marks non-article items terminally ineligible', async () => {
+    const { db } = createDb({ contentType: 'VIDEO' });
+
+    await processArticleBodyQueueMessage(message, db as never, {} as never);
+
+    expect(markArticleBodyUnavailable).toHaveBeenCalledWith(db, 'item_1', 'ITEM_NOT_ELIGIBLE');
+    expect(acquireArticleBody).not.toHaveBeenCalled();
+  });
+
+  it('classifies only transient network and HTTP failures as retryable', () => {
+    expect(articleBodyProcessorInternals.isRetryableAcquisitionFailure('FETCH_TIMEOUT')).toBe(true);
+    expect(articleBodyProcessorInternals.isRetryableAcquisitionFailure('HTTP_429')).toBe(true);
+    expect(articleBodyProcessorInternals.isRetryableAcquisitionFailure('HTTP_503')).toBe(true);
+    expect(articleBodyProcessorInternals.isRetryableAcquisitionFailure('HTTP_404')).toBe(false);
+    expect(articleBodyProcessorInternals.isRetryableAcquisitionFailure('QUALITY_REJECTED')).toBe(
+      false
+    );
+  });
+});

--- a/apps/worker/src/article-body/processor.ts
+++ b/apps/worker/src/article-body/processor.ts
@@ -1,0 +1,127 @@
+import { eq } from 'drizzle-orm';
+
+import type { Database } from '../db';
+import { creators, items } from '../db/schema';
+import { logger } from '../lib/logger';
+import type { Bindings } from '../types';
+import { acquireArticleBody } from './acquisition';
+import { markArticleBodyUnavailable, publishArticleBodyArtifact } from './service';
+import type { ArticleBodyQueueMessage } from './types';
+
+const processorLogger = logger.child('article-body-processor');
+
+export class RetryableArticleBodyError extends Error {
+  constructor(
+    public readonly errorCode: string,
+    message: string,
+    public readonly httpStatus: number | null = null
+  ) {
+    super(message);
+    this.name = 'RetryableArticleBodyError';
+  }
+}
+
+function isRetryableAcquisitionFailure(errorCode: string | null): boolean {
+  if (!errorCode) return false;
+  if (errorCode === 'FETCH_FAILED' || errorCode === 'FETCH_TIMEOUT') return true;
+  const match = /^HTTP_(\d{3})$/.exec(errorCode);
+  if (!match) return false;
+  const status = Number(match[1]);
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+export async function processArticleBodyQueueMessage(
+  message: ArticleBodyQueueMessage,
+  db: Database,
+  env: Bindings
+): Promise<void> {
+  const rows = await db
+    .select({
+      id: items.id,
+      contentType: items.contentType,
+      canonicalUrl: items.canonicalUrl,
+      title: items.title,
+      publisher: items.publisher,
+      publishedAt: items.publishedAt,
+      byline: creators.name,
+    })
+    .from(items)
+    .leftJoin(creators, eq(items.creatorId, creators.id))
+    .where(eq(items.id, message.itemId))
+    .limit(1);
+  const item = rows[0];
+
+  if (!item) {
+    processorLogger.info('Article-body item no longer exists; acknowledging job', {
+      operation: 'article_body.process',
+      event: 'article_body.process.item_missing',
+      itemId: message.itemId,
+    });
+    return;
+  }
+
+  if (item.contentType !== 'ARTICLE') {
+    await markArticleBodyUnavailable(db, item.id, 'ITEM_NOT_ELIGIBLE');
+    return;
+  }
+
+  const result = await acquireArticleBody(
+    {
+      itemId: item.id,
+      canonicalUrl: item.canonicalUrl,
+      title: item.title,
+      byline: item.byline,
+      publisher: item.publisher,
+      publishedAt: item.publishedAt,
+      embeddedCandidates: message.embeddedCandidates,
+    },
+    { extractorVersion: message.extractorVersion }
+  );
+
+  if (!result.artifact) {
+    if (isRetryableAcquisitionFailure(result.errorCode)) {
+      throw new RetryableArticleBodyError(
+        result.errorCode ?? 'ACQUISITION_FAILED',
+        `Article-body acquisition failed for ${item.id}`,
+        result.lastHttpStatus
+      );
+    }
+    await markArticleBodyUnavailable(db, item.id, result.errorCode ?? 'NO_ACCEPTABLE_BODY', {
+      httpStatus: result.lastHttpStatus,
+    });
+    return;
+  }
+
+  try {
+    const publicationStatus = result.status === 'DEGRADED' ? 'DEGRADED' : 'AVAILABLE';
+    await publishArticleBodyArtifact(db, env.ARTICLE_CONTENT, result.artifact, publicationStatus);
+    await db
+      .update(items)
+      .set({
+        wordCount: result.artifact.wordCount,
+        readingTimeMinutes: result.artifact.readingTimeMinutes,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(items.id, item.id));
+  } catch (error) {
+    throw new RetryableArticleBodyError(
+      'PUBLISH_FAILED',
+      error instanceof Error ? error.message : 'Article-body publication failed'
+    );
+  }
+
+  processorLogger.info('Article body published', {
+    operation: 'article_body.process',
+    event: 'article_body.process.published',
+    itemId: item.id,
+    trigger: message.trigger,
+    sourceKind: result.artifact.sourceKind,
+    status: result.status,
+    wordCount: result.artifact.wordCount,
+    qualityScore: result.artifact.qualityScore,
+  });
+}
+
+export const articleBodyProcessorInternals = {
+  isRetryableAcquisitionFailure,
+};

--- a/apps/worker/src/article-body/quality.test.ts
+++ b/apps/worker/src/article-body/quality.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeArticleBodyHtml } from './normalization';
+import { assessArticleBodyQuality } from './quality';
+
+function paragraphs(words: number): string {
+  const sentence = 'Evidence and context make this article useful to a careful reader. ';
+  const body = sentence.repeat(Math.ceil(words / 11));
+  return `<p>${body}</p><p>${body}</p>`;
+}
+
+describe('assessArticleBodyQuality', () => {
+  it('accepts a substantial structured body', () => {
+    const body = normalizeArticleBodyHtml(paragraphs(160), 'https://example.com/story');
+
+    expect(assessArticleBodyQuality(body)).toEqual({
+      disposition: 'AVAILABLE',
+      score: 1,
+      warnings: [],
+    });
+  });
+
+  it('degrades a short but still readable body', () => {
+    const body = normalizeArticleBodyHtml(
+      `<p>${'A useful sentence with enough context to read. '.repeat(8)}</p>`,
+      'https://example.com/story'
+    );
+
+    expect(assessArticleBodyQuality(body)).toMatchObject({
+      disposition: 'DEGRADED',
+      warnings: ['BODY_TOO_SHORT'],
+    });
+  });
+
+  it('rejects snippets that are very short and truncated', () => {
+    const body = normalizeArticleBodyHtml(
+      '<p>This is only a teaser for the original article. Read more</p>',
+      'https://example.com/story'
+    );
+
+    expect(assessArticleBodyQuality(body)).toMatchObject({
+      disposition: 'UNAVAILABLE',
+      score: 0.05,
+      warnings: ['BODY_VERY_SHORT', 'LIKELY_TRUNCATED'],
+    });
+  });
+
+  it('flags unrelated extracted titles', () => {
+    const body = normalizeArticleBodyHtml(paragraphs(160), 'https://example.com/story');
+
+    expect(
+      assessArticleBodyQuality(body, {
+        expectedTitle: 'Designing dependable article extraction',
+        extractedTitle: 'Welcome to the account login portal',
+      })
+    ).toMatchObject({ warnings: ['TITLE_MISMATCH'], score: 0.75 });
+  });
+
+  it('degrades a substantial body that runs into a related-content teaser', () => {
+    const body = normalizeArticleBodyHtml(
+      `${paragraphs(160)}<p>${'A related article teaser follows the main body. '.repeat(40)} Continue reading...</p>`,
+      'https://example.com/story'
+    );
+
+    expect(assessArticleBodyQuality(body)).toMatchObject({
+      disposition: 'DEGRADED',
+      score: 0.65,
+      warnings: ['TRAILING_RELATED_CONTENT'],
+    });
+  });
+});

--- a/apps/worker/src/article-body/quality.ts
+++ b/apps/worker/src/article-body/quality.ts
@@ -1,0 +1,120 @@
+import type { NormalizedArticleBody } from './normalization';
+
+const BOILERPLATE_PHRASES = [
+  'accept cookies',
+  'cookie policy',
+  'all rights reserved',
+  'sign up for',
+  'subscribe to',
+  'advertisement',
+  'already a subscriber',
+  'log in to continue',
+];
+
+export type ArticleBodyQualityDisposition = 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
+
+export interface ArticleBodyQualityAssessment {
+  disposition: ArticleBodyQualityDisposition;
+  score: number;
+  warnings: string[];
+}
+
+export interface ArticleBodyQualityContext {
+  expectedTitle?: string | null;
+  extractedTitle?: string | null;
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function titleTokens(value: string | null | undefined): Set<string> {
+  if (!value) return new Set();
+  return new Set(
+    (value.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []).filter((token) => token.length >= 4)
+  );
+}
+
+function titlesConflict(expected: string | null | undefined, extracted: string | null | undefined) {
+  const expectedTokens = titleTokens(expected);
+  const extractedTokens = titleTokens(extracted);
+  if (expectedTokens.size < 2 || extractedTokens.size < 2) return false;
+  return ![...expectedTokens].some((token) => extractedTokens.has(token));
+}
+
+export function assessArticleBodyQuality(
+  body: NormalizedArticleBody,
+  context: ArticleBodyQualityContext = {}
+): ArticleBodyQualityAssessment {
+  const warnings: string[] = [];
+  let score = 1;
+
+  if (body.wordCount === 0) {
+    return { disposition: 'UNAVAILABLE', score: 0, warnings: ['EMPTY_BODY'] };
+  }
+
+  if (body.wordCount < 40) {
+    warnings.push('BODY_VERY_SHORT');
+    score -= 0.65;
+  } else if (body.wordCount < 120) {
+    warnings.push('BODY_TOO_SHORT');
+    score -= 0.35;
+  }
+
+  const lowerText = body.plainText.toLocaleLowerCase();
+  const boilerplateMatches = BOILERPLATE_PHRASES.filter((phrase) => lowerText.includes(phrase));
+  if (boilerplateMatches.length >= 2) {
+    warnings.push('BOILERPLATE_HIGH');
+    score -= 0.3;
+  }
+
+  const tail = lowerText.slice(-180);
+  if (
+    body.wordCount < 500 &&
+    (/\.\.\.$/.test(tail) || /…$/.test(tail) || /(?:read|continue) more\s*$/.test(tail))
+  ) {
+    warnings.push('LIKELY_TRUNCATED');
+    score -= 0.3;
+  }
+
+  if (/continue reading(?:\.{3}|…)?\s*$/.test(tail)) {
+    warnings.push('TRAILING_RELATED_CONTENT');
+    score -= 0.35;
+  } else if (/no posts\s*$/.test(tail)) {
+    warnings.push('TRAILING_BOILERPLATE');
+    score -= 0.05;
+  }
+
+  if (body.wordCount >= 150 && body.blocks.length < 2) {
+    warnings.push('NO_PARAGRAPH_STRUCTURE');
+    score -= 0.1;
+  }
+
+  const linkDensity =
+    body.diagnostics.totalTextCharacters === 0
+      ? 0
+      : body.diagnostics.linkTextCharacters / body.diagnostics.totalTextCharacters;
+  if (linkDensity > 0.35) {
+    warnings.push('LINK_DENSITY_HIGH');
+    score -= 0.25;
+  }
+
+  if (titlesConflict(context.expectedTitle, context.extractedTitle)) {
+    warnings.push('TITLE_MISMATCH');
+    score -= 0.25;
+  }
+
+  if (body.diagnostics.droppedElements > 0 || body.diagnostics.blockedUrls > 0) {
+    warnings.push('UNSAFE_MARKUP_REMOVED');
+  }
+
+  score = Number(clamp(score).toFixed(2));
+  const disposition: ArticleBodyQualityDisposition =
+    body.wordCount >= 120 && score >= 0.7
+      ? 'AVAILABLE'
+      : body.wordCount >= 40 && score >= 0.35
+        ? 'DEGRADED'
+        : 'UNAVAILABLE';
+
+  return { disposition, score, warnings };
+}

--- a/apps/worker/src/article-body/schema.test.ts
+++ b/apps/worker/src/article-body/schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES, ArticleBodyQueueMessageSchema } from './schema';
+
+const baseMessage = {
+  itemId: 'item_1',
+  extractorVersion: 1,
+  trigger: 'ingestion' as const,
+  enqueuedAt: 1_700_000_000_000,
+};
+
+describe('article-body queue schema', () => {
+  it('accepts a bounded source-first RSS candidate', () => {
+    const parsed = ArticleBodyQueueMessageSchema.safeParse({
+      ...baseMessage,
+      embeddedCandidates: [
+        {
+          html: '<article><p>Complete story body</p></article>',
+          sourceKind: 'RSS_FULL',
+          sourceUrl: 'https://example.com/feed.xml',
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects candidate payloads that could exceed the queue message budget', () => {
+    const parsed = ArticleBodyQueueMessageSchema.safeParse({
+      ...baseMessage,
+      embeddedCandidates: [
+        {
+          html: 'x'.repeat(ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES),
+          sourceKind: 'RSS_FULL',
+          sourceUrl: 'https://example.com/feed.xml',
+        },
+      ],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/apps/worker/src/article-body/schema.ts
+++ b/apps/worker/src/article-body/schema.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+
+import {
+  ARTICLE_BODY_EXTRACTOR_VERSION,
+  ARTICLE_BODY_SCHEMA_VERSION,
+  type ArticleBodyArtifact,
+  type ArticleBodyQueueMessage,
+} from './types';
+
+export const ArticleBodyStatusSchema = z.enum([
+  'PENDING',
+  'PROCESSING',
+  'AVAILABLE',
+  'DEGRADED',
+  'UNAVAILABLE',
+]);
+
+export const ArticleBodySourceKindSchema = z.enum([
+  'LEGACY',
+  'RSS_FULL',
+  'ATOM_FULL',
+  'PUBLIC_WEB',
+  'PUBLIC_NEWSLETTER',
+  'BROWSER_RENDERED',
+]);
+
+export const ArticleBodyTriggerSchema = z.enum([
+  'ingestion',
+  'bookmark',
+  'reader_open',
+  'backfill',
+  'repair',
+]);
+
+export const ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES = 80 * 1024;
+
+export const ArticleBodyEmbeddedCandidateSchema = z.object({
+  html: z.string().min(1),
+  sourceKind: z.enum(['RSS_FULL', 'ATOM_FULL', 'PUBLIC_NEWSLETTER']),
+  sourceUrl: z.string().url(),
+});
+
+export const ArticleBodyArtifactSchema = z.object({
+  schemaVersion: z.literal(ARTICLE_BODY_SCHEMA_VERSION),
+  extractorVersion: z.number().int().positive(),
+  itemId: z.string().min(1),
+  canonicalUrl: z.string().url(),
+  title: z.string().min(1),
+  byline: z.string().nullable(),
+  publisher: z.string().nullable(),
+  publishedAt: z.string().nullable(),
+  language: z.string().nullable(),
+  sourceKind: ArticleBodySourceKindSchema,
+  sourceUrl: z.string().url(),
+  extractedAt: z.number().int().nonnegative(),
+  contentHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  wordCount: z.number().int().nonnegative(),
+  readingTimeMinutes: z.number().int().nonnegative(),
+  qualityScore: z.number().min(0).max(1),
+  qualityWarnings: z.array(z.string().min(1)).max(50),
+  sanitizedHtml: z.string(),
+  plainText: z.string(),
+  blocks: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        kind: z.string().min(1),
+        text: z.string(),
+      })
+    )
+    .max(10_000),
+}) satisfies z.ZodType<ArticleBodyArtifact>;
+
+export const ArticleBodyQueueMessageSchema = z
+  .object({
+    itemId: z.string().min(1),
+    extractorVersion: z.number().int().positive().default(ARTICLE_BODY_EXTRACTOR_VERSION),
+    trigger: ArticleBodyTriggerSchema,
+    enqueuedAt: z.number().int().nonnegative(),
+    traceId: z.string().min(1).optional(),
+    embeddedCandidates: z.array(ArticleBodyEmbeddedCandidateSchema).max(2).optional(),
+  })
+  .superRefine((message, context) => {
+    if (!message.embeddedCandidates) return;
+    const bytes = new TextEncoder().encode(JSON.stringify(message.embeddedCandidates)).byteLength;
+    if (bytes > ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['embeddedCandidates'],
+        message: `Embedded candidates exceed ${ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES} bytes`,
+      });
+    }
+  }) satisfies z.ZodType<ArticleBodyQueueMessage, z.ZodTypeDef, unknown>;
+
+export type ArticleBodyQueueMessageInput = z.infer<typeof ArticleBodyQueueMessageSchema>;

--- a/apps/worker/src/article-body/service-enqueue.test.ts
+++ b/apps/worker/src/article-body/service-enqueue.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES } from './schema';
+import { enqueueArticleBody } from './service';
+import type { ArticleBodyStatusRecord } from './service';
+
+function createDb(status: ArticleBodyStatusRecord | null) {
+  const limit = vi.fn().mockResolvedValue(status ? [status] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const leftJoin = vi.fn().mockReturnValue({ where });
+  const from = vi.fn().mockReturnValue({ leftJoin });
+  const select = vi.fn().mockReturnValue({ from });
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values });
+  return { select, insert };
+}
+
+function status(overrides: Partial<ArticleBodyStatusRecord> = {}): ArticleBodyStatusRecord {
+  return {
+    status: 'PENDING',
+    targetExtractorVersion: 1,
+    attemptCount: 0,
+    lastErrorCode: null,
+    lastHttpStatus: null,
+    lastAttemptAt: null,
+    nextAttemptAt: null,
+    updatedAt: 1,
+    versionId: null,
+    schemaVersion: null,
+    extractorVersion: null,
+    sourceKind: null,
+    contentHash: null,
+    r2Key: null,
+    wordCount: null,
+    readingTimeMinutes: null,
+    qualityScore: null,
+    qualityWarningsJson: null,
+    ...overrides,
+  };
+}
+
+describe('article-body enqueue', () => {
+  it('does not duplicate a pending job at the same extractor version', async () => {
+    const db = createDb(status());
+    const send = vi.fn();
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'backfill' }
+    );
+
+    expect(result).toEqual({ queued: false, reason: 'already_queued' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not replace a current artifact outside an explicit repair', async () => {
+    const db = createDb(
+      status({ status: 'AVAILABLE', versionId: 'version_1', extractorVersion: 1 })
+    );
+    const send = vi.fn();
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'backfill' }
+    );
+
+    expect(result).toEqual({ queued: false, reason: 'current' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('includes a bounded embedded candidate in the queue job', async () => {
+    const db = createDb(null);
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      {
+        itemId: 'item_1',
+        trigger: 'ingestion',
+        embeddedCandidates: [
+          {
+            html: '<article><p>Full body</p></article>',
+            sourceKind: 'RSS_FULL',
+            sourceUrl: 'https://example.com/feed.xml',
+          },
+        ],
+      }
+    );
+
+    expect(result).toMatchObject({ queued: true, embeddedCandidatesIncluded: true });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ embeddedCandidates: expect.any(Array) })
+    );
+  });
+
+  it('drops an oversized embedded candidate but still queues public fallback', async () => {
+    const db = createDb(null);
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      {
+        itemId: 'item_1',
+        trigger: 'ingestion',
+        embeddedCandidates: [
+          {
+            html: 'x'.repeat(ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES),
+            sourceKind: 'RSS_FULL',
+            sourceUrl: 'https://example.com/feed.xml',
+          },
+        ],
+      }
+    );
+
+    expect(result).toMatchObject({ queued: true, embeddedCandidatesIncluded: false });
+    expect(send).toHaveBeenCalledWith(
+      expect.not.objectContaining({ embeddedCandidates: expect.anything() })
+    );
+  });
+});

--- a/apps/worker/src/article-body/service.test.ts
+++ b/apps/worker/src/article-body/service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { isArticleBodyPipelineEnabled, toArticleBodyPublicStatus } from './service';
+import type { ArticleBodyStatusRecord } from './service';
+
+function record(overrides: Partial<ArticleBodyStatusRecord> = {}): ArticleBodyStatusRecord {
+  return {
+    status: 'AVAILABLE',
+    targetExtractorVersion: 1,
+    attemptCount: 1,
+    lastErrorCode: null,
+    lastHttpStatus: 200,
+    lastAttemptAt: 1_700_000_000_000,
+    nextAttemptAt: null,
+    updatedAt: 1_700_000_000_000,
+    versionId: 'version_1',
+    schemaVersion: 1,
+    extractorVersion: 1,
+    sourceKind: 'RSS_FULL',
+    contentHash: `sha256:${'a'.repeat(64)}`,
+    r2Key: 'articles/v2/item_1/hash.json',
+    wordCount: 500,
+    readingTimeMinutes: 3,
+    qualityScore: 0.95,
+    qualityWarningsJson: '[]',
+    ...overrides,
+  };
+}
+
+describe('article-body public status', () => {
+  it('keeps the foundation disabled unless explicitly enabled', () => {
+    expect(isArticleBodyPipelineEnabled({})).toBe(false);
+    expect(isArticleBodyPipelineEnabled({ ARTICLE_BODY_PIPELINE_ENABLED: 'false' })).toBe(false);
+    expect(isArticleBodyPipelineEnabled({ ARTICLE_BODY_PIPELINE_ENABLED: ' TRUE ' })).toBe(true);
+  });
+
+  it('represents legacy and absent content explicitly', () => {
+    expect(toArticleBodyPublicStatus(null, true)).toMatchObject({
+      availability: 'AVAILABLE',
+      pipelineStatus: 'LEGACY',
+      sourceKind: 'LEGACY',
+    });
+    expect(toArticleBodyPublicStatus(null, false)).toMatchObject({
+      availability: 'UNAVAILABLE',
+      pipelineStatus: 'NOT_REQUESTED',
+    });
+  });
+
+  it('never reports an available state without a current immutable version', () => {
+    expect(
+      toArticleBodyPublicStatus(record({ versionId: null, r2Key: null }), false)
+    ).toMatchObject({
+      availability: 'UNAVAILABLE',
+      pipelineStatus: 'AVAILABLE',
+      qualityWarnings: ['MISSING_CURRENT_VERSION'],
+    });
+  });
+
+  it('keeps an existing body available while a replacement is processing', () => {
+    expect(toArticleBodyPublicStatus(record({ status: 'PROCESSING' }), false)).toMatchObject({
+      availability: 'AVAILABLE',
+      pipelineStatus: 'PROCESSING',
+      contentHash: `sha256:${'a'.repeat(64)}`,
+    });
+  });
+
+  it('keeps the last good body readable as degraded when refresh is exhausted', () => {
+    expect(
+      toArticleBodyPublicStatus(
+        record({ status: 'UNAVAILABLE', lastErrorCode: 'QUEUE_RETRIES_EXHAUSTED' }),
+        false
+      )
+    ).toMatchObject({
+      availability: 'DEGRADED',
+      pipelineStatus: 'UNAVAILABLE',
+      lastErrorCode: 'QUEUE_RETRIES_EXHAUSTED',
+      qualityWarnings: ['LATEST_ACQUISITION_FAILED_USING_CURRENT_VERSION'],
+    });
+  });
+});

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -1,0 +1,406 @@
+import { and, eq } from 'drizzle-orm';
+import { ulid } from 'ulid';
+
+import type { Database } from '../db';
+import { articleBodyStates, articleBodyVersions } from '../db/schema';
+import type { Bindings } from '../types';
+import { ArticleBodyQueueMessageSchema } from './schema';
+import { putArticleBodyArtifact } from './storage';
+import {
+  ARTICLE_BODY_EXTRACTOR_VERSION,
+  type ArticleBodyArtifact,
+  type ArticleBodyEmbeddedCandidate,
+  type ArticleBodyPublicStatus,
+  type ArticleBodyQueueMessage,
+  type ArticleBodyStatus,
+  type ArticleBodyTrigger,
+} from './types';
+
+export interface ArticleBodyStatusRecord {
+  status: ArticleBodyStatus;
+  targetExtractorVersion: number;
+  attemptCount: number;
+  lastErrorCode: string | null;
+  lastHttpStatus: number | null;
+  lastAttemptAt: number | null;
+  nextAttemptAt: number | null;
+  updatedAt: number;
+  versionId: string | null;
+  schemaVersion: number | null;
+  extractorVersion: number | null;
+  sourceKind: ArticleBodyArtifact['sourceKind'] | null;
+  contentHash: string | null;
+  r2Key: string | null;
+  wordCount: number | null;
+  readingTimeMinutes: number | null;
+  qualityScore: number | null;
+  qualityWarningsJson: string | null;
+}
+
+function parseWarnings(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) && parsed.every((warning) => typeof warning === 'string')
+      ? parsed
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isArticleBodyPipelineEnabled(
+  env: Pick<Bindings, 'ARTICLE_BODY_PIPELINE_ENABLED'>
+): boolean {
+  return env.ARTICLE_BODY_PIPELINE_ENABLED?.trim().toLowerCase() === 'true';
+}
+
+export async function getArticleBodyStatus(
+  db: Database,
+  itemId: string
+): Promise<ArticleBodyStatusRecord | null> {
+  const rows = await db
+    .select({
+      status: articleBodyStates.status,
+      targetExtractorVersion: articleBodyStates.targetExtractorVersion,
+      attemptCount: articleBodyStates.attemptCount,
+      lastErrorCode: articleBodyStates.lastErrorCode,
+      lastHttpStatus: articleBodyStates.lastHttpStatus,
+      lastAttemptAt: articleBodyStates.lastAttemptAt,
+      nextAttemptAt: articleBodyStates.nextAttemptAt,
+      updatedAt: articleBodyStates.updatedAt,
+      versionId: articleBodyVersions.id,
+      schemaVersion: articleBodyVersions.schemaVersion,
+      extractorVersion: articleBodyVersions.extractorVersion,
+      sourceKind: articleBodyVersions.sourceKind,
+      contentHash: articleBodyVersions.contentHash,
+      r2Key: articleBodyVersions.r2Key,
+      wordCount: articleBodyVersions.wordCount,
+      readingTimeMinutes: articleBodyVersions.readingTimeMinutes,
+      qualityScore: articleBodyVersions.qualityScore,
+      qualityWarningsJson: articleBodyVersions.qualityWarningsJson,
+    })
+    .from(articleBodyStates)
+    .leftJoin(articleBodyVersions, eq(articleBodyStates.currentVersionId, articleBodyVersions.id))
+    .where(eq(articleBodyStates.itemId, itemId))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  return rows[0] as ArticleBodyStatusRecord;
+}
+
+export function toArticleBodyPublicStatus(
+  record: ArticleBodyStatusRecord | null,
+  legacyContentPresent: boolean
+): ArticleBodyPublicStatus {
+  if (!record) {
+    if (legacyContentPresent) {
+      return {
+        availability: 'AVAILABLE',
+        pipelineStatus: 'LEGACY',
+        schemaVersion: 0,
+        extractorVersion: null,
+        sourceKind: 'LEGACY',
+        contentHash: null,
+        wordCount: null,
+        readingTimeMinutes: null,
+        qualityScore: null,
+        qualityWarnings: ['LEGACY_UNNORMALIZED'],
+        lastErrorCode: null,
+        updatedAt: null,
+      };
+    }
+
+    return {
+      availability: 'UNAVAILABLE',
+      pipelineStatus: 'NOT_REQUESTED',
+      schemaVersion: null,
+      extractorVersion: null,
+      sourceKind: null,
+      contentHash: null,
+      wordCount: null,
+      readingTimeMinutes: null,
+      qualityScore: null,
+      qualityWarnings: [],
+      lastErrorCode: null,
+      updatedAt: null,
+    };
+  }
+
+  const hasCurrentVersion = record.versionId !== null && record.r2Key !== null;
+  const qualityWarnings = parseWarnings(record.qualityWarningsJson);
+  let availability: ArticleBodyPublicStatus['availability'];
+
+  if (record.status === 'PENDING' || record.status === 'PROCESSING') {
+    availability = hasCurrentVersion ? 'AVAILABLE' : 'PENDING';
+  } else if (record.status === 'AVAILABLE' && hasCurrentVersion) {
+    availability = 'AVAILABLE';
+  } else if (record.status === 'DEGRADED' && hasCurrentVersion) {
+    availability = 'DEGRADED';
+  } else if (record.status === 'UNAVAILABLE' && hasCurrentVersion) {
+    availability = 'DEGRADED';
+    qualityWarnings.push('LATEST_ACQUISITION_FAILED_USING_CURRENT_VERSION');
+  } else {
+    availability = 'UNAVAILABLE';
+    if ((record.status === 'AVAILABLE' || record.status === 'DEGRADED') && !hasCurrentVersion) {
+      qualityWarnings.push('MISSING_CURRENT_VERSION');
+    }
+  }
+
+  return {
+    availability,
+    pipelineStatus: record.status,
+    schemaVersion: record.schemaVersion,
+    extractorVersion: record.extractorVersion ?? record.targetExtractorVersion,
+    sourceKind: record.sourceKind,
+    contentHash: record.contentHash,
+    wordCount: record.wordCount,
+    readingTimeMinutes: record.readingTimeMinutes,
+    qualityScore: record.qualityScore,
+    qualityWarnings,
+    lastErrorCode: record.lastErrorCode,
+    updatedAt: new Date(record.updatedAt).toISOString(),
+  };
+}
+
+export async function markArticleBodyPending(
+  db: Database,
+  itemId: string,
+  extractorVersion: number,
+  now: number = Date.now()
+): Promise<void> {
+  await db
+    .insert(articleBodyStates)
+    .values({
+      itemId,
+      status: 'PENDING',
+      currentVersionId: null,
+      targetExtractorVersion: extractorVersion,
+      attemptCount: 0,
+      lastErrorCode: null,
+      lastHttpStatus: null,
+      lastAttemptAt: null,
+      nextAttemptAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: articleBodyStates.itemId,
+      set: {
+        status: 'PENDING',
+        targetExtractorVersion: extractorVersion,
+        lastErrorCode: null,
+        lastHttpStatus: null,
+        nextAttemptAt: null,
+        updatedAt: now,
+      },
+    });
+}
+
+export async function markArticleBodyProcessing(
+  db: Database,
+  itemId: string,
+  attemptCount: number,
+  now: number = Date.now()
+): Promise<void> {
+  await db
+    .update(articleBodyStates)
+    .set({
+      status: 'PROCESSING',
+      attemptCount,
+      lastAttemptAt: now,
+      nextAttemptAt: null,
+      updatedAt: now,
+    })
+    .where(eq(articleBodyStates.itemId, itemId));
+}
+
+export async function markArticleBodyRetryScheduled(
+  db: Database,
+  itemId: string,
+  errorCode: string,
+  attemptCount: number,
+  nextAttemptAt: number,
+  now: number = Date.now()
+): Promise<void> {
+  await db
+    .update(articleBodyStates)
+    .set({
+      status: 'PENDING',
+      attemptCount,
+      lastErrorCode: errorCode,
+      lastAttemptAt: now,
+      nextAttemptAt,
+      updatedAt: now,
+    })
+    .where(eq(articleBodyStates.itemId, itemId));
+}
+
+export async function markArticleBodyUnavailable(
+  db: Database,
+  itemId: string,
+  errorCode: string,
+  options: {
+    httpStatus?: number | null;
+    attemptCount?: number;
+    nextAttemptAt?: number | null;
+    now?: number;
+  } = {}
+): Promise<void> {
+  const now = options.now ?? Date.now();
+  await db
+    .update(articleBodyStates)
+    .set({
+      status: 'UNAVAILABLE',
+      ...(options.attemptCount === undefined ? {} : { attemptCount: options.attemptCount }),
+      lastErrorCode: errorCode,
+      lastHttpStatus: options.httpStatus ?? null,
+      lastAttemptAt: now,
+      nextAttemptAt: options.nextAttemptAt ?? null,
+      updatedAt: now,
+    })
+    .where(eq(articleBodyStates.itemId, itemId));
+}
+
+export async function publishArticleBodyArtifact(
+  db: Database,
+  bucket: R2Bucket,
+  artifact: ArticleBodyArtifact,
+  status: Extract<ArticleBodyStatus, 'AVAILABLE' | 'DEGRADED'>,
+  now: number = Date.now()
+): Promise<{ versionId: string; r2Key: string; created: boolean }> {
+  const stored = await putArticleBodyArtifact(bucket, artifact);
+  const proposedVersionId = ulid(now);
+
+  await db
+    .insert(articleBodyVersions)
+    .values({
+      id: proposedVersionId,
+      itemId: artifact.itemId,
+      schemaVersion: artifact.schemaVersion,
+      extractorVersion: artifact.extractorVersion,
+      sourceKind: artifact.sourceKind,
+      sourceUrl: artifact.sourceUrl,
+      contentHash: artifact.contentHash,
+      r2Key: stored.key,
+      wordCount: artifact.wordCount,
+      readingTimeMinutes: artifact.readingTimeMinutes,
+      qualityScore: artifact.qualityScore,
+      qualityWarningsJson: JSON.stringify(artifact.qualityWarnings),
+      createdAt: now,
+    })
+    .onConflictDoNothing({
+      target: [articleBodyVersions.itemId, articleBodyVersions.contentHash],
+    });
+
+  const existing = await db
+    .select({ id: articleBodyVersions.id })
+    .from(articleBodyVersions)
+    .where(
+      and(
+        eq(articleBodyVersions.itemId, artifact.itemId),
+        eq(articleBodyVersions.contentHash, artifact.contentHash)
+      )
+    )
+    .limit(1);
+
+  const versionId = existing[0]?.id;
+  if (!versionId) {
+    throw new Error('Article body version was not readable after storage');
+  }
+
+  await db
+    .insert(articleBodyStates)
+    .values({
+      itemId: artifact.itemId,
+      status,
+      currentVersionId: versionId,
+      targetExtractorVersion: artifact.extractorVersion,
+      attemptCount: 1,
+      lastErrorCode: null,
+      lastHttpStatus: null,
+      lastAttemptAt: now,
+      nextAttemptAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: articleBodyStates.itemId,
+      set: {
+        status,
+        currentVersionId: versionId,
+        targetExtractorVersion: artifact.extractorVersion,
+        lastErrorCode: null,
+        lastHttpStatus: null,
+        lastAttemptAt: now,
+        nextAttemptAt: null,
+        updatedAt: now,
+      },
+    });
+
+  return { versionId, r2Key: stored.key, created: stored.created };
+}
+
+export async function enqueueArticleBody(
+  db: Database,
+  env: Pick<Bindings, 'ARTICLE_BODY_PIPELINE_ENABLED' | 'ARTICLE_BODY_QUEUE'>,
+  input: {
+    itemId: string;
+    trigger: ArticleBodyTrigger;
+    extractorVersion?: number;
+    traceId?: string;
+    embeddedCandidates?: ArticleBodyEmbeddedCandidate[];
+    now?: number;
+  }
+): Promise<{
+  queued: boolean;
+  reason?: 'disabled' | 'queue_unavailable' | 'already_queued' | 'current';
+  embeddedCandidatesIncluded?: boolean;
+}> {
+  if (!isArticleBodyPipelineEnabled(env)) return { queued: false, reason: 'disabled' };
+  if (!env.ARTICLE_BODY_QUEUE) return { queued: false, reason: 'queue_unavailable' };
+
+  const now = input.now ?? Date.now();
+  const extractorVersion = input.extractorVersion ?? ARTICLE_BODY_EXTRACTOR_VERSION;
+  const current = await getArticleBodyStatus(db, input.itemId);
+  if (
+    current &&
+    (current.status === 'PENDING' || current.status === 'PROCESSING') &&
+    current.targetExtractorVersion >= extractorVersion
+  ) {
+    return { queued: false, reason: 'already_queued' };
+  }
+  if (
+    input.trigger !== 'repair' &&
+    current?.versionId &&
+    (current.extractorVersion ?? 0) >= extractorVersion &&
+    (current.status === 'AVAILABLE' || current.status === 'DEGRADED')
+  ) {
+    return { queued: false, reason: 'current' };
+  }
+  await markArticleBodyPending(db, input.itemId, extractorVersion, now);
+
+  const baseMessage: ArticleBodyQueueMessage = {
+    itemId: input.itemId,
+    extractorVersion,
+    trigger: input.trigger,
+    enqueuedAt: now,
+    ...(input.traceId ? { traceId: input.traceId } : {}),
+  };
+  const candidateMessage: ArticleBodyQueueMessage = {
+    ...baseMessage,
+    ...(input.embeddedCandidates?.length ? { embeddedCandidates: input.embeddedCandidates } : {}),
+  };
+  const parsedCandidateMessage = ArticleBodyQueueMessageSchema.safeParse(candidateMessage);
+  const message = parsedCandidateMessage.success ? parsedCandidateMessage.data : baseMessage;
+  try {
+    await env.ARTICLE_BODY_QUEUE.send(message);
+  } catch (error) {
+    await markArticleBodyUnavailable(db, input.itemId, 'QUEUE_SEND_FAILED', { now });
+    throw error;
+  }
+  return {
+    queued: true,
+    embeddedCandidatesIncluded: Boolean(message.embeddedCandidates?.length),
+  };
+}

--- a/apps/worker/src/article-body/storage.test.ts
+++ b/apps/worker/src/article-body/storage.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildArticleBodyArtifact } from './artifact';
+import {
+  getArticleBodyArtifact,
+  getArticleBodyArtifactKey,
+  putArticleBodyArtifact,
+} from './storage';
+
+async function artifact() {
+  return buildArticleBodyArtifact({
+    extractorVersion: 1,
+    itemId: 'item/with spaces',
+    canonicalUrl: 'https://example.com/story',
+    title: 'Story',
+    sourceKind: 'PUBLIC_WEB',
+    sourceUrl: 'https://example.com/story',
+    extractedAt: 1_700_000_000_000,
+    wordCount: 1,
+    readingTimeMinutes: 1,
+    qualityScore: 1,
+    sanitizedHtml: '<p>Body</p>',
+    plainText: 'Body',
+  });
+}
+
+describe('article-body R2 storage', () => {
+  it('writes to a content-addressed immutable key', async () => {
+    const value = await artifact();
+    const get = vi.fn().mockResolvedValue(null);
+    const put = vi.fn().mockResolvedValue(undefined);
+    const result = await putArticleBodyArtifact({ get, put } as never, value);
+
+    expect(result).toEqual({
+      key: getArticleBodyArtifactKey(value.itemId, value.contentHash),
+      created: true,
+    });
+    expect(put).toHaveBeenCalledOnce();
+    expect(put.mock.calls[0]?.[0]).toContain('articles/v2/item%2Fwith%20spaces/');
+  });
+
+  it('does not overwrite an existing valid artifact', async () => {
+    const value = await artifact();
+    const put = vi.fn();
+    const bucket = {
+      get: vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(value) }),
+      put,
+    } as never;
+
+    await expect(putArticleBodyArtifact(bucket, value)).resolves.toMatchObject({ created: false });
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('verifies integrity when reading', async () => {
+    const value = await artifact();
+    const key = getArticleBodyArtifactKey(value.itemId, value.contentHash);
+    const validBucket = {
+      get: vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(value) }),
+    } as never;
+    const invalidBucket = {
+      get: vi
+        .fn()
+        .mockResolvedValue({ json: vi.fn().mockResolvedValue({ ...value, plainText: 'bad' }) }),
+    } as never;
+
+    await expect(getArticleBodyArtifact(validBucket, key)).resolves.toEqual(value);
+    await expect(getArticleBodyArtifact(invalidBucket, key)).rejects.toThrow(
+      'failed integrity verification'
+    );
+  });
+});

--- a/apps/worker/src/article-body/storage.ts
+++ b/apps/worker/src/article-body/storage.ts
@@ -1,0 +1,70 @@
+import { ArticleBodyArtifactSchema } from './schema';
+import { verifyArticleBodyArtifactIntegrity } from './artifact';
+import type { ArticleBodyArtifact } from './types';
+
+function hashPathSegment(contentHash: string): string {
+  return contentHash.replace(/^sha256:/, '');
+}
+
+export function getArticleBodyArtifactKey(itemId: string, contentHash: string): string {
+  return `articles/v2/${encodeURIComponent(itemId)}/${hashPathSegment(contentHash)}.json`;
+}
+
+export async function putArticleBodyArtifact(
+  bucket: R2Bucket,
+  artifact: ArticleBodyArtifact
+): Promise<{ key: string; created: boolean }> {
+  const parsed = ArticleBodyArtifactSchema.parse(artifact);
+  if (!(await verifyArticleBodyArtifactIntegrity(parsed))) {
+    throw new Error('Article body artifact content hash does not match its payload');
+  }
+
+  const key = getArticleBodyArtifactKey(parsed.itemId, parsed.contentHash);
+  const existing = await bucket.get(key);
+  if (existing) {
+    const existingArtifact = ArticleBodyArtifactSchema.parse(await existing.json());
+    if (!(await verifyArticleBodyArtifactIntegrity(existingArtifact))) {
+      throw new Error(`Existing article body artifact failed integrity verification: ${key}`);
+    }
+    if (
+      existingArtifact.itemId !== parsed.itemId ||
+      existingArtifact.contentHash !== parsed.contentHash
+    ) {
+      throw new Error(
+        `Existing article body artifact does not match its content-addressed key: ${key}`
+      );
+    }
+    return { key, created: false };
+  }
+
+  await bucket.put(key, JSON.stringify(parsed), {
+    httpMetadata: { contentType: 'application/json; charset=utf-8' },
+    customMetadata: {
+      itemId: parsed.itemId,
+      contentHash: parsed.contentHash,
+      schemaVersion: String(parsed.schemaVersion),
+      extractorVersion: String(parsed.extractorVersion),
+      sourceKind: parsed.sourceKind,
+      storedAt: new Date().toISOString(),
+    },
+  });
+
+  return { key, created: true };
+}
+
+export async function getArticleBodyArtifact(
+  bucket: R2Bucket,
+  key: string
+): Promise<ArticleBodyArtifact | null> {
+  const object = await bucket.get(key);
+  if (!object) return null;
+
+  const artifact = ArticleBodyArtifactSchema.parse(await object.json());
+  if (!(await verifyArticleBodyArtifactIntegrity(artifact))) {
+    throw new Error(`Article body artifact failed integrity verification: ${key}`);
+  }
+  if (getArticleBodyArtifactKey(artifact.itemId, artifact.contentHash) !== key) {
+    throw new Error(`Article body artifact does not match its content-addressed key: ${key}`);
+  }
+  return artifact;
+}

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,0 +1,75 @@
+export const ARTICLE_BODY_SCHEMA_VERSION = 1;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 1;
+
+export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
+
+export type ArticleBodyAvailability = 'PENDING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
+
+export type ArticleBodySourceKind =
+  | 'LEGACY'
+  | 'RSS_FULL'
+  | 'ATOM_FULL'
+  | 'PUBLIC_WEB'
+  | 'PUBLIC_NEWSLETTER'
+  | 'BROWSER_RENDERED';
+
+export type ArticleBodyTrigger = 'ingestion' | 'bookmark' | 'reader_open' | 'backfill' | 'repair';
+
+export interface ArticleBodyBlock {
+  id: string;
+  kind: string;
+  text: string;
+}
+
+export interface ArticleBodyArtifact {
+  schemaVersion: number;
+  extractorVersion: number;
+  itemId: string;
+  canonicalUrl: string;
+  title: string;
+  byline: string | null;
+  publisher: string | null;
+  publishedAt: string | null;
+  language: string | null;
+  sourceKind: ArticleBodySourceKind;
+  sourceUrl: string;
+  extractedAt: number;
+  contentHash: string;
+  wordCount: number;
+  readingTimeMinutes: number;
+  qualityScore: number;
+  qualityWarnings: string[];
+  sanitizedHtml: string;
+  plainText: string;
+  blocks: ArticleBodyBlock[];
+}
+
+export interface ArticleBodyEmbeddedCandidate {
+  html: string;
+  sourceKind: Extract<ArticleBodySourceKind, 'RSS_FULL' | 'ATOM_FULL' | 'PUBLIC_NEWSLETTER'>;
+  sourceUrl: string;
+}
+
+export interface ArticleBodyQueueMessage {
+  itemId: string;
+  extractorVersion: number;
+  trigger: ArticleBodyTrigger;
+  enqueuedAt: number;
+  traceId?: string;
+  embeddedCandidates?: ArticleBodyEmbeddedCandidate[];
+}
+
+export interface ArticleBodyPublicStatus {
+  availability: ArticleBodyAvailability;
+  pipelineStatus: ArticleBodyStatus | 'LEGACY' | 'NOT_REQUESTED';
+  schemaVersion: number | null;
+  extractorVersion: number | null;
+  sourceKind: ArticleBodySourceKind | null;
+  contentHash: string | null;
+  wordCount: number | null;
+  readingTimeMinutes: number | null;
+  qualityScore: number | null;
+  qualityWarnings: string[];
+  lastErrorCode: string | null;
+  updatedAt: string | null;
+}

--- a/apps/worker/src/article-body/url-safety.ts
+++ b/apps/worker/src/article-body/url-safety.ts
@@ -1,0 +1,43 @@
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split('.').map(Number);
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+  return (
+    parts[0] === 0 ||
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    parts[0] >= 224
+  );
+}
+
+export function isSafePublicArticleUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+      return false;
+    }
+    const hostname = url.hostname.toLocaleLowerCase().replace(/^\[|\]$/g, '');
+    if (
+      hostname === 'localhost' ||
+      hostname.endsWith('.localhost') ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.internal') ||
+      isPrivateIpv4(hostname) ||
+      hostname === '::1' ||
+      (hostname.includes(':') &&
+        (hostname.startsWith('fc') || hostname.startsWith('fd') || hostname.startsWith('fe80:')))
+    ) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/worker/src/db/migrations/0024_add_article_body_foundation.sql
+++ b/apps/worker/src/db/migrations/0024_add_article_body_foundation.sql
@@ -1,0 +1,57 @@
+CREATE TABLE `article_body_versions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`item_id` text NOT NULL,
+	`schema_version` integer NOT NULL,
+	`extractor_version` integer NOT NULL,
+	`source_kind` text NOT NULL,
+	`source_url` text NOT NULL,
+	`content_hash` text NOT NULL,
+	`r2_key` text NOT NULL,
+	`word_count` integer NOT NULL,
+	`reading_time_minutes` integer NOT NULL,
+	`quality_score` real NOT NULL,
+	`quality_warnings_json` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `article_body_versions_item_hash_idx` ON `article_body_versions` (`item_id`,`content_hash`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `article_body_versions_r2_key_idx` ON `article_body_versions` (`r2_key`);
+--> statement-breakpoint
+CREATE INDEX `article_body_versions_item_created_idx` ON `article_body_versions` (`item_id`,`created_at`);
+--> statement-breakpoint
+CREATE TABLE `article_body_states` (
+	`item_id` text PRIMARY KEY NOT NULL,
+	`status` text NOT NULL,
+	`current_version_id` text,
+	`target_extractor_version` integer NOT NULL,
+	`attempt_count` integer DEFAULT 0 NOT NULL,
+	`last_error_code` text,
+	`last_http_status` integer,
+	`last_attempt_at` integer,
+	`next_attempt_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`current_version_id`) REFERENCES `article_body_versions`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `article_body_states_status_next_attempt_idx` ON `article_body_states` (`status`,`next_attempt_at`);
+--> statement-breakpoint
+CREATE INDEX `article_body_states_updated_idx` ON `article_body_states` (`updated_at`);
+--> statement-breakpoint
+CREATE TABLE `article_body_dlq_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`item_id` text,
+	`extractor_version` integer,
+	`trigger` text,
+	`attempts` integer NOT NULL,
+	`error_code` text,
+	`dead_lettered_at` integer NOT NULL,
+	FOREIGN KEY (`item_id`) REFERENCES `items`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `article_body_dlq_events_dead_lettered_idx` ON `article_body_dlq_events` (`dead_lettered_at`);
+--> statement-breakpoint
+CREATE INDEX `article_body_dlq_events_item_idx` ON `article_body_dlq_events` (`item_id`,`dead_lettered_at`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1784516400000,
       "tag": "0023_add_editorial_experiments",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1784802300000,
+      "tag": "0024_add_article_body_foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -285,6 +285,83 @@ export const items = sqliteTable(
   ]
 );
 
+// Immutable, versioned article-body artifacts. The artifact bytes live in R2;
+// this table records the durable identity and quality metadata used by clients,
+// enrichment, and operational diagnostics.
+export const articleBodyVersions = sqliteTable(
+  'article_body_versions',
+  {
+    id: text('id').primaryKey(), // ULID
+    itemId: text('item_id')
+      .notNull()
+      .references(() => items.id, { onDelete: 'cascade' }),
+    schemaVersion: integer('schema_version').notNull(),
+    extractorVersion: integer('extractor_version').notNull(),
+    sourceKind: text('source_kind').notNull(),
+    sourceUrl: text('source_url').notNull(),
+    contentHash: text('content_hash').notNull(),
+    r2Key: text('r2_key').notNull(),
+    wordCount: integer('word_count').notNull(),
+    readingTimeMinutes: integer('reading_time_minutes').notNull(),
+    qualityScore: real('quality_score').notNull(),
+    qualityWarningsJson: text('quality_warnings_json').notNull(),
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => [
+    uniqueIndex('article_body_versions_item_hash_idx').on(table.itemId, table.contentHash),
+    uniqueIndex('article_body_versions_r2_key_idx').on(table.r2Key),
+    index('article_body_versions_item_created_idx').on(table.itemId, table.createdAt),
+  ]
+);
+
+// Mutable lifecycle state for one canonical item. This deliberately lives
+// outside user_items so one successful public extraction can serve every user
+// who owns the canonical item without duplicating work or content.
+export const articleBodyStates = sqliteTable(
+  'article_body_states',
+  {
+    itemId: text('item_id')
+      .primaryKey()
+      .references(() => items.id, { onDelete: 'cascade' }),
+    status: text('status').notNull(),
+    currentVersionId: text('current_version_id').references(() => articleBodyVersions.id, {
+      onDelete: 'set null',
+    }),
+    targetExtractorVersion: integer('target_extractor_version').notNull(),
+    attemptCount: integer('attempt_count').notNull().default(0),
+    lastErrorCode: text('last_error_code'),
+    lastHttpStatus: integer('last_http_status'),
+    lastAttemptAt: integer('last_attempt_at'),
+    nextAttemptAt: integer('next_attempt_at'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('article_body_states_status_next_attempt_idx').on(table.status, table.nextAttemptAt),
+    index('article_body_states_updated_idx').on(table.updatedAt),
+  ]
+);
+
+// Durable audit of messages that exhausted queue retries. Keeping this in D1
+// lets the public health probe report safe aggregate counts after DLQ messages
+// have been acknowledged and removed from Cloudflare Queues.
+export const articleBodyDlqEvents = sqliteTable(
+  'article_body_dlq_events',
+  {
+    id: text('id').primaryKey(), // ULID
+    itemId: text('item_id').references(() => items.id, { onDelete: 'set null' }),
+    extractorVersion: integer('extractor_version'),
+    trigger: text('trigger'),
+    attempts: integer('attempts').notNull(),
+    errorCode: text('error_code'),
+    deadLetteredAt: integer('dead_lettered_at').notNull(),
+  },
+  (table) => [
+    index('article_body_dlq_events_dead_lettered_idx').on(table.deadLetteredAt),
+    index('article_body_dlq_events_item_idx').on(table.itemId, table.deadLetteredAt),
+  ]
+);
+
 // User Items (User's relationship to content)
 // NOTE: Legacy table using ISO8601 TEXT timestamps. New tables should use Unix ms INTEGER.
 // See docs/zine-tech-stack.md for timestamp standard.

--- a/apps/worker/src/diagnostics/health.test.ts
+++ b/apps/worker/src/diagnostics/health.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDependencyHealth, getQueueHealth } from './health';
 
-const { getDLQSummary } = vi.hoisted(() => ({
+const { getDLQSummary, getArticleBodyHealth } = vi.hoisted(() => ({
   getDLQSummary: vi.fn(),
+  getArticleBodyHealth: vi.fn(),
 }));
 
 vi.mock('../sync/dlq-consumer', () => ({
   getDLQSummary,
+}));
+
+vi.mock('../article-body/diagnostics', () => ({
+  getArticleBodyHealth,
 }));
 
 describe('getDependencyHealth', () => {
@@ -31,6 +36,19 @@ describe('getDependencyHealth', () => {
 describe('getQueueHealth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getArticleBodyHealth.mockResolvedValue({
+      status: 'ok',
+      enabled: false,
+      configured: true,
+      states: {
+        PENDING: 0,
+        PROCESSING: 0,
+        AVAILABLE: 10,
+        DEGRADED: 1,
+        UNAVAILABLE: 2,
+      },
+      dlqCount: 0,
+    });
   });
 
   it('returns safe DLQ summaries without correlation identifiers', async () => {
@@ -83,5 +101,31 @@ describe('getQueueHealth', () => {
         },
       },
     ]);
+    expect(result.queues.articleBody).toMatchObject({
+      enabled: false,
+      configured: true,
+      states: { AVAILABLE: 10, DEGRADED: 1, UNAVAILABLE: 2 },
+      dlqCount: 0,
+    });
+  });
+
+  it('degrades when article-body DLQ events exist', async () => {
+    getDLQSummary.mockResolvedValue({
+      count: 0,
+      oldestAt: null,
+      newestAt: null,
+      recent: [],
+    });
+    getArticleBodyHealth.mockResolvedValue({
+      status: 'ok',
+      enabled: false,
+      configured: true,
+      states: {},
+      dlqCount: 1,
+    });
+
+    const result = await getQueueHealth({ OAUTH_STATE_KV: {} } as never);
+
+    expect(result.status).toBe('degraded');
   });
 });

--- a/apps/worker/src/diagnostics/health.ts
+++ b/apps/worker/src/diagnostics/health.ts
@@ -1,4 +1,5 @@
 import { getDLQSummary } from '../sync/dlq-consumer';
+import { getArticleBodyHealth } from '../article-body/diagnostics';
 import type { Bindings } from '../types';
 
 type CheckStatus = 'ok' | 'error';
@@ -66,10 +67,16 @@ export async function getDependencyHealth(env: Bindings) {
 }
 
 export async function getQueueHealth(env: Bindings) {
-  const dlqSummary = await getDLQSummary(env.OAUTH_STATE_KV);
+  const [dlqSummary, articleBody] = await Promise.all([
+    getDLQSummary(env.OAUTH_STATE_KV),
+    getArticleBodyHealth(env),
+  ]);
+
+  const degraded =
+    dlqSummary.count > 0 || articleBody.status === 'error' || articleBody.dlqCount > 0;
 
   return {
-    status: dlqSummary.count > 0 ? 'degraded' : 'ok',
+    status: degraded ? 'degraded' : 'ok',
     queues: {
       sync: {
         configured: Boolean(env.SYNC_QUEUE),
@@ -85,6 +92,7 @@ export async function getQueueHealth(env: Bindings) {
           release: entry.message.meta?.release,
         })),
       },
+      articleBody,
     },
   };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -7,6 +7,8 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { trpcServer } from '@hono/trpc-server';
+import { handleArticleBodyDLQ, handleArticleBodyQueue } from './article-body/consumer';
+import type { ArticleBodyQueueMessage } from './article-body/types';
 import {
   ZINE_VERSION,
   TELEMETRY_CLIENT_REQUEST_HEADER,
@@ -33,6 +35,7 @@ import { appRouter } from './trpc/router';
 import { createContext } from './trpc/context';
 import { getDependencyHealth, getQueueHealth } from './diagnostics/health';
 import { backfillBookmarkEnrichment } from './admin/enrichment-backfill';
+import { backfillArticleBodies } from './admin/article-body-backfill';
 
 // Create Hono app with typed environment
 const app = new Hono<Env>();
@@ -209,6 +212,49 @@ app.post('/admin/enrichment/backfill', async (c) => {
   });
 });
 
+app.post('/admin/article-bodies/backfill', async (c) => {
+  const configuredSecret = c.env.ARTICLE_BODY_BACKFILL_SECRET;
+  if (!configuredSecret) {
+    return c.json(
+      {
+        error: 'Article-body backfill is not configured',
+        code: 'BACKFILL_NOT_CONFIGURED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      503
+    );
+  }
+
+  const authHeader = c.req.header('Authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token || token !== configuredSecret) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const result = await backfillArticleBodies(c.env, {
+    dryRun: typeof body.dryRun === 'boolean' ? body.dryRun : true,
+    limit: typeof body.limit === 'number' ? body.limit : undefined,
+    cursor: typeof body.cursor === 'string' && body.cursor.length > 0 ? body.cursor : null,
+    traceId: c.get('traceId'),
+  });
+
+  return c.json({
+    ...result,
+    requestId: c.get('requestId'),
+    traceId: c.get('traceId'),
+  });
+});
+
 // tRPC Routes
 
 // Apply auth middleware to tRPC routes (required for protected procedures)
@@ -322,7 +368,7 @@ export default {
   /**
    * Queue handler for async jobs and DLQ monitoring.
    *
-   * Handles four queues:
+   * Handles six queues:
    * 1. SYNC_QUEUE: Primary sync queue for processing subscriptions
    *    - Non-blocking pull-to-refresh (< 500ms response time)
    *    - Error isolation (one subscription failing doesn't affect others)
@@ -331,9 +377,11 @@ export default {
    * 2. SYNC_DLQ: Dead Letter Queue for failed sync messages
    * 3. ENRICHMENT_QUEUE: Bookmark enrichment and embedding generation
    * 4. ENRICHMENT_DLQ: Dead Letter Queue for failed enrichment messages
+   * 5. ARTICLE_BODY_QUEUE: Versioned article-body acquisition jobs
+   * 6. ARTICLE_BODY_DLQ: Durable audit of exhausted article-body jobs
    *    - Captures messages that exhausted all retries
    *    - Logs at ERROR level for Cloudflare dashboard alerts
-   *    - Stores entries in KV for investigation and potential replay
+   *    - Stores aggregate-safe events in D1 for investigation and potential replay
    *
    * The queue name is available in batch.queue to differentiate handlers.
    *
@@ -341,10 +389,20 @@ export default {
    * @see zine-m2oq: Task: Add monitoring/alerting for sync queue DLQ
    */
   async queue(
-    batch: MessageBatch<SyncQueueMessage | EnrichmentQueueMessage>,
+    batch: MessageBatch<SyncQueueMessage | EnrichmentQueueMessage | ArticleBodyQueueMessage>,
     env: Bindings,
     _ctx: ExecutionContext
   ): Promise<void> {
+    if (batch.queue.includes('article-body-dlq')) {
+      await handleArticleBodyDLQ(batch as MessageBatch<ArticleBodyQueueMessage>, env);
+      return;
+    }
+
+    if (batch.queue.includes('article-body')) {
+      await handleArticleBodyQueue(batch as MessageBatch<ArticleBodyQueueMessage>, env);
+      return;
+    }
+
     if (batch.queue.includes('enrichment-dlq')) {
       await handleEnrichmentDLQ(batch as MessageBatch<EnrichmentQueueMessage>, env);
       return;

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -911,8 +911,8 @@
       "get": {
         "tags": ["Reading"],
         "operationId": "getBookmarkArticleContent",
-        "summary": "Get stored article content",
-        "description": "REST equivalent of tRPC items.getArticleContent. Returns null content when no extracted article body is stored.",
+        "summary": "Get article content and availability",
+        "description": "Returns the current immutable article-body artifact when available, otherwise legacy stored HTML. Availability metadata distinguishes pending, degraded, unavailable, and legacy content.",
         "security": [
           {
             "bearerAuth": []
@@ -927,7 +927,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Stored article content.",
+            "description": "Article content with explicit availability and provenance.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3978,15 +3978,74 @@
           },
           {
             "type": "object",
-            "required": ["content"],
+            "required": ["content", "articleBody"],
             "properties": {
               "content": {
                 "type": ["string", "null"],
                 "description": "Stored article HTML or null."
+              },
+              "articleBody": {
+                "$ref": "#/components/schemas/ArticleBodyStatus"
               }
             }
           }
         ]
+      },
+      "ArticleBodyStatus": {
+        "type": "object",
+        "required": [
+          "availability",
+          "pipelineStatus",
+          "schemaVersion",
+          "extractorVersion",
+          "sourceKind",
+          "contentHash",
+          "wordCount",
+          "readingTimeMinutes",
+          "qualityScore",
+          "qualityWarnings",
+          "lastErrorCode",
+          "updatedAt"
+        ],
+        "properties": {
+          "availability": {
+            "type": "string",
+            "enum": ["PENDING", "AVAILABLE", "DEGRADED", "UNAVAILABLE"]
+          },
+          "pipelineStatus": {
+            "type": "string",
+            "enum": [
+              "NOT_REQUESTED",
+              "LEGACY",
+              "PENDING",
+              "PROCESSING",
+              "AVAILABLE",
+              "DEGRADED",
+              "UNAVAILABLE"
+            ]
+          },
+          "schemaVersion": { "type": ["integer", "null"] },
+          "extractorVersion": { "type": ["integer", "null"] },
+          "sourceKind": {
+            "type": ["string", "null"],
+            "enum": [
+              "LEGACY",
+              "RSS_FULL",
+              "ATOM_FULL",
+              "PUBLIC_WEB",
+              "PUBLIC_NEWSLETTER",
+              "BROWSER_RENDERED",
+              null
+            ]
+          },
+          "contentHash": { "type": ["string", "null"] },
+          "wordCount": { "type": ["integer", "null"] },
+          "readingTimeMinutes": { "type": ["integer", "null"] },
+          "qualityScore": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+          "qualityWarnings": { "type": "array", "items": { "type": "string" } },
+          "lastErrorCode": { "type": ["string", "null"] },
+          "updatedAt": { "type": ["string", "null"], "format": "date-time" }
+        }
       },
       "YouTubeSubscription": {
         "type": "object",

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -29,6 +29,8 @@ const {
   mockMarkOpened,
   mockUpdateProgress,
   mockGetArticleContent,
+  mockGetArticleBodyStatus,
+  mockGetArticleBodyArtifact,
   mockListTags,
   mockPreview,
   mockSave,
@@ -104,6 +106,8 @@ const {
   mockMarkOpened: vi.fn(),
   mockUpdateProgress: vi.fn(),
   mockGetArticleContent: vi.fn(),
+  mockGetArticleBodyStatus: vi.fn(),
+  mockGetArticleBodyArtifact: vi.fn(),
   mockListTags: vi.fn(),
   mockPreview: vi.fn(),
   mockSave: vi.fn(),
@@ -160,6 +164,18 @@ const {
 
 vi.mock('../db', () => ({
   createDb: mockCreateDb,
+}));
+
+vi.mock('../article-body/service', async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    getArticleBodyStatus: mockGetArticleBodyStatus,
+  };
+});
+
+vi.mock('../article-body/storage', () => ({
+  getArticleBodyArtifact: mockGetArticleBodyArtifact,
 }));
 
 vi.mock('../trpc/context', () => ({
@@ -370,6 +386,8 @@ describe('apiV1Routes', () => {
       userId: 'clerk_user_123',
       payload: { sub: 'clerk_user_123' },
     });
+    mockGetArticleBodyStatus.mockResolvedValue(null);
+    mockGetArticleBodyArtifact.mockResolvedValue(null);
     mockConnectionsList.mockResolvedValue({
       YOUTUBE: null,
       SPOTIFY: null,
@@ -2443,6 +2461,131 @@ describe('apiV1Routes', () => {
     expect(mockGetArticleContent).toHaveBeenCalledWith({ itemId: 'item_1' });
     expect((await res.json()) as JsonBody).toMatchObject({
       content: '<article>Body</article>',
+      articleBody: {
+        availability: 'AVAILABLE',
+        pipelineStatus: 'LEGACY',
+        sourceKind: 'LEGACY',
+        qualityWarnings: ['LEGACY_UNNORMALIZED'],
+      },
+    });
+  });
+
+  it('reports unavailable when no article body has been requested or stored', async () => {
+    mockGetItem.mockResolvedValue({ id: 'ui_1', itemId: 'item_1', title: 'Article' });
+    mockGetArticleContent.mockResolvedValue({ content: null });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      content: null,
+      articleBody: {
+        availability: 'UNAVAILABLE',
+        pipelineStatus: 'NOT_REQUESTED',
+      },
+    });
+  });
+
+  it('serves the current versioned artifact with its availability metadata', async () => {
+    mockGetItem.mockResolvedValue({ id: 'ui_1', itemId: 'item_1', title: 'Article' });
+    mockGetArticleContent.mockResolvedValue({ content: '<article>Legacy</article>' });
+    mockGetArticleBodyStatus.mockResolvedValue({
+      status: 'AVAILABLE',
+      targetExtractorVersion: 1,
+      attemptCount: 1,
+      lastErrorCode: null,
+      lastHttpStatus: 200,
+      lastAttemptAt: 1700000000000,
+      nextAttemptAt: null,
+      updatedAt: 1700000000000,
+      versionId: 'version_1',
+      schemaVersion: 1,
+      extractorVersion: 1,
+      sourceKind: 'RSS_FULL',
+      contentHash: `sha256:${'a'.repeat(64)}`,
+      r2Key: 'articles/v2/item_1/hash.json',
+      wordCount: 500,
+      readingTimeMinutes: 3,
+      qualityScore: 0.98,
+      qualityWarningsJson: '[]',
+    });
+    mockGetArticleBodyArtifact.mockResolvedValue({
+      sanitizedHtml: '<article>Versioned</article>',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetArticleBodyArtifact).toHaveBeenCalledWith(
+      expect.anything(),
+      'articles/v2/item_1/hash.json'
+    );
+    expect((await res.json()) as JsonBody).toMatchObject({
+      content: '<article>Versioned</article>',
+      articleBody: {
+        availability: 'AVAILABLE',
+        pipelineStatus: 'AVAILABLE',
+        sourceKind: 'RSS_FULL',
+        wordCount: 500,
+      },
+    });
+  });
+
+  it('serves legacy content as degraded when the current immutable artifact is missing', async () => {
+    mockGetItem.mockResolvedValue({ id: 'ui_1', itemId: 'item_1', title: 'Article' });
+    mockGetArticleContent.mockResolvedValue({ content: '<article>Legacy fallback</article>' });
+    mockGetArticleBodyStatus.mockResolvedValue({
+      status: 'AVAILABLE',
+      targetExtractorVersion: 1,
+      attemptCount: 1,
+      lastErrorCode: null,
+      lastHttpStatus: 200,
+      lastAttemptAt: 1700000000000,
+      nextAttemptAt: null,
+      updatedAt: 1700000000000,
+      versionId: 'version_1',
+      schemaVersion: 1,
+      extractorVersion: 1,
+      sourceKind: 'PUBLIC_WEB',
+      contentHash: `sha256:${'b'.repeat(64)}`,
+      r2Key: 'articles/v2/item_1/missing.json',
+      wordCount: 100,
+      readingTimeMinutes: 1,
+      qualityScore: 0.9,
+      qualityWarningsJson: '[]',
+    });
+    mockGetArticleBodyArtifact.mockResolvedValue(null);
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      content: '<article>Legacy fallback</article>',
+      articleBody: {
+        availability: 'DEGRADED',
+        pipelineStatus: 'AVAILABLE',
+        sourceKind: 'LEGACY',
+        lastErrorCode: 'ARTIFACT_MISSING',
+        qualityWarnings: ['MISSING_CURRENT_VERSION', 'CURRENT_ARTIFACT_MISSING_FALLBACK_LEGACY'],
+      },
     });
   });
 

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -26,6 +26,8 @@ import {
 } from '@zine/editorial-schema';
 import type { Env } from '../types';
 import { createDb } from '../db';
+import { getArticleBodyStatus, toArticleBodyPublicStatus } from '../article-body/service';
+import { getArticleBodyArtifact } from '../article-body/storage';
 import { apiTokens, userItemConsumptionEvents, userItems } from '../db/schema';
 import { appRouter } from '../trpc/router';
 import { createContext } from '../trpc/context';
@@ -1931,9 +1933,32 @@ apiV1Routes.get('/bookmarks/:id/article-content', apiAuth('bookmarks:read'), asy
 
   try {
     const item = await caller.items.get({ id: c.req.param('id') });
-    const result = await caller.items.getArticleContent({ itemId: item.itemId });
+    const legacy = await caller.items.getArticleContent({ itemId: item.itemId });
+    const record = await getArticleBodyStatus(createDb(c.env.DB), item.itemId);
+    const artifact = record?.r2Key
+      ? await getArticleBodyArtifact(c.env.ARTICLE_CONTENT, record.r2Key)
+      : null;
+    const artifactMissing = Boolean(record?.r2Key && !artifact);
+    const effectiveRecord = artifactMissing
+      ? { ...record!, versionId: null, r2Key: null, lastErrorCode: 'ARTIFACT_MISSING' }
+      : record;
+    let articleBody = toArticleBodyPublicStatus(effectiveRecord, Boolean(legacy.content));
+
+    if (artifactMissing && legacy.content) {
+      articleBody = {
+        ...articleBody,
+        availability: 'DEGRADED',
+        sourceKind: 'LEGACY',
+        qualityWarnings: [
+          ...articleBody.qualityWarnings,
+          'CURRENT_ARTIFACT_MISSING_FALLBACK_LEGACY',
+        ],
+      };
+    }
+
     return c.json({
-      ...result,
+      content: artifact?.sanitizedHtml ?? legacy.content,
+      articleBody,
       requestId: c.get('requestId'),
       traceId: c.get('traceId'),
     });

--- a/apps/worker/src/rss/parser.test.ts
+++ b/apps/worker/src/rss/parser.test.ts
@@ -62,6 +62,36 @@ describe('parseRssFeedXml', () => {
     expect(parsed.entries[0].creator).toBe('Atom Author');
     expect(parsed.entries[0].canonicalUrl).toBe('https://atom.example.com/post-1');
     expect(parsed.entries[0].imageUrl).toBe('https://cdn.atom.example.com/post-1.jpg');
+    expect(parsed.entries[0].articleBodyCandidate).toMatchObject({
+      sourceKind: 'ATOM_FULL',
+      sourceUrl: 'https://atom.example.com/feed.xml',
+      html: expect.stringContaining('<p>Atom summary</p>'),
+    });
+  });
+
+  it('retains richer RSS content separately from the display summary', () => {
+    const richBody = `<p>${'Full article paragraph with meaningful reporting. '.repeat(30)}</p>`;
+    const xml = `<?xml version="1.0"?>
+      <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+        <channel>
+          <title>Rich Feed</title>
+          <item>
+            <title>Full story</title>
+            <link>https://example.com/full-story</link>
+            <description><![CDATA[Short display summary]]></description>
+            <content:encoded><![CDATA[${richBody}]]></content:encoded>
+          </item>
+        </channel>
+      </rss>`;
+
+    const entry = parseRssFeedXml(xml, 'https://example.com/feed.xml').entries[0];
+
+    expect(entry.summary).toBe('Short display summary');
+    expect(entry.articleBodyCandidate).toEqual({
+      html: richBody,
+      sourceKind: 'RSS_FULL',
+      sourceUrl: 'https://example.com/feed.xml',
+    });
   });
 
   it('falls back to hash identity when link/guid are missing', () => {

--- a/apps/worker/src/rss/parser.ts
+++ b/apps/worker/src/rss/parser.ts
@@ -1,6 +1,13 @@
 import { XMLParser } from 'fast-xml-parser';
 
 import { deriveIdentityHash, normalizeContentUrl } from './url';
+import type { ArticleBodySourceKind } from '../article-body/types';
+
+export interface ParsedArticleBodyCandidate {
+  html: string;
+  sourceKind: Extract<ArticleBodySourceKind, 'RSS_FULL' | 'ATOM_FULL'>;
+  sourceUrl: string;
+}
 
 export interface ParsedRssEntry {
   entryId: string;
@@ -12,6 +19,7 @@ export interface ParsedRssEntry {
   creatorImageUrl?: string;
   publishedAt?: number;
   imageUrl?: string;
+  articleBodyCandidate?: ParsedArticleBodyCandidate;
 }
 
 export interface ParsedRssFeed {
@@ -87,6 +95,14 @@ function decodeCommonHtmlEntities(input: string): string {
     .replace(/&amp;/gi, '&');
 }
 
+function normalizeEmbeddedHtmlCandidate(value: string | null): string | null {
+  if (!value) return null;
+  const decoded = /&(?:lt|gt|quot|apos|amp|#39);/i.test(value)
+    ? decodeCommonHtmlEntities(value)
+    : value;
+  return decoded.trim() || null;
+}
+
 function extractImageFromHtmlSnippet(value: string): string | null {
   const extractFrom = (candidate: string): string | null => {
     const match = IMG_SRC_REGEX.exec(candidate);
@@ -148,6 +164,9 @@ function parseRssChannel(channel: Record<string, unknown>, feedUrl: string): Par
       const itemTitle = firstText(item, ['title']) ?? 'Untitled';
       const summary =
         firstText(item, ['description', 'content:encoded', 'content', 'summary']) ?? '';
+      const embeddedHtml = normalizeEmbeddedHtmlCandidate(
+        firstText(item, ['content:encoded', 'content', 'description'])
+      );
       const publishedAt = toTimestamp(
         firstText(item, ['pubDate', 'published', 'updated', 'dc:date'])
       );
@@ -183,6 +202,9 @@ function parseRssChannel(channel: Record<string, unknown>, feedUrl: string): Par
         creatorImageUrl: imageUrl,
         publishedAt,
         imageUrl: normalizeContentUrl(imageCandidate, feedUrl) ?? undefined,
+        articleBodyCandidate: embeddedHtml
+          ? { html: embeddedHtml, sourceKind: 'RSS_FULL', sourceUrl: feedUrl }
+          : undefined,
       } satisfies ParsedRssEntry;
     })
     .filter((entry) => entry.title && entry.providerId);
@@ -227,6 +249,9 @@ function parseAtomFeed(feed: Record<string, unknown>, feedUrl: string): ParsedRs
             ?.href
         ) ?? textValue(entryLinks[0]?.href);
       const summary = firstText(entry, ['summary', 'content', 'description']) ?? '';
+      const embeddedHtml = normalizeEmbeddedHtmlCandidate(
+        firstText(entry, ['content', 'summary', 'description'])
+      );
       const publishedAt = toTimestamp(firstText(entry, ['published', 'updated']));
       const authorNode = (entry.author as Record<string, unknown> | undefined) ?? {};
       const creator =
@@ -262,6 +287,9 @@ function parseAtomFeed(feed: Record<string, unknown>, feedUrl: string): ParsedRs
         creatorImageUrl: iconUrl,
         publishedAt,
         imageUrl: normalizeContentUrl(imageCandidate, feedUrl) ?? undefined,
+        articleBodyCandidate: embeddedHtml
+          ? { html: embeddedHtml, sourceKind: 'ATOM_FULL', sourceUrl: feedUrl }
+          : undefined,
       } satisfies ParsedRssEntry;
     })
     .filter((entry) => entry.title && entry.providerId);

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Context } from 'hono';
+import type { ArticleBodyQueueMessage } from './article-body/types';
 import type { EnrichmentQueueMessage } from './enrichment/types';
 import type { SyncQueueMessage } from './sync/types';
 
@@ -82,10 +83,16 @@ export interface Bindings {
   RELEASE_RING?: string;
   /** Secret for privileged enrichment backfill operations */
   ENRICHMENT_BACKFILL_SECRET?: string;
+  /** Secret for privileged article-body cohort/backfill operations */
+  ARTICLE_BODY_BACKFILL_SECRET?: string;
+  /** Opt-in switch for article-body queue production and consumption. */
+  ARTICLE_BODY_PIPELINE_ENABLED?: string;
   /** Queue for async pull-to-refresh sync (optional - not available in all envs) */
   SYNC_QUEUE?: Queue<SyncQueueMessage>;
   /** Queue for async bookmark enrichment (optional - not available in all envs) */
   ENRICHMENT_QUEUE?: Queue<EnrichmentQueueMessage>;
+  /** Queue for durable article-body acquisition (optional - not available in all envs) */
+  ARTICLE_BODY_QUEUE?: Queue<ArticleBodyQueueMessage>;
 }
 
 /**

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -59,6 +59,10 @@ binding = "SYNC_QUEUE"
 queue = "zine-enrichment-queue-dev"
 binding = "ENRICHMENT_QUEUE"
 
+[[queues.producers]]
+queue = "zine-article-body-queue-dev"
+binding = "ARTICLE_BODY_QUEUE"
+
 [[queues.consumers]]
 queue = "zine-sync-queue-dev"
 max_batch_size = 10
@@ -86,6 +90,18 @@ queue = "zine-enrichment-dlq-dev"
 max_batch_size = 5
 max_batch_timeout = 30
 
+[[queues.consumers]]
+queue = "zine-article-body-queue-dev"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-article-body-dlq-dev"
+
+[[queues.consumers]]
+queue = "zine-article-body-dlq-dev"
+max_batch_size = 5
+max_batch_timeout = 30
+
 # Observability settings
 [observability]
 [observability.logs]
@@ -100,6 +116,7 @@ SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
+ARTICLE_BODY_PIPELINE_ENABLED = "false"
 # CLERK_JWKS_URL = "https://clerk.your-domain.com/.well-known/jwks.json"
 # CLERK_WEBHOOK_SECRET = "whsec_..." # From Clerk Dashboard > Webhooks
 
@@ -137,6 +154,7 @@ SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
+ARTICLE_BODY_PIPELINE_ENABLED = "false"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.staging.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
@@ -146,6 +164,9 @@ binding = "SYNC_QUEUE"
 [[env.staging.queues.producers]]
 queue = "zine-enrichment-queue-staging"
 binding = "ENRICHMENT_QUEUE"
+[[env.staging.queues.producers]]
+queue = "zine-article-body-queue-staging"
+binding = "ARTICLE_BODY_QUEUE"
 [[env.staging.queues.consumers]]
 queue = "zine-sync-queue-staging"
 max_batch_size = 10
@@ -166,6 +187,16 @@ max_retries = 3
 dead_letter_queue = "zine-enrichment-dlq-staging"
 [[env.staging.queues.consumers]]
 queue = "zine-enrichment-dlq-staging"
+max_batch_size = 5
+max_batch_timeout = 30
+[[env.staging.queues.consumers]]
+queue = "zine-article-body-queue-staging"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-article-body-dlq-staging"
+[[env.staging.queues.consumers]]
+queue = "zine-article-body-dlq-staging"
 max_batch_size = 5
 max_batch_timeout = 30
 [env.staging.observability]
@@ -212,6 +243,7 @@ SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
+ARTICLE_BODY_PIPELINE_ENABLED = "false"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
@@ -221,6 +253,9 @@ binding = "SYNC_QUEUE"
 [[env.production.queues.producers]]
 queue = "zine-enrichment-queue-prod"
 binding = "ENRICHMENT_QUEUE"
+[[env.production.queues.producers]]
+queue = "zine-article-body-queue-prod"
+binding = "ARTICLE_BODY_QUEUE"
 [[env.production.queues.consumers]]
 queue = "zine-sync-queue-prod"
 max_batch_size = 10
@@ -243,6 +278,16 @@ dead_letter_queue = "zine-enrichment-dlq-prod"
 queue = "zine-enrichment-dlq-prod"
 max_batch_size = 5
 max_batch_timeout = 30
+[[env.production.queues.consumers]]
+queue = "zine-article-body-queue-prod"
+max_batch_size = 5
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "zine-article-body-dlq-prod"
+[[env.production.queues.consumers]]
+queue = "zine-article-body-dlq-prod"
+max_batch_size = 5
+max_batch_timeout = 30
 [env.production.observability]
 [env.production.observability.logs]
 enabled = true
@@ -254,6 +299,7 @@ invocation_logs = true
 # ============================================================================
 # - CLERK_WEBHOOK_SECRET: Signing secret from Clerk Dashboard > Webhooks
 # - ENRICHMENT_BACKFILL_SECRET: Bearer token for admin enrichment backfill route
+# - ARTICLE_BODY_BACKFILL_SECRET: Bearer token for dry-run and bounded article-body cohorts
 # - X_BEARER_TOKEN: X API bearer token for inferred profile/avatar resolution
 #
 # Required KV Namespace (create via `wrangler kv:namespace create WEBHOOK_IDEMPOTENCY`)

--- a/docs/article-body-extraction.md
+++ b/docs/article-body-extraction.md
@@ -1,0 +1,49 @@
+# Article-body extraction quality (phase 2a)
+
+Phase 2a supplies and measures article-body acquisition without enrolling production items. The phase-one queue remains disabled and no ingestion, bookmark, reader-open, or backfill path calls `enqueueArticleBody`.
+
+## Acquisition cascade
+
+1. Evaluate full-body candidates retained from RSS `content:encoded`, RSS `content`/`description`, Atom `content`, Atom `summary`, or a public newsletter payload.
+2. If an embedded candidate is high quality, use it without fetching the public page.
+3. If embedded content is missing, rejected, or merely degraded, fetch the canonical public page and run Readability.
+4. Select the highest-quality acceptable result. Preserve a degraded embedded result when public fetching fails.
+5. Normalize and sanitize the selected body, compute exact word and reading-time metrics, and build the phase-one immutable artifact.
+
+Public acquisition accepts only HTTP(S), rejects credentialed and local/private destinations, follows at most five redirects while validating every hop before fetching it, requires HTML, enforces a five-megabyte response ceiling, and uses a twelve-second timeout.
+
+## Normalization and quality
+
+Normalization removes active and navigation markup, strips unapproved attributes, resolves safe relative links and images, blocks non-HTTP URLs, generates plain text and semantic blocks, and computes Unicode-aware word counts.
+
+Quality scoring distinguishes:
+
+- substantial structured bodies;
+- short or very short bodies;
+- likely truncated feed teasers;
+- high-link-density or boilerplate-heavy pages;
+- title mismatches;
+- unsafe markup that was removed during normalization.
+
+Only bodies with at least 120 words and a score of at least 0.70 are `AVAILABLE`. Bodies with at least 40 words and a score of at least 0.35 are retained as `DEGRADED`; weaker candidates are rejected.
+
+## Repeatable review corpus
+
+Run:
+
+```sh
+bun run article-body:review
+```
+
+The checked-in manifest contains 20 current Zine-shaped cases covering RSS, Atom, ordinary public pages, Medium feeds, and Substack pages. The runner fetches the latest entry from feed cases, exercises the complete cascade, and writes gitignored JSON and Markdown reports under `.local-data/article-body/reviews/`.
+
+The automated gate requires:
+
+- at least 90% of cases to produce an available or degraded body;
+- at least 95% of produced bodies to be high-quality `AVAILABLE` results.
+
+The Markdown report includes beginning, middle, and ending samples for human checks of topicality, continuity, truncation, and trailing boilerplate. Passing the automated gate does not replace that reading review.
+
+## Phase boundary
+
+This phase did not publish artifacts, create queues remotely, apply production migrations, or change live extraction behavior. Phase 2b now adapts this function into the queue processor and provides a dry-run-first bounded cohort endpoint. No automatic feed, bookmark, or reader-open enrollment has been added; the staged production burn remains a separate operational step.

--- a/docs/article-body-foundation.md
+++ b/docs/article-body-foundation.md
@@ -1,0 +1,52 @@
+# Article-body foundation (phase 1)
+
+Phase 1 makes article-body availability a durable, observable backend primitive without changing acquisition behavior. The phase 2b processor and cohort controls are now installed, but the pipeline remains disabled in every Wrangler environment until the staged activation checklist is completed.
+
+The extraction and review implementation that builds on this contract is documented in [Article-body extraction quality](./article-body-extraction.md).
+
+## Definition of done
+
+- D1 owns explicit per-item lifecycle state: pending, processing, available, degraded, or unavailable.
+- Every successful body is an immutable, schema-versioned, extractor-versioned, content-addressed R2 artifact.
+- D1 points to the current artifact and retains version metadata, quality signals, retry state, and error codes.
+- Queue retries are bounded and exhausted jobs leave a durable D1 DLQ audit event.
+- `/api/v1/bookmarks/:id/article-content` remains compatible with legacy HTML and exposes truthful availability, provenance, quality, and failure metadata.
+- `/health/queues` reports safe aggregate article-body state and DLQ counts without item or user identifiers.
+- The queue and DLQ are configured in development, staging, and production, while `ARTICLE_BODY_PIPELINE_ENABLED` remains `false` in all three.
+- Phase 1 shipped without ingestion, bookmark, reader-open, or backfill enrollment; phase 2b adds only the protected bounded backfill described below.
+
+## Storage contract
+
+Artifacts use `articles/v2/<encoded item id>/<sha256>.json`. The hash covers normalized content and provenance, but not extraction time, so replaying the same extraction is idempotent. Existing objects are read and integrity-checked rather than overwritten.
+
+R2 is written before D1 metadata. If D1 publication fails, the result is an unreferenced immutable object rather than a database pointer to missing bytes. A later repair job can safely publish or clean up that object.
+
+## Lifecycle contract
+
+`article_body_states` contains one mutable row per canonical item. `article_body_versions` is append-only in normal operation. A state may report available or degraded to clients only when it resolves to a current version and R2 key; otherwise the API reports unavailable and adds `MISSING_CURRENT_VERSION`. A failed refresh does not hide the last good version: it remains readable as degraded with `LATEST_ACQUISITION_FAILED_USING_CURRENT_VERSION`.
+
+Legacy `items.article_content_key` content remains readable. It is labeled `LEGACY` and `LEGACY_UNNORMALIZED` rather than being presented as equivalent to a verified versioned artifact. If a current version points to a missing R2 object but legacy HTML exists, the API serves the fallback as degraded and reports `CURRENT_ARTIFACT_MISSING_FALLBACK_LEGACY`.
+
+## Queue contract
+
+Messages carry an item ID, target extractor version, trigger, enqueue time, optional trace ID, and up to two source-first embedded candidates. Candidate JSON is capped at 80 KiB so the full job remains comfortably below the Cloudflare Queue message limit; an oversized candidate is omitted and public-page acquisition remains available. Invalid poison messages are acknowledged. Transient network, rate-limit, and server failures retry with bounded exponential delay; terminal extraction failures are acknowledged with an explicit unavailable reason. Exhausted messages are recorded in `article_body_dlq_events` and the item becomes unavailable with `QUEUE_RETRIES_EXHAUSTED`.
+
+The real processor loads canonical item metadata, runs the source-first/public fallback acquisition cascade, publishes immutable artifacts, and mirrors exact reading metrics onto the item. The dry-run-first `/admin/article-bodies/backfill` endpoint selects only canonical article items already accepted into at least one user's Zine. It never inserts `items` or `user_items`, so bounded cohorts cannot create historical inbox content or bypass latest-only source seeding.
+
+## Phase 2b activation checklist
+
+1. Keep `ARTICLE_BODY_PIPELINE_ENABLED=false` while deploying the code, queue configuration, and migration.
+2. Configure `ARTICLE_BODY_BACKFILL_SECRET` and call `POST /admin/article-bodies/backfill` with `{ "dryRun": true, "limit": 10 }`; manually inspect the returned canonical-item cohort.
+3. Confirm `/health/queues` is healthy and article-body pending, processing, unavailable, and DLQ counts are at their expected baseline.
+4. Enable `ARTICLE_BODY_PIPELINE_ENABLED` only for the environment being piloted. Automatic ingestion enrollment is not installed, so this switch alone does not create a broad cohort.
+5. Execute exactly one reviewed page with `{ "dryRun": false, "limit": 10 }`. Repeating the request is safe: pending/processing jobs and current extractor versions are skipped.
+6. Wait for terminal states, manually read beginning/middle/end from every produced artifact, and inspect degraded/unavailable reasons and DLQ counts.
+7. Disable the flag if the cohort misses the quality gate. Do not add automatic feed or bookmark enrollment until the staged cohort passes.
+
+## Manual verification checklist
+
+1. Apply migration `0024_add_article_body_foundation.sql` to an isolated local D1 database.
+2. Verify foreign keys, unique indexes, item-delete cascade, and DLQ item `SET NULL` behavior.
+3. Run the article-body artifact, storage, service, consumer, diagnostics, API, and OpenAPI tests.
+4. Confirm the feature flag is false and both queue consumers are configured in all environments.
+5. Verify the admin cohort is the only production enrollment caller; automatic ingestion, bookmark, and reader-open enrollment should remain absent.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:worktree": "./scripts/dev.sh",
     "data:prod:local": "bun run ./scripts/sync-prod-user-to-local.mjs",
     "data:people-names:prod": "bun run ./scripts/repair-prod-people-display-names.mjs",
+    "article-body:review": "bun run ./scripts/review-article-body-corpus.ts",
     "design-system:check": "node ./scripts/check-mobile-design-system.mjs",
     "storybook:mobile": "bun run --cwd apps/mobile storybook",
     "storybook:web": "bun run --cwd apps/web storybook",

--- a/scripts/fixtures/article-body-review-corpus.json
+++ b/scripts/fixtures/article-body-review-corpus.json
@@ -1,0 +1,95 @@
+{
+  "version": 1,
+  "cases": [
+    { "id": "feed-ajey-gore", "category": "feed", "url": "https://ajeygore.in/feed" },
+    { "id": "feed-sunil-pai", "category": "feed", "url": "https://sunilpai.dev/rss.xml" },
+    {
+      "id": "feed-mitchell-hashimoto",
+      "category": "feed",
+      "url": "https://mitchellh.com/feed.xml"
+    },
+    { "id": "feed-rands", "category": "feed", "url": "https://randsinrepose.com/rss" },
+    {
+      "id": "feed-simon-willison",
+      "category": "feed",
+      "url": "https://simonwillison.net/atom/everything"
+    },
+    {
+      "id": "feed-sean-goedecke",
+      "category": "feed",
+      "url": "https://www.seangoedecke.com/rss.xml"
+    },
+    {
+      "id": "feed-steve-yegge-medium",
+      "category": "feed",
+      "url": "https://steve-yegge.medium.com/feed"
+    },
+    { "id": "feed-steipete", "category": "feed", "url": "https://steipete.me/rss.xml" },
+    {
+      "id": "feed-armin-ronacher",
+      "category": "feed",
+      "url": "https://lucumr.pocoo.org/feed.atom"
+    },
+    { "id": "feed-boris-tane", "category": "feed", "url": "https://boristane.com/rss.xml" },
+    {
+      "id": "web-mitchell-simd",
+      "category": "web",
+      "url": "https://mitchellh.com/writing/everyone-should-know-simd",
+      "title": "Everyone Should Know SIMD"
+    },
+    {
+      "id": "web-sean-open-weight",
+      "category": "web",
+      "url": "https://seangoedecke.com/powerful-ais-might-escape-by-releasing-open-weight-models",
+      "title": "Powerful AIs might escape containment by releasing themselves as open-weight models"
+    },
+    {
+      "id": "web-sunil-document",
+      "category": "web",
+      "url": "https://sunilpai.dev/posts/one-document-two-hands",
+      "title": "one document, two hands"
+    },
+    {
+      "id": "web-simon-runaway-agent",
+      "category": "web",
+      "url": "https://simonwillison.net/2026/Jul/23/the-first-known-runaway-ai-agent",
+      "title": "The first known runaway AI agent or a very bad marketing stunt?"
+    },
+    {
+      "id": "substack-pragmatic-engineer",
+      "category": "substack",
+      "url": "https://pragmaticengineer.substack.com/p/pushing-software-engineering-limits",
+      "title": "Pushing software engineering limits with napkin math"
+    },
+    {
+      "id": "substack-john-cochrane",
+      "category": "substack",
+      "url": "https://johnhcochrane.substack.com/p/ai-regulation",
+      "title": "AI regulation"
+    },
+    {
+      "id": "substack-the-skip",
+      "category": "substack",
+      "url": "https://theskip.substack.com/p/inside-pm-at-stripe-what-comes-after",
+      "title": "Inside PM at Stripe: What Comes After Become a Builder?"
+    },
+    {
+      "id": "substack-tidy-first",
+      "category": "substack",
+      "url": "https://tidyfirst.substack.com/p/how-do-you-know-that",
+      "title": "How Do You Know That?"
+    },
+    {
+      "id": "substack-lenny-sabbatical",
+      "category": "substack",
+      "url": "https://lenny.substack.com/p/how-to-take-a-sabbatical",
+      "title": "Why a sabbatical can change everything"
+    },
+    {
+      "id": "substack-the-mack",
+      "category": "substack",
+      "url": "https://themack.substack.com/p/overthinking-hates-a-moving-target",
+      "title": "Overthinking hates a moving target"
+    }
+  ]
+}

--- a/scripts/review-article-body-corpus.ts
+++ b/scripts/review-article-body-corpus.ts
@@ -1,0 +1,223 @@
+import path from 'node:path';
+
+import {
+  acquireArticleBody,
+  type ArticleBodyAcquisitionResult,
+} from '../apps/worker/src/article-body/acquisition';
+import { parseRssFeedXml } from '../apps/worker/src/rss/parser';
+
+interface CorpusCase {
+  id: string;
+  category: 'feed' | 'web' | 'substack';
+  url: string;
+  title?: string;
+}
+
+interface CorpusFile {
+  version: number;
+  cases: CorpusCase[];
+}
+
+interface ReviewRow {
+  id: string;
+  category: CorpusCase['category'];
+  canonicalUrl: string;
+  title: string;
+  status: ArticleBodyAcquisitionResult['status'];
+  sourceKind: string | null;
+  qualityScore: number;
+  wordCount: number;
+  warnings: string[];
+  attempts: ArticleBodyAcquisitionResult['attempts'];
+  excerpt: string;
+  middleExcerpt: string;
+  endingExcerpt: string;
+  errorCode: string | null;
+}
+
+const DEFAULT_CORPUS = path.resolve('scripts/fixtures/article-body-review-corpus.json');
+const FETCH_TIMEOUT_MS = 20_000;
+
+function argumentValue(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? (process.argv[index + 1] ?? null) : null;
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: {
+      'User-Agent': 'ZineBodyReview/1.0 (+https://zine.app/bot)',
+      Accept: 'application/rss+xml,application/atom+xml,application/xml,text/xml,text/html',
+    },
+  });
+  if (!response.ok) throw new Error(`HTTP_${response.status}`);
+  return response.text();
+}
+
+function compactExcerpt(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, 240);
+}
+
+function excerptAt(value: string, ratio: number): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  if (compact.length <= 240) return compact;
+  const start = Math.max(0, Math.min(compact.length - 240, Math.floor(compact.length * ratio)));
+  return compact.slice(start, start + 240);
+}
+
+async function runCase(entry: CorpusCase): Promise<ReviewRow> {
+  try {
+    let canonicalUrl = entry.url;
+    let title = entry.title ?? entry.id;
+    let publisher: string | null = null;
+    let publishedAt: string | null = null;
+    let embeddedCandidates: Parameters<typeof acquireArticleBody>[0]['embeddedCandidates'];
+
+    if (entry.category === 'feed') {
+      const parsed = parseRssFeedXml(await fetchText(entry.url), entry.url);
+      const latest = parsed.entries[0];
+      if (!latest) throw new Error('FEED_EMPTY');
+      canonicalUrl = latest.canonicalUrl;
+      title = latest.title;
+      publisher = parsed.title ?? null;
+      publishedAt = latest.publishedAt ? new Date(latest.publishedAt).toISOString() : null;
+      embeddedCandidates = latest.articleBodyCandidate ? [latest.articleBodyCandidate] : [];
+    }
+
+    const result = await acquireArticleBody({
+      itemId: `review:${entry.id}`,
+      canonicalUrl,
+      title,
+      publisher,
+      publishedAt,
+      embeddedCandidates,
+    });
+
+    return {
+      id: entry.id,
+      category: entry.category,
+      canonicalUrl,
+      title,
+      status: result.status,
+      sourceKind: result.artifact?.sourceKind ?? null,
+      qualityScore: result.artifact?.qualityScore ?? 0,
+      wordCount: result.artifact?.wordCount ?? 0,
+      warnings: result.artifact?.qualityWarnings ?? [],
+      attempts: result.attempts,
+      excerpt: compactExcerpt(result.artifact?.plainText ?? ''),
+      middleExcerpt: excerptAt(result.artifact?.plainText ?? '', 0.5),
+      endingExcerpt: excerptAt(result.artifact?.plainText ?? '', 1),
+      errorCode: result.errorCode,
+    };
+  } catch (error) {
+    return {
+      id: entry.id,
+      category: entry.category,
+      canonicalUrl: entry.url,
+      title: entry.title ?? entry.id,
+      status: 'UNAVAILABLE',
+      sourceKind: null,
+      qualityScore: 0,
+      wordCount: 0,
+      warnings: [],
+      attempts: [],
+      excerpt: '',
+      middleExcerpt: '',
+      endingExcerpt: '',
+      errorCode: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  operation: (value: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let cursor = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (cursor < values.length) {
+        const index = cursor++;
+        results[index] = await operation(values[index]);
+      }
+    })
+  );
+  return results;
+}
+
+function markdownReport(report: {
+  generatedAt: string;
+  corpusVersion: number;
+  summary: Record<string, number | boolean>;
+  rows: ReviewRow[];
+}): string {
+  const lines = [
+    '# Article-body extraction review',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Corpus: ${report.summary.total} cases · available ${report.summary.available} · degraded ${report.summary.degraded} · unavailable ${report.summary.unavailable}`,
+    '',
+    `Availability: ${report.summary.availabilityPercent}% · high-quality among available: ${report.summary.highQualityPercent}% · automated gate: ${report.summary.meetsAutomatedGate ? 'PASS' : 'FAIL'}`,
+    '',
+    '| Case | Category | Result | Source | Score | Words | Warnings |',
+    '| --- | --- | --- | --- | ---: | ---: | --- |',
+  ];
+
+  for (const row of report.rows) {
+    lines.push(
+      `| ${row.id} | ${row.category} | ${row.status} | ${row.sourceKind ?? '—'} | ${row.qualityScore.toFixed(2)} | ${row.wordCount} | ${row.warnings.join(', ') || '—'} |`
+    );
+  }
+  lines.push('', '## Manual reading samples', '');
+  for (const row of report.rows) {
+    lines.push(`### ${row.id}`, '', `[Original](${row.canonicalUrl})`, '');
+    if (!row.excerpt) {
+      lines.push(`No body available (${row.errorCode ?? 'unknown error'}).`, '');
+      continue;
+    }
+    lines.push(`Start: ${row.excerpt}`, '', `Middle: ${row.middleExcerpt}`, '');
+    lines.push(`End: ${row.endingExcerpt}`, '');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+const corpusPath = path.resolve(argumentValue('--corpus') ?? DEFAULT_CORPUS);
+const corpus = (await Bun.file(corpusPath).json()) as CorpusFile;
+const rows = await mapWithConcurrency(corpus.cases, 4, runCase);
+const available = rows.filter((row) => row.status === 'AVAILABLE').length;
+const degraded = rows.filter((row) => row.status === 'DEGRADED').length;
+const unavailable = rows.length - available - degraded;
+const availableBodies = available + degraded;
+const availabilityPercent = Number(((availableBodies / rows.length) * 100).toFixed(1));
+const highQualityPercent = Number(
+  ((availableBodies === 0 ? 0 : available / availableBodies) * 100).toFixed(1)
+);
+const report = {
+  generatedAt: new Date().toISOString(),
+  corpusVersion: corpus.version,
+  summary: {
+    total: rows.length,
+    available,
+    degraded,
+    unavailable,
+    availabilityPercent,
+    highQualityPercent,
+    meetsAutomatedGate: availabilityPercent >= 90 && highQualityPercent >= 95,
+  },
+  rows,
+};
+
+const timestamp = report.generatedAt.replace(/[:.]/g, '-');
+const outputDirectory = path.resolve('.local-data/article-body/reviews');
+const jsonPath = path.join(outputDirectory, `${timestamp}.json`);
+const markdownPath = path.join(outputDirectory, `${timestamp}.md`);
+await Bun.write(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+await Bun.write(markdownPath, markdownReport(report));
+
+console.log(JSON.stringify({ summary: report.summary, jsonPath, markdownPath }, null, 2));
+
+if (!report.summary.meetsAutomatedGate) process.exitCode = 1;


### PR DESCRIPTION
## Summary

- add durable article-body lifecycle state in D1 with immutable, versioned R2 artifacts and truthful API/health reporting
- implement source-first acquisition with safe public-page fallback, normalization, sanitization, quality scoring, bounded retries, and DLQ auditing
- add a protected dry-run-first cohort backfill, embedded feed candidates, review-corpus tooling, and stable Substack share-URL normalization
- keep automatic enrollment absent and the production pipeline disabled after the bounded rollout

## Validation

- `bun run test:worker:ci` — 82 files, 1,644 tests passed
- pre-push gate — format, design-system, typecheck, 75 web tests, and 1,644 worker tests passed
- production cohort — 9 available, 1 explicit `NOT_READERABLE`, 0 degraded, 0 DLQ, and 0 queue backlog after review
- manually reviewed the beginning, middle, and end of all 9 available production artifacts
- authenticated production API readback confirmed versioned content plus availability, provenance, and quality metadata
- production health readback confirmed the article-body queues are configured and `ARTICLE_BODY_PIPELINE_ENABLED=false`

## Rollout notes

- migration `0024_add_article_body_foundation.sql` is already applied in production
- production queues and the protected backfill secret are configured
- the feature remains cohort-only; this PR does not add automatic ingestion, bookmark, or reader-open enrollment
