### PR TITLE
fix: add reviewed article body repairs

### DIFF
--- a/apps/worker/src/admin/article-body-repair.test.ts
+++ b/apps/worker/src/admin/article-body-repair.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  acquireArticleBody,
+  processArticleBodyQueueMessage,
+  getArticleBodyStatus,
+  markArticleBodyUnavailable,
+  resolveArticleBodyDlqEvents,
+  createDb,
+} = vi.hoisted(() => ({
+  acquireArticleBody: vi.fn(),
+  processArticleBodyQueueMessage: vi.fn(),
+  getArticleBodyStatus: vi.fn(),
+  markArticleBodyUnavailable: vi.fn(),
+  resolveArticleBodyDlqEvents: vi.fn(),
+  createDb: vi.fn(() => ({ kind: 'db' })),
+}));
+
+vi.mock('../article-body/acquisition', async (importOriginal) => ({
+  ...(await importOriginal()),
+  acquireArticleBody,
+}));
+vi.mock('../article-body/processor', () => ({ processArticleBodyQueueMessage }));
+vi.mock('../article-body/service', () => ({
+  getArticleBodyStatus,
+  markArticleBodyUnavailable,
+  resolveArticleBodyDlqEvents,
+}));
+vi.mock('../db', () => ({ createDb }));
+
+import {
+  ArticleBodyCandidateRepairSchema,
+  repairArticleBodyFromCandidate,
+} from './article-body-repair';
+
+const candidate = {
+  html: '<article><p>A reviewed public article body.</p></article>',
+  sourceKind: 'PUBLIC_NEWSLETTER' as const,
+  sourceUrl: 'https://newsletter.example.com/post',
+};
+const artifact = {
+  schemaVersion: 1,
+  extractorVersion: 9,
+  sourceKind: 'PUBLIC_NEWSLETTER',
+  sourceUrl: candidate.sourceUrl,
+  contentHash: `sha256:${'a'.repeat(64)}`,
+  wordCount: 720,
+  readingTimeMinutes: 4,
+  qualityScore: 1,
+  qualityWarnings: [],
+};
+
+function environment(item: Record<string, unknown> | null = {}) {
+  const first = vi.fn().mockResolvedValue(
+    item === null
+      ? null
+      : {
+          id: 'item_1',
+          canonical_url: 'https://newsletter.example.com/post',
+          title: 'Reviewed post',
+          publisher: 'Example',
+          published_at: null,
+          ...item,
+        }
+  );
+  const bind = vi.fn().mockReturnValue({ first });
+  const prepare = vi.fn().mockReturnValue({ bind });
+  return { DB: { prepare }, ARTICLE_CONTENT: {} } as never;
+}
+
+describe('article-body candidate repair', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    acquireArticleBody.mockResolvedValue({
+      status: 'AVAILABLE',
+      artifact,
+      attempts: [],
+      errorCode: null,
+      lastHttpStatus: null,
+    });
+    getArticleBodyStatus.mockResolvedValue({ status: 'AVAILABLE' });
+  });
+
+  it('previews a bounded candidate without publishing it', async () => {
+    const result = await repairArticleBodyFromCandidate(environment(), {
+      itemId: 'item_1',
+      dryRun: true,
+      candidate,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      published: false,
+      preview: { contentHash: artifact.contentHash, qualityScore: 1, wordCount: 720 },
+    });
+    expect(processArticleBodyQueueMessage).not.toHaveBeenCalled();
+  });
+
+  it('publishes only the exact candidate confirmed after dry-run', async () => {
+    const env = environment();
+    const result = await repairArticleBodyFromCandidate(env, {
+      itemId: 'item_1',
+      dryRun: false,
+      confirmedContentHash: artifact.contentHash,
+      candidate,
+    });
+
+    expect(processArticleBodyQueueMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: 'item_1',
+        trigger: 'repair',
+        embeddedCandidates: [candidate],
+      }),
+      expect.anything(),
+      env
+    );
+    expect(result).toMatchObject({ published: true, currentStatus: 'AVAILABLE' });
+  });
+
+  it('rejects a changed candidate hash', async () => {
+    await expect(
+      repairArticleBodyFromCandidate(environment(), {
+        itemId: 'item_1',
+        dryRun: false,
+        confirmedContentHash: `sha256:${'b'.repeat(64)}`,
+        candidate,
+      })
+    ).rejects.toMatchObject({
+      code: 'HASH_MISMATCH',
+      status: 409,
+    });
+    expect(processArticleBodyQueueMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe sources and oversized candidates at the boundary', async () => {
+    await expect(
+      repairArticleBodyFromCandidate(environment(), {
+        itemId: 'item_1',
+        dryRun: true,
+        candidate: { ...candidate, sourceUrl: 'http://127.0.0.1/private' },
+      })
+    ).rejects.toMatchObject({ code: 'UNSAFE_SOURCE_URL', status: 422 });
+
+    expect(
+      ArticleBodyCandidateRepairSchema.safeParse({
+        itemId: 'item_1',
+        dryRun: true,
+        candidate: { ...candidate, html: 'x'.repeat(90 * 1024) },
+      }).success
+    ).toBe(false);
+  });
+
+  it('dry-runs and confirms an authoritative terminal repair', async () => {
+    const env = environment();
+    const terminal = {
+      errorCode: 'HTTP_404' as const,
+      sourceUrl: 'https://newsletter.example.com/api/v1/posts/missing',
+    };
+
+    const dryRun = await repairArticleBodyFromCandidate(env, {
+      itemId: 'item_1',
+      dryRun: true,
+      terminal,
+    });
+    expect(dryRun).toMatchObject({
+      dryRun: true,
+      preview: { status: 'UNAVAILABLE', errorCode: 'HTTP_404', httpStatus: 404 },
+    });
+    expect(markArticleBodyUnavailable).not.toHaveBeenCalled();
+
+    getArticleBodyStatus.mockResolvedValue({ status: 'UNAVAILABLE' });
+    const result = await repairArticleBodyFromCandidate(env, {
+      itemId: 'item_1',
+      dryRun: false,
+      confirmedTerminalCode: 'HTTP_404',
+      terminal,
+    });
+    expect(markArticleBodyUnavailable).toHaveBeenCalledWith(
+      expect.anything(),
+      'item_1',
+      'HTTP_404',
+      { httpStatus: 404 }
+    );
+    expect(resolveArticleBodyDlqEvents).toHaveBeenCalledWith(expect.anything(), 'item_1', 9);
+    expect(result).toMatchObject({ published: false, currentStatus: 'UNAVAILABLE' });
+  });
+});

