### PR TITLE
fix: recover stale article body retries

### DIFF
--- a/apps/worker/src/article-body/consumer.test.ts
+++ b/apps/worker/src/article-body/consumer.test.ts
@@ -134,6 +134,27 @@ describe('article-body queue consumers', () => {
     expect(processor).not.toHaveBeenCalled();
   });
 
+  it('acks a late duplicate after the same extractor version has already published', async () => {
+    const message = queueMessage();
+    const processor = vi.fn();
+    getArticleBodyStatus.mockResolvedValue({
+      status: 'AVAILABLE',
+      targetExtractorVersion: 1,
+      extractorVersion: 1,
+      versionId: 'version_1',
+    });
+
+    await handleArticleBodyQueue(
+      batch(message),
+      { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never,
+      processor
+    );
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(markArticleBodyProcessing).not.toHaveBeenCalled();
+    expect(processor).not.toHaveBeenCalled();
+  });
+
   it('retries processor failures with bounded backoff', async () => {
     const message = queueMessage(body(), 2);
     const processor = vi.fn().mockRejectedValue(new Error('not installed'));

--- a/apps/worker/src/article-body/consumer.ts
+++ b/apps/worker/src/article-body/consumer.ts
@@ -71,6 +71,22 @@ export async function handleArticleBodyQueue(
       message.ack();
       continue;
     }
+    if (
+      current?.versionId &&
+      (current.status === 'AVAILABLE' || current.status === 'DEGRADED') &&
+      (current.extractorVersion ?? 0) >= parsed.data.extractorVersion
+    ) {
+      articleBodyLogger.info('Completed article-body queue message acknowledged', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.completed',
+        messageId: message.id,
+        itemId: parsed.data.itemId,
+        messageExtractorVersion: parsed.data.extractorVersion,
+        currentExtractorVersion: current.extractorVersion,
+      });
+      message.ack();
+      continue;
+    }
 
     try {
       await markArticleBodyProcessing(db, parsed.data.itemId, message.attempts);

--- a/apps/worker/src/article-body/service-enqueue.test.ts
+++ b/apps/worker/src/article-body/service-enqueue.test.ts
@@ -55,6 +55,25 @@ describe('article-body enqueue', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('allows reader demand to recover a retry that remains pending past its grace window', async () => {
+    const now = 1_700_001_000_000;
+    const db = createDb(
+      status({
+        status: 'PENDING',
+        nextAttemptAt: now - 10 * 60 * 1_000,
+      })
+    );
+    const send = vi.fn().mockResolvedValue(undefined);
+    const result = await enqueueArticleBody(
+      db as never,
+      { ARTICLE_BODY_PIPELINE_ENABLED: 'true', ARTICLE_BODY_QUEUE: { send } as never },
+      { itemId: 'item_1', trigger: 'reader_open', now }
+    );
+
+    expect(result).toMatchObject({ queued: true });
+    expect(send).toHaveBeenCalledOnce();
+  });
+
   it('does not replace a current artifact outside an explicit repair', async () => {
     const db = createDb(
       status({

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -17,6 +17,8 @@ import {
   type ArticleBodyTrigger,
 } from './types';
 
+const ARTICLE_BODY_PENDING_RECOVERY_GRACE_MS = 10 * 60 * 1_000;
+
 export interface ArticleBodyStatusRecord {
   status: ArticleBodyStatus;
   targetExtractorVersion: number;
@@ -429,10 +431,16 @@ export async function enqueueArticleBody(
   const now = input.now ?? Date.now();
   const extractorVersion = input.extractorVersion ?? ARTICLE_BODY_EXTRACTOR_VERSION;
   const current = await getArticleBodyStatus(db, input.itemId);
+  const canRecoverOverduePending =
+    current?.status === 'PENDING' &&
+    current.nextAttemptAt !== null &&
+    current.nextAttemptAt <= now - ARTICLE_BODY_PENDING_RECOVERY_GRACE_MS &&
+    (input.trigger === 'reader_open' || input.trigger === 'repair');
   if (
     current &&
     (current.status === 'PENDING' || current.status === 'PROCESSING') &&
-    current.targetExtractorVersion >= extractorVersion
+    current.targetExtractorVersion >= extractorVersion &&
+    !canRecoverOverduePending
   ) {
     return { queued: false, reason: 'already_queued' };
   }

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -16,6 +16,7 @@ Phase 3 turns the article-body foundation into a user-facing native reading expe
 - If a public Substack page and its public post JSON endpoint are both throttled, acquisition may use Jina Reader's unauthenticated, rate-limited HTML rendering endpoint for that same public URL. The result still passes Zine's normal extraction, sanitization, provenance, and quality gates.
 - `/health/queues` reports safe aggregate enrollment outcomes, source mix, latency, failure codes, pending age, and DLQ count without exposing item or user identifiers.
 - Dead-letter audit rows remain durable, but a later successful repair marks matching item/version events resolved so queue health reflects the actionable backlog rather than permanent history.
+- Authenticated reader demand may recover a retry that remains pending for ten minutes beyond its advisory delivery time; at-least-once late duplicates are acknowledged once the same extractor version is already current.
 - The production rollout passes the reader-demand, saved-item, and new-RSS-entry stages; the reviewed production cohort meets the extraction quality gate; the native app is built, installed, launched, and manually checked on a physical iPhone.
 - The merged `main` Worker deployment is verified by release SHA and production health/API readback.
 


### PR DESCRIPTION
## Summary

- allow authenticated reader demand to re-enqueue a pending retry only after it is ten minutes overdue
- acknowledge late at-least-once duplicate deliveries once the same extractor version is already current
- retain normal duplicate suppression for fresh pending and processing jobs

## Validation

- focused enqueue, consumer, and REST tests: 88 passed
- format and full typecheck gates
- pre-push web tests: 75 passed
- pre-push Worker CI subset: 1,665 passed
- production evidence: two repair jobs remained pending more than ten minutes beyond their stored advisory retry timestamps