### PR TITLE
fix(today): batch daily feed relationship queries

### DIFF
--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -91,10 +91,16 @@ const earlierAlice = postRow({
 });
 
 function fakeArchiveDb(
-  options: { configuredSources?: boolean; sourceCapturedAt?: number } = {}
+  options: {
+    configuredSources?: boolean;
+    sourceCapturedAt?: number;
+    postRows?: ReturnType<typeof postRow>[];
+    relationshipBindingCounts?: number[];
+  } = {}
 ): D1Database {
   const configuredSources = options.configuredSources ?? true;
   const sourceCapturedAt = options.sourceCapturedAt ?? NOW.getTime();
+  const rowsForRun = options.postRows ?? todayRows;
   return {
     prepare(sql: string) {
       let bindings: unknown[] = [];
@@ -121,9 +127,10 @@ function fakeArchiveDb(
             };
           }
           if (sql.includes('FROM x_timeline_run_items i')) {
-            return { results: todayRows };
+            return { results: rowsForRun };
           }
           if (sql.includes('FROM x_post_relationships r')) {
+            options.relationshipBindingCounts?.push(bindings.length);
             const sourceIds = new Set(bindings.slice(1));
             return {
               results: sourceIds.has('100')
@@ -238,6 +245,34 @@ describe('people-first daily feed', () => {
     expect(result.freshness.warnings).toContain(
       'Favorite/list membership was captured on a different day than the frozen post run.'
     );
+  });
+
+  it('batches relationship lookups below the production D1 bind-variable limit', async () => {
+    const relationshipBindingCounts: number[] = [];
+    const postRows = Array.from({ length: 205 }, (_, index) =>
+      postRow({
+        id: `bulk-${index}`,
+        authorKey: `id:bulk-${index}`,
+        username: `bulk${index}`,
+        name: `Bulk ${index}`,
+        text: `Bulk post ${index}`,
+        publishedAt: '2026-07-24T12:00:00.000Z',
+        position: index,
+      })
+    );
+
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        configuredSources: false,
+        postRows,
+        relationshipBindingCounts,
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.posts).toHaveLength(205);
+    expect(relationshipBindingCounts).toEqual([91, 91, 26]);
   });
 
   it('returns all available author posts for today and the past week with context', async () => {

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -1,5 +1,6 @@
 const DEFAULT_TIMEZONE = 'America/Chicago';
 const MAX_RUN_POSTS = 500;
+const RELATIONSHIP_QUERY_POST_LIMIT = 90;
 const MAX_AUTHOR_POSTS = 500;
 
 type ArchiveRunRow = {
@@ -204,45 +205,50 @@ async function relationshipsForPosts(
   tweetIds: string[]
 ): Promise<Map<string, DailyRelationship[]>> {
   if (tweetIds.length === 0) return new Map();
-  const placeholders = tweetIds.map(() => '?').join(',');
-  const rows = await db
-    .prepare(
-      `SELECT r.source_tweet_id, r.relationship_type, r.target_tweet_id, r.target_url,
-        target.text AS target_text, target.author_key AS target_author_key,
-        target_author.username AS target_username, target_author.name AS target_author_name,
-        target_author.profile_image_url AS target_profile_image_url
-       FROM x_post_relationships r
-       LEFT JOIN x_posts target
-         ON target.user_id = r.user_id AND target.tweet_id = r.target_tweet_id
-       LEFT JOIN x_authors target_author
-         ON target_author.user_id = target.user_id AND target_author.author_key = target.author_key
-       WHERE r.user_id = ? AND r.source_tweet_id IN (${placeholders})`
-    )
-    .bind(userId, ...tweetIds)
-    .all<RelationshipRow>();
   const result = new Map<string, DailyRelationship[]>();
-  for (const row of rows.results) {
-    const target =
-      row.target_text && row.target_author_key && row.target_username && row.target_author_name
-        ? {
-            tweetId: row.target_tweet_id,
-            text: row.target_text,
-            url: row.target_url ?? `https://x.com/i/status/${row.target_tweet_id}`,
-            author: {
-              key: row.target_author_key,
-              username: row.target_username,
-              name: row.target_author_name,
-              profileImageUrl: row.target_profile_image_url,
-            },
-          }
-        : null;
-    const relationship = {
-      type: row.relationship_type,
-      tweetId: row.target_tweet_id,
-      url: row.target_url,
-      target,
-    };
-    result.set(row.source_tweet_id, [...(result.get(row.source_tweet_id) ?? []), relationship]);
+
+  for (let offset = 0; offset < tweetIds.length; offset += RELATIONSHIP_QUERY_POST_LIMIT) {
+    const batch = tweetIds.slice(offset, offset + RELATIONSHIP_QUERY_POST_LIMIT);
+    const placeholders = batch.map(() => '?').join(',');
+    const rows = await db
+      .prepare(
+        `SELECT r.source_tweet_id, r.relationship_type, r.target_tweet_id, r.target_url,
+          target.text AS target_text, target.author_key AS target_author_key,
+          target_author.username AS target_username, target_author.name AS target_author_name,
+          target_author.profile_image_url AS target_profile_image_url
+         FROM x_post_relationships r
+         LEFT JOIN x_posts target
+           ON target.user_id = r.user_id AND target.tweet_id = r.target_tweet_id
+         LEFT JOIN x_authors target_author
+           ON target_author.user_id = target.user_id AND target_author.author_key = target.author_key
+         WHERE r.user_id = ? AND r.source_tweet_id IN (${placeholders})`
+      )
+      .bind(userId, ...batch)
+      .all<RelationshipRow>();
+
+    for (const row of rows.results) {
+      const target =
+        row.target_text && row.target_author_key && row.target_username && row.target_author_name
+          ? {
+              tweetId: row.target_tweet_id,
+              text: row.target_text,
+              url: row.target_url ?? `https://x.com/i/status/${row.target_tweet_id}`,
+              author: {
+                key: row.target_author_key,
+                username: row.target_username,
+                name: row.target_author_name,
+                profileImageUrl: row.target_profile_image_url,
+              },
+            }
+          : null;
+      const relationship = {
+        type: row.relationship_type,
+        tweetId: row.target_tweet_id,
+        url: row.target_url,
+        target,
+      };
+      result.set(row.source_tweet_id, [...(result.get(row.source_tweet_id) ?? []), relationship]);
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary

- batch frozen-run relationship lookups so a 500-post Daily View does not exceed Cloudflare D1 bind-variable limits
- add a 205-post regression case that verifies every relationship query stays below the production limit
- fixes the production `/api/v1/today/feed` 500 observed after PR #350 deployed (`D1_ERROR: too many SQL variables`)

## Validation

- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker vitest run src/lib/daily-feed.test.ts src/routes/api-v1.test.ts` (78 tests passed)
- repository pre-push gates (format, design-system, monorepo typecheck, 75 web tests, 1,680 Worker tests)