### PR TITLE
fix: retry exhausted article reader requests

### DIFF
--- a/apps/worker/src/article-body/service-enqueue.test.ts
+++ b/apps/worker/src/article-body/service-enqueue.test.ts
@@ -112,6 +112,25 @@ describe('article-body enqueue', () => {
     expect(send).toHaveBeenCalledOnce();
   });
 
+  it('allows reader demand to repair a job after bounded queue retries are exhausted', async () => {
+    const db = createDb(
+      status({
+        status: 'UNAVAILABLE',
+        lastErrorCode: 'QUEUE_RETRIES_EXHAUSTED',
+        targetExtractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      })
+    );
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'reader_open' }
+    );
+
+    expect(result).toMatchObject({ queued: true });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it('includes a bounded embedded candidate in the queue job', async () => {
     const db = createDb(null);
     const send = vi.fn().mockResolvedValue(undefined);

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -77,6 +77,7 @@ function isRetryableStoredFailure(errorCode: string | null): boolean {
   if (!errorCode) return false;
   if (
     errorCode === 'QUEUE_SEND_FAILED' ||
+    errorCode === 'QUEUE_RETRIES_EXHAUSTED' ||
     errorCode === 'FETCH_FAILED' ||
     errorCode === 'FETCH_TIMEOUT' ||
     errorCode === 'PUBLISH_FAILED'


### PR DESCRIPTION
## Summary

- classify `QUEUE_RETRIES_EXHAUSTED` as a retryable stored acquisition failure
- allow a later authenticated reader-demand request to enqueue a fresh bounded job
- retain terminal suppression for genuinely non-retryable extraction failures

## Validation

- focused service and REST tests: 79 passed
- full typecheck and format gates
- pre-push web tests: 75 passed
- pre-push Worker CI subset: 1,663 passed
- regression test covers exhausted reader-demand repair