### PR TITLE
feat(today): add people-first daily view

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -56,6 +56,33 @@ struct APIClient {
         try await request(url: baseURL.appending(path: "/api/v1/editorial/today"))
     }
 
+    func getDailyFeed(date: String? = nil) async throws -> DailyFeedResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/today/feed"),
+            resolvingAgainstBaseURL: false
+        )!
+        if let date {
+            components.queryItems = [URLQueryItem(name: "date", value: date)]
+        }
+        return try await request(url: components.url!)
+    }
+
+    func getDailyAuthorActivity(
+        authorKey: String,
+        date: String,
+        range: DailyAuthorRange
+    ) async throws -> DailyAuthorActivityResponse {
+        var components = URLComponents(
+            url: baseURL.appending(path: "/api/v1/today/authors/\(authorKey)"),
+            resolvingAgainstBaseURL: false
+        )!
+        components.queryItems = [
+            URLQueryItem(name: "date", value: date),
+            URLQueryItem(name: "range", value: range.rawValue),
+        ]
+        return try await request(url: components.url!)
+    }
+
     func listEditorialExperiments(limit: Int = 20) async throws -> EditorialExperimentListResponse {
         var components = URLComponents(
             url: baseURL.appending(path: "/api/v1/editorial/experiments"),

--- a/apps/ios/ZineNative/Core/Models/DailyFeed.swift
+++ b/apps/ios/ZineNative/Core/Models/DailyFeed.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+struct DailyFeedResponse: Decodable, Hashable {
+    let schemaVersion: Int
+    let variant: DailyFeedVariant
+    let date: String
+    let timezone: String
+    let frozenAt: String?
+    let freshness: DailyFeedFreshness
+    let coverage: DailyFeedCoverage
+    let sources: [DailyFeedSource]
+    let conversations: [DailyConversation]
+    let posts: [DailyPost]
+    let requestId: String
+    let traceId: String
+}
+
+struct DailyFeedVariant: Decodable, Hashable {
+    enum Mode: String, Decodable, Hashable {
+        case review = "REVIEW"
+    }
+
+    let id: String
+    let mode: Mode
+}
+
+enum DailyCoverageStatus: String, Decodable, Hashable {
+    case complete = "COMPLETE"
+    case partial = "PARTIAL"
+    case unavailable = "UNAVAILABLE"
+}
+
+struct DailyFeedFreshness: Decodable, Hashable {
+    let isCurrent: Bool
+    let status: DailyCoverageStatus
+    let warnings: [String]
+}
+
+struct DailyFeedCoverage: Decodable, Hashable {
+    enum SelectionStatus: String, Decodable, Hashable {
+        case complete = "COMPLETE"
+        case stale = "STALE"
+        case fallback = "FALLBACK"
+        case missing = "MISSING"
+    }
+
+    let status: DailyCoverageStatus
+    let archiveStatus: DailyCoverageStatus
+    let selectionStatus: SelectionStatus
+    let runId: String?
+    let requestedCount: Int
+    let collectedCount: Int
+    let message: String
+}
+
+struct DailyFeedSource: Decodable, Hashable, Identifiable {
+    enum SourceType: String, Decodable, Hashable {
+        case favorites = "FAVORITES"
+        case list = "LIST"
+        case followingFallback = "FOLLOWING_FALLBACK"
+    }
+
+    let id: String
+    let type: SourceType
+    let name: String
+    let selected: Bool
+    let capturedAt: String?
+    let authorCount: Int
+}
+
+struct DailyConversation: Decodable, Hashable, Identifiable {
+    enum EvidenceType: String, Decodable, Hashable {
+        case directRelationship = "DIRECT_RELATIONSHIP"
+        case sharedLink = "SHARED_LINK"
+    }
+
+    let id: String
+    let evidenceType: EvidenceType
+    let label: String
+    let evidence: String
+    let postIds: [String]
+    let authors: [String]
+    let relationshipTypes: [String]
+}
+
+struct DailyPost: Decodable, Hashable, Identifiable {
+    let id: String
+    let url: String
+    let text: String
+    let publishedAt: String?
+    let observedAt: String?
+    let kind: String
+    let author: DailyAuthor
+    let media: [DailyPostMedia]
+    let links: [DailyPostLink]
+    let metrics: DailyPostMetrics
+    let relationships: [DailyPostRelationship]
+    let presentation: String
+    let repostedBy: DailyAuthor?
+    let sourceIds: [String]
+
+    var postURL: URL? { URL(string: url) }
+
+    var effectiveDate: Date? {
+        let value = publishedAt ?? observedAt
+        return value.flatMap { try? Date($0, strategy: .iso8601) }
+    }
+}
+
+struct DailyAuthor: Decodable, Hashable {
+    let key: String
+    let username: String
+    let name: String
+    let profileUrl: String?
+    let profileImageUrl: String?
+    let verified: Bool?
+
+    var profileURL: URL? { profileUrl.flatMap(URL.init(string:)) }
+    var profileImageURL: URL? { profileImageUrl.flatMap(URL.init(string:)) }
+}
+
+struct DailyPostMedia: Decodable, Hashable, Identifiable {
+    let type: String
+    let url: String
+    let previewUrl: String?
+    let altText: String?
+    let width: Int?
+    let height: Int?
+    let durationMs: Int?
+
+    var id: String { "\(type):\(url)" }
+    var displayURL: URL? { URL(string: previewUrl ?? url) }
+}
+
+struct DailyPostLink: Decodable, Hashable, Identifiable {
+    let url: String
+    let normalizedUrl: String
+    let displayUrl: String?
+    let redirectUrl: String?
+    let source: String
+    let card: DailyPostLinkCard?
+
+    var id: String { normalizedUrl }
+    var destinationURL: URL? { URL(string: normalizedUrl) ?? URL(string: url) }
+}
+
+struct DailyPostLinkCard: Decodable, Hashable {
+    let title: String?
+    let description: String?
+    let domain: String?
+    let imageUrl: String?
+}
+
+struct DailyPostMetrics: Decodable, Hashable {
+    let replies: Int?
+    let reposts: Int?
+    let likes: Int?
+    let views: Int?
+    let bookmarks: Int?
+}
+
+struct DailyPostRelationship: Decodable, Hashable, Identifiable {
+    let type: String
+    let tweetId: String
+    let url: String?
+    let target: DailyRelatedPost?
+
+    var id: String { "\(type):\(tweetId)" }
+}
+
+struct DailyRelatedPost: Decodable, Hashable {
+    let tweetId: String
+    let text: String
+    let url: String
+    let author: DailyAuthor
+}
+
+enum DailyAuthorRange: String, Codable, Hashable, CaseIterable, Identifiable {
+    case today = "TODAY"
+    case week = "WEEK"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .today: "Today"
+        case .week: "Past week"
+        }
+    }
+}
+
+struct DailyAuthorActivityResponse: Decodable, Hashable {
+    let schemaVersion: Int
+    let variant: DailyFeedVariant
+    let date: String
+    let range: DailyAuthorRange
+    let startDate: String
+    let timezone: String
+    let author: DailyAuthor?
+    let coverage: DailyAuthorCoverage
+    let posts: [DailyPost]
+    let requestId: String
+    let traceId: String
+}
+
+struct DailyAuthorCoverage: Decodable, Hashable {
+    let status: DailyCoverageStatus
+    let runIds: [String]
+    let warnings: [String]
+}