--- a/apps/worker/src/admin/article-body-repair.ts
+++ b/apps/worker/src/admin/article-body-repair.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+
+import { acquireArticleBody, isSafePublicArticleUrl } from '../article-body/acquisition';
+import { processArticleBodyQueueMessage } from '../article-body/processor';
+import { ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES } from '../article-body/schema';
+import {
+  getArticleBodyStatus,
+  markArticleBodyUnavailable,
+  resolveArticleBodyDlqEvents,
+} from '../article-body/service';
+import { ARTICLE_BODY_EXTRACTOR_VERSION } from '../article-body/types';
+import { createDb } from '../db';
+import type { Bindings } from '../types';
+
+const CandidateSchema = z.object({
+  html: z.string().min(1),
+  sourceKind: z.enum(['RSS_FULL', 'ATOM_FULL', 'PUBLIC_NEWSLETTER']),
+  sourceUrl: z.string().url(),
+});
+
+const TerminalSchema = z.object({
+  errorCode: z.enum(['HTTP_404', 'HTTP_410', 'NOT_READERABLE']),
+  sourceUrl: z.string().url(),
+});
+
+export const ArticleBodyCandidateRepairSchema = z
+  .object({
+    itemId: z.string().min(1),
+    dryRun: z.boolean().default(true),
+    confirmedContentHash: z
+      .string()
+      .regex(/^sha256:[a-f0-9]{64}$/)
+      .optional(),
+    confirmedTerminalCode: TerminalSchema.shape.errorCode.optional(),
+    candidate: CandidateSchema.optional(),
+    terminal: TerminalSchema.optional(),
+  })
+  .superRefine((input, context) => {
+    if (Boolean(input.candidate) === Boolean(input.terminal)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['candidate'],
+        message: 'Provide exactly one candidate or terminal result',
+      });
+    }
+    const bytes = input.candidate
+      ? new TextEncoder().encode(JSON.stringify([input.candidate])).byteLength
+      : 0;
+    if (bytes > ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['candidate'],
+        message: `Candidate exceeds ${ARTICLE_BODY_QUEUE_CANDIDATE_MAX_BYTES} bytes`,
+      });
+    }
+    if (!input.dryRun) {
+      if (input.candidate && !input.confirmedContentHash) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['confirmedContentHash'],
+          message: 'confirmedContentHash is required for candidate publication',
+        });
+      }
+      if (input.terminal && !input.confirmedTerminalCode) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['confirmedTerminalCode'],
+          message: 'confirmedTerminalCode is required for terminal repair',
+        });
+      }
+    }
+  });
+
+export type ArticleBodyCandidateRepairInput = z.infer<typeof ArticleBodyCandidateRepairSchema>;
+
+export class ArticleBodyCandidateRepairError extends Error {
+  constructor(
+    public readonly code:
+      | 'ITEM_NOT_FOUND'
+      | 'UNSAFE_SOURCE_URL'
+      | 'CANDIDATE_REJECTED'
+      | 'HASH_MISMATCH',
+    message: string,
+    public readonly status: 404 | 409 | 422
+  ) {
+    super(message);
+    this.name = 'ArticleBodyCandidateRepairError';
+  }
+}
+
+export async function repairArticleBodyFromCandidate(
+  env: Pick<Bindings, 'DB' | 'ARTICLE_CONTENT'>,
+  input: ArticleBodyCandidateRepairInput
+) {
+  const sourceUrl = input.candidate?.sourceUrl ?? input.terminal?.sourceUrl;
+  if (!sourceUrl || !isSafePublicArticleUrl(sourceUrl)) {
+    throw new ArticleBodyCandidateRepairError(
+      'UNSAFE_SOURCE_URL',
+      'Candidate source URL must be a safe public HTTP URL',
+      422
+    );
+  }
+
+  const item = await env.DB.prepare(
+    `SELECT id, canonical_url, title, publisher, published_at
+     FROM items
+     WHERE id = ?
+       AND content_type = 'ARTICLE'
+       AND EXISTS (SELECT 1 FROM user_items WHERE user_items.item_id = items.id)`
+  )
+    .bind(input.itemId)
+    .first<{
+      id: string;
+      canonical_url: string;
+      title: string;
+      publisher: string | null;
+      published_at: string | null;
+    }>();
+  if (!item) {
+    throw new ArticleBodyCandidateRepairError(
+      'ITEM_NOT_FOUND',
+      'Accepted article item not found',
+      404
+    );
+  }
+
+  const db = createDb(env.DB);
+  if (input.terminal) {
+    const httpStatus = Number(/^HTTP_(\d{3})$/.exec(input.terminal.errorCode)?.[1] ?? 0) || null;
+    const preview = {
+      status: 'UNAVAILABLE' as const,
+      extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      errorCode: input.terminal.errorCode,
+      httpStatus,
+      sourceUrl: input.terminal.sourceUrl,
+    };
+    if (input.dryRun) {
+      return { dryRun: true, published: false, preview };
+    }
+    if (input.confirmedTerminalCode !== input.terminal.errorCode) {
+      throw new ArticleBodyCandidateRepairError(
+        'HASH_MISMATCH',
+        'Terminal result changed after dry-run review',
+        409
+      );
+    }
+
+    await markArticleBodyUnavailable(db, item.id, input.terminal.errorCode, { httpStatus });
+    await resolveArticleBodyDlqEvents(db, item.id, ARTICLE_BODY_EXTRACTOR_VERSION);
+    const current = await getArticleBodyStatus(db, item.id);
+    return {
+      dryRun: false,
+      published: false,
+      preview,
+      currentStatus: current?.status ?? null,
+    };
+  }
+
+  const candidate = input.candidate!;
+
+  const acquisition = await acquireArticleBody(
+    {
+      itemId: item.id,
+      canonicalUrl: item.canonical_url,
+      title: item.title,
+      publisher: item.publisher,
+      publishedAt: item.published_at,
+      embeddedCandidates: [candidate],
+    },
+    {
+      extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      fetch: async () => new Response('Candidate-only repair', { status: 404 }),
+    }
+  );
+  if (!acquisition.artifact) {
+    const candidateAttempt = acquisition.attempts[0];
+    throw new ArticleBodyCandidateRepairError(
+      'CANDIDATE_REJECTED',
+      `Candidate failed quality gates${candidateAttempt?.errorCode ? `: ${candidateAttempt.errorCode}` : ''}`,
+      422
+    );
+  }
+
+  const preview = {
+    status: acquisition.status,
+    schemaVersion: acquisition.artifact.schemaVersion,
+    extractorVersion: acquisition.artifact.extractorVersion,
+    sourceKind: acquisition.artifact.sourceKind,
+    sourceUrl: acquisition.artifact.sourceUrl,
+    contentHash: acquisition.artifact.contentHash,
+    wordCount: acquisition.artifact.wordCount,
+    readingTimeMinutes: acquisition.artifact.readingTimeMinutes,
+    qualityScore: acquisition.artifact.qualityScore,
+    qualityWarnings: acquisition.artifact.qualityWarnings,
+  };
+  if (input.dryRun) {
+    return { dryRun: true, published: false, preview };
+  }
+  if (input.confirmedContentHash !== acquisition.artifact.contentHash) {
+    throw new ArticleBodyCandidateRepairError(
+      'HASH_MISMATCH',
+      'Candidate content changed after dry-run review',
+      409
+    );
+  }
+
+  await processArticleBodyQueueMessage(
+    {
+      itemId: item.id,
+      extractorVersion: ARTICLE_BODY_EXTRACTOR_VERSION,
+      trigger: 'repair',
+      enqueuedAt: Date.now(),
+      embeddedCandidates: [candidate],
+    },
+    db,
+    env as Bindings
+  );
+  const current = await getArticleBodyStatus(db, item.id);
+
+  return {
+    dryRun: false,
+    published: current?.status === 'AVAILABLE' || current?.status === 'DEGRADED',
+    preview,
+    currentStatus: current?.status ?? null,
+  };
+}

