### PR TITLE
feat: add native article reader beta

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -55,7 +55,8 @@ private struct AuthenticatedAppView: View {
                     throw APIError.missingSession
                 }
                 return token
-            }
+            },
+            articleBodyCache: ArticleBodyCache(userID: userID)
         )
         editorialCache = EditorialIssueCache(userID: userID)
         homeCache = HomeCache(userID: userID)

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -62,6 +62,10 @@ struct ZineNativeApp: App {
 #if DEBUG
         if ProcessInfo.processInfo.arguments.contains("-screenshot-bookmark-detail-fixture") {
             ScreenshotBookmarkDetailView()
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-article-reader-fixture") {
+            ScreenshotArticleReaderView(unavailable: false)
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-article-reader-unavailable-fixture") {
+            ScreenshotArticleReaderView(unavailable: true)
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-today-story-fixture") {
             ScreenshotTodayStoryView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-today-fixtures") {

--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -33,7 +33,20 @@ struct APIClient {
 
     let baseURL: URL
     let tokenProvider: TokenProvider
-    var session: URLSession = .shared
+    var session: URLSession
+    private let articleBodyCache: ArticleBodyCache?
+
+    init(
+        baseURL: URL,
+        tokenProvider: @escaping TokenProvider,
+        session: URLSession = .shared,
+        articleBodyCache: ArticleBodyCache? = nil
+    ) {
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
+        self.session = session
+        self.articleBodyCache = articleBodyCache
+    }
 
     func getHome() async throws -> HomeResponse {
         try await request(url: baseURL.appending(path: "/api/v1/home"))
@@ -276,6 +289,39 @@ struct APIClient {
         let _: EmptyResponse = try await send(request)
     }
 
+    func getArticleContent(id: String) async throws -> ArticleContentResponse {
+        try await request(
+            url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/article-content")
+        )
+    }
+
+    func requestArticleContent(id: String) async throws -> ArticleContentResponse {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/article-content")
+        )
+        request.httpMethod = "POST"
+        return try await send(request)
+    }
+
+    func updateProgress(id: String, fraction: Double) async throws {
+        let clamped = min(max(fraction, 0), 1)
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/progress"))
+        request.httpMethod = "PUT"
+        request.httpBody = try JSONEncoder().encode(
+            ReadingProgressRequest(position: clamped, duration: 1)
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
+    func cachedArticleContent(id: String) async -> ArticleContentResponse? {
+        await articleBodyCache?.load(bookmarkID: id)
+    }
+
+    func cacheArticleContent(_ response: ArticleContentResponse, id: String) async {
+        await articleBodyCache?.save(response, bookmarkID: id)
+    }
+
     func listSubscriptionSources() async throws -> SubscriptionsHubResponse {
         try await request(url: baseURL.appending(path: "/api/v1/subscriptions"))
     }
@@ -507,6 +553,11 @@ private struct AddProviderSubscriptionRequest: Encodable {
     let channelId: String
     let name: String
     let imageUrl: String?
+}
+
+private struct ReadingProgressRequest: Encodable {
+    let position: Double
+    let duration: Double
 }
 
 private struct RegisterOAuthStateRequest: Encodable {

--- a/apps/ios/ZineNative/Core/Models/ArticleBody.swift
+++ b/apps/ios/ZineNative/Core/Models/ArticleBody.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum ArticleBodyAvailability: String, Codable {
+    case pending = "PENDING"
+    case available = "AVAILABLE"
+    case degraded = "DEGRADED"
+    case unavailable = "UNAVAILABLE"
+}
+
+enum ArticleBodyPipelineStatus: String, Codable {
+    case notRequested = "NOT_REQUESTED"
+    case legacy = "LEGACY"
+    case pending = "PENDING"
+    case processing = "PROCESSING"
+    case available = "AVAILABLE"
+    case degraded = "DEGRADED"
+    case unavailable = "UNAVAILABLE"
+}
+
+struct ArticleBodyStatus: Codable, Equatable {
+    let availability: ArticleBodyAvailability
+    let pipelineStatus: ArticleBodyPipelineStatus
+    let schemaVersion: Int?
+    let extractorVersion: Int?
+    let sourceKind: String?
+    let contentHash: String?
+    let wordCount: Int?
+    let readingTimeMinutes: Int?
+    let qualityScore: Double?
+    let qualityWarnings: [String]
+    let lastErrorCode: String?
+    let updatedAt: String?
+
+    var isReadable: Bool {
+        availability == .available || availability == .degraded
+    }
+
+    var isPreparing: Bool {
+        availability == .pending || pipelineStatus == .pending || pipelineStatus == .processing
+    }
+}
+
+struct ArticleContentRequestResult: Codable, Equatable {
+    let queued: Bool
+    let reason: String?
+}
+
+struct ArticleContentResponse: Codable, Equatable {
+    let content: String?
+    let articleBody: ArticleBodyStatus
+    let request: ArticleContentRequestResult?
+    let requestId: String?
+    let traceId: String?
+
+    var readableContent: String? {
+        guard articleBody.isReadable,
+              let content,
+              !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return content
+    }
+}
+
+struct ArticleReaderMetadata: Equatable {
+    let bookmarkID: String
+    let title: String
+    let creator: String
+    let canonicalURL: URL
+    let readingTimeMinutes: Int?
+    let initialProgress: BookmarkProgress?
+    let isFinished: Bool
+}
+
+struct ArticleReaderDocument: Equatable {
+    let metadata: ArticleReaderMetadata
+    let response: ArticleContentResponse
+
+    var contentHash: String {
+        response.articleBody.contentHash ?? "legacy:\(metadata.bookmarkID)"
+    }
+
+    var isDegraded: Bool {
+        response.articleBody.availability == .degraded
+    }
+}

--- a/apps/ios/ZineNative/Core/Models/Bookmark.swift
+++ b/apps/ios/ZineNative/Core/Models/Bookmark.swift
@@ -76,7 +76,7 @@ struct Bookmark: Codable, Hashable, Identifiable {
     let ingestedAt: String
     let bookmarkedAt: String?
     let lastOpenedAt: String?
-    let progress: BookmarkProgress?
+    var progress: BookmarkProgress?
     var isFinished: Bool
     var finishedAt: String?
     let tags: [BookmarkTag]

--- a/apps/ios/ZineNative/Core/Persistence/ArticleBodyCache.swift
+++ b/apps/ios/ZineNative/Core/Persistence/ArticleBodyCache.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+private struct CachedArticleBody: Codable {
+    let response: ArticleContentResponse
+    let savedAt: Date
+}
+
+actor ArticleBodyCache {
+    private static let maximumDocuments = 50
+
+    private let fileURL: URL
+    private var documents: [String: CachedArticleBody]?
+
+    init(userID: String, baseDirectory: URL? = nil) {
+        let root = baseDirectory ?? FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        let safeUserID = userID.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+            ?? "unknown-user"
+        fileURL = root
+            .appending(path: "ZineNative/Articles", directoryHint: .isDirectory)
+            .appending(path: "\(safeUserID).json")
+    }
+
+    func load(bookmarkID: String) -> ArticleContentResponse? {
+        loadDocumentsIfNeeded()
+        return documents?[bookmarkID]?.response
+    }
+
+    func save(_ response: ArticleContentResponse, bookmarkID: String) {
+        guard response.readableContent != nil else { return }
+        loadDocumentsIfNeeded()
+        documents?[bookmarkID] = CachedArticleBody(response: response, savedAt: Date())
+        pruneDocuments()
+        persistDocuments()
+    }
+
+    private func loadDocumentsIfNeeded() {
+        guard documents == nil else { return }
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: CachedArticleBody].self, from: data)
+        else {
+            documents = [:]
+            return
+        }
+        documents = decoded
+    }
+
+    private func pruneDocuments() {
+        guard let documents, documents.count > Self.maximumDocuments else { return }
+        let retainedKeys = documents
+            .sorted { $0.value.savedAt > $1.value.savedAt }
+            .prefix(Self.maximumDocuments)
+            .map(\.key)
+        self.documents = documents.filter { retainedKeys.contains($0.key) }
+    }
+
+    private func persistDocuments() {
+        guard let documents,
+              let data = try? JSONEncoder().encode(documents)
+        else { return }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: [.atomic, .completeFileProtection])
+        } catch {
+            // The cache is an optimization; the authenticated API remains the source of truth.
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -16,9 +16,12 @@ struct BookmarkDetailContent: Equatable {
     let creator: String
     let creatorImageUrl: URL?
     let creatorId: String?
+    let publisher: String?
     let summary: String?
     let duration: Int?
     let readingTimeMinutes: Int?
+    let progress: BookmarkProgress?
+    let isFinished: Bool
     let tags: [BookmarkTag]
 
     init(bookmark: Bookmark) {
@@ -31,9 +34,12 @@ struct BookmarkDetailContent: Equatable {
         creator = bookmark.creator
         creatorImageUrl = bookmark.creatorImageUrl
         creatorId = bookmark.creatorId
+        publisher = bookmark.publisher
         summary = bookmark.summary
         duration = bookmark.duration
         readingTimeMinutes = bookmark.readingTimeMinutes
+        progress = bookmark.progress
+        isFinished = bookmark.isFinished
         tags = bookmark.tags
     }
 
@@ -47,9 +53,12 @@ struct BookmarkDetailContent: Equatable {
         creator = item.creator
         creatorImageUrl = item.creatorImageUrl
         creatorId = item.creatorId
+        publisher = item.publisher
         summary = item.summary
         duration = item.duration
         readingTimeMinutes = item.readingTimeMinutes
+        progress = item.progress
+        isFinished = false
         tags = []
     }
 
@@ -74,9 +83,12 @@ struct BookmarkDetailContent: Equatable {
         self.creator = creator
         creatorImageUrl = nil
         creatorId = nil
+        publisher = source.publisher
         summary = presentation?.excerpt
         duration = nil
         readingTimeMinutes = nil
+        progress = nil
+        isFinished = false
         tags = []
     }
 
@@ -274,12 +286,43 @@ struct BookmarkDetailView: View {
 
             Spacer(minLength: 0)
 
-            ProviderOpenButton(
-                provider: content.provider,
-                destination: content.canonicalUrl,
-                onOpen: { onExternalOpen(bookmark) }
-            )
+            if content.contentType == .article {
+                NavigationLink {
+                    ArticleReaderView(
+                        metadata: ArticleReaderMetadata(
+                            bookmarkID: content.id,
+                            title: content.title,
+                            creator: content.creator,
+                            canonicalURL: content.canonicalUrl,
+                            readingTimeMinutes: content.readingTimeMinutes,
+                            initialProgress: content.progress,
+                            isFinished: content.isFinished
+                        ),
+                        client: client,
+                        onRead: { onExternalOpen(bookmark) },
+                        onProgressSaved: updateReadingProgress,
+                        onFinishedChanged: updateFinishedState
+                    )
+                } label: {
+                    Label("Read", systemImage: "book.pages")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 18)
+                        .frame(minHeight: 48)
+                        .background(Color.accentColor, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Read in Zine")
+                .actionRowHaptic()
                 .padding(.trailing, 8)
+            } else {
+                ProviderOpenButton(
+                    provider: content.provider,
+                    destination: content.canonicalUrl,
+                    onOpen: { onExternalOpen(bookmark) }
+                )
+                    .padding(.trailing, 8)
+            }
         }
     }
 
@@ -599,5 +642,20 @@ struct BookmarkDetailView: View {
             onBookmarkChange(bookmark, previousValue, .rollback)
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func updateReadingProgress(_ progress: BookmarkProgress) {
+        guard var bookmark else { return }
+        bookmark.progress = progress
+        self.bookmark = bookmark
+        onUpdate(bookmark)
+    }
+
+    private func updateFinishedState(_ isFinished: Bool) {
+        guard var bookmark else { return }
+        bookmark.isFinished = isFinished
+        bookmark.finishedAt = isFinished ? Date().formatted(.iso8601) : nil
+        self.bookmark = bookmark
+        onUpdate(bookmark)
     }
 }

--- a/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import WebKit
+
+enum ArticleHTMLDocumentBuilder {
+    static func makeHTML(for document: ArticleReaderDocument) -> String {
+        let metadata = document.metadata
+        let readingTime = metadata.readingTimeMinutes.map { "\($0) min read" }
+        let meta = [metadata.creator, readingTime]
+            .compactMap { $0 }
+            .map(escape)
+            .joined(separator: " · ")
+        let body = document.response.readableContent ?? ""
+
+        return """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https: http: data:; style-src 'unsafe-inline'; script-src 'none'; connect-src 'none'; frame-src 'none'; media-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+          <style>
+            :root { color-scheme: light dark; }
+            * { box-sizing: border-box; }
+            html { -webkit-text-size-adjust: 100%; }
+            body {
+              margin: 0 auto;
+              max-width: 760px;
+              padding: 32px 22px 96px;
+              background: #ffffff;
+              color: #1c1c1e;
+              font: -apple-system-body;
+              line-height: 1.66;
+              overflow-wrap: anywhere;
+            }
+            header { margin: 6px 0 34px; }
+            h1 {
+              margin: 0 0 12px;
+              font: -apple-system-title1;
+              font-weight: 750;
+              line-height: 1.12;
+              letter-spacing: -0.02em;
+            }
+            .meta {
+              color: #636366;
+              font: -apple-system-subheadline;
+              line-height: 1.4;
+            }
+            main > :first-child { margin-top: 0; }
+            p, ul, ol, blockquote, pre, figure { margin: 0 0 1.25em; }
+            h2, h3, h4 {
+              margin: 1.7em 0 0.65em;
+              line-height: 1.2;
+              letter-spacing: -0.012em;
+            }
+            h2 { font: -apple-system-title2; font-weight: 700; }
+            h3 { font: -apple-system-title3; font-weight: 700; }
+            h4 { font: -apple-system-headline; }
+            ul, ol { padding-left: 1.4em; }
+            li { margin-bottom: 0.45em; }
+            img, video {
+              display: block;
+              width: auto;
+              max-width: 100%;
+              height: auto;
+              margin: 1.6em auto;
+              border-radius: 12px;
+            }
+            figure { margin-left: 0; margin-right: 0; }
+            figcaption {
+              margin-top: -0.8em;
+              color: #6e6e73;
+              font-size: 14px;
+              line-height: 1.45;
+              text-align: center;
+            }
+            blockquote {
+              margin-left: 0;
+              padding-left: 18px;
+              border-left: 3px solid #c7c7cc;
+              color: #48484a;
+            }
+            pre, code {
+              font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+              font-size: 0.88em;
+            }
+            pre {
+              padding: 15px;
+              overflow-x: auto;
+              white-space: pre-wrap;
+              background: #f2f2f7;
+              border-radius: 12px;
+            }
+            a { color: #0066cc; text-decoration-thickness: 0.08em; }
+            hr { border: 0; border-top: 1px solid #d1d1d6; margin: 2em 0; }
+            @media (prefers-color-scheme: dark) {
+              body { background: #000000; color: #f2f2f7; }
+              .meta, figcaption { color: #a1a1a6; }
+              blockquote { color: #d1d1d6; border-left-color: #636366; }
+              pre { background: #1c1c1e; }
+              a { color: #64a8ff; }
+              hr { border-top-color: #38383a; }
+            }
+            @media (max-width: 420px) {
+              body { padding-left: 20px; padding-right: 20px; }
+            }
+          </style>
+        </head>
+        <body>
+          <header>
+            <h1>\(escape(metadata.title))</h1>
+            <div class="meta">\(meta)</div>
+          </header>
+          <main>\(body)</main>
+        </body>
+        </html>
+        """
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}
+
+struct ArticleHTMLView: UIViewRepresentable {
+    let document: ArticleReaderDocument
+    let initialProgress: Double
+    let onProgressChanged: (Double) -> Void
+    let onOpenURL: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            initialProgress: initialProgress,
+            onProgressChanged: onProgressChanged,
+            onOpenURL: onOpenURL
+        )
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = false
+        preferences.preferredContentMode = .mobile
+        configuration.defaultWebpagePreferences = preferences
+        configuration.websiteDataStore = .nonPersistent()
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.scrollView.delegate = context.coordinator
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.scrollView.keyboardDismissMode = .interactive
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        context.coordinator.load(document, in: webView)
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard context.coordinator.loadedContentHash != document.contentHash else { return }
+        context.coordinator.load(document, in: webView)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate {
+        private let initialProgress: Double
+        private let onProgressChanged: (Double) -> Void
+        private let onOpenURL: (URL) -> Void
+        private var isRestoringProgress = false
+        fileprivate var loadedContentHash: String?
+
+        init(
+            initialProgress: Double,
+            onProgressChanged: @escaping (Double) -> Void,
+            onOpenURL: @escaping (URL) -> Void
+        ) {
+            self.initialProgress = min(max(initialProgress, 0), 1)
+            self.onProgressChanged = onProgressChanged
+            self.onOpenURL = onOpenURL
+        }
+
+        func load(_ document: ArticleReaderDocument, in webView: WKWebView) {
+            loadedContentHash = document.contentHash
+            webView.loadHTMLString(
+                ArticleHTMLDocumentBuilder.makeHTML(for: document),
+                baseURL: document.metadata.canonicalURL
+            )
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+            guard initialProgress > 0 else { return }
+            isRestoringProgress = true
+            DispatchQueue.main.async { [weak self, weak webView] in
+                guard let self, let webView else { return }
+                let scrollView = webView.scrollView
+                let maximumOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 0)
+                scrollView.setContentOffset(
+                    CGPoint(x: 0, y: maximumOffset * initialProgress),
+                    animated: false
+                )
+                isRestoringProgress = false
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard navigationAction.navigationType == .linkActivated,
+                  let url = navigationAction.request.url
+            else {
+                decisionHandler(.allow)
+                return
+            }
+            decisionHandler(.cancel)
+            onOpenURL(url)
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            guard !isRestoringProgress else { return }
+            let maximumOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 1)
+            let fraction = min(max(scrollView.contentOffset.y / maximumOffset, 0), 1)
+            onProgressChanged(fraction)
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
@@ -117,6 +117,7 @@ final class ArticleReaderStore {
         let delays: [Duration] = [
             .seconds(1), .seconds(1), .seconds(2), .seconds(2),
             .seconds(3), .seconds(3), .seconds(4), .seconds(4),
+            .seconds(5), .seconds(5), .seconds(5), .seconds(5), .seconds(5),
         ]
 
         for delay in delays {

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Observation
+
+enum ArticleReaderPhase: Equatable {
+    case loading
+    case preparing
+    case ready(ArticleReaderDocument)
+    case unavailable(String)
+    case failed(String)
+}
+
+@MainActor
+@Observable
+final class ArticleReaderStore {
+    private(set) var phase: ArticleReaderPhase
+    private(set) var isFinished: Bool
+
+    let metadata: ArticleReaderMetadata
+    let initialProgressFraction: Double
+
+    private let client: APIClient
+    private var loadGeneration = 0
+
+    init(
+        metadata: ArticleReaderMetadata,
+        client: APIClient,
+        initialPhase: ArticleReaderPhase = .loading
+    ) {
+        self.metadata = metadata
+        self.client = client
+        phase = initialPhase
+        isFinished = metadata.isFinished
+        initialProgressFraction = min(
+            max((metadata.initialProgress?.percent ?? 0) / 100, 0),
+            1
+        )
+    }
+
+    var readyDocument: ArticleReaderDocument? {
+        guard case let .ready(document) = phase else { return nil }
+        return document
+    }
+
+    func load() async {
+        loadGeneration += 1
+        let generation = loadGeneration
+        var hasReadableCache = false
+
+        if let cached = await client.cachedArticleContent(id: metadata.bookmarkID),
+           cached.readableContent != nil
+        {
+            phase = .ready(ArticleReaderDocument(metadata: metadata, response: cached))
+            hasReadableCache = true
+        } else {
+            phase = .loading
+        }
+
+        do {
+            let current = try await client.getArticleContent(id: metadata.bookmarkID)
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            if await acceptIfReadable(current) { return }
+
+            phase = .preparing
+            let requested = try await client.requestArticleContent(id: metadata.bookmarkID)
+            guard !Task.isCancelled, generation == loadGeneration else { return }
+            if await acceptIfReadable(requested) { return }
+
+            if requested.articleBody.isPreparing || requested.request?.queued == true {
+                await pollUntilTerminal(generation: generation)
+            } else {
+                phase = .unavailable(Self.unavailableMessage(for: requested.articleBody))
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !hasReadableCache, generation == loadGeneration else { return }
+            phase = .failed("Zine couldn’t load this article. Check your connection and try again.")
+        }
+    }
+
+    func persistProgress(_ fraction: Double) async -> BookmarkProgress? {
+        let clamped = min(max(fraction, 0), 1)
+        do {
+            try await client.updateProgress(id: metadata.bookmarkID, fraction: clamped)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            do {
+                try await Task.sleep(for: .milliseconds(500))
+                try await client.updateProgress(id: metadata.bookmarkID, fraction: clamped)
+            } catch {
+                return nil
+            }
+        }
+
+        return BookmarkProgress(
+            position: clamped,
+            duration: 1,
+            percent: clamped * 100
+        )
+    }
+
+    func toggleFinished() async -> Bool? {
+        do {
+            let result = try await client.setFinished(
+                id: metadata.bookmarkID,
+                isFinished: !isFinished
+            )
+            isFinished = result.isFinished
+            return result.isFinished
+        } catch {
+            return nil
+        }
+    }
+
+    private func pollUntilTerminal(generation: Int) async {
+        let delays: [Duration] = [
+            .seconds(1), .seconds(1), .seconds(2), .seconds(2),
+            .seconds(3), .seconds(3), .seconds(4), .seconds(4),
+        ]
+
+        for delay in delays {
+            do {
+                try await Task.sleep(for: delay)
+                guard !Task.isCancelled, generation == loadGeneration else { return }
+                let response = try await client.getArticleContent(id: metadata.bookmarkID)
+                guard !Task.isCancelled, generation == loadGeneration else { return }
+                if await acceptIfReadable(response) { return }
+                if !response.articleBody.isPreparing {
+                    phase = .unavailable(Self.unavailableMessage(for: response.articleBody))
+                    return
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                // A later poll may still succeed; preserve the preparation state.
+            }
+        }
+
+        guard generation == loadGeneration else { return }
+        phase = .failed("This article is taking longer than expected. You can try again or open the original.")
+    }
+
+    private func acceptIfReadable(_ response: ArticleContentResponse) async -> Bool {
+        guard response.readableContent != nil else { return false }
+        await client.cacheArticleContent(response, id: metadata.bookmarkID)
+        phase = .ready(ArticleReaderDocument(metadata: metadata, response: response))
+        return true
+    }
+
+    private static func unavailableMessage(for status: ArticleBodyStatus) -> String {
+        switch status.lastErrorCode {
+        case "NOT_READERABLE", "QUALITY_REJECTED", "NO_ACCEPTABLE_BODY":
+            "This page doesn’t contain a dependable article body, so Zine won’t show an incomplete version."
+        case "ITEM_NOT_ELIGIBLE":
+            "This item isn’t an article that Zine can display in the reader."
+        default:
+            "Zine can’t display this article reliably yet."
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+struct ArticleReaderView: View {
+    @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    @State private var store: ArticleReaderStore
+    @State private var scrollProgress: Double
+    @State private var lastPersistedProgress: Double
+    @State private var hasRecordedOpen = false
+    @State private var isUpdatingFinished = false
+
+    private let onRead: () -> Void
+    private let onProgressSaved: (BookmarkProgress) -> Void
+    private let onFinishedChanged: (Bool) -> Void
+    private let loadsOnAppear: Bool
+
+    init(
+        metadata: ArticleReaderMetadata,
+        client: APIClient,
+        initialPhase: ArticleReaderPhase = .loading,
+        loadsOnAppear: Bool = true,
+        onRead: @escaping () -> Void = {},
+        onProgressSaved: @escaping (BookmarkProgress) -> Void = { _ in },
+        onFinishedChanged: @escaping (Bool) -> Void = { _ in }
+    ) {
+        let initialProgress = min(max((metadata.initialProgress?.percent ?? 0) / 100, 0), 1)
+        _store = State(
+            initialValue: ArticleReaderStore(
+                metadata: metadata,
+                client: client,
+                initialPhase: initialPhase
+            )
+        )
+        _scrollProgress = State(initialValue: initialProgress)
+        _lastPersistedProgress = State(initialValue: initialProgress)
+        self.onRead = onRead
+        self.onProgressSaved = onProgressSaved
+        self.onFinishedChanged = onFinishedChanged
+        self.loadsOnAppear = loadsOnAppear
+    }
+
+    var body: some View {
+        ZStack {
+            Color(uiColor: .systemBackground)
+                .ignoresSafeArea()
+
+            phaseContent
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(dynamicTypeSize.isAccessibilitySize ? "" : "Reader")
+        .toolbar { readerToolbar }
+        .task(id: store.metadata.bookmarkID) {
+            guard loadsOnAppear else { return }
+            await store.load()
+        }
+        .task(id: progressWriteKey) {
+            guard store.readyDocument != nil,
+                  scrollProgress > 0,
+                  abs(scrollProgress - lastPersistedProgress) >= 0.01
+            else { return }
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+            await persistProgress()
+        }
+        .onChange(of: store.readyDocument?.contentHash, initial: true) { _, hash in
+            guard hash != nil else { return }
+            recordOpenIfNeeded()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase != .active else { return }
+            flushProgress()
+        }
+        .onDisappear {
+            flushProgress()
+        }
+    }
+
+    @ViewBuilder
+    private var phaseContent: some View {
+        switch store.phase {
+        case .loading:
+            loadingView(label: "Loading article…")
+        case .preparing:
+            loadingView(label: "Getting the article ready…")
+        case let .ready(document):
+            reader(document)
+        case let .unavailable(message):
+            unavailableView(message: message, retryable: false)
+        case let .failed(message):
+            unavailableView(message: message, retryable: true)
+        }
+    }
+
+    private func loadingView(label: String) -> some View {
+        VStack(spacing: 18) {
+            ProgressView()
+                .controlSize(.large)
+            Text(label)
+                .font(.headline)
+            Button("Open Original") {
+                openOriginal()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(24)
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private func reader(_ document: ArticleReaderDocument) -> some View {
+        VStack(spacing: 0) {
+            if document.isDegraded {
+                degradedNotice
+            }
+
+            ArticleHTMLView(
+                document: document,
+                initialProgress: store.initialProgressFraction,
+                onProgressChanged: { scrollProgress = $0 },
+                onOpenURL: { openURL($0) }
+            )
+            .accessibilityIdentifier("article-reader-content")
+        }
+    }
+
+    private var degradedNotice: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text("This article may be incomplete.")
+                .font(.subheadline.weight(.medium))
+            Spacer(minLength: 8)
+            Button("View Original") {
+                openOriginal()
+            }
+            .font(.subheadline.weight(.semibold))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.orange.opacity(0.1))
+    }
+
+    private func unavailableView(message: String, retryable: Bool) -> some View {
+        ContentUnavailableView {
+            Label("Reader unavailable", systemImage: "doc.text.magnifyingglass")
+        } description: {
+            Text(message)
+        } actions: {
+            if retryable {
+                Button("Try Again") {
+                    Task { await store.load() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            Button("Open Original") {
+                openOriginal()
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var readerToolbar: some ToolbarContent {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            ShareLink(item: store.metadata.canonicalURL) {
+                Image(systemName: "square.and.arrow.up")
+            }
+            .accessibilityLabel("Share article")
+
+            Button {
+                openOriginal()
+            } label: {
+                Image(systemName: "safari")
+            }
+            .accessibilityLabel("Open original article")
+
+            Button {
+                Task { await toggleFinished() }
+            } label: {
+                Image(systemName: store.isFinished ? "checkmark.circle.fill" : "checkmark.circle")
+                    .foregroundStyle(store.isFinished ? .green : .primary)
+            }
+            .disabled(isUpdatingFinished)
+            .accessibilityLabel(store.isFinished ? "Mark unfinished" : "Mark finished")
+        }
+    }
+
+    private var progressWriteKey: Int {
+        Int((scrollProgress * 100).rounded(.down))
+    }
+
+    private func recordOpenIfNeeded() {
+        guard !hasRecordedOpen else { return }
+        hasRecordedOpen = true
+        onRead()
+    }
+
+    private func openOriginal() {
+        recordOpenIfNeeded()
+        openURL(store.metadata.canonicalURL)
+    }
+
+    private func persistProgress() async {
+        guard let progress = await store.persistProgress(scrollProgress) else { return }
+        lastPersistedProgress = scrollProgress
+        onProgressSaved(progress)
+    }
+
+    private func flushProgress() {
+        guard store.readyDocument != nil,
+              scrollProgress > 0,
+              abs(scrollProgress - lastPersistedProgress) >= 0.005
+        else { return }
+        let progress = scrollProgress
+        Task {
+            guard let saved = await store.persistProgress(progress) else { return }
+            await MainActor.run {
+                lastPersistedProgress = progress
+                onProgressSaved(saved)
+            }
+        }
+    }
+
+    private func toggleFinished() async {
+        guard !isUpdatingFinished else { return }
+        isUpdatingFinished = true
+        defer { isUpdatingFinished = false }
+        guard let value = await store.toggleFinished() else { return }
+        onFinishedChanged(value)
+    }
+}

--- a/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct ScreenshotArticleReaderView: View {
+    let unavailable: Bool
+
+    private let metadata = ArticleReaderMetadata(
+        bookmarkID: "fixture-reader",
+        title: "Designing Calm Software in a Noisy World",
+        creator: "Mina Park",
+        canonicalURL: URL(string: "https://example.com/calm-software")!,
+        readingTimeMinutes: 7,
+        initialProgress: BookmarkProgress(position: 0.18, duration: 1, percent: 18),
+        isFinished: false
+    )
+
+    private let client = APIClient(
+        baseURL: URL(string: "https://api.myzine.app")!,
+        tokenProvider: { "fixture-token" }
+    )
+
+    var body: some View {
+        NavigationStack {
+            ArticleReaderView(
+                metadata: metadata,
+                client: client,
+                initialPhase: unavailable ? .unavailable(
+                    "This page doesn’t contain a dependable article body, so Zine won’t show an incomplete version."
+                ) : .ready(document),
+                loadsOnAppear: false
+            )
+        }
+    }
+
+    private var document: ArticleReaderDocument {
+        ArticleReaderDocument(
+            metadata: metadata,
+            response: ArticleContentResponse(
+                content: """
+                <p>Good reading software should feel less like another feed and more like a quiet room.</p>
+                <h2>Start with the reader’s intent</h2>
+                <p>The interface can recede when hierarchy, spacing, and typography do their jobs. A calm product does not remove useful controls; it places them where they are needed and nowhere else.</p>
+                <blockquote><p>Clarity is not the absence of detail. It is detail arranged around a purpose.</p></blockquote>
+                <p>That principle applies to the system behind the page too. Reliable state, explicit failure, and a safe path back to the original source make the reading surface trustworthy.</p>
+                """,
+                articleBody: ArticleBodyStatus(
+                    availability: .available,
+                    pipelineStatus: .available,
+                    schemaVersion: 1,
+                    extractorVersion: 1,
+                    sourceKind: "PUBLIC_WEB",
+                    contentHash: "fixture-content-hash",
+                    wordCount: 1460,
+                    readingTimeMinutes: 7,
+                    qualityScore: 0.98,
+                    qualityWarnings: [],
+                    lastErrorCode: nil,
+                    updatedAt: "2026-07-24T12:00:00Z"
+                ),
+                request: nil,
+                requestId: "fixture-request",
+                traceId: "fixture-trace"
+            )
+        )
+    }
+}
+
+#Preview("Article reader") {
+    ScreenshotArticleReaderView(unavailable: false)
+}
+
+#Preview("Article unavailable") {
+    ScreenshotArticleReaderView(unavailable: true)
+}

--- a/apps/ios/ZineNativeTests/ArticleReaderTests.swift
+++ b/apps/ios/ZineNativeTests/ArticleReaderTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import XCTest
+@testable import ZineNative
+
+final class ArticleReaderTests: XCTestCase {
+    func testArticleContentDecodesReadableAvailability() throws {
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+
+        XCTAssertEqual(response.articleBody.availability, .available)
+        XCTAssertEqual(response.articleBody.pipelineStatus, .available)
+        XCTAssertEqual(response.articleBody.wordCount, 640)
+        XCTAssertEqual(response.readableContent, "<article><p>Readable body</p></article>")
+    }
+
+    func testHTMLDocumentEscapesMetadataAndInstallsDefenseInDepthPolicy() throws {
+        let metadata = Self.metadata(title: "A <quiet> & useful reader")
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let html = ArticleHTMLDocumentBuilder.makeHTML(
+            for: ArticleReaderDocument(metadata: metadata, response: response)
+        )
+
+        XCTAssertTrue(html.contains("A &lt;quiet&gt; &amp; useful reader"))
+        XCTAssertTrue(html.contains("script-src 'none'"))
+        XCTAssertTrue(html.contains("frame-src 'none'"))
+        XCTAssertTrue(html.contains("<article><p>Readable body</p></article>"))
+    }
+
+    func testCachePersistsOnlyReadableDocumentsPerUser() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "article-cache-\(UUID().uuidString)", directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let readable = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let unavailable = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.unavailableJSON.utf8)
+        )
+        let cache = ArticleBodyCache(userID: "user/one", baseDirectory: directory)
+        await cache.save(readable, bookmarkID: "bookmark-1")
+        await cache.save(unavailable, bookmarkID: "bookmark-2")
+
+        let reloaded = ArticleBodyCache(userID: "user/one", baseDirectory: directory)
+        let otherUser = ArticleBodyCache(userID: "user/two", baseDirectory: directory)
+        let cachedReadable = await reloaded.load(bookmarkID: "bookmark-1")
+        let cachedUnavailable = await reloaded.load(bookmarkID: "bookmark-2")
+        let crossUser = await otherUser.load(bookmarkID: "bookmark-1")
+
+        XCTAssertEqual(cachedReadable?.articleBody.contentHash, "hash-1")
+        XCTAssertNil(cachedUnavailable)
+        XCTAssertNil(crossUser)
+    }
+
+    @MainActor
+    func testStoreLoadsAnAvailableArticleWithoutRequestingAgain() async throws {
+        let client = Self.client { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            return (200, Self.availableJSON)
+        }
+        let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
+
+        await store.load()
+
+        guard case let .ready(document) = store.phase else {
+            return XCTFail("Expected a ready reader, got \(store.phase)")
+        }
+        XCTAssertEqual(document.response.articleBody.contentHash, "hash-1")
+        XCTAssertEqual(ArticleReaderURLProtocol.requests.count, 1)
+    }
+
+    @MainActor
+    func testStoreRequestsOnceThenShowsATerminalUnavailableState() async throws {
+        let client = Self.client { request in
+            if request.httpMethod == "POST" {
+                return (200, Self.unavailableJSON.replacingOccurrences(
+                    of: "\"traceId\":\"trace-1\"",
+                    with: "\"request\":{\"queued\":false,\"reason\":\"terminal\"},\"traceId\":\"trace-1\""
+                ))
+            }
+            return (200, Self.notRequestedJSON)
+        }
+        let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
+
+        await store.load()
+
+        guard case let .unavailable(message) = store.phase else {
+            return XCTFail("Expected an unavailable reader, got \(store.phase)")
+        }
+        XCTAssertTrue(message.contains("dependable article body"))
+        XCTAssertEqual(ArticleReaderURLProtocol.requests.map(\.httpMethod), ["GET", "POST"])
+    }
+
+    private static func metadata(title: String = "A dependable reader") -> ArticleReaderMetadata {
+        ArticleReaderMetadata(
+            bookmarkID: "bookmark-1",
+            title: title,
+            creator: "Author",
+            canonicalURL: URL(string: "https://example.com/article")!,
+            readingTimeMinutes: 4,
+            initialProgress: BookmarkProgress(position: 0.25, duration: 1, percent: 25),
+            isFinished: false
+        )
+    }
+
+    private static func client(
+        handler: @escaping (URLRequest) throws -> (Int, String)
+    ) -> APIClient {
+        ArticleReaderURLProtocol.handler = handler
+        ArticleReaderURLProtocol.requests = []
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ArticleReaderURLProtocol.self]
+        return APIClient(
+            baseURL: URL(string: "https://api.myzine.app")!,
+            tokenProvider: { "test-token" },
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private static let availableJSON = """
+    {
+      "content":"<article><p>Readable body</p></article>",
+      "articleBody":{
+        "availability":"AVAILABLE","pipelineStatus":"AVAILABLE","schemaVersion":1,
+        "extractorVersion":1,"sourceKind":"PUBLIC_WEB","contentHash":"hash-1",
+        "wordCount":640,"readingTimeMinutes":4,"qualityScore":0.98,
+        "qualityWarnings":[],"lastErrorCode":null,"updatedAt":"2026-07-24T12:00:00Z"
+      },
+      "requestId":"request-1","traceId":"trace-1"
+    }
+    """
+
+    private static let notRequestedJSON = """
+    {
+      "content":null,
+      "articleBody":{
+        "availability":"UNAVAILABLE","pipelineStatus":"NOT_REQUESTED","schemaVersion":null,
+        "extractorVersion":null,"sourceKind":null,"contentHash":null,"wordCount":null,
+        "readingTimeMinutes":null,"qualityScore":null,"qualityWarnings":[],
+        "lastErrorCode":null,"updatedAt":null
+      },
+      "requestId":"request-1","traceId":"trace-1"
+    }
+    """
+
+    private static let unavailableJSON = """
+    {
+      "content":null,
+      "articleBody":{
+        "availability":"UNAVAILABLE","pipelineStatus":"UNAVAILABLE","schemaVersion":null,
+        "extractorVersion":1,"sourceKind":null,"contentHash":null,"wordCount":null,
+        "readingTimeMinutes":null,"qualityScore":null,"qualityWarnings":[],
+        "lastErrorCode":"NOT_READERABLE","updatedAt":"2026-07-24T12:00:00Z"
+      },
+      "requestId":"request-1","traceId":"trace-1"
+    }
+    """
+}
+
+private final class ArticleReaderURLProtocol: URLProtocol, @unchecked Sendable {
+    static var handler: ((URLRequest) throws -> (Int, String))?
+    static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.requests.append(request)
+        do {
+            let (status, body) = try Self.handler?(request) ?? (500, "{}")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/apps/worker/src/admin/article-body-backfill.test.ts
+++ b/apps/worker/src/admin/article-body-backfill.test.ts
@@ -9,6 +9,7 @@ vi.mock('../db', () => ({ createDb }));
 vi.mock('../article-body/service', () => ({ enqueueArticleBody }));
 
 import { backfillArticleBodies } from './article-body-backfill';
+import { ARTICLE_BODY_EXTRACTOR_VERSION } from '../article-body/types';
 
 const rows = [
   {
@@ -48,7 +49,7 @@ describe('article-body backfill', () => {
 
     expect(result).toMatchObject({
       dryRun: true,
-      extractorVersion: 1,
+      extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
       limit: 2,
       nextCursor: 'item_002',
       scanned: 2,
@@ -83,7 +84,7 @@ describe('article-body backfill', () => {
     const { env, bind, prepare } = createEnv([]);
     await backfillArticleBodies(env as never, { cursor: 'item_099', limit: 7 });
 
-    expect(bind).toHaveBeenCalledWith(1, 'item_099', 7);
+    expect(bind).toHaveBeenCalledWith(ARTICLE_BODY_EXTRACTOR_VERSION, 'item_099', 7);
     const query = prepare.mock.calls[0][0] as string;
     expect(query).toContain("i.content_type = 'ARTICLE'");
     expect(query).toContain("abs.status NOT IN ('PENDING', 'PROCESSING')");

--- a/apps/worker/src/article-body/acquisition.test.ts
+++ b/apps/worker/src/article-body/acquisition.test.ts
@@ -161,6 +161,43 @@ describe('acquireArticleBody', () => {
       expect.objectContaining({ redirect: 'manual' })
     );
   });
+
+  it('falls back to the public Substack post body when the HTML page is rate limited', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            title: 'Text is king',
+            post_date: '2026-01-20T18:55:47.327Z',
+            body_html: `<p>${articleText(40)}</p><p>${articleText(40)}</p>`,
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      );
+
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        canonicalUrl:
+          'https://open.substack.com/pub/experimentalhistory/p/text-is-king?r=share-token',
+        title: 'Text is king',
+      },
+      { fetch: fetch as never }
+    );
+
+    expect(result).toMatchObject({ status: 'AVAILABLE', errorCode: null });
+    expect(result.artifact).toMatchObject({
+      sourceKind: 'PUBLIC_NEWSLETTER',
+      title: 'Text is king',
+    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://experimentalhistory.substack.com/api/v1/posts/text-is-king',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
 });
 
 describe('isSafePublicArticleUrl', () => {
@@ -185,5 +222,18 @@ describe('article-body public URL resolution', () => {
         'https://open.substack.com/redirect?url=https://example.com'
       )
     ).toBe('https://open.substack.com/redirect?url=https://example.com');
+  });
+
+  it('derives a same-origin public post endpoint only from post paths', () => {
+    expect(
+      articleBodyAcquisitionInternals.resolveSubstackPostApiUrl(
+        'https://newsletter.example.com/p/a-public-post?utm_source=share'
+      )
+    ).toBe('https://newsletter.example.com/api/v1/posts/a-public-post');
+    expect(
+      articleBodyAcquisitionInternals.resolveSubstackPostApiUrl(
+        'https://newsletter.example.com/archive'
+      )
+    ).toBeNull();
   });
 });

--- a/apps/worker/src/article-body/acquisition.test.ts
+++ b/apps/worker/src/article-body/acquisition.test.ts
@@ -198,6 +198,49 @@ describe('acquireArticleBody', () => {
       expect.objectContaining({ redirect: 'manual' })
     );
   });
+
+  it('uses the bounded reader proxy when both Substack origins are rate limited', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              title: 'Text is king',
+              publishedTime: '2026-01-20T18:55:47.327Z',
+              html: page('Text is king'),
+            },
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      );
+
+    const result = await acquireArticleBody(
+      {
+        ...input(),
+        canonicalUrl:
+          'https://open.substack.com/pub/experimentalhistory/p/text-is-king?r=share-token',
+        title: 'Text is king',
+      },
+      { fetch: fetch as never }
+    );
+
+    expect(result).toMatchObject({ status: 'AVAILABLE', errorCode: null });
+    expect(result.artifact).toMatchObject({
+      sourceKind: 'BROWSER_RENDERED',
+      title: 'Text is king',
+    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      'https://r.jina.ai/https://experimentalhistory.substack.com/p/text-is-king',
+      expect.objectContaining({
+        redirect: 'manual',
+        headers: expect.objectContaining({ 'X-Return-Format': 'html' }),
+      })
+    );
+  });
 });
 
 describe('isSafePublicArticleUrl', () => {

--- a/apps/worker/src/article-body/acquisition.ts
+++ b/apps/worker/src/article-body/acquisition.ts
@@ -29,6 +29,13 @@ function resolvePublicArticleFetchUrl(canonicalUrl: string): string {
   return `https://${match[1]}.substack.com/p/${match[2]}`;
 }
 
+function resolveSubstackPostApiUrl(articleUrl: string): string | null {
+  const url = new URL(articleUrl);
+  const match = /^\/p\/([a-z0-9-]+)\/?$/i.exec(url.pathname);
+  if (!match) return null;
+  return new URL(`/api/v1/posts/${match[1]}`, url.origin).href;
+}
+
 export interface ArticleBodyAcquisitionInput {
   itemId: string;
   canonicalUrl: string;
@@ -147,6 +154,68 @@ function failedAttempt(
   };
 }
 
+async function fetchSubstackApiCandidate(
+  input: ArticleBodyAcquisitionInput,
+  articleUrl: string,
+  fetchImplementation: typeof fetch,
+  extractedAt: number,
+  extractorVersion: number,
+  signal: AbortSignal
+): Promise<EvaluatedCandidate | null> {
+  const apiUrl = resolveSubstackPostApiUrl(articleUrl);
+  if (!apiUrl || !isSafePublicArticleUrl(apiUrl)) return null;
+
+  let responseUrl = apiUrl;
+  let response: Response | null = null;
+  for (let redirects = 0; redirects <= MAX_ARTICLE_REDIRECTS; redirects += 1) {
+    response = await fetchImplementation(responseUrl, {
+      redirect: 'manual',
+      signal,
+      headers: {
+        'User-Agent': 'ZineBot/2.0 (+https://zine.app/bot)',
+        Accept: 'application/json',
+      },
+    });
+    if (response.status < 300 || response.status >= 400) break;
+
+    const location = response.headers.get('location');
+    if (!location || redirects === MAX_ARTICLE_REDIRECTS) return null;
+    const nextUrl = new URL(location, responseUrl).href;
+    if (!isSafePublicArticleUrl(nextUrl)) return null;
+    responseUrl = nextUrl;
+  }
+
+  if (!response?.ok) return null;
+  const contentLength = Number(response.headers.get('content-length') ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_ARTICLE_HTML_BYTES) return null;
+  const raw = await response.text();
+  if (new TextEncoder().encode(raw).byteLength > MAX_ARTICLE_HTML_BYTES) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  const post = payload as Record<string, unknown>;
+  if (typeof post.body_html !== 'string' || post.body_html.trim().length === 0) return null;
+
+  return evaluateCandidate(
+    input,
+    {
+      html: post.body_html,
+      sourceKind: 'PUBLIC_NEWSLETTER',
+      sourceUrl: responseUrl,
+      extractedTitle: typeof post.title === 'string' ? post.title : null,
+      publishedAt: typeof post.post_date === 'string' ? post.post_date : null,
+      httpStatus: response.status,
+    },
+    extractedAt,
+    extractorVersion
+  );
+}
+
 async function fetchPublicCandidate(
   input: ArticleBodyAcquisitionInput,
   fetchImplementation: typeof fetch,
@@ -206,6 +275,17 @@ async function fetchPublicCandidate(
     }
     if (!response) throw new Error('Article fetch returned no response');
     if (!response.ok) {
+      const substackCandidate = await fetchSubstackApiCandidate(
+        input,
+        responseUrl,
+        fetchImplementation,
+        extractedAt,
+        extractorVersion,
+        controller.signal
+      );
+      if (substackCandidate) {
+        return { evaluated: substackCandidate, attempt: substackCandidate.attempt };
+      }
       return {
         evaluated: null,
         attempt: failedAttempt(input, `HTTP_${response.status}`, {
@@ -380,4 +460,5 @@ export const articleBodyAcquisitionLimits = {
 
 export const articleBodyAcquisitionInternals = {
   resolvePublicArticleFetchUrl,
+  resolveSubstackPostApiUrl,
 };

--- a/apps/worker/src/article-body/acquisition.ts
+++ b/apps/worker/src/article-body/acquisition.ts
@@ -216,6 +216,68 @@ async function fetchSubstackApiCandidate(
   );
 }
 
+async function fetchReaderProxyCandidate(
+  input: ArticleBodyAcquisitionInput,
+  articleUrl: string,
+  fetchImplementation: typeof fetch,
+  extractedAt: number,
+  extractorVersion: number,
+  signal: AbortSignal
+): Promise<EvaluatedCandidate | null> {
+  if (!resolveSubstackPostApiUrl(articleUrl)) return null;
+  const readerUrl = `https://r.jina.ai/${articleUrl}`;
+
+  const response = await fetchImplementation(readerUrl, {
+    redirect: 'manual',
+    signal,
+    headers: {
+      'User-Agent': 'ZineBot/2.0 (+https://zine.app/bot)',
+      Accept: 'application/json',
+      'X-Return-Format': 'html',
+      'X-Timeout': '10',
+    },
+  });
+  if (!response.ok) return null;
+  const contentLength = Number(response.headers.get('content-length') ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_ARTICLE_HTML_BYTES) return null;
+  const raw = await response.text();
+  if (new TextEncoder().encode(raw).byteLength > MAX_ARTICLE_HTML_BYTES) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  const data = (payload as { data?: unknown }).data;
+  if (!data || typeof data !== 'object') return null;
+  const reader = data as Record<string, unknown>;
+  if (typeof reader.html !== 'string' || reader.html.trim().length === 0) return null;
+
+  const extracted = extractArticleFromHtml(reader.html, articleUrl);
+  if (!extracted?.isArticle || !extracted.content) return null;
+  return evaluateCandidate(
+    input,
+    {
+      html: extracted.content,
+      sourceKind: 'BROWSER_RENDERED',
+      sourceUrl: articleUrl,
+      extractedTitle:
+        typeof reader.title === 'string' && reader.title.trim().length > 0
+          ? reader.title
+          : extracted.title,
+      byline: extracted.author,
+      publisher: extracted.siteName,
+      publishedAt:
+        typeof reader.publishedTime === 'string' ? reader.publishedTime : extracted.publishedAt,
+      httpStatus: response.status,
+    },
+    extractedAt,
+    extractorVersion
+  );
+}
+
 async function fetchPublicCandidate(
   input: ArticleBodyAcquisitionInput,
   fetchImplementation: typeof fetch,
@@ -285,6 +347,17 @@ async function fetchPublicCandidate(
       );
       if (substackCandidate) {
         return { evaluated: substackCandidate, attempt: substackCandidate.attempt };
+      }
+      const readerCandidate = await fetchReaderProxyCandidate(
+        input,
+        responseUrl,
+        fetchImplementation,
+        extractedAt,
+        extractorVersion,
+        controller.signal
+      );
+      if (readerCandidate) {
+        return { evaluated: readerCandidate, attempt: readerCandidate.attempt };
       }
       return {
         evaluated: null,

--- a/apps/worker/src/article-body/consumer.test.ts
+++ b/apps/worker/src/article-body/consumer.test.ts
@@ -8,6 +8,7 @@ const {
   markArticleBodyProcessing,
   markArticleBodyRetryScheduled,
   markArticleBodyUnavailable,
+  getArticleBodyStatus,
   dlqValues,
   findItem,
 } = vi.hoisted(() => ({
@@ -15,6 +16,7 @@ const {
   markArticleBodyProcessing: vi.fn(),
   markArticleBodyRetryScheduled: vi.fn(),
   markArticleBodyUnavailable: vi.fn(),
+  getArticleBodyStatus: vi.fn(),
   dlqValues: vi.fn(),
   findItem: vi.fn(),
 }));
@@ -26,6 +28,7 @@ vi.mock('./service', () => ({
   markArticleBodyProcessing,
   markArticleBodyRetryScheduled,
   markArticleBodyUnavailable,
+  getArticleBodyStatus,
 }));
 
 import { handleArticleBodyDLQ, handleArticleBodyQueue } from './consumer';
@@ -63,6 +66,7 @@ function batch(message: ReturnType<typeof queueMessage>, queue = 'zine-article-b
 describe('article-body queue consumers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getArticleBodyStatus.mockResolvedValue(null);
     createDb.mockReturnValue({
       query: { items: { findFirst: findItem } },
       insert: vi.fn().mockReturnValue({ values: dlqValues }),
@@ -112,6 +116,22 @@ describe('article-body queue consumers', () => {
     expect(processor).toHaveBeenCalledWith(body(), expect.anything(), env);
     expect(message.ack).toHaveBeenCalledOnce();
     expect(message.retry).not.toHaveBeenCalled();
+  });
+
+  it('acks an older extractor job without overwriting newer lifecycle state', async () => {
+    const message = queueMessage();
+    const processor = vi.fn();
+    getArticleBodyStatus.mockResolvedValue({ targetExtractorVersion: 2 });
+
+    await handleArticleBodyQueue(
+      batch(message),
+      { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never,
+      processor
+    );
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(markArticleBodyProcessing).not.toHaveBeenCalled();
+    expect(processor).not.toHaveBeenCalled();
   });
 
   it('retries processor failures with bounded backoff', async () => {

--- a/apps/worker/src/article-body/consumer.ts
+++ b/apps/worker/src/article-body/consumer.ts
@@ -7,6 +7,7 @@ import type { Bindings } from '../types';
 import { processArticleBodyQueueMessage, RetryableArticleBodyError } from './processor';
 import { ArticleBodyQueueMessageSchema } from './schema';
 import {
+  getArticleBodyStatus,
   isArticleBodyPipelineEnabled,
   markArticleBodyProcessing,
   markArticleBodyRetryScheduled,
@@ -52,6 +53,20 @@ export async function handleArticleBodyQueue(
         event: 'article_body.queue.disabled',
         messageId: message.id,
         itemId: parsed.data.itemId,
+      });
+      message.ack();
+      continue;
+    }
+
+    const current = await getArticleBodyStatus(db, parsed.data.itemId);
+    if (current && current.targetExtractorVersion > parsed.data.extractorVersion) {
+      articleBodyLogger.info('Stale article-body queue message acknowledged', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.stale',
+        messageId: message.id,
+        itemId: parsed.data.itemId,
+        messageExtractorVersion: parsed.data.extractorVersion,
+        targetExtractorVersion: current.targetExtractorVersion,
       });
       message.ack();
       continue;

--- a/apps/worker/src/article-body/diagnostics.test.ts
+++ b/apps/worker/src/article-body/diagnostics.test.ts
@@ -4,25 +4,45 @@ import { getArticleBodyHealth } from './diagnostics';
 
 describe('article-body diagnostics', () => {
   it('returns aggregate lifecycle and DLQ counts without item identifiers', async () => {
-    const all = vi.fn().mockResolvedValue({
+    const statesAll = vi.fn().mockResolvedValue({
       results: [
         { status: 'AVAILABLE', count: 12 },
         { status: 'UNAVAILABLE', count: 2 },
         { status: 'UNKNOWN', count: 99 },
       ],
     });
-    const first = vi.fn().mockResolvedValue({ count: 1 });
-    const prepare = vi.fn().mockReturnValueOnce({ all }).mockReturnValueOnce({ first });
+    const triggerAll = vi.fn().mockResolvedValue({
+      results: [{ trigger: 'reader_open', status: 'AVAILABLE', count: 4 }],
+    });
+    const sourceAll = vi.fn().mockResolvedValue({
+      results: [{ sourceKind: 'PUBLIC_WEB', count: 9 }],
+    });
+    const failureAll = vi.fn().mockResolvedValue({
+      results: [{ code: 'NOT_READERABLE', count: 1 }],
+    });
+    const prepare = vi
+      .fn()
+      .mockReturnValueOnce({ all: statesAll })
+      .mockReturnValueOnce({ first: vi.fn().mockResolvedValue({ count: 1 }) })
+      .mockReturnValueOnce({ first: vi.fn().mockResolvedValue({ timestamp: 1_700_000_000_000 }) })
+      .mockReturnValueOnce({
+        first: vi.fn().mockResolvedValue({ count: 4, average: 1234.4, maximum: 3000 }),
+      })
+      .mockReturnValueOnce({ all: triggerAll })
+      .mockReturnValueOnce({ all: sourceAll })
+      .mockReturnValueOnce({ all: failureAll });
 
     const result = await getArticleBodyHealth({
       DB: { prepare },
       ARTICLE_BODY_QUEUE: {},
       ARTICLE_BODY_PIPELINE_ENABLED: 'false',
+      ARTICLE_BODY_ENROLLMENT_MODE: 'reader',
     } as never);
 
     expect(result).toEqual({
       status: 'ok',
       enabled: false,
+      enrollmentMode: 'reader',
       configured: true,
       states: {
         PENDING: 0,
@@ -31,6 +51,11 @@ describe('article-body diagnostics', () => {
         DEGRADED: 0,
         UNAVAILABLE: 2,
       },
+      oldestPendingAt: '2023-11-14T22:13:20.000Z',
+      terminalLatencyMs: { sampleCount: 4, average: 1234, maximum: 3000 },
+      outcomesByTrigger: { reader_open: { AVAILABLE: 4 } },
+      sourceKinds: { PUBLIC_WEB: 9 },
+      failureCodes: [{ code: 'NOT_READERABLE', count: 1 }],
       dlqCount: 1,
     });
     expect(JSON.stringify(result)).not.toContain('item_');

--- a/apps/worker/src/article-body/diagnostics.ts
+++ b/apps/worker/src/article-body/diagnostics.ts
@@ -1,6 +1,11 @@
 import type { Bindings } from '../types';
-import { isArticleBodyPipelineEnabled } from './service';
-import type { ArticleBodyStatus } from './types';
+import { getArticleBodyEnrollmentMode, isArticleBodyPipelineEnabled } from './service';
+import type {
+  ArticleBodyEnrollmentMode,
+  ArticleBodySourceKind,
+  ArticleBodyStatus,
+  ArticleBodyTrigger,
+} from './types';
 
 const STATUSES: ArticleBodyStatus[] = [
   'PENDING',
@@ -13,8 +18,16 @@ const STATUSES: ArticleBodyStatus[] = [
 export interface ArticleBodyHealth {
   status: 'ok' | 'error';
   enabled: boolean;
+  enrollmentMode: ArticleBodyEnrollmentMode;
   configured: boolean;
   states: Record<ArticleBodyStatus, number>;
+  oldestPendingAt: string | null;
+  terminalLatencyMs: { sampleCount: number; average: number | null; maximum: number | null };
+  outcomesByTrigger: Partial<
+    Record<ArticleBodyTrigger, Partial<Record<ArticleBodyStatus, number>>>
+  >;
+  sourceKinds: Partial<Record<ArticleBodySourceKind, number>>;
+  failureCodes: Array<{ code: string; count: number }>;
   dlqCount: number;
   error?: string;
 }
@@ -29,28 +42,81 @@ function emptyStateCounts(): Record<ArticleBodyStatus, number> {
 export async function getArticleBodyHealth(env: Bindings): Promise<ArticleBodyHealth> {
   const base = {
     enabled: isArticleBodyPipelineEnabled(env),
+    enrollmentMode: getArticleBodyEnrollmentMode(env),
     configured: Boolean(env.ARTICLE_BODY_QUEUE),
     states: emptyStateCounts(),
+    oldestPendingAt: null,
+    terminalLatencyMs: { sampleCount: 0, average: null, maximum: null },
+    outcomesByTrigger: {},
+    sourceKinds: {},
+    failureCodes: [],
     dlqCount: 0,
   };
 
   try {
-    const [statesResult, dlqResult] = await Promise.all([
+    const [
+      statesResult,
+      dlqResult,
+      oldestPendingResult,
+      latencyResult,
+      triggerResult,
+      sourceResult,
+      failureResult,
+    ] = await Promise.all([
       env.DB.prepare(
         'SELECT status, COUNT(*) AS count FROM article_body_states GROUP BY status'
       ).all<{ status: ArticleBodyStatus; count: number }>(),
       env.DB.prepare('SELECT COUNT(*) AS count FROM article_body_dlq_events').first<{
         count: number;
       }>(),
+      env.DB.prepare(
+        "SELECT MIN(COALESCE(requested_at, updated_at)) AS timestamp FROM article_body_states WHERE status IN ('PENDING', 'PROCESSING')"
+      ).first<{ timestamp: number | null }>(),
+      env.DB.prepare(
+        'SELECT COUNT(*) AS count, AVG(terminal_at - requested_at) AS average, MAX(terminal_at - requested_at) AS maximum FROM article_body_states WHERE requested_at IS NOT NULL AND terminal_at IS NOT NULL'
+      ).first<{ count: number; average: number | null; maximum: number | null }>(),
+      env.DB.prepare(
+        'SELECT enrollment_trigger AS trigger, status, COUNT(*) AS count FROM article_body_states WHERE enrollment_trigger IS NOT NULL GROUP BY enrollment_trigger, status'
+      ).all<{ trigger: ArticleBodyTrigger; status: ArticleBodyStatus; count: number }>(),
+      env.DB.prepare(
+        'SELECT v.source_kind AS sourceKind, COUNT(*) AS count FROM article_body_states s JOIN article_body_versions v ON v.id = s.current_version_id GROUP BY v.source_kind'
+      ).all<{ sourceKind: ArticleBodySourceKind; count: number }>(),
+      env.DB.prepare(
+        'SELECT last_error_code AS code, COUNT(*) AS count FROM article_body_states WHERE last_error_code IS NOT NULL GROUP BY last_error_code ORDER BY count DESC LIMIT 5'
+      ).all<{ code: string; count: number }>(),
     ]);
 
     for (const row of statesResult.results) {
       if (STATUSES.includes(row.status)) base.states[row.status] = Number(row.count);
     }
 
+    const outcomesByTrigger: ArticleBodyHealth['outcomesByTrigger'] = {};
+    for (const row of triggerResult.results) {
+      outcomesByTrigger[row.trigger] = {
+        ...outcomesByTrigger[row.trigger],
+        [row.status]: Number(row.count),
+      };
+    }
+    const sourceKinds: ArticleBodyHealth['sourceKinds'] = {};
+    for (const row of sourceResult.results) sourceKinds[row.sourceKind] = Number(row.count);
+
     return {
       status: 'ok',
       ...base,
+      oldestPendingAt: oldestPendingResult?.timestamp
+        ? new Date(Number(oldestPendingResult.timestamp)).toISOString()
+        : null,
+      terminalLatencyMs: {
+        sampleCount: Number(latencyResult?.count ?? 0),
+        average: latencyResult?.average == null ? null : Math.round(Number(latencyResult.average)),
+        maximum: latencyResult?.maximum == null ? null : Math.round(Number(latencyResult.maximum)),
+      },
+      outcomesByTrigger,
+      sourceKinds,
+      failureCodes: failureResult.results.map((row) => ({
+        code: row.code,
+        count: Number(row.count),
+      })),
       dlqCount: Number(dlqResult?.count ?? 0),
     };
   } catch (error) {

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -58,4 +58,30 @@ describe('normalizeArticleBodyHtml', () => {
     expect(normalized.sanitizedHtml).toContain('<p>This is a complete prose sentence');
     expect(normalized.sanitizedHtml).toContain('<pre>function keepAsCode()');
   });
+
+  it('removes consecutive duplicate blocks at the article tail but preserves earlier repetition', () => {
+    const repeated = 'This deliberate refrain belongs in the article.';
+    const duplicateFootnote = 'This post was based on a useful source comment.';
+    const normalized = normalizeArticleBodyHtml(
+      `<p>${repeated}</p><p>${repeated}</p>${Array.from({ length: 10 }, (_, index) => `<p>Body paragraph ${index + 1} carries distinct context.</p>`).join('')}<p>${duplicateFootnote}</p><p>${duplicateFootnote}</p>`,
+      'https://example.com/story'
+    );
+
+    expect(normalized.blocks.filter((block) => block.text === repeated)).toHaveLength(2);
+    expect(normalized.blocks.filter((block) => block.text === duplicateFootnote)).toHaveLength(1);
+    expect(normalized.diagnostics.droppedElements).toBe(1);
+  });
+
+  it('counts nested list and quote content once in semantic text and metrics', () => {
+    const normalized = normalizeArticleBodyHtml(
+      '<ul><li><p>A nested list item with useful detail.</p></li></ul><blockquote><p>A nested quotation.</p></blockquote>',
+      'https://example.com/story'
+    );
+
+    expect(normalized.blocks).toEqual([
+      { id: 'b1', kind: 'list_item', text: 'A nested list item with useful detail.' },
+      { id: 'b2', kind: 'quote', text: 'A nested quotation.' },
+    ]);
+    expect(normalized.wordCount).toBe(10);
+  });
 });

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -48,14 +48,15 @@ describe('normalizeArticleBodyHtml', () => {
 
   it('removes stacked site controls and privacy copy from the article tail', () => {
     const normalized = normalizeArticleBodyHtml(
-      '<p>A complete article conclusion.</p><p>copy as / view markdown</p><p>This page respects your privacy by not using cookies or similar technologies and by not collecting personally identifiable information.</p>',
+      '<p>A complete article conclusion.</p><p>copy as / view markdown</p><p>This page respects your privacy by not using cookies or similar technologies and by not collecting personally identifiable information.</p><p>No posts</p>',
       'https://example.com/story'
     );
 
     expect(normalized.plainText).toBe('A complete article conclusion.');
     expect(normalized.sanitizedHtml).not.toContain('view markdown');
     expect(normalized.sanitizedHtml).not.toContain('respects your privacy');
-    expect(normalized.diagnostics.droppedElements).toBe(2);
+    expect(normalized.sanitizedHtml).not.toContain('No posts');
+    expect(normalized.diagnostics.droppedElements).toBe(3);
   });
 
   it('recovers long prose wrapped in a pre element without rewriting code blocks', () => {

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -45,4 +45,17 @@ describe('normalizeArticleBodyHtml', () => {
     expect(normalized.sanitizedHtml).not.toContain('blog comments powered by Disqus');
     expect(normalized.diagnostics.droppedElements).toBe(1);
   });
+
+  it('recovers long prose wrapped in a pre element without rewriting code blocks', () => {
+    const proseParagraph =
+      'This is a complete prose sentence about dependable reading systems and careful product decisions.';
+    const normalized = normalizeArticleBodyHtml(
+      `<pre>${Array.from({ length: 12 }, (_, index) => `${proseParagraph} Paragraph ${index + 1}.`).join('\n\n')}</pre><pre>function keepAsCode() {\n  return true;\n}</pre>`,
+      'https://example.com/story'
+    );
+
+    expect(normalized.blocks.filter((block) => block.kind === 'paragraph')).toHaveLength(12);
+    expect(normalized.sanitizedHtml).toContain('<p>This is a complete prose sentence');
+    expect(normalized.sanitizedHtml).toContain('<pre>function keepAsCode()');
+  });
 });

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -32,4 +32,17 @@ describe('normalizeArticleBodyHtml', () => {
     expect(normalized.wordCount).toBe(7);
     expect(normalized.readingTimeMinutes).toBe(1);
   });
+
+  it('removes a known comments widget footer only when it trails the article', () => {
+    const normalized = normalizeArticleBodyHtml(
+      '<p>The article discusses comments powered by Disqus as part of its analysis.</p><p>A complete conclusion.</p><p>blog comments powered by Disqus</p>',
+      'https://example.com/story'
+    );
+
+    expect(normalized.plainText).toBe(
+      'The article discusses comments powered by Disqus as part of its analysis.\n\nA complete conclusion.'
+    );
+    expect(normalized.sanitizedHtml).not.toContain('blog comments powered by Disqus');
+    expect(normalized.diagnostics.droppedElements).toBe(1);
+  });
 });

--- a/apps/worker/src/article-body/normalization.test.ts
+++ b/apps/worker/src/article-body/normalization.test.ts
@@ -46,6 +46,18 @@ describe('normalizeArticleBodyHtml', () => {
     expect(normalized.diagnostics.droppedElements).toBe(1);
   });
 
+  it('removes stacked site controls and privacy copy from the article tail', () => {
+    const normalized = normalizeArticleBodyHtml(
+      '<p>A complete article conclusion.</p><p>copy as / view markdown</p><p>This page respects your privacy by not using cookies or similar technologies and by not collecting personally identifiable information.</p>',
+      'https://example.com/story'
+    );
+
+    expect(normalized.plainText).toBe('A complete article conclusion.');
+    expect(normalized.sanitizedHtml).not.toContain('view markdown');
+    expect(normalized.sanitizedHtml).not.toContain('respects your privacy');
+    expect(normalized.diagnostics.droppedElements).toBe(2);
+  });
+
   it('recovers long prose wrapped in a pre element without rewriting code blocks', () => {
     const proseParagraph =
       'This is a complete prose sentence about dependable reading systems and careful product decisions.';

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -116,6 +116,15 @@ function blockKind(element: Element): string {
   return 'paragraph';
 }
 
+function hasSelectedBlockAncestor(element: Element, root: Element): boolean {
+  let ancestor = element.parentElement;
+  while (ancestor && ancestor !== root) {
+    if (ancestor.matches(BLOCK_SELECTOR)) return true;
+    ancestor = ancestor.parentElement;
+  }
+  return false;
+}
+
 function recoverProsePreBlocks(root: Element): void {
   const document = root.ownerDocument;
   if (!document) return;
@@ -152,6 +161,22 @@ function dropKnownTrailingBoilerplate(
     if (!text) continue;
     if (!TRAILING_BOILERPLATE_PATTERNS.some((pattern) => pattern.test(text))) return;
     block.remove();
+    diagnostics.droppedElements += 1;
+  }
+}
+
+function dropTrailingConsecutiveDuplicateBlocks(
+  root: Element,
+  diagnostics: ArticleBodyNormalizationDiagnostics
+): void {
+  const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR));
+  if (blocks.length < 5) return;
+  const firstTailIndex = Math.max(1, blocks.length - 5);
+  for (let index = blocks.length - 1; index >= firstTailIndex; index -= 1) {
+    const text = normalizeWhitespace(blocks[index].textContent ?? '');
+    const previousText = normalizeWhitespace(blocks[index - 1].textContent ?? '');
+    if (text.length < 20 || text !== previousText) continue;
+    blocks[index].remove();
     diagnostics.droppedElements += 1;
   }
 }
@@ -228,9 +253,11 @@ export function normalizeArticleBodyHtml(rawHtml: string, baseUrl: string): Norm
   }
 
   recoverProsePreBlocks(root);
+  dropTrailingConsecutiveDuplicateBlocks(root, diagnostics);
   dropKnownTrailingBoilerplate(root, diagnostics);
 
   const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR))
+    .filter((element) => !hasSelectedBlockAncestor(element, root))
     .map((element, index) => ({
       id: `b${index + 1}`,
       kind: blockKind(element),

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -116,6 +116,31 @@ function blockKind(element: Element): string {
   return 'paragraph';
 }
 
+function recoverProsePreBlocks(root: Element): void {
+  const document = root.ownerDocument;
+  if (!document) return;
+
+  for (const pre of Array.from(root.querySelectorAll('pre'))) {
+    const rawText = (pre.textContent ?? '').replace(/\r\n?/g, '\n').trim();
+    const wordCount = rawText.match(WORD_PATTERN)?.length ?? 0;
+    const paragraphTexts = rawText
+      .split(/\n\s*\n+/)
+      .map(normalizeWhitespace)
+      .filter(Boolean);
+    const sentenceCount = rawText.match(/[.!?](?:\s|$)/g)?.length ?? 0;
+
+    if (wordCount < 120 || paragraphTexts.length < 3 || sentenceCount < 5) continue;
+
+    const replacement = document.createElement('div');
+    for (const text of paragraphTexts) {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = text;
+      replacement.appendChild(paragraph);
+    }
+    pre.replaceWith(replacement);
+  }
+}
+
 function dropKnownTrailingBoilerplate(
   root: Element,
   diagnostics: ArticleBodyNormalizationDiagnostics
@@ -202,6 +227,7 @@ export function normalizeArticleBodyHtml(rawHtml: string, baseUrl: string): Norm
     }
   }
 
+  recoverProsePreBlocks(root);
   dropKnownTrailingBoilerplate(root, diagnostics);
 
   const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR))

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -60,6 +60,10 @@ const ALLOWED_TAGS = new Set([
 
 const BLOCK_SELECTOR = 'h1,h2,h3,h4,h5,h6,p,blockquote,pre,li,figcaption,th,td';
 const WORD_PATTERN = /[\p{L}\p{N}]+(?:[’'-][\p{L}\p{N}]+)*/gu;
+const TRAILING_BOILERPLATE_PATTERNS = [
+  /^(?:blog )?comments powered by disqus$/i,
+  /^powered by disqus$/i,
+];
 
 export interface ArticleBodyNormalizationDiagnostics {
   droppedElements: number;
@@ -110,6 +114,21 @@ function blockKind(element: Element): string {
   if (tag === 'figcaption') return 'caption';
   if (tag === 'th' || tag === 'td') return 'table_cell';
   return 'paragraph';
+}
+
+function dropKnownTrailingBoilerplate(
+  root: Element,
+  diagnostics: ArticleBodyNormalizationDiagnostics
+): void {
+  const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR));
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    const text = normalizeWhitespace(block.textContent ?? '');
+    if (!text) continue;
+    if (!TRAILING_BOILERPLATE_PATTERNS.some((pattern) => pattern.test(text))) return;
+    block.remove();
+    diagnostics.droppedElements += 1;
+  }
 }
 
 export function normalizeArticleBodyHtml(rawHtml: string, baseUrl: string): NormalizedArticleBody {
@@ -182,6 +201,8 @@ export function normalizeArticleBodyHtml(rawHtml: string, baseUrl: string): Norm
       }
     }
   }
+
+  dropKnownTrailingBoilerplate(root, diagnostics);
 
   const blocks = Array.from(root.querySelectorAll(BLOCK_SELECTOR))
     .map((element, index) => ({

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -63,6 +63,8 @@ const WORD_PATTERN = /[\p{L}\p{N}]+(?:[’'-][\p{L}\p{N}]+)*/gu;
 const TRAILING_BOILERPLATE_PATTERNS = [
   /^(?:blog )?comments powered by disqus$/i,
   /^powered by disqus$/i,
+  /^copy as\s*\/\s*view markdown$/i,
+  /^this page respects your privacy by not using cookies or similar technologies\b/i,
 ];
 
 export interface ArticleBodyNormalizationDiagnostics {

--- a/apps/worker/src/article-body/normalization.ts
+++ b/apps/worker/src/article-body/normalization.ts
@@ -65,6 +65,7 @@ const TRAILING_BOILERPLATE_PATTERNS = [
   /^powered by disqus$/i,
   /^copy as\s*\/\s*view markdown$/i,
   /^this page respects your privacy by not using cookies or similar technologies\b/i,
+  /^no posts$/i,
 ];
 
 export interface ArticleBodyNormalizationDiagnostics {

--- a/apps/worker/src/article-body/service-enqueue.test.ts
+++ b/apps/worker/src/article-body/service-enqueue.test.ts
@@ -69,6 +69,36 @@ describe('article-body enqueue', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('does not repeat a terminal failure at the current extractor version', async () => {
+    const db = createDb(
+      status({ status: 'UNAVAILABLE', lastErrorCode: 'NOT_READERABLE', targetExtractorVersion: 1 })
+    );
+    const send = vi.fn();
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'reader_open' }
+    );
+
+    expect(result).toEqual({ queued: false, reason: 'terminal' });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('allows a reader request to retry a transient stored failure', async () => {
+    const db = createDb(
+      status({ status: 'UNAVAILABLE', lastErrorCode: 'HTTP_503', targetExtractorVersion: 1 })
+    );
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'reader_open' }
+    );
+
+    expect(result).toMatchObject({ queued: true });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it('includes a bounded embedded candidate in the queue job', async () => {
     const db = createDb(null);
     const send = vi.fn().mockResolvedValue(undefined);

--- a/apps/worker/src/article-body/service-enqueue.test.ts
+++ b/apps/worker/src/article-body/service-enqueue.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES } from './schema';
 import { enqueueArticleBody } from './service';
 import type { ArticleBodyStatusRecord } from './service';
+import { ARTICLE_BODY_EXTRACTOR_VERSION } from './types';
 
 function createDb(status: ArticleBodyStatusRecord | null) {
   const limit = vi.fn().mockResolvedValue(status ? [status] : []);
@@ -19,7 +20,7 @@ function createDb(status: ArticleBodyStatusRecord | null) {
 function status(overrides: Partial<ArticleBodyStatusRecord> = {}): ArticleBodyStatusRecord {
   return {
     status: 'PENDING',
-    targetExtractorVersion: 1,
+    targetExtractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
     attemptCount: 0,
     lastErrorCode: null,
     lastHttpStatus: null,
@@ -56,7 +57,11 @@ describe('article-body enqueue', () => {
 
   it('does not replace a current artifact outside an explicit repair', async () => {
     const db = createDb(
-      status({ status: 'AVAILABLE', versionId: 'version_1', extractorVersion: 1 })
+      status({
+        status: 'AVAILABLE',
+        versionId: 'version_1',
+        extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      })
     );
     const send = vi.fn();
     const result = await enqueueArticleBody(
@@ -71,7 +76,11 @@ describe('article-body enqueue', () => {
 
   it('does not repeat a terminal failure at the current extractor version', async () => {
     const db = createDb(
-      status({ status: 'UNAVAILABLE', lastErrorCode: 'NOT_READERABLE', targetExtractorVersion: 1 })
+      status({
+        status: 'UNAVAILABLE',
+        lastErrorCode: 'NOT_READERABLE',
+        targetExtractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      })
     );
     const send = vi.fn();
     const result = await enqueueArticleBody(
@@ -86,7 +95,11 @@ describe('article-body enqueue', () => {
 
   it('allows a reader request to retry a transient stored failure', async () => {
     const db = createDb(
-      status({ status: 'UNAVAILABLE', lastErrorCode: 'HTTP_503', targetExtractorVersion: 1 })
+      status({
+        status: 'UNAVAILABLE',
+        lastErrorCode: 'HTTP_503',
+        targetExtractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      })
     );
     const send = vi.fn().mockResolvedValue(undefined);
     const result = await enqueueArticleBody(

--- a/apps/worker/src/article-body/service.test.ts
+++ b/apps/worker/src/article-body/service.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isArticleBodyPipelineEnabled, toArticleBodyPublicStatus } from './service';
+import {
+  getArticleBodyEnrollmentMode,
+  isArticleBodyEnrollmentEnabled,
+  isArticleBodyPipelineEnabled,
+  toArticleBodyPublicStatus,
+} from './service';
 import type { ArticleBodyStatusRecord } from './service';
 
 function record(overrides: Partial<ArticleBodyStatusRecord> = {}): ArticleBodyStatusRecord {
@@ -32,6 +37,30 @@ describe('article-body public status', () => {
     expect(isArticleBodyPipelineEnabled({})).toBe(false);
     expect(isArticleBodyPipelineEnabled({ ARTICLE_BODY_PIPELINE_ENABLED: 'false' })).toBe(false);
     expect(isArticleBodyPipelineEnabled({ ARTICLE_BODY_PIPELINE_ENABLED: ' TRUE ' })).toBe(true);
+  });
+
+  it('uses progressive enrollment modes and treats unknown values as off', () => {
+    expect(getArticleBodyEnrollmentMode({})).toBe('off');
+    expect(getArticleBodyEnrollmentMode({ ARTICLE_BODY_ENROLLMENT_MODE: 'unexpected' })).toBe(
+      'off'
+    );
+    expect(getArticleBodyEnrollmentMode({ ARTICLE_BODY_ENROLLMENT_MODE: ' Saved ' })).toBe('saved');
+
+    expect(
+      isArticleBodyEnrollmentEnabled({ ARTICLE_BODY_ENROLLMENT_MODE: 'reader' }, 'reader_open')
+    ).toBe(true);
+    expect(
+      isArticleBodyEnrollmentEnabled({ ARTICLE_BODY_ENROLLMENT_MODE: 'reader' }, 'bookmark')
+    ).toBe(false);
+    expect(
+      isArticleBodyEnrollmentEnabled({ ARTICLE_BODY_ENROLLMENT_MODE: 'saved' }, 'bookmark')
+    ).toBe(true);
+    expect(
+      isArticleBodyEnrollmentEnabled({ ARTICLE_BODY_ENROLLMENT_MODE: 'saved' }, 'ingestion')
+    ).toBe(false);
+    expect(
+      isArticleBodyEnrollmentEnabled({ ARTICLE_BODY_ENROLLMENT_MODE: 'all' }, 'ingestion')
+    ).toBe(true);
   });
 
   it('represents legacy and absent content explicitly', () => {

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -10,6 +10,7 @@ import {
   ARTICLE_BODY_EXTRACTOR_VERSION,
   type ArticleBodyArtifact,
   type ArticleBodyEmbeddedCandidate,
+  type ArticleBodyEnrollmentMode,
   type ArticleBodyPublicStatus,
   type ArticleBodyQueueMessage,
   type ArticleBodyStatus,
@@ -53,6 +54,39 @@ export function isArticleBodyPipelineEnabled(
   env: Pick<Bindings, 'ARTICLE_BODY_PIPELINE_ENABLED'>
 ): boolean {
   return env.ARTICLE_BODY_PIPELINE_ENABLED?.trim().toLowerCase() === 'true';
+}
+
+export function getArticleBodyEnrollmentMode(
+  env: Pick<Bindings, 'ARTICLE_BODY_ENROLLMENT_MODE'>
+): ArticleBodyEnrollmentMode {
+  const value = env.ARTICLE_BODY_ENROLLMENT_MODE?.trim().toLowerCase();
+  return value === 'reader' || value === 'saved' || value === 'all' ? value : 'off';
+}
+
+export function isArticleBodyEnrollmentEnabled(
+  env: Pick<Bindings, 'ARTICLE_BODY_ENROLLMENT_MODE'>,
+  trigger: Extract<ArticleBodyTrigger, 'reader_open' | 'bookmark' | 'ingestion'>
+): boolean {
+  const mode = getArticleBodyEnrollmentMode(env);
+  if (mode === 'all') return true;
+  if (mode === 'saved') return trigger === 'reader_open' || trigger === 'bookmark';
+  return mode === 'reader' && trigger === 'reader_open';
+}
+
+function isRetryableStoredFailure(errorCode: string | null): boolean {
+  if (!errorCode) return false;
+  if (
+    errorCode === 'QUEUE_SEND_FAILED' ||
+    errorCode === 'FETCH_FAILED' ||
+    errorCode === 'FETCH_TIMEOUT' ||
+    errorCode === 'PUBLISH_FAILED'
+  ) {
+    return true;
+  }
+  const match = /^HTTP_(\d{3})$/.exec(errorCode);
+  if (!match) return false;
+  const status = Number(match[1]);
+  return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
 export async function getArticleBodyStatus(
@@ -167,6 +201,7 @@ export async function markArticleBodyPending(
   db: Database,
   itemId: string,
   extractorVersion: number,
+  trigger: ArticleBodyTrigger,
   now: number = Date.now()
 ): Promise<void> {
   await db
@@ -181,6 +216,9 @@ export async function markArticleBodyPending(
       lastHttpStatus: null,
       lastAttemptAt: null,
       nextAttemptAt: null,
+      enrollmentTrigger: trigger,
+      requestedAt: now,
+      terminalAt: null,
       createdAt: now,
       updatedAt: now,
     })
@@ -192,6 +230,9 @@ export async function markArticleBodyPending(
         lastErrorCode: null,
         lastHttpStatus: null,
         nextAttemptAt: null,
+        enrollmentTrigger: trigger,
+        requestedAt: now,
+        terminalAt: null,
         updatedAt: now,
       },
     });
@@ -231,6 +272,7 @@ export async function markArticleBodyRetryScheduled(
       lastErrorCode: errorCode,
       lastAttemptAt: now,
       nextAttemptAt,
+      terminalAt: null,
       updatedAt: now,
     })
     .where(eq(articleBodyStates.itemId, itemId));
@@ -257,6 +299,7 @@ export async function markArticleBodyUnavailable(
       lastHttpStatus: options.httpStatus ?? null,
       lastAttemptAt: now,
       nextAttemptAt: options.nextAttemptAt ?? null,
+      terminalAt: now,
       updatedAt: now,
     })
     .where(eq(articleBodyStates.itemId, itemId));
@@ -321,6 +364,7 @@ export async function publishArticleBodyArtifact(
       lastHttpStatus: null,
       lastAttemptAt: now,
       nextAttemptAt: null,
+      terminalAt: now,
       createdAt: now,
       updatedAt: now,
     })
@@ -334,6 +378,7 @@ export async function publishArticleBodyArtifact(
         lastHttpStatus: null,
         lastAttemptAt: now,
         nextAttemptAt: null,
+        terminalAt: now,
         updatedAt: now,
       },
     });
@@ -354,7 +399,7 @@ export async function enqueueArticleBody(
   }
 ): Promise<{
   queued: boolean;
-  reason?: 'disabled' | 'queue_unavailable' | 'already_queued' | 'current';
+  reason?: 'disabled' | 'queue_unavailable' | 'already_queued' | 'current' | 'terminal';
   embeddedCandidatesIncluded?: boolean;
 }> {
   if (!isArticleBodyPipelineEnabled(env)) return { queued: false, reason: 'disabled' };
@@ -378,7 +423,15 @@ export async function enqueueArticleBody(
   ) {
     return { queued: false, reason: 'current' };
   }
-  await markArticleBodyPending(db, input.itemId, extractorVersion, now);
+  if (
+    input.trigger !== 'repair' &&
+    current?.status === 'UNAVAILABLE' &&
+    current.targetExtractorVersion >= extractorVersion &&
+    !isRetryableStoredFailure(current.lastErrorCode)
+  ) {
+    return { queued: false, reason: 'terminal' };
+  }
+  await markArticleBodyPending(db, input.itemId, extractorVersion, input.trigger, now);
 
   const baseMessage: ArticleBodyQueueMessage = {
     itemId: input.itemId,
@@ -404,3 +457,5 @@ export async function enqueueArticleBody(
     embeddedCandidatesIncluded: Boolean(message.embeddedCandidates?.length),
   };
 }
+
+export const articleBodyEnrollmentInternals = { isRetryableStoredFailure };

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -15,6 +15,8 @@ export type ArticleBodySourceKind =
 
 export type ArticleBodyTrigger = 'ingestion' | 'bookmark' | 'reader_open' | 'backfill' | 'repair';
 
+export type ArticleBodyEnrollmentMode = 'off' | 'reader' | 'saved' | 'all';
+
 export interface ArticleBodyBlock {
   id: string;
   kind: string;

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 8;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 9;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 4;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 5;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 5;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 6;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 6;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 7;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 3;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 4;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 1;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 2;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 7;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 8;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/article-body/types.ts
+++ b/apps/worker/src/article-body/types.ts
@@ -1,5 +1,5 @@
 export const ARTICLE_BODY_SCHEMA_VERSION = 1;
-export const ARTICLE_BODY_EXTRACTOR_VERSION = 2;
+export const ARTICLE_BODY_EXTRACTOR_VERSION = 3;
 
 export type ArticleBodyStatus = 'PENDING' | 'PROCESSING' | 'AVAILABLE' | 'DEGRADED' | 'UNAVAILABLE';
 

--- a/apps/worker/src/db/migrations/0025_add_article_body_enrollment_diagnostics.sql
+++ b/apps/worker/src/db/migrations/0025_add_article_body_enrollment_diagnostics.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `article_body_states` ADD `enrollment_trigger` text;
+--> statement-breakpoint
+ALTER TABLE `article_body_states` ADD `requested_at` integer;
+--> statement-breakpoint
+ALTER TABLE `article_body_states` ADD `terminal_at` integer;
+--> statement-breakpoint
+CREATE INDEX `article_body_states_trigger_status_idx` ON `article_body_states` (`enrollment_trigger`,`status`);
+--> statement-breakpoint
+CREATE INDEX `article_body_states_requested_idx` ON `article_body_states` (`requested_at`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1784802300000,
       "tag": "0024_add_article_body_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784891400000,
+      "tag": "0025_add_article_body_enrollment_diagnostics",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -333,12 +333,17 @@ export const articleBodyStates = sqliteTable(
     lastHttpStatus: integer('last_http_status'),
     lastAttemptAt: integer('last_attempt_at'),
     nextAttemptAt: integer('next_attempt_at'),
+    enrollmentTrigger: text('enrollment_trigger'),
+    requestedAt: integer('requested_at'),
+    terminalAt: integer('terminal_at'),
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },
   (table) => [
     index('article_body_states_status_next_attempt_idx').on(table.status, table.nextAttemptAt),
     index('article_body_states_updated_idx').on(table.updatedAt),
+    index('article_body_states_trigger_status_idx').on(table.enrollmentTrigger, table.status),
+    index('article_body_states_requested_idx').on(table.requestedAt),
   ]
 );
 

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -946,6 +946,45 @@
             "$ref": "#/components/responses/NotFound"
           }
         }
+      },
+      "post": {
+        "tags": ["Reading"],
+        "operationId": "requestBookmarkArticleContent",
+        "summary": "Ensure article content is available",
+        "description": "Idempotently requests article-body acquisition for an article the token owner can access. Current and terminal results are returned without duplicate queue work.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:write"],
+        "x-api-status": "current",
+        "parameters": [{ "$ref": "#/components/parameters/UserItemId" }],
+        "responses": {
+          "200": {
+            "description": "The article already has a current or terminal result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ArticleContentRequestResponse" }
+              }
+            }
+          },
+          "202": {
+            "description": "Article acquisition was queued or is already processing.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ArticleContentRequestResponse" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "422": {
+            "description": "The item is not an article.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/tags": {
@@ -3986,6 +4025,37 @@
               },
               "articleBody": {
                 "$ref": "#/components/schemas/ArticleBodyStatus"
+              }
+            }
+          }
+        ]
+      },
+      "ArticleContentRequestResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArticleContentResponse"
+          },
+          {
+            "type": "object",
+            "required": ["request"],
+            "properties": {
+              "request": {
+                "type": "object",
+                "required": ["queued"],
+                "properties": {
+                  "queued": { "type": "boolean" },
+                  "reason": {
+                    "type": "string",
+                    "enum": [
+                      "disabled",
+                      "enrollment_disabled",
+                      "queue_unavailable",
+                      "already_queued",
+                      "current",
+                      "terminal"
+                    ]
+                  }
+                }
               }
             }
           }

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -31,6 +31,7 @@ const {
   mockGetArticleContent,
   mockGetArticleBodyStatus,
   mockGetArticleBodyArtifact,
+  mockEnqueueArticleBody,
   mockListTags,
   mockPreview,
   mockSave,
@@ -108,6 +109,7 @@ const {
   mockGetArticleContent: vi.fn(),
   mockGetArticleBodyStatus: vi.fn(),
   mockGetArticleBodyArtifact: vi.fn(),
+  mockEnqueueArticleBody: vi.fn(),
   mockListTags: vi.fn(),
   mockPreview: vi.fn(),
   mockSave: vi.fn(),
@@ -171,6 +173,7 @@ vi.mock('../article-body/service', async (importOriginal) => {
   return {
     ...actual,
     getArticleBodyStatus: mockGetArticleBodyStatus,
+    enqueueArticleBody: mockEnqueueArticleBody,
   };
 });
 
@@ -388,6 +391,7 @@ describe('apiV1Routes', () => {
     });
     mockGetArticleBodyStatus.mockResolvedValue(null);
     mockGetArticleBodyArtifact.mockResolvedValue(null);
+    mockEnqueueArticleBody.mockResolvedValue({ queued: false, reason: 'current' });
     mockConnectionsList.mockResolvedValue({
       YOUTUBE: null,
       SPOTIFY: null,
@@ -1981,19 +1985,34 @@ describe('apiV1Routes', () => {
   });
 
   it('moves an inbox item to bookmarks', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_inbox_1',
+      itemId: 'item_1',
+      contentType: 'ARTICLE',
+    });
     mockBookmarkInboxItem.mockResolvedValue({ success: true });
     const app = createTestApp();
+    const env = {
+      ...createMockEnv(),
+      ARTICLE_BODY_PIPELINE_ENABLED: 'true',
+      ARTICLE_BODY_ENROLLMENT_MODE: 'saved',
+    } as Env['Bindings'];
 
     const res = await app.fetch(
       new Request('http://localhost/api/v1/inbox/ui_inbox_1/bookmark', {
         method: 'POST',
         headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
       }),
-      createMockEnv()
+      env
     );
 
     expect(res.status).toBe(200);
     expect(mockBookmarkInboxItem).toHaveBeenCalledWith({ id: 'ui_inbox_1' });
+    expect(mockEnqueueArticleBody).toHaveBeenCalledWith(
+      expect.anything(),
+      env,
+      expect.objectContaining({ itemId: 'item_1', trigger: 'bookmark' })
+    );
     expect((await res.json()) as JsonBody).toMatchObject({
       success: true,
       requestId: 'test-request-id',
@@ -2119,6 +2138,11 @@ describe('apiV1Routes', () => {
       status: 'created',
     });
     const app = createTestApp();
+    const env = {
+      ...createMockEnv(),
+      ARTICLE_BODY_PIPELINE_ENABLED: 'true',
+      ARTICLE_BODY_ENROLLMENT_MODE: 'saved',
+    } as Env['Bindings'];
 
     const res = await app.fetch(
       new Request('http://localhost/api/v1/bookmarks', {
@@ -2129,7 +2153,7 @@ describe('apiV1Routes', () => {
         },
         body: JSON.stringify({ url: 'https://example.com/article', tags: ['Design', ' api '] }),
       }),
-      createMockEnv()
+      env
     );
 
     expect(res.status).toBe(200);
@@ -2140,6 +2164,11 @@ describe('apiV1Routes', () => {
         title: 'Article title',
         tags: ['Design', ' api '],
       })
+    );
+    expect(mockEnqueueArticleBody).toHaveBeenCalledWith(
+      expect.anything(),
+      env,
+      expect.objectContaining({ itemId: 'item_1', trigger: 'bookmark' })
     );
     expect((await res.json()) as JsonBody).toMatchObject({
       bookmark: {
@@ -2490,6 +2519,128 @@ describe('apiV1Routes', () => {
         pipelineStatus: 'NOT_REQUESTED',
       },
     });
+  });
+
+  it('idempotently requests article content for an eligible reader open', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_1',
+      itemId: 'item_1',
+      title: 'Article',
+      contentType: 'ARTICLE',
+    });
+    mockGetArticleContent.mockResolvedValue({ content: null });
+    mockEnqueueArticleBody.mockResolvedValue({ queued: true });
+    const app = createTestApp();
+    const env = {
+      ...createMockEnv(),
+      ARTICLE_BODY_PIPELINE_ENABLED: 'true',
+      ARTICLE_BODY_ENROLLMENT_MODE: 'reader',
+    } as Env['Bindings'];
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      env
+    );
+
+    expect(res.status).toBe(202);
+    expect(mockEnqueueArticleBody).toHaveBeenCalledWith(
+      expect.anything(),
+      env,
+      expect.objectContaining({
+        itemId: 'item_1',
+        trigger: 'reader_open',
+        traceId: 'test-trace-id',
+      })
+    );
+    expect((await res.json()) as JsonBody).toMatchObject({
+      content: null,
+      articleBody: { availability: 'UNAVAILABLE', pipelineStatus: 'NOT_REQUESTED' },
+      request: { queued: true },
+    });
+  });
+
+  it('returns a terminal reader result without requeueing it', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_1',
+      itemId: 'item_1',
+      title: 'Interactive page',
+      contentType: 'ARTICLE',
+    });
+    mockGetArticleContent.mockResolvedValue({ content: null });
+    mockEnqueueArticleBody.mockResolvedValue({ queued: false, reason: 'terminal' });
+    mockGetArticleBodyStatus.mockResolvedValue({
+      status: 'UNAVAILABLE',
+      targetExtractorVersion: 1,
+      attemptCount: 1,
+      lastErrorCode: 'NOT_READERABLE',
+      lastHttpStatus: 200,
+      lastAttemptAt: 1700000000000,
+      nextAttemptAt: null,
+      updatedAt: 1700000000000,
+      versionId: null,
+      schemaVersion: null,
+      extractorVersion: null,
+      sourceKind: null,
+      contentHash: null,
+      r2Key: null,
+      wordCount: null,
+      readingTimeMinutes: null,
+      qualityScore: null,
+      qualityWarningsJson: null,
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      {
+        ...createMockEnv(),
+        ARTICLE_BODY_PIPELINE_ENABLED: 'true',
+        ARTICLE_BODY_ENROLLMENT_MODE: 'reader',
+      } as Env['Bindings']
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      articleBody: {
+        availability: 'UNAVAILABLE',
+        pipelineStatus: 'UNAVAILABLE',
+        lastErrorCode: 'NOT_READERABLE',
+      },
+      request: { queued: false, reason: 'terminal' },
+    });
+  });
+
+  it('rejects reader requests for non-article content', async () => {
+    mockGetItem.mockResolvedValue({
+      id: 'ui_1',
+      itemId: 'item_1',
+      title: 'Video',
+      contentType: 'VIDEO',
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/article-content', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      {
+        ...createMockEnv(),
+        ARTICLE_BODY_ENROLLMENT_MODE: 'reader',
+      } as Env['Bindings']
+    );
+
+    expect(res.status).toBe(422);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'ARTICLE_BODY_NOT_ELIGIBLE',
+    });
+    expect(mockEnqueueArticleBody).not.toHaveBeenCalled();
   });
 
   it('serves the current versioned artifact with its availability metadata', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -26,7 +26,12 @@ import {
 } from '@zine/editorial-schema';
 import type { Env } from '../types';
 import { createDb } from '../db';
-import { getArticleBodyStatus, toArticleBodyPublicStatus } from '../article-body/service';
+import {
+  enqueueArticleBody,
+  getArticleBodyStatus,
+  isArticleBodyEnrollmentEnabled,
+  toArticleBodyPublicStatus,
+} from '../article-body/service';
 import { getArticleBodyArtifact } from '../article-body/storage';
 import { apiTokens, userItemConsumptionEvents, userItems } from '../db/schema';
 import { appRouter } from '../trpc/router';
@@ -55,6 +60,7 @@ import {
   storeEditorialEdition,
 } from '../lib/editorial-storage';
 import { verifyClerkRequestToken } from '../middleware/auth';
+import { logger } from '../lib/logger';
 import { getEditorialToday } from '../lib/editorial-today';
 import {
   EditorialFeedbackConflictError,
@@ -88,6 +94,61 @@ import {
 
 const DEFAULT_BOOKMARKS_LIMIT = 10;
 const MAX_BOOKMARKS_LIMIT = 50;
+const apiLogger = logger.child('api-v1');
+
+async function readArticleContent(
+  env: Env['Bindings'],
+  itemId: string,
+  legacyContent: string | null
+) {
+  const record = await getArticleBodyStatus(createDb(env.DB), itemId);
+  const artifact = record?.r2Key
+    ? await getArticleBodyArtifact(env.ARTICLE_CONTENT, record.r2Key)
+    : null;
+  const artifactMissing = Boolean(record?.r2Key && !artifact);
+  const effectiveRecord = artifactMissing
+    ? { ...record!, versionId: null, r2Key: null, lastErrorCode: 'ARTIFACT_MISSING' }
+    : record;
+  let articleBody = toArticleBodyPublicStatus(effectiveRecord, Boolean(legacyContent));
+
+  if (artifactMissing && legacyContent) {
+    articleBody = {
+      ...articleBody,
+      availability: 'DEGRADED' as const,
+      sourceKind: 'LEGACY' as const,
+      qualityWarnings: [...articleBody.qualityWarnings, 'CURRENT_ARTIFACT_MISSING_FALLBACK_LEGACY'],
+    };
+  }
+
+  return {
+    content: artifact?.sanitizedHtml ?? legacyContent,
+    articleBody,
+  };
+}
+
+async function enrollSavedArticleBestEffort(
+  env: Env['Bindings'],
+  item: { itemId: string; contentType: string },
+  traceId: string
+): Promise<void> {
+  if (item.contentType !== 'ARTICLE' || !isArticleBodyEnrollmentEnabled(env, 'bookmark')) {
+    return;
+  }
+
+  try {
+    await enqueueArticleBody(createDb(env.DB), env, {
+      itemId: item.itemId,
+      trigger: 'bookmark',
+      traceId,
+    });
+  } catch (error) {
+    apiLogger.warn('Article-body bookmark enrollment failed without blocking the bookmark', {
+      operation: 'article_body.enroll.bookmark',
+      traceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 const SaveBookmarkBodySchema = z.object({
   url: z.string().url('Invalid URL format'),
@@ -1507,7 +1568,9 @@ apiV1Routes.post('/inbox/:id/bookmark', apiAuth('bookmarks:write'), async (c) =>
   const caller = appRouter.createCaller(await createContext(c));
 
   try {
+    const item = await caller.items.get({ id: c.req.param('id') });
     const result = await caller.items.bookmark({ id: c.req.param('id') });
+    await enrollSavedArticleBestEffort(c.env, item, c.get('traceId'));
     return c.json({
       ...result,
       requestId: c.get('requestId'),
@@ -1707,6 +1770,11 @@ apiV1Routes.post('/bookmarks', apiAuth('bookmarks:write'), async (c) => {
       url: parsedBody.data.url,
       tags: parsedBody.data.tags,
     });
+    await enrollSavedArticleBestEffort(
+      c.env,
+      { itemId: bookmark.itemId, contentType: preview.contentType },
+      c.get('traceId')
+    );
 
     return c.json({
       bookmark,
@@ -1934,34 +2002,54 @@ apiV1Routes.get('/bookmarks/:id/article-content', apiAuth('bookmarks:read'), asy
   try {
     const item = await caller.items.get({ id: c.req.param('id') });
     const legacy = await caller.items.getArticleContent({ itemId: item.itemId });
-    const record = await getArticleBodyStatus(createDb(c.env.DB), item.itemId);
-    const artifact = record?.r2Key
-      ? await getArticleBodyArtifact(c.env.ARTICLE_CONTENT, record.r2Key)
-      : null;
-    const artifactMissing = Boolean(record?.r2Key && !artifact);
-    const effectiveRecord = artifactMissing
-      ? { ...record!, versionId: null, r2Key: null, lastErrorCode: 'ARTIFACT_MISSING' }
-      : record;
-    let articleBody = toArticleBodyPublicStatus(effectiveRecord, Boolean(legacy.content));
-
-    if (artifactMissing && legacy.content) {
-      articleBody = {
-        ...articleBody,
-        availability: 'DEGRADED',
-        sourceKind: 'LEGACY',
-        qualityWarnings: [
-          ...articleBody.qualityWarnings,
-          'CURRENT_ARTIFACT_MISSING_FALLBACK_LEGACY',
-        ],
-      };
-    }
+    const result = await readArticleContent(c.env, item.itemId, legacy.content);
 
     return c.json({
-      content: artifact?.sanitizedHtml ?? legacy.content,
-      articleBody,
+      ...result,
       requestId: c.get('requestId'),
       traceId: c.get('traceId'),
     });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
+apiV1Routes.post('/bookmarks/:id/article-content', apiAuth('bookmarks:write'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const item = await caller.items.get({ id: c.req.param('id') });
+    if (item.contentType !== 'ARTICLE') {
+      return c.json(
+        {
+          error: 'Article reading is only available for article items',
+          code: 'ARTICLE_BODY_NOT_ELIGIBLE',
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        422
+      );
+    }
+
+    const requestResult = isArticleBodyEnrollmentEnabled(c.env, 'reader_open')
+      ? await enqueueArticleBody(createDb(c.env.DB), c.env, {
+          itemId: item.itemId,
+          trigger: 'reader_open',
+          traceId: c.get('traceId'),
+        })
+      : { queued: false as const, reason: 'enrollment_disabled' as const };
+    const legacy = await caller.items.getArticleContent({ itemId: item.itemId });
+    const result = await readArticleContent(c.env, item.itemId, legacy.content);
+    const response = {
+      ...result,
+      request: requestResult,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    };
+
+    return requestResult.queued || requestResult.reason === 'already_queued'
+      ? c.json(response, 202)
+      : c.json(response);
   } catch (error) {
     return trpcErrorResponse(c, error);
   }

--- a/apps/worker/src/rss/parser.test.ts
+++ b/apps/worker/src/rss/parser.test.ts
@@ -94,6 +94,33 @@ describe('parseRssFeedXml', () => {
     });
   });
 
+  it('preserves escaped markup examples inside a CDATA article body', () => {
+    const xml = `<?xml version="1.0" encoding="utf-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Code Feed</title>
+        <entry>
+          <id>code-example</id>
+          <title>Markup examples</title>
+          <link href="https://example.com/code-example" rel="alternate" />
+          <updated>2026-07-24T10:00:00Z</updated>
+          <content type="html"><![CDATA[
+            <p>Before the example.</p>
+            <p>Use a <code>&lt;script&gt;</code> tag when embedding JSON.</p>
+            <h2>The final section</h2>
+            <p>This tail must remain part of the candidate.</p>
+          ]]></content>
+        </entry>
+      </feed>`;
+
+    const entry = parseRssFeedXml(xml, 'https://example.com/atom.xml').entries[0];
+
+    expect(entry.articleBodyCandidate?.html).toContain('<code>&lt;script&gt;</code>');
+    expect(entry.articleBodyCandidate?.html).toContain('<h2>The final section</h2>');
+    expect(entry.articleBodyCandidate?.html).toContain(
+      '<p>This tail must remain part of the candidate.</p>'
+    );
+  });
+
   it('falls back to hash identity when link/guid are missing', () => {
     const xml = `<?xml version="1.0"?>
       <rss version="2.0">

--- a/apps/worker/src/rss/parser.ts
+++ b/apps/worker/src/rss/parser.ts
@@ -97,9 +97,16 @@ function decodeCommonHtmlEntities(input: string): string {
 
 function normalizeEmbeddedHtmlCandidate(value: string | null): string | null {
   if (!value) return null;
-  const decoded = /&(?:lt|gt|quot|apos|amp|#39);/i.test(value)
-    ? decodeCommonHtmlEntities(value)
-    : value;
+  // XML parsers can leave a fully entity-escaped HTML fragment encoded, but
+  // CDATA feed bodies already contain real markup alongside escaped prose.
+  // Decoding the latter wholesale can turn examples such as
+  // `&lt;script&gt;` into active markup and make the HTML parser consume the
+  // remainder of the article as an unterminated element.
+  const hasHtmlMarkup = /<\/?[a-z][^>]*>/i.test(value);
+  const decoded =
+    !hasHtmlMarkup && /&(?:lt|gt|quot|apos|amp|#39);/i.test(value)
+      ? decodeCommonHtmlEntities(value)
+      : value;
   return decoded.trim() || null;
 }
 

--- a/apps/worker/src/rss/service.test.ts
+++ b/apps/worker/src/rss/service.test.ts
@@ -9,6 +9,14 @@ import { items } from '../db/schema';
 const mockPrepareItem = vi.fn();
 const mockFetchLinkPreview = vi.fn();
 const mockGetOrCreateCreator = vi.fn();
+const { mockEnqueueArticleBody } = vi.hoisted(() => ({
+  mockEnqueueArticleBody: vi.fn(),
+}));
+
+vi.mock('../article-body/service', async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return { ...actual, enqueueArticleBody: mockEnqueueArticleBody };
+});
 
 vi.mock('../ingestion/processor/prepare', () => ({
   prepareItem: (...args: Parameters<typeof prepareItem>) => mockPrepareItem(...args),
@@ -137,6 +145,7 @@ describe('syncRssFeed', () => {
     mockPrepareItem.mockResolvedValue({ status: 'skipped' });
     mockFetchLinkPreview.mockResolvedValue(null);
     mockGetOrCreateCreator.mockResolvedValue(null);
+    mockEnqueueArticleBody.mockResolvedValue({ queued: true });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(sampleAtom, {
         status: 200,
@@ -184,6 +193,56 @@ describe('syncRssFeed', () => {
 
     expect(result.processedEntries).toBe(2);
     expect(mockPrepareItem).toHaveBeenCalledTimes(2);
+  });
+
+  it('enrolls a new RSS article with its embedded Atom candidate in all mode', async () => {
+    mockPrepareItem.mockResolvedValue({
+      status: 'prepared',
+      item: {
+        newItem: {
+          id: 'new_item_123',
+          contentType: ContentType.ARTICLE,
+          provider: Provider.RSS,
+          providerId: 'https://example.com/posts/1',
+          canonicalUrl: 'https://example.com/posts/1',
+          title: 'Entry With Image',
+          description: 'Body',
+          creator: 'Example Feed',
+          publishedAt: Date.now(),
+          createdAt: Date.now(),
+        },
+        rawItem: {},
+        providerId: 'https://example.com/posts/1',
+        canonicalItemId: 'item_123',
+        canonicalItemExists: true,
+        userItemId: 'user_item_123',
+        creatorId: null,
+      },
+    });
+    const { db } = createMockDb();
+    const articleBodyEnv = {
+      ARTICLE_BODY_PIPELINE_ENABLED: 'true',
+      ARTICLE_BODY_ENROLLMENT_MODE: 'all',
+      ARTICLE_BODY_QUEUE: { send: vi.fn() },
+    } as never;
+
+    await syncRssFeed(db, feed as SyncFeed, {
+      maxEntries: 1,
+      useConditional: false,
+      articleBodyEnv,
+    });
+
+    expect(mockEnqueueArticleBody).toHaveBeenCalledWith(
+      db,
+      articleBodyEnv,
+      expect.objectContaining({
+        itemId: 'item_123',
+        trigger: 'ingestion',
+        embeddedCandidates: [
+          expect.objectContaining({ sourceKind: 'ATOM_FULL', sourceUrl: feed.feedUrl }),
+        ],
+      })
+    );
   });
 
   it('backfills thumbnail, summary, and creator for skipped RSS items', async () => {

--- a/apps/worker/src/rss/service.ts
+++ b/apps/worker/src/rss/service.ts
@@ -10,6 +10,7 @@ import { getOrCreateCreator } from '../ingestion/processor/creators';
 import { prepareItem } from '../ingestion/processor/prepare';
 import { fetchLinkPreview } from '../lib/link-preview';
 import { logger } from '../lib/logger';
+import { enqueueArticleBody, isArticleBodyEnrollmentEnabled } from '../article-body/service';
 import { releaseLock, tryAcquireLock } from '../lib/locks';
 import type { Bindings } from '../types';
 import { parseRssFeedXml, type ParsedRssEntry, type ParsedRssFeed } from './parser';
@@ -53,6 +54,10 @@ interface FetchFeedResult {
 interface SyncOptions {
   maxEntries?: number;
   useConditional?: boolean;
+  articleBodyEnv?: Pick<
+    Bindings,
+    'ARTICLE_BODY_PIPELINE_ENABLED' | 'ARTICLE_BODY_ENROLLMENT_MODE' | 'ARTICLE_BODY_QUEUE'
+  >;
 }
 
 async function fetchFeed(feed: RssFeedRow, useConditional: boolean): Promise<FetchFeedResult> {
@@ -221,8 +226,9 @@ async function ingestEntry(params: {
   userId: string;
   feedId: string;
   entry: ParsedRssEntry;
+  articleBodyEnv?: SyncOptions['articleBodyEnv'];
 }): Promise<boolean> {
-  const { db, userId, feedId, entry } = params;
+  const { db, userId, feedId, entry, articleBodyEnv } = params;
   const enrichedEntry = await enrichRssEntryMetadata(entry, feedId);
 
   const prepared = await prepareItem({
@@ -360,6 +366,24 @@ async function ingestEntry(params: {
   );
 
   await db.batch(statements as [BatchItem<'sqlite'>, ...BatchItem<'sqlite'>[]]);
+
+  if (articleBodyEnv && isArticleBodyEnrollmentEnabled(articleBodyEnv, 'ingestion')) {
+    try {
+      await enqueueArticleBody(db, articleBodyEnv, {
+        itemId: prepared.item.canonicalItemId,
+        trigger: 'ingestion',
+        embeddedCandidates: enrichedEntry.articleBodyCandidate
+          ? [enrichedEntry.articleBodyCandidate]
+          : undefined,
+      });
+    } catch (error) {
+      rssLogger.warn('Article-body enrollment failed without blocking RSS ingestion', {
+        operation: 'article_body.enroll.ingestion',
+        feedId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
   return true;
 }
 
@@ -369,6 +393,7 @@ async function ingestEntries(params: {
   feedId: string;
   entries: ParsedRssEntry[];
   maxEntries: number;
+  articleBodyEnv?: SyncOptions['articleBodyEnv'];
 }): Promise<{ newItems: number; processedEntries: number }> {
   const sortedEntries = sortEntriesByPublishDate(params.entries).slice(0, params.maxEntries);
   let newItems = 0;
@@ -380,6 +405,7 @@ async function ingestEntries(params: {
         userId: params.userId,
         feedId: params.feedId,
         entry,
+        articleBodyEnv: params.articleBodyEnv,
       });
       if (created) {
         newItems += 1;
@@ -504,6 +530,7 @@ export async function syncRssFeed(
       feedId: feed.id,
       entries: parsed.entries,
       maxEntries,
+      articleBodyEnv: options.articleBodyEnv,
     });
 
     await markFeedSuccess({
@@ -589,6 +616,7 @@ export async function pollRssFeeds(env: Bindings, _ctx: ExecutionContext): Promi
         const result = await syncRssFeed(db, feed, {
           maxEntries: MAX_ENTRIES_PER_SYNC,
           useConditional: true,
+          articleBodyEnv: env,
         });
         processedFeeds += 1;
         newItems += result.newItems;

--- a/apps/worker/src/trpc/routers/rss.ts
+++ b/apps/worker/src/trpc/routers/rss.ts
@@ -152,6 +152,7 @@ export const rssRouter = router({
       const seedResult = await syncRssFeed(ctx.db, feed, {
         maxEntries: seedMode === 'none' ? 0 : 1,
         useConditional: false,
+        articleBodyEnv: ctx.env,
       });
 
       const refreshedFeed = await ctx.db.query.rssFeeds.findFirst({
@@ -309,6 +310,7 @@ export const rssRouter = router({
         maxEntries: 20,
         // Manual sync is user-initiated and should always attempt metadata repair/backfill.
         useConditional: false,
+        articleBodyEnv: ctx.env,
       });
 
       return {

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -87,6 +87,8 @@ export interface Bindings {
   ARTICLE_BODY_BACKFILL_SECRET?: string;
   /** Opt-in switch for article-body queue production and consumption. */
   ARTICLE_BODY_PIPELINE_ENABLED?: string;
+  /** Controlled automatic article-body enrollment: off, reader, saved, or all. */
+  ARTICLE_BODY_ENROLLMENT_MODE?: string;
   /** Queue for async pull-to-refresh sync (optional - not available in all envs) */
   SYNC_QUEUE?: Queue<SyncQueueMessage>;
   /** Queue for async bookmark enrichment (optional - not available in all envs) */

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -117,6 +117,7 @@ ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 ARTICLE_BODY_PIPELINE_ENABLED = "false"
+ARTICLE_BODY_ENROLLMENT_MODE = "off"
 # CLERK_JWKS_URL = "https://clerk.your-domain.com/.well-known/jwks.json"
 # CLERK_WEBHOOK_SECRET = "whsec_..." # From Clerk Dashboard > Webhooks
 
@@ -155,6 +156,7 @@ ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 ARTICLE_BODY_PIPELINE_ENABLED = "false"
+ARTICLE_BODY_ENROLLMENT_MODE = "off"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.staging.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]
@@ -244,6 +246,7 @@ ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 ARTICLE_BODY_PIPELINE_ENABLED = "false"
+ARTICLE_BODY_ENROLLMENT_MODE = "off"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -245,8 +245,8 @@ SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
 ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
-ARTICLE_BODY_PIPELINE_ENABLED = "false"
-ARTICLE_BODY_ENROLLMENT_MODE = "off"
+ARTICLE_BODY_PIPELINE_ENABLED = "true"
+ARTICLE_BODY_ENROLLMENT_MODE = "reader"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -92,9 +92,10 @@ max_batch_timeout = 30
 
 [[queues.consumers]]
 queue = "zine-article-body-queue-dev"
-max_batch_size = 5
+max_batch_size = 1
 max_batch_timeout = 30
 max_retries = 3
+max_concurrency = 1
 dead_letter_queue = "zine-article-body-dlq-dev"
 
 [[queues.consumers]]
@@ -193,9 +194,10 @@ max_batch_size = 5
 max_batch_timeout = 30
 [[env.staging.queues.consumers]]
 queue = "zine-article-body-queue-staging"
-max_batch_size = 5
+max_batch_size = 1
 max_batch_timeout = 30
 max_retries = 3
+max_concurrency = 1
 dead_letter_queue = "zine-article-body-dlq-staging"
 [[env.staging.queues.consumers]]
 queue = "zine-article-body-dlq-staging"
@@ -283,9 +285,10 @@ max_batch_size = 5
 max_batch_timeout = 30
 [[env.production.queues.consumers]]
 queue = "zine-article-body-queue-prod"
-max_batch_size = 5
+max_batch_size = 1
 max_batch_timeout = 30
 max_retries = 3
+max_concurrency = 1
 dead_letter_queue = "zine-article-body-dlq-prod"
 [[env.production.queues.consumers]]
 queue = "zine-article-body-dlq-prod"

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -246,7 +246,7 @@ ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 ARTICLE_BODY_PIPELINE_ENABLED = "true"
-ARTICLE_BODY_ENROLLMENT_MODE = "saved"
+ARTICLE_BODY_ENROLLMENT_MODE = "all"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -246,7 +246,7 @@ ENRICHMENT_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 EMBEDDING_MODEL = "@cf/qwen/qwen3-embedding-0.6b"
 EMBEDDING_DIMENSIONS = "1024"
 ARTICLE_BODY_PIPELINE_ENABLED = "true"
-ARTICLE_BODY_ENROLLMENT_MODE = "reader"
+ARTICLE_BODY_ENROLLMENT_MODE = "saved"
 # Set via wrangler secret: CLERK_WEBHOOK_SECRET
 [env.production.triggers]
 crons = ["0 * * * *", "15 * * * *", "30 * * * *", "45 * * * *", "5 8 * * *"]

--- a/docs/article-body-extraction.md
+++ b/docs/article-body-extraction.md
@@ -1,6 +1,6 @@
 # Article-body extraction quality (phase 2a)
 
-Phase 2a supplies and measures article-body acquisition without enrolling production items. The phase-one queue remains disabled and no ingestion, bookmark, reader-open, or backfill path calls `enqueueArticleBody`.
+Phase 2a supplied and measured article-body acquisition without automatically enrolling production items. Phase 2b subsequently added the protected bounded backfill, and Phase 3 adds the independently controlled product enrollment ladder documented in [Native article reader beta](./article-reader-beta.md).
 
 ## Acquisition cascade
 
@@ -46,4 +46,4 @@ The Markdown report includes beginning, middle, and ending samples for human che
 
 ## Phase boundary
 
-This phase did not publish artifacts, create queues remotely, apply production migrations, or change live extraction behavior. Phase 2b now adapts this function into the queue processor and provides a dry-run-first bounded cohort endpoint. No automatic feed, bookmark, or reader-open enrollment has been added; the staged production burn remains a separate operational step.
+Phase 2a did not publish artifacts, create queues remotely, apply production migrations, or change live extraction behavior. Phase 2b adapted this function into the queue processor and provided a dry-run-first bounded cohort endpoint. Phase 3 adds native reader demand, saved-bookmark, and new-RSS-entry enrollment behind an explicit staged mode; historical bulk enrollment remains outside that product path.

--- a/docs/article-body-foundation.md
+++ b/docs/article-body-foundation.md
@@ -1,6 +1,6 @@
 # Article-body foundation (phase 1)
 
-Phase 1 makes article-body availability a durable, observable backend primitive without changing acquisition behavior. The phase 2b processor and cohort controls are now installed, but the pipeline remains disabled in every Wrangler environment until the staged activation checklist is completed.
+Phase 1 makes article-body availability a durable, observable backend primitive without changing acquisition behavior. Phase 2 installed and validated the processor and bounded cohort controls. Phase 3's native reader and staged enrollment contract are documented in [Native article reader beta](./article-reader-beta.md).
 
 The extraction and review implementation that builds on this contract is documented in [Article-body extraction quality](./article-body-extraction.md).
 

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -12,6 +12,7 @@ Phase 3 turns the article-body foundation into a user-facing native reading expe
 - The protected cache is isolated by authenticated user, stores only readable responses, and retains at most 50 immutable article documents.
 - Enrollment is staged independently from queue processing with `ARTICLE_BODY_ENROLLMENT_MODE=off|reader|saved|all`. Terminal failures at the current extractor version are not repeatedly enqueued by ordinary product triggers; repair jobs and extractor upgrades remain available.
 - Bookmark and RSS enrollment are best effort and never make the primary save or ingestion operation fail.
+- Article acquisition is intentionally serialized in one-message queue batches so a bounded cohort cannot create a burst of requests that trips publisher rate limits.
 - `/health/queues` reports safe aggregate enrollment outcomes, source mix, latency, failure codes, pending age, and DLQ count without exposing item or user identifiers.
 - The production rollout passes the reader-demand, saved-item, and new-RSS-entry stages; the reviewed production cohort meets the extraction quality gate; the native app is built, installed, launched, and manually checked on a physical iPhone.
 - The merged `main` Worker deployment is verified by release SHA and production health/API readback.

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -13,6 +13,7 @@ Phase 3 turns the article-body foundation into a user-facing native reading expe
 - Enrollment is staged independently from queue processing with `ARTICLE_BODY_ENROLLMENT_MODE=off|reader|saved|all`. Terminal failures at the current extractor version are not repeatedly enqueued by ordinary product triggers; repair jobs and extractor upgrades remain available.
 - Bookmark and RSS enrollment are best effort and never make the primary save or ingestion operation fail.
 - Article acquisition is intentionally serialized in one-message queue batches so a bounded cohort cannot create a burst of requests that trips publisher rate limits.
+- If a public Substack page and its public post JSON endpoint are both throttled, acquisition may use Jina Reader's unauthenticated, rate-limited HTML rendering endpoint for that same public URL. The result still passes Zine's normal extraction, sanitization, provenance, and quality gates.
 - `/health/queues` reports safe aggregate enrollment outcomes, source mix, latency, failure codes, pending age, and DLQ count without exposing item or user identifiers.
 - The production rollout passes the reader-demand, saved-item, and new-RSS-entry stages; the reviewed production cohort meets the extraction quality gate; the native app is built, installed, launched, and manually checked on a physical iPhone.
 - The merged `main` Worker deployment is verified by release SHA and production health/API readback.

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -22,7 +22,7 @@ Phase 3 turns the article-body foundation into a user-facing native reading expe
 
 `POST /api/v1/bookmarks/:id/article-content` is the reader-demand request. It verifies that the user owns the bookmark and that the canonical item is an article, attempts idempotent enrollment when reader enrollment is enabled, and returns the same content/status envelope plus a `request` result. A newly queued or already-active request returns `202`; current, terminal, disabled, or otherwise non-queued results return `200`. Non-article items return `422`.
 
-The iOS client performs GET first, POSTs only when no readable body exists, and polls the GET endpoint for at most 20 seconds. A terminal acquisition result becomes an explicit unavailable state. A polling timeout or transport failure is retryable and never substitutes partial page text.
+The iOS client performs GET first, POSTs only when no readable body exists, and polls the GET endpoint for at most 45 seconds. A terminal acquisition result becomes an explicit unavailable state. A polling timeout or transport failure is retryable and never substitutes partial page text.
 
 ## Enrollment ladder
 

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -1,0 +1,55 @@
+# Native article reader beta (phase 3)
+
+Phase 3 turns the article-body foundation into a user-facing native reading experience. The supported client is `apps/ios`; the deprecated Expo client is intentionally unchanged.
+
+## Definition of done
+
+- Article bookmarks expose a native **Read** action while every reader state retains **Open Original**.
+- A readable current artifact or truthful degraded legacy fallback renders with native typography, light and dark appearance, Dynamic Type scaling, semantic article markup, responsive media, and external-link handoff.
+- Active content cannot execute JavaScript, submit forms, embed frames, open network connections, or persist website data inside the reader.
+- Reader demand can enroll one eligible canonical article through the authenticated REST API and observes loading, preparing, available, degraded, unavailable, retryable failure, and offline-cache states without inventing content.
+- Scroll progress is restored and saved through the existing bookmark progress API. Opened and finished state continue to use the existing bookmark contracts.
+- The protected cache is isolated by authenticated user, stores only readable responses, and retains at most 50 immutable article documents.
+- Enrollment is staged independently from queue processing with `ARTICLE_BODY_ENROLLMENT_MODE=off|reader|saved|all`. Terminal failures at the current extractor version are not repeatedly enqueued by ordinary product triggers; repair jobs and extractor upgrades remain available.
+- Bookmark and RSS enrollment are best effort and never make the primary save or ingestion operation fail.
+- `/health/queues` reports safe aggregate enrollment outcomes, source mix, latency, failure codes, pending age, and DLQ count without exposing item or user identifiers.
+- The production rollout passes the reader-demand, saved-item, and new-RSS-entry stages; the reviewed production cohort meets the extraction quality gate; the native app is built, installed, launched, and manually checked on a physical iPhone.
+- The merged `main` Worker deployment is verified by release SHA and production health/API readback.
+
+## REST contract
+
+`GET /api/v1/bookmarks/:id/article-content` remains a read-only status and content lookup. It does not enroll work.
+
+`POST /api/v1/bookmarks/:id/article-content` is the reader-demand request. It verifies that the user owns the bookmark and that the canonical item is an article, attempts idempotent enrollment when reader enrollment is enabled, and returns the same content/status envelope plus a `request` result. A newly queued or already-active request returns `202`; current, terminal, disabled, or otherwise non-queued results return `200`. Non-article items return `422`.
+
+The iOS client performs GET first, POSTs only when no readable body exists, and polls the GET endpoint for at most 20 seconds. A terminal acquisition result becomes an explicit unavailable state. A polling timeout or transport failure is retryable and never substitutes partial page text.
+
+## Enrollment ladder
+
+Queue processing and enrollment use separate controls:
+
+1. `ARTICLE_BODY_PIPELINE_ENABLED=true`, `ARTICLE_BODY_ENROLLMENT_MODE=reader`: only explicit native reader demand enrolls.
+2. `ARTICLE_BODY_ENROLLMENT_MODE=saved`: reader demand plus newly saved article bookmarks enroll.
+3. `ARTICLE_BODY_ENROLLMENT_MODE=all`: reader demand, new saved articles, and newly ingested RSS articles enroll. Full RSS/Atom content is carried as a source-first candidate when available.
+
+Changing the enrollment mode to `off` stops new automatic work without hiding already published artifacts. Setting `ARTICLE_BODY_PIPELINE_ENABLED=false` is the stronger queue-processing kill switch. Neither rollback deletes artifacts or lifecycle history.
+
+## Production verification
+
+At every stage:
+
+1. Confirm the deployed Worker release matches the intended commit.
+2. Read `/health/queues` before and after the action. Pending work must drain; DLQ must not unexpectedly increase; trigger/source aggregates must match the action.
+3. Inspect the authenticated API response and the immutable R2 artifact rather than inferring success from queue submission.
+4. Read the beginning, middle, and end of every pilot artifact. Reject topic mismatch, truncation, navigation boilerplate, duplicated blocks, missing conclusions, or active markup.
+5. Verify the corresponding native state, original-source escape hatch, progress restoration, completion toggle, and cached reopen behavior.
+
+Advance from `reader` to `saved`, and from `saved` to `all`, only after the preceding stage is terminal and correct. Return enrollment to `off` if pending age grows unexpectedly, the DLQ changes, acquisition quality misses the gate, primary save/ingestion regresses, or the client presents a misleading state.
+
+## Local verification
+
+- Run the worker article-body, RSS, REST, diagnostics, and OpenAPI tests.
+- Apply migrations to an isolated local D1 database and confirm the new nullable diagnostic columns preserve existing lifecycle rows.
+- Run native unit tests and build the `ZineNative` scheme.
+- Launch the deterministic reader and unavailable fixtures in light and dark appearance, inspect screenshots, and run the full native test target.
+- Complete the repository format, design-system, lint, typecheck, test, and build gates before publishing the change.


### PR DESCRIPTION
## Summary

- add the native SwiftUI article reader with protected per-user caching, progress restoration, finished state, Dynamic Type, dark mode, safe external-link handoff, and explicit unavailable/offline states
- add authenticated reader-demand enrollment plus staged saved-item and RSS enrollment, lifecycle diagnostics, migration coverage, and bounded production rollout controls
- harden extraction from production review: source-first RSS/Atom bodies, Substack throttling fallbacks, serialized acquisition, stale-job suppression, truncation/duplication/tail cleanup, and immutable provenance

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 1,125 legacy mobile, 1,682 Worker, and 75 web tests passed
- `bun run build`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination 'platform=iOS Simulator,id=86C4DF23-FA16-4570-98E3-74E5B58F7117' test`
- local D1 migrations 0001–0025 applied and migration 0025 schema/index preservation verified
- production reader, saved-item, and RSS enrollment stages verified by API, D1, R2, and beginning/middle/end artifact review
- reviewed 30-item production cohort: 27/30 readable (90%); 26/27 readable artifacts met the high-quality threshold (96.3%); zero article-body DLQ events
- deterministic native reader fixtures manually inspected in light, dark, unavailable, and accessibility-size configurations