--- a/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+struct DailyAuthorActivityView: View {
+    let author: DailyAuthor
+
+    @State private var store: DailyAuthorActivityStore
+    @State private var range = DailyAuthorRange.today
+
+    init(client: APIClient, author: DailyAuthor, date: String) {
+        self.author = author
+        _store = State(
+            initialValue: DailyAuthorActivityStore(
+                client: client,
+                authorKey: author.key,
+                date: date
+            )
+        )
+    }
+
+    var body: some View {
+        content
+            .navigationTitle(author.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .task(id: range) { await store.load(range: range) }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading, store.response == nil {
+            ProgressView("Loading @\(author.username)…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = store.errorMessage, store.response == nil {
+            ContentUnavailableView {
+                Label("Activity unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") { Task { await store.load(range: range) } }
+            }
+        } else if let response = store.response {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    authorHeader
+
+                    Picker("Activity range", selection: $range) {
+                        ForEach(DailyAuthorRange.allCases) { value in
+                            Text(value.title).tag(value)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("daily-author-range")
+
+                    coverageNotice(response.coverage)
+
+                    if response.posts.isEmpty, !store.isLoading {
+                        ContentUnavailableView(
+                            "No archived posts",
+                            systemImage: "text.bubble",
+                            description: Text(
+                                range == .today
+                                    ? "No posts from @\(author.username) are available for this day."
+                                    : "No posts from @\(author.username) are available for this week."
+                            )
+                        )
+                        .padding(.top, 30)
+                    } else {
+                        ForEach(response.posts) { post in
+                            DailyFeedPostCard(
+                                post: post,
+                                sourceNames: [:]
+                            )
+                        }
+                    }
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 18)
+                .padding(.bottom, 36)
+            }
+            .overlay {
+                if store.isLoading, store.response != nil {
+                    ProgressView()
+                        .padding(12)
+                        .background(.regularMaterial, in: Circle())
+                }
+            }
+        }
+    }
+
+    private var authorHeader: some View {
+        HStack(spacing: 13) {
+            AsyncImage(url: author.profileImageURL) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                ZStack {
+                    Circle().fill(Color.secondary.opacity(0.15))
+                    Text(author.name.prefix(1).uppercased())
+                        .font(.title2.weight(.bold))
+                }
+            }
+            .frame(width: 58, height: 58)
+            .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(author.name)
+                    .font(.title2.weight(.bold))
+                Text("@\(author.username)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("All posts available in Zine’s X archive")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func coverageNotice(_ coverage: DailyAuthorCoverage) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Label("Archive coverage", systemImage: "archivebox")
+                .font(.caption.weight(.semibold))
+            ForEach(coverage.warnings, id: \.self) { warning in
+                Text(warning)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.09), in: RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -1,0 +1,672 @@
+import SwiftUI
+
+private struct DailyAuthorRoute: Hashable {
+    let author: DailyAuthor
+    let date: String
+}
+
+struct DailyFeedReviewView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var store: DailyFeedStore
+    @State private var selectedSourceID: String?
+
+    private let client: APIClient
+
+    init(client: APIClient) {
+        self.client = client
+        _store = State(initialValue: DailyFeedStore(client: client))
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Daily View")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Text("REVIEW")
+                            .font(.caption2.weight(.heavy))
+                            .tracking(1.2)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+                .navigationDestination(for: DailyAuthorRoute.self) { route in
+                    DailyAuthorActivityView(
+                        client: client,
+                        author: route.author,
+                        date: route.date
+                    )
+                }
+        }
+        .task { await store.load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if store.isLoading, store.response == nil {
+            ProgressView("Loading frozen X posts…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = store.errorMessage, store.response == nil {
+            ContentUnavailableView {
+                Label("Daily View unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Try again") { Task { await store.load() } }
+            }
+        } else if let response = store.response {
+            DailyFeedContent(
+                response: response,
+                selectedSourceID: $selectedSourceID
+            )
+            .refreshable { await store.load() }
+        }
+    }
+}
+
+private struct DailyFeedContent: View {
+    let response: DailyFeedResponse
+    @Binding var selectedSourceID: String?
+
+    private var filteredPosts: [DailyPost] {
+        guard let selectedSourceID else { return response.posts }
+        return response.posts.filter { $0.sourceIds.contains(selectedSourceID) }
+    }
+
+    private var sourceNames: [String: String] {
+        Dictionary(uniqueKeysWithValues: response.sources.map { ($0.id, $0.name) })
+    }
+
+    private var peopleSectionTitle: String {
+        switch response.coverage.selectionStatus {
+        case .complete:
+            return "Real posts from Favorites and lists"
+        case .stale:
+            return "Real posts; source membership may be stale"
+        case .fallback:
+            return "Real posts from an explicit Following fallback"
+        case .missing:
+            return "Real posts; source membership unavailable"
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                DailyFeedHeader(response: response)
+                    .padding(.horizontal, 18)
+                    .padding(.top, 18)
+
+                DailyCoverageNotice(response: response)
+                    .padding(.horizontal, 18)
+                    .padding(.top, 16)
+
+                sectionTitle("IN CONVERSATION", "Only what the posts show")
+                    .padding(.horizontal, 18)
+                    .padding(.top, 30)
+
+                if response.conversations.isEmpty {
+                    Text("No multi-author reply, quote, repost, or shared-link convergence was found in this slice.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 18)
+                        .padding(.top, 10)
+                } else {
+                    VStack(spacing: 12) {
+                        ForEach(response.conversations) { conversation in
+                            DailyConversationCard(
+                                conversation: conversation,
+                                posts: conversation.postIds.compactMap { id in
+                                    response.posts.first { $0.id == id }
+                                },
+                                date: response.date
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.top, 14)
+                }
+
+                sectionTitle("YOUR PEOPLE", peopleSectionTitle)
+                    .padding(.horizontal, 18)
+                    .padding(.top, 34)
+
+                DailySourceFilter(
+                    sources: response.sources,
+                    selectedSourceID: $selectedSourceID
+                )
+                .padding(.top, 12)
+
+                if filteredPosts.isEmpty {
+                    ContentUnavailableView(
+                        "No posts in this source",
+                        systemImage: "person.2.slash",
+                        description: Text("The frozen run has no matching posts for this filter.")
+                    )
+                    .padding(.top, 34)
+                } else {
+                    LazyVStack(spacing: 14) {
+                        ForEach(filteredPosts) { post in
+                            DailyFeedPostCard(
+                                post: post,
+                                sourceNames: sourceNames,
+                                authorDestinationDate: response.date
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.top, 16)
+                    .padding(.bottom, 38)
+                }
+            }
+        }
+    }
+
+    private func sectionTitle(_ eyebrow: String, _ title: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(eyebrow)
+                .font(.caption2.weight(.heavy))
+                .tracking(1.2)
+                .foregroundStyle(Color.accentColor)
+            Text(title)
+                .font(.title2.weight(.bold))
+        }
+    }
+}
+
+private struct DailyFeedHeader: View {
+    let response: DailyFeedResponse
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack {
+                Label("People-first prototype", systemImage: "person.2.fill")
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text("FROZEN")
+                    .font(.caption2.weight(.heavy))
+                    .tracking(0.9)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(formattedDate)
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .tracking(-0.8)
+
+            Text("The posts are the source of truth. Groups above them are navigation backed by explicit archive evidence, not generated headlines.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var formattedDate: String {
+        let components = response.date.split(separator: "-").compactMap { Int($0) }
+        guard components.count == 3 else { return response.date }
+        var value = DateComponents()
+        value.calendar = Calendar(identifier: .gregorian)
+        value.timeZone = TimeZone(identifier: response.timezone)
+        value.year = components[0]
+        value.month = components[1]
+        value.day = components[2]
+        return value.date?.formatted(.dateTime.weekday(.wide).month(.wide).day()) ?? response.date
+    }
+}
+
+private struct DailyCoverageNotice: View {
+    let response: DailyFeedResponse
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 8) {
+                Image(systemName: statusIcon)
+                    .foregroundStyle(statusColor)
+                Text(statusTitle)
+                    .font(.subheadline.weight(.semibold))
+                Spacer()
+                Text("\(response.coverage.collectedCount)/\(response.coverage.requestedCount)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(response.coverage.message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ForEach(response.freshness.warnings, id: \.self) { warning in
+                Label(warning, systemImage: "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .background(statusColor.opacity(0.09), in: RoundedRectangle(cornerRadius: 14))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var statusTitle: String {
+        switch response.coverage.status {
+        case .complete: "Complete review coverage"
+        case .partial: "Partial review coverage"
+        case .unavailable: "Archive unavailable"
+        }
+    }
+
+    private var statusIcon: String {
+        response.coverage.status == .complete ? "checkmark.seal.fill" : "exclamationmark.triangle.fill"
+    }
+
+    private var statusColor: Color {
+        response.coverage.status == .complete ? .green : .orange
+    }
+}
+
+private struct DailySourceFilter: View {
+    let sources: [DailyFeedSource]
+    @Binding var selectedSourceID: String?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                filterButton(title: "All", sourceID: nil, count: nil)
+                ForEach(sources) { source in
+                    filterButton(
+                        title: source.name,
+                        sourceID: source.id,
+                        count: source.authorCount
+                    )
+                }
+            }
+            .padding(.horizontal, 18)
+        }
+    }
+
+    private func filterButton(title: String, sourceID: String?, count: Int?) -> some View {
+        let isSelected = selectedSourceID == sourceID
+        return Button {
+            selectedSourceID = sourceID
+        } label: {
+            HStack(spacing: 5) {
+                Text(title)
+                if let count {
+                    Text("\(count)")
+                        .foregroundStyle(isSelected ? .white.opacity(0.72) : .secondary)
+                }
+            }
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .foregroundStyle(isSelected ? Color.white : Color.primary)
+            .background(
+                isSelected ? Color.accentColor : Color.secondary.opacity(0.12),
+                in: Capsule()
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct DailyConversationCard: View {
+    let conversation: DailyConversation
+    let posts: [DailyPost]
+    let date: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: conversation.evidenceType == .directRelationship ? "arrow.triangle.branch" : "link")
+                    .foregroundStyle(Color.accentColor)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(conversation.label)
+                        .font(.headline)
+                    Text(conversation.evidence)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            ForEach(posts) { post in
+                NavigationLink(value: DailyAuthorRoute(author: post.author, date: date)) {
+                    HStack(alignment: .top, spacing: 9) {
+                        DailyAuthorAvatar(author: post.author, size: 30)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("\(post.author.name)  @\(post.author.username)")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.primary)
+                            Text(post.text)
+                                .font(.subheadline)
+                                .foregroundStyle(.primary)
+                                .lineLimit(3)
+                                .multilineTextAlignment(.leading)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(14)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+struct DailyFeedPostCard: View {
+    let post: DailyPost
+    let sourceNames: [String: String]
+    private let authorDestinationDate: String?
+
+    init(
+        post: DailyPost,
+        sourceNames: [String: String],
+        authorDestinationDate: String? = nil
+    ) {
+        self.post = post
+        self.sourceNames = sourceNames
+        self.authorDestinationDate = authorDestinationDate
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let repostedBy = post.repostedBy {
+                Label("Reposted by @\(repostedBy.username)", systemImage: "arrow.2.squarepath")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            authorHeader
+
+            Text(post.text)
+                .font(.body)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !post.relationships.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(post.relationships) { relationship in
+                        DailyRelationshipContext(relationship: relationship)
+                    }
+                }
+            }
+
+            if !post.media.isEmpty {
+                DailyPostMediaStrip(media: post.media)
+            }
+
+            ForEach(Array(post.links.prefix(2))) { link in
+                DailyPostLinkView(link: link)
+            }
+
+            HStack(spacing: 12) {
+                if let postURL = post.postURL {
+                    Link(destination: postURL) {
+                        Label("Open on X", systemImage: "arrow.up.right")
+                    }
+                }
+                Spacer()
+                DailyPostMetricsView(metrics: post.metrics)
+            }
+            .font(.caption.weight(.semibold))
+
+            if !post.sourceIds.isEmpty {
+                HStack(spacing: 5) {
+                    ForEach(post.sourceIds, id: \.self) { sourceID in
+                        Text(sourceNames[sourceID] ?? sourceID)
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 4)
+                            .background(Color.accentColor.opacity(0.1), in: Capsule())
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    @ViewBuilder
+    private var authorHeader: some View {
+        if let authorDestinationDate {
+            NavigationLink(
+                value: DailyAuthorRoute(author: post.author, date: authorDestinationDate)
+            ) { authorIdentity }
+                .buttonStyle(.plain)
+        } else {
+            authorIdentity
+        }
+    }
+
+    private var authorIdentity: some View {
+        HStack(spacing: 10) {
+            DailyAuthorAvatar(author: post.author, size: 40)
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 4) {
+                    Text(post.author.name)
+                        .font(.subheadline.weight(.semibold))
+                    if post.author.verified == true {
+                        Image(systemName: "checkmark.seal.fill")
+                            .font(.caption2)
+                            .foregroundStyle(Color.accentColor)
+                    }
+                }
+                HStack(spacing: 5) {
+                    Text("@\(post.author.username)")
+                    if let date = post.effectiveDate {
+                        Text("·")
+                        Text(date, style: .relative)
+                    }
+                    if post.kind != "POST" {
+                        Text("· \(post.kind.capitalized)")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if authorDestinationDate != nil {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+private struct DailyAuthorAvatar: View {
+    let author: DailyAuthor
+    let size: CGFloat
+
+    var body: some View {
+        AsyncImage(url: author.profileImageURL) { image in
+            image.resizable().scaledToFill()
+        } placeholder: {
+            ZStack {
+                Circle().fill(Color.secondary.opacity(0.16))
+                Text(author.name.prefix(1).uppercased())
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .accessibilityHidden(true)
+    }
+}
+
+private struct DailyRelationshipContext: View {
+    let relationship: DailyPostRelationship
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(label, systemImage: icon)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if let target = relationship.target {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("\(target.author.name)  @\(target.author.username)")
+                        .font(.caption.weight(.semibold))
+                    Text(target.text)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(4)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+            }
+        }
+    }
+
+    private var label: String {
+        switch relationship.type {
+        case "REPLY_TO": "Reply context"
+        case "QUOTE_OF": "Quoted post"
+        case "REPOST_OF": "Reposted post"
+        default: relationship.type.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    private var icon: String {
+        switch relationship.type {
+        case "REPLY_TO": "arrowshape.turn.up.left"
+        case "QUOTE_OF": "quote.bubble"
+        case "REPOST_OF": "arrow.2.squarepath"
+        default: "link"
+        }
+    }
+}
+
+private struct DailyPostMediaStrip: View {
+    let media: [DailyPostMedia]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Array(media.prefix(3))) { item in
+                    AsyncImage(url: item.displayURL) { image in
+                        image.resizable().scaledToFill()
+                    } placeholder: {
+                        ZStack {
+                            Color.secondary.opacity(0.12)
+                            Image(systemName: item.type == "VIDEO" ? "play.fill" : "photo")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(width: 220, height: 128)
+                    .clipShape(RoundedRectangle(cornerRadius: 11))
+                    .accessibilityLabel(item.altText ?? "Post media")
+                }
+            }
+        }
+    }
+}
+
+private struct DailyPostLinkView: View {
+    let link: DailyPostLink
+
+    var body: some View {
+        if let destination = link.destinationURL {
+            Link(destination: destination) {
+                HStack(spacing: 10) {
+                    if let imageUrl = link.card?.imageUrl, let imageURL = URL(string: imageUrl) {
+                        AsyncImage(url: imageURL) { image in
+                            image.resizable().scaledToFill()
+                        } placeholder: {
+                            Color.secondary.opacity(0.12)
+                        }
+                        .frame(width: 54, height: 54)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(link.card?.domain ?? domain)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(link.card?.title ?? link.displayUrl ?? link.normalizedUrl)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .lineLimit(2)
+                    }
+                    Spacer(minLength: 0)
+                    Image(systemName: "arrow.up.right")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(9)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 11))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var domain: String {
+        link.destinationURL?.host() ?? link.normalizedUrl
+    }
+}
+
+private struct DailyPostMetricsView: View {
+    let metrics: DailyPostMetrics
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let replies = metrics.replies, replies > 0 {
+                Label("\(replies)", systemImage: "bubble")
+            }
+            if let reposts = metrics.reposts, reposts > 0 {
+                Label("\(reposts)", systemImage: "arrow.2.squarepath")
+            }
+            if let likes = metrics.likes, likes > 0 {
+                Label("\(likes)", systemImage: "heart")
+            }
+        }
+        .foregroundStyle(.secondary)
+    }
+}
+
+#Preview("Real post card") {
+    NavigationStack {
+        DailyFeedPostCard(
+            post: .preview,
+            sourceNames: ["favorites": "Favorites"],
+            authorDestinationDate: "2026-07-24"
+        )
+        .padding()
+    }
+}
+
+private extension DailyAuthor {
+    static let preview = DailyAuthor(
+        key: "id:ada",
+        username: "ada",
+        name: "Ada Example",
+        profileUrl: "https://x.com/ada",
+        profileImageUrl: nil,
+        verified: true
+    )
+}
+
+private extension DailyPost {
+    static let preview = DailyPost(
+        id: "123",
+        url: "https://x.com/ada/status/123",
+        text: "The prototype should keep this real post visible instead of replacing it with a generated headline.",
+        publishedAt: "2026-07-24T15:00:00.000Z",
+        observedAt: "2026-07-24T15:01:00.000Z",
+        kind: "POST",
+        author: .preview,
+        media: [],
+        links: [],
+        metrics: DailyPostMetrics(replies: 2, reposts: 1, likes: 12, views: 200, bookmarks: 3),
+        relationships: [],
+        presentation: "POST",
+        repostedBy: nil,
+        sourceIds: ["favorites"]
+    )
+}

--- a/apps/ios/ZineNative/Features/Today/DailyFeedStore.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedStore.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DailyFeedStore {
+    private(set) var response: DailyFeedResponse?
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private let client: APIClient
+
+    init(client: APIClient) {
+        self.client = client
+    }
+
+    func load() async {
+        isLoading = response == nil
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            response = try await client.getDailyFeed(date: response?.date)
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class DailyAuthorActivityStore {
+    private(set) var response: DailyAuthorActivityResponse?
+    private(set) var isLoading = false
+    private(set) var errorMessage: String?
+
+    private let client: APIClient
+    private let authorKey: String
+    private let date: String
+
+    init(client: APIClient, authorKey: String, date: String) {
+        self.client = client
+        self.authorKey = authorKey
+        self.date = date
+    }
+
+    func load(range: DailyAuthorRange) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            response = try await client.getDailyAuthorActivity(
+                authorKey: authorKey,
+                date: date,
+                range: range
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Today/TodayView.swift
+++ b/apps/ios/ZineNative/Features/Today/TodayView.swift
@@ -9,6 +9,7 @@ struct TodayView: View {
     @State private var store: TodayStore
     @State private var labStore: EditorialLabStore
     @State private var isShowingLab = false
+    @State private var isShowingDailyFeedReview = false
 
     init(
         client: APIClient,
@@ -40,6 +41,14 @@ struct TodayView: View {
                             ProgressView()
                                 .accessibilityLabel("Refreshing today’s issue")
                         }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            isShowingDailyFeedReview = true
+                        } label: {
+                            Image(systemName: "person.2.fill")
+                        }
+                        .accessibilityLabel("Open people-first Daily View preview")
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {
@@ -79,6 +88,9 @@ struct TodayView: View {
             )
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(isPresented: $isShowingDailyFeedReview) {
+            DailyFeedReviewView(client: client)
         }
         .alert("Couldn’t update Today", isPresented: actionErrorBinding) {
             Button("OK", role: .cancel) {

--- a/apps/ios/ZineNativeTests/EditorialTests.swift
+++ b/apps/ios/ZineNativeTests/EditorialTests.swift
@@ -3,6 +3,92 @@ import XCTest
 @testable import ZineNative
 
 final class EditorialTests: XCTestCase {
+    func testDecodesPeopleFirstDailyFeedWithEvidenceAndPostContext() throws {
+        let response = try JSONDecoder().decode(
+            DailyFeedResponse.self,
+            from: Data(
+                """
+                {
+                  "schemaVersion":1,
+                  "variant":{"id":"people-first-v1","mode":"REVIEW"},
+                  "date":"2026-07-24",
+                  "timezone":"America/Chicago",
+                  "frozenAt":"2026-07-24T13:00:00.000Z",
+                  "freshness":{
+                    "isCurrent":true,
+                    "status":"PARTIAL",
+                    "warnings":["Favorite/list membership is partial."]
+                  },
+                  "coverage":{
+                    "status":"PARTIAL",
+                    "archiveStatus":"COMPLETE",
+                    "selectionStatus":"FALLBACK",
+                    "runId":"run-1",
+                    "requestedCount":500,
+                    "collectedCount":500,
+                    "message":"Usable with explicit limits."
+                  },
+                  "sources":[{
+                    "id":"following-fallback",
+                    "type":"FOLLOWING_FALLBACK",
+                    "name":"Following",
+                    "selected":true,
+                    "capturedAt":"2026-07-24T13:00:00.000Z",
+                    "authorCount":2
+                  }],
+                  "conversations":[{
+                    "id":"relationship:100:101",
+                    "evidenceType":"DIRECT_RELATIONSHIP",
+                    "label":"Direct conversation · @alice, @bob",
+                    "evidence":"2 posts are connected by reply metadata.",
+                    "postIds":["100","101"],
+                    "authors":["alice","bob"],
+                    "relationshipTypes":["REPLY_TO"]
+                  }],
+                  "posts":[{
+                    "id":"100",
+                    "url":"https://x.com/alice/status/100",
+                    "text":"A real reply.",
+                    "publishedAt":"2026-07-24T12:15:00.000Z",
+                    "observedAt":"2026-07-24T13:00:00.000Z",
+                    "kind":"REPLY",
+                    "author":{"key":"id:alice","username":"alice","name":"Alice"},
+                    "media":[],
+                    "links":[{
+                      "url":"https://example.com/story",
+                      "normalizedUrl":"https://example.com/story",
+                      "source":"TEXT"
+                    }],
+                    "metrics":{"likes":12},
+                    "relationships":[{
+                      "type":"REPLY_TO",
+                      "tweetId":"101",
+                      "url":"https://x.com/bob/status/101",
+                      "target":{
+                        "tweetId":"101",
+                        "text":"The post being answered.",
+                        "url":"https://x.com/bob/status/101",
+                        "author":{"key":"id:bob","username":"bob","name":"Bob"}
+                      }
+                    }],
+                    "presentation":"POST",
+                    "repostedBy":null,
+                    "sourceIds":["following-fallback"]
+                  }],
+                  "requestId":"request-1",
+                  "traceId":"trace-1"
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(response.variant.mode, .review)
+        XCTAssertEqual(response.coverage.selectionStatus, .fallback)
+        XCTAssertEqual(response.conversations.first?.evidenceType, .directRelationship)
+        XCTAssertEqual(response.posts.first?.relationships.first?.target?.author.username, "bob")
+        XCTAssertEqual(response.posts.first?.links.first?.destinationURL?.host(), "example.com")
+    }
+
     func testDecodesTodayContractWithoutAnIssue() throws {
         let response = try JSONDecoder().decode(
             EditorialTodayResponse.self,

--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+
+import { getDailyAuthorActivity, getDailyFeed } from './daily-feed';
+
+const USER_ID = 'daily-user';
+const NOW = new Date('2026-07-24T16:00:00.000Z');
+
+function postRow(input: {
+  id: string;
+  authorKey: string;
+  username: string;
+  name: string;
+  text: string;
+  publishedAt: string;
+  position?: number | null;
+  kind?: string;
+  links?: unknown[];
+}) {
+  const timestamp = Date.parse(input.publishedAt);
+  return {
+    tweet_id: input.id,
+    url: `https://x.com/i/status/${input.id}`,
+    text: input.text,
+    published_at: timestamp,
+    lang: 'en',
+    kind: input.kind ?? 'POST',
+    author_key: input.authorKey,
+    username: input.username,
+    author_name: input.name,
+    profile_url: `https://x.com/${input.username}`,
+    profile_image_url: `https://example.com/${input.username}.jpg`,
+    verified: 0,
+    media_json: '[]',
+    links_json: JSON.stringify(input.links ?? []),
+    metrics_json: '{}',
+    first_seen_at: timestamp,
+    last_seen_at: timestamp,
+    position: input.position ?? null,
+    observed_at: Date.parse('2026-07-24T13:00:00.000Z'),
+    presentation: 'POST',
+    reposted_by_json: null,
+  };
+}
+
+const todayRows = [
+  postRow({
+    id: '100',
+    authorKey: 'id:alice',
+    username: 'alice',
+    name: 'Alice',
+    text: 'Alice replies with context.',
+    publishedAt: '2026-07-24T12:15:00.000Z',
+    position: 0,
+    kind: 'REPLY',
+    links: [
+      {
+        url: 'https://example.com/story',
+        normalizedUrl: 'https://example.com/story',
+        source: 'TEXT',
+      },
+    ],
+  }),
+  postRow({
+    id: '101',
+    authorKey: 'id:bob',
+    username: 'bob',
+    name: 'Bob',
+    text: 'Bob starts the thread.',
+    publishedAt: '2026-07-24T12:00:00.000Z',
+    position: 1,
+  }),
+  postRow({
+    id: '102',
+    authorKey: 'id:other',
+    username: 'other',
+    name: 'Other',
+    text: 'An unrelated post.',
+    publishedAt: '2026-07-24T11:00:00.000Z',
+    position: 2,
+  }),
+];
+
+const earlierAlice = postRow({
+  id: '099',
+  authorKey: 'id:alice',
+  username: 'alice',
+  name: 'Alice',
+  text: 'Alice earlier in the week.',
+  publishedAt: '2026-07-20T12:00:00.000Z',
+  kind: 'QUOTE',
+});
+
+function fakeArchiveDb(
+  options: { configuredSources?: boolean; sourceCapturedAt?: number } = {}
+): D1Database {
+  const configuredSources = options.configuredSources ?? true;
+  const sourceCapturedAt = options.sourceCapturedAt ?? NOW.getTime();
+  return {
+    prepare(sql: string) {
+      let bindings: unknown[] = [];
+      return {
+        bind(...values: unknown[]) {
+          bindings = values;
+          return this;
+        },
+        async all() {
+          if (sql.includes('FROM x_timeline_runs')) {
+            return {
+              results: [
+                {
+                  id: 'run-1',
+                  requested_count: 3,
+                  collected_count: 3,
+                  status: 'COMPLETE',
+                  started_at: Date.parse('2026-07-24T12:00:00.000Z'),
+                  completed_at: Date.parse('2026-07-24T13:00:00.000Z'),
+                  excluded_ads: 0,
+                  failure_reason: null,
+                },
+              ],
+            };
+          }
+          if (sql.includes('FROM x_timeline_run_items i')) {
+            return { results: todayRows };
+          }
+          if (sql.includes('FROM x_post_relationships r')) {
+            const sourceIds = new Set(bindings.slice(1));
+            return {
+              results: sourceIds.has('100')
+                ? [
+                    {
+                      source_tweet_id: '100',
+                      relationship_type: 'REPLY_TO',
+                      target_tweet_id: '101',
+                      target_url: 'https://x.com/i/status/101',
+                      target_text: 'Bob starts the thread.',
+                      target_author_key: 'id:bob',
+                      target_username: 'bob',
+                      target_author_name: 'Bob',
+                      target_profile_image_url: 'https://example.com/bob.jpg',
+                    },
+                  ]
+                : [],
+            };
+          }
+          if (sql.includes('FROM x_daily_sources s')) {
+            return {
+              results: configuredSources
+                ? [
+                    {
+                      source_id: 'favorites',
+                      source_type: 'FAVORITES',
+                      name: 'Favorites',
+                      is_selected: 1,
+                      captured_at: sourceCapturedAt,
+                      author_key: 'id:alice',
+                    },
+                    {
+                      source_id: 'favorites',
+                      source_type: 'FAVORITES',
+                      name: 'Favorites',
+                      is_selected: 1,
+                      captured_at: sourceCapturedAt,
+                      author_key: 'id:bob',
+                    },
+                  ]
+                : [],
+            };
+          }
+          if (sql.includes('FROM x_posts p') && sql.includes('p.author_key = ?')) {
+            const authorKey = bindings[1];
+            return {
+              results: authorKey === 'id:alice' ? [todayRows[0], earlierAlice] : [todayRows[1]],
+            };
+          }
+          throw new Error(`Unexpected all query: ${sql}`);
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('people-first daily feed', () => {
+  it('filters to explicit sources and groups only relationship-backed conversations', async () => {
+    const result = await getDailyFeed(fakeArchiveDb(), USER_ID, { now: NOW });
+
+    expect(result.coverage).toMatchObject({
+      status: 'COMPLETE',
+      archiveStatus: 'COMPLETE',
+      selectionStatus: 'COMPLETE',
+      collectedCount: 3,
+    });
+    expect(result.posts.map((post) => post.id)).toEqual(['100', '101']);
+    expect(result.posts[0]).toMatchObject({
+      author: { username: 'alice' },
+      sourceIds: ['favorites'],
+      relationships: [
+        {
+          type: 'REPLY_TO',
+          target: { tweetId: '101', text: 'Bob starts the thread.' },
+        },
+      ],
+    });
+    expect(result.conversations).toEqual([
+      expect.objectContaining({
+        evidenceType: 'DIRECT_RELATIONSHIP',
+        postIds: ['100', '101'],
+        authors: ['alice', 'bob'],
+      }),
+    ]);
+  });
+
+  it('labels Following as a partial fallback instead of claiming favorites', async () => {
+    const result = await getDailyFeed(fakeArchiveDb({ configuredSources: false }), USER_ID, {
+      now: NOW,
+    });
+
+    expect(result.coverage.selectionStatus).toBe('FALLBACK');
+    expect(result.coverage.status).toBe('PARTIAL');
+    expect(result.sources).toEqual([
+      expect.objectContaining({ id: 'following-fallback', type: 'FOLLOWING_FALLBACK' }),
+    ]);
+    expect(result.freshness.warnings.join(' ')).toContain(
+      'Favorite and selected-list membership has not been captured'
+    );
+    expect(result.posts).toHaveLength(3);
+  });
+
+  it('marks source membership captured on another day as stale', async () => {
+    const result = await getDailyFeed(
+      fakeArchiveDb({ sourceCapturedAt: Date.parse('2026-07-23T16:00:00.000Z') }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.coverage.selectionStatus).toBe('STALE');
+    expect(result.coverage.status).toBe('PARTIAL');
+    expect(result.freshness.warnings).toContain(
+      'Favorite/list membership was captured on a different day than the frozen post run.'
+    );
+  });
+
+  it('returns all available author posts for today and the past week with context', async () => {
+    const db = fakeArchiveDb();
+    const today = await getDailyAuthorActivity(db, USER_ID, 'id:alice', {
+      date: '2026-07-24',
+      range: 'TODAY',
+      now: NOW,
+    });
+    expect(today.posts.map((post) => post.id)).toEqual(['100']);
+
+    const week = await getDailyAuthorActivity(db, USER_ID, 'id:alice', {
+      date: '2026-07-24',
+      range: 'WEEK',
+      now: NOW,
+    });
+    expect(week.posts.map((post) => post.id)).toEqual(['100', '099']);
+    expect(week.posts[0].relationships[0].target?.author.username).toBe('bob');
+    expect(week.coverage.warnings[0]).toContain('every post available');
+  });
+});

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -1,0 +1,638 @@
+const DEFAULT_TIMEZONE = 'America/Chicago';
+const MAX_RUN_POSTS = 500;
+const MAX_AUTHOR_POSTS = 500;
+
+type ArchiveRunRow = {
+  id: string;
+  requested_count: number;
+  collected_count: number;
+  status: string;
+  started_at: number;
+  completed_at: number | null;
+  excluded_ads: number;
+  failure_reason: string | null;
+};
+
+type ArchivePostRow = {
+  tweet_id: string;
+  url: string;
+  text: string;
+  published_at: number | null;
+  lang: string | null;
+  kind: string;
+  author_key: string;
+  username: string;
+  author_name: string;
+  profile_url: string | null;
+  profile_image_url: string | null;
+  verified: number | null;
+  media_json: string;
+  links_json: string;
+  metrics_json: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  position: number | null;
+  observed_at: number | null;
+  presentation: string | null;
+  reposted_by_json: string | null;
+};
+
+type RelationshipRow = {
+  source_tweet_id: string;
+  relationship_type: string;
+  target_tweet_id: string;
+  target_url: string | null;
+  target_text: string | null;
+  target_author_key: string | null;
+  target_username: string | null;
+  target_author_name: string | null;
+  target_profile_image_url: string | null;
+};
+
+type DailySourceRow = {
+  source_id: string;
+  source_type: 'FAVORITES' | 'LIST';
+  name: string;
+  is_selected: number;
+  captured_at: number;
+  author_key: string | null;
+};
+
+type DailySource = {
+  id: string;
+  type: 'FAVORITES' | 'LIST' | 'FOLLOWING_FALLBACK';
+  name: string;
+  selected: boolean;
+  capturedAt: string | null;
+  authorCount: number;
+};
+
+type DailyRelationship = {
+  type: string;
+  tweetId: string;
+  url: string | null;
+  target: {
+    tweetId: string;
+    text: string;
+    url: string;
+    author: {
+      key: string;
+      username: string;
+      name: string;
+      profileImageUrl: string | null;
+    };
+  } | null;
+};
+
+export type DailyPost = ReturnType<typeof publicPost>;
+
+function parseJson(value: string | null, fallback: unknown): unknown {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return fallback;
+  }
+}
+
+function localDate(value: Date, timezone = DEFAULT_TIMEZONE): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(value);
+  const part = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((entry) => entry.type === type)?.value ?? '';
+  return `${part('year')}-${part('month')}-${part('day')}`;
+}
+
+function addDays(date: string, days: number): string {
+  const [year, month, day] = date.split('-').map(Number);
+  const value = new Date(Date.UTC(year, month - 1, day + days));
+  return value.toISOString().slice(0, 10);
+}
+
+function postTimestamp(row: ArchivePostRow): number {
+  return row.published_at ?? row.observed_at ?? row.last_seen_at;
+}
+
+function publicPost(
+  row: ArchivePostRow,
+  sourceIds: string[],
+  relationships: DailyRelationship[] = []
+) {
+  return {
+    id: row.tweet_id,
+    url: row.url,
+    text: row.text,
+    publishedAt: row.published_at ? new Date(row.published_at).toISOString() : null,
+    observedAt: row.observed_at ? new Date(row.observed_at).toISOString() : null,
+    kind: row.kind,
+    author: {
+      key: row.author_key,
+      username: row.username,
+      name: row.author_name,
+      profileUrl: row.profile_url,
+      profileImageUrl: row.profile_image_url,
+      verified: row.verified === null ? null : Boolean(row.verified),
+    },
+    media: parseJson(row.media_json, []),
+    links: parseJson(row.links_json, []),
+    metrics: parseJson(row.metrics_json, {}),
+    relationships,
+    presentation: row.presentation ?? row.kind,
+    repostedBy: parseJson(row.reposted_by_json, null),
+    sourceIds,
+  };
+}
+
+async function archiveRuns(db: D1Database, userId: string): Promise<ArchiveRunRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT id, requested_count, collected_count, status, started_at, completed_at,
+        excluded_ads, failure_reason
+       FROM x_timeline_runs
+       WHERE user_id = ? AND status IN ('COMPLETE', 'PARTIAL') AND completed_at IS NOT NULL
+       ORDER BY completed_at DESC, id DESC LIMIT 60`
+    )
+    .bind(userId)
+    .all<ArchiveRunRow>();
+  return rows.results;
+}
+
+async function selectRun(
+  db: D1Database,
+  userId: string,
+  date: string | undefined,
+  timezone: string
+): Promise<ArchiveRunRow | null> {
+  const runs = await archiveRuns(db, userId);
+  if (!date) return runs[0] ?? null;
+  return (
+    runs.find(
+      (run) => localDate(new Date(run.completed_at ?? run.started_at), timezone) === date
+    ) ?? null
+  );
+}
+
+async function postsForRun(
+  db: D1Database,
+  userId: string,
+  runId: string
+): Promise<ArchivePostRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT i.position, i.observed_at, i.presentation, i.reposted_by_json,
+        p.tweet_id, p.url, p.text, p.published_at, p.lang, p.kind, p.author_key,
+        a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified,
+        p.media_json, p.links_json, p.metrics_json, p.first_seen_at, p.last_seen_at
+       FROM x_timeline_run_items i
+       JOIN x_posts p ON p.user_id = i.user_id AND p.tweet_id = i.tweet_id
+       JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+       WHERE i.user_id = ? AND i.run_id = ?
+       ORDER BY i.position ASC LIMIT ?`
+    )
+    .bind(userId, runId, MAX_RUN_POSTS)
+    .all<ArchivePostRow>();
+  return rows.results;
+}
+
+async function relationshipsForPosts(
+  db: D1Database,
+  userId: string,
+  tweetIds: string[]
+): Promise<Map<string, DailyRelationship[]>> {
+  if (tweetIds.length === 0) return new Map();
+  const placeholders = tweetIds.map(() => '?').join(',');
+  const rows = await db
+    .prepare(
+      `SELECT r.source_tweet_id, r.relationship_type, r.target_tweet_id, r.target_url,
+        target.text AS target_text, target.author_key AS target_author_key,
+        target_author.username AS target_username, target_author.name AS target_author_name,
+        target_author.profile_image_url AS target_profile_image_url
+       FROM x_post_relationships r
+       LEFT JOIN x_posts target
+         ON target.user_id = r.user_id AND target.tweet_id = r.target_tweet_id
+       LEFT JOIN x_authors target_author
+         ON target_author.user_id = target.user_id AND target_author.author_key = target.author_key
+       WHERE r.user_id = ? AND r.source_tweet_id IN (${placeholders})`
+    )
+    .bind(userId, ...tweetIds)
+    .all<RelationshipRow>();
+  const result = new Map<string, DailyRelationship[]>();
+  for (const row of rows.results) {
+    const target =
+      row.target_text && row.target_author_key && row.target_username && row.target_author_name
+        ? {
+            tweetId: row.target_tweet_id,
+            text: row.target_text,
+            url: row.target_url ?? `https://x.com/i/status/${row.target_tweet_id}`,
+            author: {
+              key: row.target_author_key,
+              username: row.target_username,
+              name: row.target_author_name,
+              profileImageUrl: row.target_profile_image_url,
+            },
+          }
+        : null;
+    const relationship = {
+      type: row.relationship_type,
+      tweetId: row.target_tweet_id,
+      url: row.target_url,
+      target,
+    };
+    result.set(row.source_tweet_id, [...(result.get(row.source_tweet_id) ?? []), relationship]);
+  }
+  return result;
+}
+
+async function dailySources(
+  db: D1Database,
+  userId: string
+): Promise<{
+  sources: DailySource[];
+  authorsBySource: Map<string, Set<string>>;
+  warning: string | null;
+}> {
+  try {
+    const rows = await db
+      .prepare(
+        `SELECT s.source_id, s.source_type, s.name, s.is_selected, s.captured_at, m.author_key
+         FROM x_daily_sources s
+         LEFT JOIN x_daily_source_members m
+           ON m.user_id = s.user_id AND m.source_id = s.source_id
+         WHERE s.user_id = ? AND s.is_selected = 1
+         ORDER BY CASE s.source_type WHEN 'FAVORITES' THEN 0 ELSE 1 END, s.name`
+      )
+      .bind(userId)
+      .all<DailySourceRow>();
+    const sourceMap = new Map<string, DailySource>();
+    const authorsBySource = new Map<string, Set<string>>();
+    for (const row of rows.results) {
+      const authors = authorsBySource.get(row.source_id) ?? new Set<string>();
+      if (row.author_key) authors.add(row.author_key);
+      authorsBySource.set(row.source_id, authors);
+      sourceMap.set(row.source_id, {
+        id: row.source_id,
+        type: row.source_type,
+        name: row.name,
+        selected: true,
+        capturedAt: new Date(row.captured_at).toISOString(),
+        authorCount: authors.size,
+      });
+    }
+    return { sources: [...sourceMap.values()], authorsBySource, warning: null };
+  } catch (error) {
+    return {
+      sources: [],
+      authorsBySource: new Map(),
+      warning: `Favorite/list membership could not be read: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}
+
+function sourceIdsForAuthor(
+  authorKey: string,
+  sources: DailySource[],
+  authorsBySource: Map<string, Set<string>>
+): string[] {
+  return sources
+    .filter((source) => authorsBySource.get(source.id)?.has(authorKey))
+    .map((source) => source.id);
+}
+
+function uniqueAuthors(posts: DailyPost[]): string[] {
+  return [...new Set(posts.map((post) => post.author.username))];
+}
+
+function conversationGroups(posts: DailyPost[]) {
+  const postById = new Map(posts.map((post) => [post.id, post]));
+  const parents = new Map(posts.map((post) => [post.id, post.id]));
+  const find = (id: string): string => {
+    const parent = parents.get(id) ?? id;
+    if (parent === id) return id;
+    const root = find(parent);
+    parents.set(id, root);
+    return root;
+  };
+  const union = (a: string, b: string) => {
+    const left = find(a);
+    const right = find(b);
+    if (left !== right) parents.set(right, left);
+  };
+
+  for (const post of posts) {
+    for (const relationship of post.relationships) {
+      if (postById.has(relationship.tweetId)) union(post.id, relationship.tweetId);
+    }
+  }
+
+  const direct = new Map<string, DailyPost[]>();
+  for (const post of posts) {
+    const root = find(post.id);
+    direct.set(root, [...(direct.get(root) ?? []), post]);
+  }
+
+  const candidates: Array<{
+    id: string;
+    evidenceType: 'DIRECT_RELATIONSHIP' | 'SHARED_LINK';
+    label: string;
+    evidence: string;
+    postIds: string[];
+    authors: string[];
+    relationshipTypes: string[];
+  }> = [];
+  for (const groupPosts of direct.values()) {
+    const authors = uniqueAuthors(groupPosts);
+    if (groupPosts.length < 2 || authors.length < 2) continue;
+    const relationshipTypes = [
+      ...new Set(
+        groupPosts.flatMap((post) =>
+          post.relationships
+            .filter((relationship) => postById.has(relationship.tweetId))
+            .map((relationship) => relationship.type)
+        )
+      ),
+    ];
+    candidates.push({
+      id: `relationship:${groupPosts
+        .map((post) => post.id)
+        .sort()
+        .join(':')}`,
+      evidenceType: 'DIRECT_RELATIONSHIP',
+      label: `Direct conversation · ${authors
+        .slice(0, 3)
+        .map((author) => `@${author}`)
+        .join(', ')}`,
+      evidence: `${groupPosts.length} posts are connected by ${relationshipTypes
+        .map((type) => type.toLocaleLowerCase().replaceAll('_', ' '))
+        .join(', ')} metadata.`,
+      postIds: groupPosts.slice(0, 4).map((post) => post.id),
+      authors,
+      relationshipTypes,
+    });
+  }
+
+  const linkGroups = new Map<string, DailyPost[]>();
+  for (const post of posts) {
+    for (const link of post.links as Array<{
+      normalizedUrl?: string;
+      card?: { domain?: string | null } | null;
+    }>) {
+      if (!link.normalizedUrl) continue;
+      linkGroups.set(link.normalizedUrl, [...(linkGroups.get(link.normalizedUrl) ?? []), post]);
+    }
+  }
+  for (const [url, linkedPosts] of linkGroups) {
+    const uniquePosts = [...new Map(linkedPosts.map((post) => [post.id, post])).values()];
+    const authors = uniqueAuthors(uniquePosts);
+    if (uniquePosts.length < 2 || authors.length < 2) continue;
+    const ids = uniquePosts.map((post) => post.id);
+    if (candidates.some((candidate) => ids.every((id) => candidate.postIds.includes(id)))) continue;
+    let domain = url;
+    try {
+      domain = new URL(url).hostname.replace(/^www\./, '');
+    } catch {
+      // Keep the normalized URL as explicit evidence when it cannot be parsed.
+    }
+    candidates.push({
+      id: `link:${url}`,
+      evidenceType: 'SHARED_LINK',
+      label: `Shared link · ${domain}`,
+      evidence: `${authors.length} authors linked to the same normalized URL.`,
+      postIds: ids.slice(0, 4),
+      authors,
+      relationshipTypes: [],
+    });
+  }
+
+  return candidates
+    .sort(
+      (a, b) =>
+        (a.evidenceType === 'DIRECT_RELATIONSHIP' ? 0 : 1) -
+          (b.evidenceType === 'DIRECT_RELATIONSHIP' ? 0 : 1) ||
+        b.authors.length - a.authors.length ||
+        b.postIds.length - a.postIds.length
+    )
+    .slice(0, 3);
+}
+
+export async function getDailyFeed(
+  db: D1Database,
+  userId: string,
+  options: { date?: string; timezone?: string; now?: Date } = {}
+) {
+  const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+  const now = options.now ?? new Date();
+  const expectedDate = localDate(now, timezone);
+  const run = await selectRun(db, userId, options.date, timezone);
+  if (!run) {
+    return {
+      schemaVersion: 1,
+      variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+      date: options.date ?? expectedDate,
+      timezone,
+      frozenAt: null,
+      freshness: { isCurrent: false, status: 'UNAVAILABLE' as const, warnings: [] as string[] },
+      coverage: {
+        status: 'UNAVAILABLE' as const,
+        archiveStatus: 'UNAVAILABLE' as const,
+        selectionStatus: 'MISSING' as const,
+        runId: null,
+        requestedCount: 0,
+        collectedCount: 0,
+        message: 'No complete or partial X Following archive run is available for this day.',
+      },
+      sources: [] as DailySource[],
+      conversations: [] as ReturnType<typeof conversationGroups>,
+      posts: [] as DailyPost[],
+    };
+  }
+
+  const frozenAt = new Date(run.completed_at ?? run.started_at);
+  const date = localDate(frozenAt, timezone);
+  const archivePosts = await postsForRun(db, userId, run.id);
+  const relationships = await relationshipsForPosts(
+    db,
+    userId,
+    archivePosts.map((post) => post.tweet_id)
+  );
+  const sourceResult = await dailySources(db, userId);
+  let sources = sourceResult.sources;
+  let selectionStatus: 'COMPLETE' | 'STALE' | 'FALLBACK' | 'MISSING' =
+    sources.length > 0 ? 'COMPLETE' : 'MISSING';
+  let selectedRows = archivePosts
+    .map((row) => ({
+      row,
+      sourceIds: sourceIdsForAuthor(row.author_key, sources, sourceResult.authorsBySource),
+    }))
+    .filter((entry) => entry.sourceIds.length > 0);
+  const warnings: string[] = [];
+  if (sourceResult.warning) warnings.push(sourceResult.warning);
+  if (sources.length === 0 || selectedRows.length === 0) {
+    selectionStatus = 'FALLBACK';
+    sources = [
+      {
+        id: 'following-fallback',
+        type: 'FOLLOWING_FALLBACK',
+        name: 'Following',
+        selected: true,
+        capturedAt: frozenAt.toISOString(),
+        authorCount: new Set(archivePosts.map((post) => post.author_key)).size,
+      },
+    ];
+    selectedRows = archivePosts.map((row) => ({ row, sourceIds: ['following-fallback'] }));
+    warnings.push(
+      sourceResult.sources.length === 0
+        ? 'Favorite and selected-list membership has not been captured; showing the frozen Following run.'
+        : 'No posts in the frozen run matched the selected Favorite/list sources; showing Following as an explicit fallback.'
+    );
+  } else if (
+    sources.some(
+      (source) => source.capturedAt && localDate(new Date(source.capturedAt), timezone) !== date
+    )
+  ) {
+    selectionStatus = 'STALE';
+    warnings.push(
+      'Favorite/list membership was captured on a different day than the frozen post run.'
+    );
+  }
+
+  const sourceRank = new Map(
+    sources.map((source, index) => [source.id, source.type === 'FAVORITES' ? -1 : index])
+  );
+  selectedRows.sort(
+    (a, b) =>
+      Math.min(...a.sourceIds.map((id) => sourceRank.get(id) ?? 100)) -
+        Math.min(...b.sourceIds.map((id) => sourceRank.get(id) ?? 100)) ||
+      (a.row.position ?? 10_000) - (b.row.position ?? 10_000)
+  );
+  const posts = selectedRows.map(({ row, sourceIds }) =>
+    publicPost(row, sourceIds, relationships.get(row.tweet_id) ?? [])
+  );
+  const archiveComplete = run.status === 'COMPLETE' && run.collected_count >= run.requested_count;
+  if (!archiveComplete) {
+    warnings.push(
+      `X run ${run.id} is ${run.status.toLocaleLowerCase()} (${run.collected_count}/${run.requested_count} requested posts).`
+    );
+  }
+  if (run.failure_reason) warnings.push(run.failure_reason);
+  if (date !== expectedDate) {
+    warnings.push(`Frozen review data is from ${date}; the current local date is ${expectedDate}.`);
+  }
+  const status =
+    archiveComplete && selectionStatus === 'COMPLETE'
+      ? ('COMPLETE' as const)
+      : ('PARTIAL' as const);
+
+  return {
+    schemaVersion: 1,
+    variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+    date,
+    timezone,
+    frozenAt: frozenAt.toISOString(),
+    freshness: { isCurrent: date === expectedDate, status, warnings },
+    coverage: {
+      status,
+      archiveStatus: archiveComplete ? ('COMPLETE' as const) : ('PARTIAL' as const),
+      selectionStatus,
+      runId: run.id,
+      requestedCount: run.requested_count,
+      collectedCount: run.collected_count,
+      message:
+        status === 'COMPLETE'
+          ? 'Frozen archive coverage and Favorite/list membership are complete for this review slice.'
+          : 'This review slice is usable with the coverage limits shown above.',
+    },
+    sources,
+    conversations: conversationGroups(posts),
+    posts,
+  };
+}
+
+async function postsForAuthor(
+  db: D1Database,
+  userId: string,
+  authorKey: string
+): Promise<ArchivePostRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT p.tweet_id, p.url, p.text, p.published_at, p.lang, p.kind, p.author_key,
+        a.username, a.name AS author_name, a.profile_url, a.profile_image_url, a.verified,
+        p.media_json, p.links_json, p.metrics_json, p.first_seen_at, p.last_seen_at,
+        i.position, i.observed_at, i.presentation, i.reposted_by_json
+       FROM x_posts p
+       JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+       LEFT JOIN x_timeline_run_items i
+         ON i.user_id = p.user_id AND i.tweet_id = p.tweet_id
+        AND i.observed_at = (
+          SELECT MAX(latest.observed_at) FROM x_timeline_run_items latest
+          WHERE latest.user_id = p.user_id AND latest.tweet_id = p.tweet_id
+        )
+       WHERE p.user_id = ? AND p.author_key = ?
+       ORDER BY COALESCE(p.published_at, i.observed_at, p.last_seen_at) DESC
+       LIMIT ?`
+    )
+    .bind(userId, authorKey, MAX_AUTHOR_POSTS)
+    .all<ArchivePostRow>();
+  return rows.results;
+}
+
+export async function getDailyAuthorActivity(
+  db: D1Database,
+  userId: string,
+  authorKey: string,
+  options: { date: string; range: 'TODAY' | 'WEEK'; timezone?: string; now?: Date }
+) {
+  const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+  const startDate = options.range === 'WEEK' ? addDays(options.date, -6) : options.date;
+  const rows = (await postsForAuthor(db, userId, authorKey)).filter((row) => {
+    const date = localDate(new Date(postTimestamp(row)), timezone);
+    return date >= startDate && date <= options.date;
+  });
+  const relationshipMap = await relationshipsForPosts(
+    db,
+    userId,
+    rows.map((row) => row.tweet_id)
+  );
+  const sourceResult = await dailySources(db, userId);
+  const posts = rows.map((row) =>
+    publicPost(
+      row,
+      sourceIdsForAuthor(row.author_key, sourceResult.sources, sourceResult.authorsBySource),
+      relationshipMap.get(row.tweet_id) ?? []
+    )
+  );
+  const author = posts[0]?.author ?? null;
+  const runs = await archiveRuns(db, userId);
+  const relevantRuns = runs.filter((run) => {
+    const runDate = localDate(new Date(run.completed_at ?? run.started_at), timezone);
+    return runDate >= startDate && runDate <= options.date;
+  });
+  const warnings = [
+    'Shows every post available in the X Following archive, which is a sampled timeline rather than a complete author export.',
+  ];
+  if (sourceResult.warning) warnings.push(sourceResult.warning);
+  if (relevantRuns.some((run) => run.status !== 'COMPLETE')) {
+    warnings.push('At least one archive run in this range has partial coverage.');
+  }
+
+  return {
+    schemaVersion: 1,
+    variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+    date: options.date,
+    range: options.range,
+    startDate,
+    timezone,
+    author,
+    coverage: {
+      status: relevantRuns.length > 0 ? ('PARTIAL' as const) : ('UNAVAILABLE' as const),
+      runIds: relevantRuns.map((run) => run.id),
+      warnings,
+    },
+    posts,
+  };
+}

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -1043,6 +1043,62 @@
         }
       }
     },
+    "/api/v1/today/feed": {
+      "get": {
+        "tags": ["Editorial"],
+        "operationId": "getPeopleFirstDailyFeed",
+        "summary": "Get the frozen people-first Today review feed",
+        "description": "Returns real X posts from Favorite and selected-list source snapshots, explicit relationship/shared-link conversation groups, and archive coverage. This review route does not replace the live editorial Today issue.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "experimental",
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "schema": { "type": "string", "format": "date" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Frozen people-first review feed." },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/api/v1/today/authors/{authorKey}": {
+      "get": {
+        "tags": ["Editorial"],
+        "operationId": "getPeopleFirstAuthorActivity",
+        "summary": "Get all archived posts available for an author",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "experimental",
+        "parameters": [
+          { "name": "authorKey", "in": "path", "required": true, "schema": { "type": "string" } },
+          {
+            "name": "date",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "range",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["TODAY", "WEEK"], "default": "TODAY" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Every available archived post for the author in the selected range."
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
     "/api/v1/editorial/experiments": {
       "get": {
         "tags": ["Editorial"],

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -84,6 +84,8 @@ const {
   mockGetEditorialExperimentVariantPreview,
   mockReviewEditorialExperiment,
   mockPromoteEditorialExperiment,
+  mockGetDailyFeed,
+  mockGetDailyAuthorActivity,
 } = vi.hoisted(() => ({
   mockCreateDb: vi.fn(),
   mockCreateContext: vi.fn(async (c: { get: (key: string) => unknown }) => ({
@@ -162,6 +164,8 @@ const {
   mockGetEditorialExperimentVariantPreview: vi.fn(),
   mockReviewEditorialExperiment: vi.fn(),
   mockPromoteEditorialExperiment: vi.fn(),
+  mockGetDailyFeed: vi.fn(),
+  mockGetDailyAuthorActivity: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
@@ -243,6 +247,11 @@ vi.mock('../lib/editorial-experiments', () => {
   };
 });
 
+vi.mock('../lib/daily-feed', () => ({
+  getDailyFeed: mockGetDailyFeed,
+  getDailyAuthorActivity: mockGetDailyAuthorActivity,
+}));
+
 vi.mock('../sync/service', async () => {
   class RateLimitError extends Error {
     constructor(message: string) {
@@ -301,6 +310,7 @@ function createTestApp() {
 function createMockEnv(): Env['Bindings'] {
   return {
     DB: {} as D1Database,
+    X_ARCHIVE_DB: {} as D1Database,
     WEBHOOK_IDEMPOTENCY: {} as KVNamespace,
     OAUTH_STATE_KV: {} as KVNamespace,
     ARTICLE_CONTENT: {} as R2Bucket,
@@ -457,6 +467,37 @@ describe('apiV1Routes', () => {
       sourceIds: [],
     });
     mockListEditorialExperiments.mockResolvedValue([]);
+    mockGetDailyFeed.mockResolvedValue({
+      schemaVersion: 1,
+      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      date: '2026-07-24',
+      timezone: 'America/Chicago',
+      frozenAt: '2026-07-24T13:00:00.000Z',
+      freshness: { isCurrent: true, status: 'COMPLETE', warnings: [] },
+      coverage: {
+        status: 'COMPLETE',
+        archiveStatus: 'COMPLETE',
+        selectionStatus: 'COMPLETE',
+        runId: 'run-1',
+        requestedCount: 500,
+        collectedCount: 500,
+        message: 'Complete.',
+      },
+      sources: [],
+      conversations: [],
+      posts: [],
+    });
+    mockGetDailyAuthorActivity.mockResolvedValue({
+      schemaVersion: 1,
+      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      date: '2026-07-24',
+      range: 'TODAY',
+      startDate: '2026-07-24',
+      timezone: 'America/Chicago',
+      author: null,
+      coverage: { status: 'PARTIAL', runIds: ['run-1'], warnings: [] },
+      posts: [],
+    });
     mockCreateEditorialExperiment.mockResolvedValue({
       experiment: editorialExperimentFixture(),
       created: true,
@@ -558,6 +599,8 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/article-content');
     expect(body.paths).toHaveProperty('/api/v1/tags');
     expect(body.paths).toHaveProperty('/api/v1/editorial/today');
+    expect(body.paths).toHaveProperty('/api/v1/today/feed');
+    expect(body.paths).toHaveProperty('/api/v1/today/authors/{authorKey}');
     expect(body.paths).toHaveProperty('/api/v1/editorial/experiments');
     expect(body.paths).toHaveProperty('/api/v1/editorial/experiments/{id}');
     expect(body.paths).toHaveProperty('/api/v1/editorial/experiments/{id}/lock');
@@ -592,6 +635,40 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/connection/callback');
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}');
     expect(body.paths).toHaveProperty('/api/v1/subscriptions/youtube/{subscriptionId}/sync');
+  });
+
+  it('reads the isolated people-first daily feed and author activity', async () => {
+    const app = createTestApp();
+    const env = createMockEnv();
+    const feed = await app.fetch(
+      new Request('http://localhost/api/v1/today/feed?date=2026-07-24', {
+        headers: { Authorization: `Bearer ${READ_ONLY_TOKEN}` },
+      }),
+      env
+    );
+    expect(feed.status).toBe(200);
+    expect(await feed.json()).toMatchObject({
+      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      date: '2026-07-24',
+    });
+    expect(mockGetDailyFeed).toHaveBeenCalledWith(expect.anything(), 'user_123', {
+      date: '2026-07-24',
+    });
+
+    const author = await app.fetch(
+      new Request(
+        'http://localhost/api/v1/today/authors/id%3Aauthor-1?date=2026-07-24&range=WEEK',
+        { headers: { Authorization: `Bearer ${READ_ONLY_TOKEN}` } }
+      ),
+      env
+    );
+    expect(author.status).toBe(200);
+    expect(mockGetDailyAuthorActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      'user_123',
+      'id:author-1',
+      { date: '2026-07-24', range: 'WEEK' }
+    );
   });
 
   it('reads the bounded editorial tuning profile with read authentication', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -62,6 +62,7 @@ import {
 import { verifyClerkRequestToken } from '../middleware/auth';
 import { logger } from '../lib/logger';
 import { getEditorialToday } from '../lib/editorial-today';
+import { getDailyAuthorActivity, getDailyFeed } from '../lib/daily-feed';
 import {
   EditorialFeedbackConflictError,
   EditorialFeedbackTargetError,
@@ -237,6 +238,18 @@ const UpdateProgressBodySchema = z
     duration: z.number().min(0),
   })
   .strict();
+
+const DailyFeedQuerySchema = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+const DailyAuthorQuerySchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  range: z.enum(['TODAY', 'WEEK']).default('TODAY'),
+});
 
 const FinishBookmarkBodySchema = z
   .object({
@@ -2064,6 +2077,50 @@ apiV1Routes.get('/tags', apiAuth('bookmarks:read'), async (c) => {
     requestId: c.get('requestId'),
     traceId: c.get('traceId'),
   });
+});
+
+apiV1Routes.get('/today/feed', apiAuth('bookmarks:read'), async (c) => {
+  const parsed = DailyFeedQuerySchema.safeParse({ date: c.req.query('date') });
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: 'Invalid daily feed query',
+        code: 'INVALID_QUERY',
+        issues: parsed.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+  const result = await getDailyFeed(c.env.X_ARCHIVE_DB, c.get('userId')!, parsed.data);
+  return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
+});
+
+apiV1Routes.get('/today/authors/:authorKey', apiAuth('bookmarks:read'), async (c) => {
+  const parsed = DailyAuthorQuerySchema.safeParse({
+    date: c.req.query('date'),
+    range: c.req.query('range'),
+  });
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: 'Invalid author activity query',
+        code: 'INVALID_QUERY',
+        issues: parsed.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+  const result = await getDailyAuthorActivity(
+    c.env.X_ARCHIVE_DB,
+    c.get('userId')!,
+    c.req.param('authorKey'),
+    parsed.data
+  );
+  return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
 });
 
 apiV1Routes.get('/editorial/today', apiAuth('bookmarks:read'), async (c) => {

--- a/apps/worker/src/routes/auth.test.ts
+++ b/apps/worker/src/routes/auth.test.ts
@@ -83,6 +83,7 @@ function createMockEnv(): Env['Bindings'] {
     DB: {
       // Mock D1Database - not used directly since we mock createDb
     } as unknown as D1Database,
+    X_ARCHIVE_DB: {} as unknown as D1Database,
     WEBHOOK_IDEMPOTENCY: {
       get: vi.fn().mockResolvedValue(null),
       put: vi.fn().mockResolvedValue(undefined),

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -13,6 +13,8 @@ import type { SyncQueueMessage } from './sync/types';
 export interface Bindings {
   /** D1 database for persistent storage */
   DB: D1Database;
+  /** Read-only access to the canonical X Following archive for people-first Today. */
+  X_ARCHIVE_DB: D1Database;
   /** KV namespace for webhook idempotency */
   WEBHOOK_IDEMPOTENCY: KVNamespace;
   /** KV namespace for OAuth state storage */

--- a/apps/worker/wrangler.test.toml
+++ b/apps/worker/wrangler.test.toml
@@ -29,6 +29,12 @@ database_name = "zine-db-test"
 database_id = "test-zine-db"
 migrations_dir = "src/db/migrations"
 
+[[d1_databases]]
+binding = "X_ARCHIVE_DB"
+database_name = "zine-x-archive-test"
+database_id = "test-zine-x-archive"
+migrations_dir = "../x-archive/src/db/migrations"
+
 [[queues.producers]]
 queue = "zine-sync-queue-test"
 binding = "SYNC_QUEUE"

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -42,6 +42,11 @@ database_name = "zine-db-dev"
 database_id = "2ce5331a-233c-48ec-9265-d04ecb539599"
 migrations_dir = "src/db/migrations"
 
+[[d1_databases]]
+binding = "X_ARCHIVE_DB"
+database_name = "zine-x-archive-dev"
+database_id = "a69f0e9e-2c1c-4c10-8538-0ef4c03418c0"
+
 # Cron triggers for scheduled ingestion
 # YouTube polls at :00, Gmail newsletters at :15, Spotify at :30, RSS at :45
 # Each provider has its own distributed lock for failure isolation
@@ -150,6 +155,10 @@ binding = "DB"
 database_name = "zine-db-staging"
 database_id = "feaff315-9e1d-41ce-94c4-563489ccffba"
 migrations_dir = "src/db/migrations"
+[[env.staging.d1_databases]]
+binding = "X_ARCHIVE_DB"
+database_name = "zine-x-archive-staging"
+database_id = "8eee0d54-70e4-4afd-b62b-908574ef301b"
 [env.staging.vars]
 ENVIRONMENT = "staging"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"
@@ -241,6 +250,10 @@ binding = "DB"
 database_name = "zine-db-production"
 database_id = "82911dea-5a6b-411b-ab4b-4145cb0c191d"
 migrations_dir = "src/db/migrations"
+[[env.production.d1_databases]]
+binding = "X_ARCHIVE_DB"
+database_name = "zine-x-archive-production"
+database_id = "ad6f4c42-f2e9-449d-a9c6-7780fc08e9fa"
 [env.production.vars]
 ENVIRONMENT = "production"
 SPOTIFY_EPISODE_FETCH_CONCURRENCY = "5"

--- a/apps/x-archive/src/db/migrations/0002_daily_sources.sql
+++ b/apps/x-archive/src/db/migrations/0002_daily_sources.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS x_daily_sources (
+  user_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_type TEXT NOT NULL CHECK (source_type IN ('FAVORITES', 'LIST')),
+  name TEXT NOT NULL,
+  is_selected INTEGER NOT NULL DEFAULT 1,
+  captured_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, source_id)
+);
+
+CREATE TABLE IF NOT EXISTS x_daily_source_members (
+  user_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  author_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (user_id, source_id, author_key),
+  FOREIGN KEY (user_id, source_id)
+    REFERENCES x_daily_sources(user_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id, author_key)
+    REFERENCES x_authors(user_id, author_key) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS x_daily_source_members_author_idx
+  ON x_daily_source_members(user_id, author_key, source_id);

--- a/apps/x-archive/src/index.test.ts
+++ b/apps/x-archive/src/index.test.ts
@@ -58,10 +58,46 @@ function post(tweetId: string) {
   };
 }
 
+async function insertCapturedRunForDailySources() {
+  await api('/api/v1/x-timeline/runs', {
+    method: 'POST',
+    body: JSON.stringify({
+      runId: 'run-daily-sources',
+      requestedCount: 1,
+      startedAt: '2026-07-11T13:00:00.000Z',
+      collectorVersion: 'test-v1',
+    }),
+  });
+  await api('/api/v1/x-timeline/runs/run-daily-sources/chunks/0', {
+    method: 'PUT',
+    body: JSON.stringify({
+      posts: [post('daily-source-post')],
+      items: [
+        {
+          tweetId: 'daily-source-post',
+          position: 0,
+          observedAt: '2026-07-11T13:00:00.000Z',
+          presentation: 'POST',
+        },
+      ],
+    }),
+  });
+  await api('/api/v1/x-timeline/runs/run-daily-sources/complete', {
+    method: 'POST',
+    body: JSON.stringify({
+      collectedCount: 1,
+      completedAt: '2026-07-11T13:01:00.000Z',
+      excludedAds: 0,
+      status: 'COMPLETE',
+      failureReason: null,
+    }),
+  });
+}
+
 beforeEach(async () => {
   await testEnv.AUTH_DB.exec('DELETE FROM api_tokens;');
   await testEnv.ARCHIVE_DB.exec(
-    'DELETE FROM x_ingest_chunks; DELETE FROM x_timeline_run_items; DELETE FROM x_post_links; DELETE FROM x_post_relationships; DELETE FROM x_posts; DELETE FROM x_authors; DELETE FROM x_timeline_runs;'
+    'DELETE FROM x_daily_source_members; DELETE FROM x_daily_sources; DELETE FROM x_ingest_chunks; DELETE FROM x_timeline_run_items; DELETE FROM x_post_links; DELETE FROM x_post_relationships; DELETE FROM x_posts; DELETE FROM x_authors; DELETE FROM x_timeline_runs;'
   );
   await testEnv.AUTH_DB.prepare(
     `INSERT INTO api_tokens
@@ -184,6 +220,37 @@ describe('X archive worker', () => {
     const exported = await api('/api/v1/x-timeline/runs/run-00000001/export');
     expect(exported.status).toBe(200);
     expect(exported.headers.get('content-encoding')).toBe('gzip');
+  });
+
+  it('stores explicit Favorite/list author snapshots for daily review', async () => {
+    await insertCapturedRunForDailySources();
+    const put = await api('/api/v1/x-timeline/daily-sources/favorites', {
+      method: 'PUT',
+      body: JSON.stringify({
+        sourceType: 'FAVORITES',
+        name: 'Favorites',
+        selected: true,
+        capturedAt: '2026-07-11T13:02:00.000Z',
+        usernames: ['example', 'missing'],
+      }),
+    });
+    expect(put.status).toBe(200);
+    expect(await put.json()).toMatchObject({
+      source: { id: 'favorites', type: 'FAVORITES', authorCount: 1 },
+      unresolvedUsernames: ['missing'],
+    });
+
+    const read = await api('/api/v1/x-timeline/daily-sources');
+    expect(await read.json()).toMatchObject({
+      sources: [
+        {
+          id: 'favorites',
+          type: 'FAVORITES',
+          selected: true,
+          authors: [{ username: 'example' }],
+        },
+      ],
+    });
   });
 
   it('stores one canonical post across multiple runs', async () => {

--- a/apps/x-archive/src/index.ts
+++ b/apps/x-archive/src/index.ts
@@ -8,6 +8,7 @@ import {
   type XPostLink,
   XPostLinkSchema,
 } from '@zine/x-archive-schema';
+import { z } from 'zod';
 
 type Bindings = Env;
 type Variables = { userId: string; requestId: string };
@@ -15,6 +16,16 @@ type AppEnv = { Bindings: Bindings; Variables: Variables };
 
 const API_TOKEN_PREFIX = 'zine_pat_';
 const MAX_PAGE_SIZE = 100;
+
+const DailySourceSnapshotSchema = z
+  .object({
+    sourceType: z.enum(['FAVORITES', 'LIST']),
+    name: z.string().trim().min(1).max(120),
+    selected: z.boolean().default(true),
+    capturedAt: z.string().datetime(),
+    usernames: z.array(z.string().trim().min(1).max(64)).max(5_000),
+  })
+  .strict();
 
 type TokenRow = {
   id: string;
@@ -716,6 +727,144 @@ app.get('/api/v1/x-timeline/runs', async (c) => {
     .bind(userId, limit)
     .all<RunRow>();
   return c.json({ runs: rows.results.map(publicRun) });
+});
+
+app.get('/api/v1/x-timeline/daily-sources', async (c) => {
+  const userId = c.get('userId');
+  const rows = await c.env.ARCHIVE_DB.prepare(
+    `SELECT s.source_id, s.source_type, s.name, s.is_selected, s.captured_at,
+      a.author_key, a.username, a.name AS author_name
+     FROM x_daily_sources s
+     LEFT JOIN x_daily_source_members m
+       ON m.user_id = s.user_id AND m.source_id = s.source_id
+     LEFT JOIN x_authors a
+       ON a.user_id = m.user_id AND a.author_key = m.author_key
+     WHERE s.user_id = ?
+     ORDER BY CASE s.source_type WHEN 'FAVORITES' THEN 0 ELSE 1 END, s.name, a.username`
+  )
+    .bind(userId)
+    .all<{
+      source_id: string;
+      source_type: 'FAVORITES' | 'LIST';
+      name: string;
+      is_selected: number;
+      captured_at: number;
+      author_key: string | null;
+      username: string | null;
+      author_name: string | null;
+    }>();
+  const sources = new Map<
+    string,
+    {
+      id: string;
+      type: 'FAVORITES' | 'LIST';
+      name: string;
+      selected: boolean;
+      capturedAt: string;
+      authors: Array<{ key: string; username: string; name: string }>;
+    }
+  >();
+  for (const row of rows.results) {
+    const source = sources.get(row.source_id) ?? {
+      id: row.source_id,
+      type: row.source_type,
+      name: row.name,
+      selected: Boolean(row.is_selected),
+      capturedAt: new Date(row.captured_at).toISOString(),
+      authors: [],
+    };
+    if (row.author_key && row.username && row.author_name) {
+      source.authors.push({
+        key: row.author_key,
+        username: row.username,
+        name: row.author_name,
+      });
+    }
+    sources.set(row.source_id, source);
+  }
+  return c.json({ sources: [...sources.values()] });
+});
+
+app.put('/api/v1/x-timeline/daily-sources/:sourceId', async (c) => {
+  const sourceId = c.req.param('sourceId');
+  if (!/^[A-Za-z0-9:_-]{1,120}$/.test(sourceId)) {
+    return c.json({ error: 'Invalid source id', code: 'INVALID_INPUT' }, 400);
+  }
+  const parsed = DailySourceSnapshotSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: 'Invalid daily source snapshot',
+        code: 'INVALID_INPUT',
+        issues: parsed.error.issues,
+      },
+      400
+    );
+  }
+
+  const userId = c.get('userId');
+  const input = parsed.data;
+  const usernames = [...new Set(input.usernames.map((value) => value.toLocaleLowerCase()))];
+  const placeholders = usernames.map(() => '?').join(',');
+  const authors = usernames.length
+    ? await c.env.ARCHIVE_DB.prepare(
+        `SELECT author_key, username FROM x_authors
+         WHERE user_id = ? AND lower(username) IN (${placeholders})`
+      )
+        .bind(userId, ...usernames)
+        .all<{ author_key: string; username: string }>()
+    : { results: [] as Array<{ author_key: string; username: string }> };
+  const resolved = new Set(authors.results.map((author) => author.username.toLocaleLowerCase()));
+  const now = Date.now();
+
+  await c.env.ARCHIVE_DB.prepare(
+    `INSERT INTO x_daily_sources
+      (user_id, source_id, source_type, name, is_selected, captured_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(user_id, source_id) DO UPDATE SET
+       source_type = excluded.source_type,
+       name = excluded.name,
+       is_selected = excluded.is_selected,
+       captured_at = excluded.captured_at,
+       updated_at = excluded.updated_at`
+  )
+    .bind(
+      userId,
+      sourceId,
+      input.sourceType,
+      input.name,
+      input.selected ? 1 : 0,
+      Date.parse(input.capturedAt),
+      now
+    )
+    .run();
+  await c.env.ARCHIVE_DB.prepare(
+    'DELETE FROM x_daily_source_members WHERE user_id = ? AND source_id = ?'
+  )
+    .bind(userId, sourceId)
+    .run();
+  if (authors.results.length > 0) {
+    await c.env.ARCHIVE_DB.batch(
+      authors.results.map((author) =>
+        c.env.ARCHIVE_DB.prepare(
+          `INSERT INTO x_daily_source_members (user_id, source_id, author_key, created_at)
+           VALUES (?, ?, ?, ?)`
+        ).bind(userId, sourceId, author.author_key, now)
+      )
+    );
+  }
+
+  return c.json({
+    source: {
+      id: sourceId,
+      type: input.sourceType,
+      name: input.name,
+      selected: input.selected,
+      capturedAt: input.capturedAt,
+      authorCount: authors.results.length,
+    },
+    unresolvedUsernames: usernames.filter((username) => !resolved.has(username)),
+  });
 });
 
 app.get('/api/v1/x-timeline/runs/:runId/export', async (c) => {


### PR DESCRIPTION
## Summary

- add an isolated, frozen people-first Daily View review surface in the native iOS app, with evidence-backed conversation groups, real Favorites/list posts, source filters, and Today/past-week author activity
- add Clerk-authenticated `/api/v1/today/feed` and author-activity contracts over X archive data, preserving reply, quote, repost, link, media, freshness, provenance, and partial-coverage context
- add X-archive daily-source persistence and source snapshot APIs, including explicit stale and Following-fallback states; live Today is unchanged and legacy Expo is untouched

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` (75 tests passed)
- `bun run --cwd apps/worker test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"` (1,679 tests passed)
- `bun run --cwd apps/x-archive lint`
- `bun run --cwd apps/x-archive typecheck`
- `bun run --cwd apps/x-archive test:run` (5 tests passed)
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -sdk iphonesimulator -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`

Native test note: the added decoder test compiles as part of the test bundle, but final simulator-runner attempts failed before executing tests with CoreSimulator communication / Mach `-308` infrastructure errors. The generic simulator app build succeeds.