--- a/apps/worker/src/article-body/consumer.test.ts
+++ b/apps/worker/src/article-body/consumer.test.ts
@@ -25,6 +25,8 @@ vi.mock('../db', () => ({ createDb }));
 vi.mock('./service', () => ({
   isArticleBodyPipelineEnabled: (env: { ARTICLE_BODY_PIPELINE_ENABLED?: string }) =>
     env.ARTICLE_BODY_PIPELINE_ENABLED?.trim().toLowerCase() === 'true',
+  isRetryableStoredFailure: (errorCode: string | null) =>
+    errorCode === 'QUEUE_RETRIES_EXHAUSTED' || errorCode === 'HTTP_429',
   markArticleBodyProcessing,
   markArticleBodyRetryScheduled,
   markArticleBodyUnavailable,
@@ -142,6 +144,27 @@ describe('article-body queue consumers', () => {
       targetExtractorVersion: 1,
       extractorVersion: 1,
       versionId: 'version_1',
+    });
+
+    await handleArticleBodyQueue(
+      batch(message),
+      { DB: {}, ARTICLE_BODY_PIPELINE_ENABLED: 'true' } as never,
+      processor
+    );
+
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(markArticleBodyProcessing).not.toHaveBeenCalled();
+    expect(processor).not.toHaveBeenCalled();
+  });
+
+  it('acks a late duplicate after a reviewed terminal repair', async () => {
+    const message = queueMessage();
+    const processor = vi.fn();
+    getArticleBodyStatus.mockResolvedValue({
+      status: 'UNAVAILABLE',
+      targetExtractorVersion: 1,
+      lastErrorCode: 'HTTP_404',
+      updatedAt: body().enqueuedAt + 1,
     });
 
     await handleArticleBodyQueue(

--- a/apps/worker/src/article-body/consumer.ts
+++ b/apps/worker/src/article-body/consumer.ts
@@ -8,6 +8,7 @@ import { processArticleBodyQueueMessage, RetryableArticleBodyError } from './pro
 import { ArticleBodyQueueMessageSchema } from './schema';
 import {
   getArticleBodyStatus,
+  isRetryableStoredFailure,
   isArticleBodyPipelineEnabled,
   markArticleBodyProcessing,
   markArticleBodyRetryScheduled,
@@ -83,6 +84,22 @@ export async function handleArticleBodyQueue(
         itemId: parsed.data.itemId,
         messageExtractorVersion: parsed.data.extractorVersion,
         currentExtractorVersion: current.extractorVersion,
+      });
+      message.ack();
+      continue;
+    }
+    if (
+      current?.status === 'UNAVAILABLE' &&
+      current.targetExtractorVersion >= parsed.data.extractorVersion &&
+      current.updatedAt >= parsed.data.enqueuedAt &&
+      !isRetryableStoredFailure(current.lastErrorCode)
+    ) {
+      articleBodyLogger.info('Terminal article-body queue message acknowledged', {
+        operation: 'article_body.queue',
+        event: 'article_body.queue.terminal',
+        messageId: message.id,
+        itemId: parsed.data.itemId,
+        errorCode: current.lastErrorCode,
       });
       message.ack();
       continue;

--- a/apps/worker/src/article-body/service.ts
+++ b/apps/worker/src/article-body/service.ts
@@ -75,7 +75,7 @@ export function isArticleBodyEnrollmentEnabled(
   return mode === 'reader' && trigger === 'reader_open';
 }
 
-function isRetryableStoredFailure(errorCode: string | null): boolean {
+export function isRetryableStoredFailure(errorCode: string | null): boolean {
   if (!errorCode) return false;
   if (
     errorCode === 'QUEUE_SEND_FAILED' ||

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -36,6 +36,11 @@ import { createContext } from './trpc/context';
 import { getDependencyHealth, getQueueHealth } from './diagnostics/health';
 import { backfillBookmarkEnrichment } from './admin/enrichment-backfill';
 import { backfillArticleBodies } from './admin/article-body-backfill';
+import {
+  ArticleBodyCandidateRepairError,
+  ArticleBodyCandidateRepairSchema,
+  repairArticleBodyFromCandidate,
+} from './admin/article-body-repair';
 
 // Create Hono app with typed environment
 const app = new Hono<Env>();
@@ -253,6 +258,71 @@ app.post('/admin/article-bodies/backfill', async (c) => {
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),
   });
+});
+
+app.post('/admin/article-bodies/repair', async (c) => {
+  const configuredSecret = c.env.ARTICLE_BODY_REPAIR_SECRET;
+  if (!configuredSecret) {
+    return c.json(
+      {
+        error: 'Article-body repair is not configured',
+        code: 'REPAIR_NOT_CONFIGURED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      503
+    );
+  }
+
+  const authHeader = c.req.header('Authorization');
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  if (!token || token !== configuredSecret) {
+    return c.json(
+      {
+        error: 'Unauthorized',
+        code: 'UNAUTHORIZED',
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      401
+    );
+  }
+
+  const parsed = ArticleBodyCandidateRepairSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: 'Invalid article-body repair request',
+        code: 'INVALID_REPAIR_REQUEST',
+        details: parsed.error.flatten(),
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
+  try {
+    const result = await repairArticleBodyFromCandidate(c.env, parsed.data);
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    if (error instanceof ArticleBodyCandidateRepairError) {
+      return c.json(
+        {
+          error: error.message,
+          code: error.code,
+          requestId: c.get('requestId'),
+          traceId: c.get('traceId'),
+        },
+        error.status
+      );
+    }
+    throw error;
+  }
 });
 
 // tRPC Routes

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -85,6 +85,7 @@ export interface Bindings {
   ENRICHMENT_BACKFILL_SECRET?: string;
   /** Secret for privileged article-body cohort/backfill operations */
   ARTICLE_BODY_BACKFILL_SECRET?: string;
+  ARTICLE_BODY_REPAIR_SECRET?: string;
   /** Opt-in switch for article-body queue production and consumption. */
   ARTICLE_BODY_PIPELINE_ENABLED?: string;
   /** Controlled automatic article-body enrollment: off, reader, saved, or all. */

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -306,6 +306,7 @@ invocation_logs = true
 # - CLERK_WEBHOOK_SECRET: Signing secret from Clerk Dashboard > Webhooks
 # - ENRICHMENT_BACKFILL_SECRET: Bearer token for admin enrichment backfill route
 # - ARTICLE_BODY_BACKFILL_SECRET: Bearer token for dry-run and bounded article-body cohorts
+# - ARTICLE_BODY_REPAIR_SECRET: Bearer token for dry-run-first reviewed public candidate repairs
 # - X_BEARER_TOKEN: X API bearer token for inferred profile/avatar resolution
 #
 # Required KV Namespace (create via `wrangler kv:namespace create WEBHOOK_IDEMPOTENCY`)

--- a/docs/article-reader-beta.md
+++ b/docs/article-reader-beta.md
@@ -50,6 +50,8 @@ At every stage:
 
 Advance from `reader` to `saved`, and from `saved` to `all`, only after the preceding stage is terminal and correct. Return enrollment to `off` if pending age grows unexpectedly, the DLQ changes, acquisition quality misses the gate, primary save/ingestion regresses, or the client presents a misleading state.
 
+When every Worker egress path is blocked but a reviewer can retrieve the same public article, `POST /admin/article-bodies/repair` provides the bounded operational escape hatch. It uses the dedicated `ARTICLE_BODY_REPAIR_SECRET`, accepts only safe public source URLs and either a queue-sized source candidate or a reviewed terminal result, and defaults to `dryRun: true`. A candidate dry run returns the exact normalized content hash and quality metadata; publication requires resubmitting the unchanged candidate with `dryRun: false` and that hash as `confirmedContentHash`. A terminal dry run accepts only `HTTP_404`, `HTTP_410`, or `NOT_READERABLE`, and execution requires the same value as `confirmedTerminalCode`. Normal lifecycle and DLQ-resolution contracts still apply, and late queue duplicates cannot overwrite a newer reviewed terminal repair. Never use mailbox HTML, authenticated page content, or another user's private material as a repair candidate.
+
 ## Local verification
 
 - Run the worker article-body, RSS, REST, diagnostics, and OpenAPI tests.


### PR DESCRIPTION
## Summary
- add a dedicated, dry-run-first admin repair route for bounded public article candidates and authoritative terminal outcomes
- require exact content-hash or terminal-code confirmation before mutating production state
- resolve historical article-body DLQ events and prevent late queue retries from overwriting reviewed terminal results
- document the public-only operational safety boundary

## Validation
- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- pre-push CI-parity checks