### PR TITLE
fix: resolve repaired article body DLQ events

### DIFF
--- a/apps/worker/src/article-body/diagnostics.test.ts
+++ b/apps/worker/src/article-body/diagnostics.test.ts
@@ -58,6 +58,10 @@ describe('article-body diagnostics', () => {
       failureCodes: [{ code: 'NOT_READERABLE', count: 1 }],
       dlqCount: 1,
     });
+    expect(prepare).toHaveBeenNthCalledWith(
+      2,
+      'SELECT COUNT(*) AS count FROM article_body_dlq_events WHERE resolved_at IS NULL'
+    );
     expect(JSON.stringify(result)).not.toContain('item_');
   });
 

--- a/apps/worker/src/article-body/diagnostics.ts
+++ b/apps/worker/src/article-body/diagnostics.ts
@@ -66,7 +66,9 @@ export async function getArticleBodyHealth(env: Bindings): Promise<ArticleBodyHe
       env.DB.prepare(
         'SELECT status, COUNT(*) AS count FROM article_body_states GROUP BY status'
       ).all<{ status: ArticleBodyStatus; count: number }>(),
-      env.DB.prepare('SELECT COUNT(*) AS count FROM article_body_dlq_events').first<{
+      env.DB.prepare(
+        'SELECT COUNT(*) AS count FROM article_body_dlq_events WHERE resolved_at IS NULL'
+      ).first<{
         count: number;
       }>(),
       env.DB.prepare(

--- a/apps/worker/src/article-body/service-dlq.test.ts
+++ b/apps/worker/src/article-body/service-dlq.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { articleBodyDlqEvents } from '../db/schema';
+import { resolveArticleBodyDlqEvents } from './service';
+
+describe('article-body DLQ recovery', () => {
+  it('marks unresolved audit rows resolved after a successful current-or-newer publication', async () => {
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where });
+    const update = vi.fn().mockReturnValue({ set });
+    const db = { update };
+
+    await resolveArticleBodyDlqEvents(db as never, 'item_1', 9, 1_700_000_000_000);
+
+    expect(update).toHaveBeenCalledWith(articleBodyDlqEvents);
+    expect(set).toHaveBeenCalledWith({ resolvedAt: 1_700_000_000_000 });
+    expect(where).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -1,8 +1,8 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull, lte } from 'drizzle-orm';
 import { ulid } from 'ulid';
 
 import type { Database } from '../db';
-import { articleBodyStates, articleBodyVersions } from '../db/schema';
+import { articleBodyDlqEvents, articleBodyStates, articleBodyVersions } from '../db/schema';
 import type { Bindings } from '../types';
 import { ArticleBodyQueueMessageSchema } from './schema';
 import { putArticleBodyArtifact } from './storage';
@@ -383,7 +383,27 @@ export async function publishArticleBodyArtifact(
       },
     });
 
+  await resolveArticleBodyDlqEvents(db, artifact.itemId, artifact.extractorVersion, now);
+
   return { versionId, r2Key: stored.key, created: stored.created };
+}
+
+export async function resolveArticleBodyDlqEvents(
+  db: Database,
+  itemId: string,
+  extractorVersion: number,
+  now: number = Date.now()
+): Promise<void> {
+  await db
+    .update(articleBodyDlqEvents)
+    .set({ resolvedAt: now })
+    .where(
+      and(
+        eq(articleBodyDlqEvents.itemId, itemId),
+        lte(articleBodyDlqEvents.extractorVersion, extractorVersion),
+        isNull(articleBodyDlqEvents.resolvedAt)
+      )
+    );
 }
 
 export async function enqueueArticleBody(

--- a/apps/worker/src/db/migrations/0026_add_article_body_dlq_resolution.sql
+++ b/apps/worker/src/db/migrations/0026_add_article_body_dlq_resolution.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `article_body_dlq_events` ADD `resolved_at` integer;
+--> statement-breakpoint
+CREATE INDEX `article_body_dlq_events_resolved_idx` ON `article_body_dlq_events` (`resolved_at`,`dead_lettered_at`);

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1784891400000,
       "tag": "0025_add_article_body_enrollment_diagnostics",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1784899320000,
+      "tag": "0026_add_article_body_dlq_resolution",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -360,10 +360,12 @@ export const articleBodyDlqEvents = sqliteTable(
     attempts: integer('attempts').notNull(),
     errorCode: text('error_code'),
     deadLetteredAt: integer('dead_lettered_at').notNull(),
+    resolvedAt: integer('resolved_at'),
   },
   (table) => [
     index('article_body_dlq_events_dead_lettered_idx').on(table.deadLetteredAt),
     index('article_body_dlq_events_item_idx').on(table.itemId, table.deadLetteredAt),
+    index('article_body_dlq_events_resolved_idx').on(table.resolvedAt, table.deadLetteredAt),
   ]
 );
 

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -15,6 +15,7 @@ Phase 3 turns the article-body foundation into a user-facing native reading expe
 - Article acquisition is intentionally serialized in one-message queue batches so a bounded cohort cannot create a burst of requests that trips publisher rate limits.
 - If a public Substack page and its public post JSON endpoint are both throttled, acquisition may use Jina Reader's unauthenticated, rate-limited HTML rendering endpoint for that same public URL. The result still passes Zine's normal extraction, sanitization, provenance, and quality gates.
 - `/health/queues` reports safe aggregate enrollment outcomes, source mix, latency, failure codes, pending age, and DLQ count without exposing item or user identifiers.
+- Dead-letter audit rows remain durable, but a later successful repair marks matching item/version events resolved so queue health reflects the actionable backlog rather than permanent history.
 - The production rollout passes the reader-demand, saved-item, and new-RSS-entry stages; the reviewed production cohort meets the extraction quality gate; the native app is built, installed, launched, and manually checked on a physical iPhone.
 - The merged `main` Worker deployment is verified by release SHA and production health/API readback.
 


### PR DESCRIPTION
## Summary

- preserve article-body dead-letter events as durable audit history while adding an explicit resolution timestamp
- resolve matching current-or-older DLQ events only after a same-or-newer artifact publishes successfully
- report only unresolved article-body DLQ events as an actionable health backlog

## Why

Phase 3 production verification exposed six exhausted reader-demand jobs. A later repair could publish successfully, but the durable DLQ rows had no resolution lifecycle, so `/health/queues` would remain degraded forever.

## Validation

- full format, design-system, lint, typecheck, test, and build gates
- 1,125 legacy mobile compatibility tests
- 1,683 Worker tests
- 75 web tests
- full native `ZineNative` Xcode test target, including `ArticleReaderTests`
- isolated local D1 application of migrations 0000-0026 and `resolved_at` schema readback
- pre-push parity gate (web + 1,662 Worker CI subset)