### PR TITLE
fix(today): normalize legacy repost authors

### DIFF
--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -15,6 +15,7 @@ function postRow(input: {
   position?: number | null;
   kind?: string;
   links?: unknown[];
+  repostedBy?: unknown;
 }) {
   const timestamp = Date.parse(input.publishedAt);
   return {
@@ -38,7 +39,7 @@ function postRow(input: {
     position: input.position ?? null,
     observed_at: Date.parse('2026-07-24T13:00:00.000Z'),
     presentation: 'POST',
-    reposted_by_json: null,
+    reposted_by_json: input.repostedBy ? JSON.stringify(input.repostedBy) : null,
   };
 }
 
@@ -59,6 +60,12 @@ const todayRows = [
         source: 'TEXT',
       },
     ],
+    repostedBy: {
+      username: 'reposter',
+      name: 'Reposter',
+      profileUrl: 'https://x.com/reposter',
+      profileImageUrl: null,
+    },
   }),
   postRow({
     id: '101',
@@ -200,6 +207,14 @@ describe('people-first daily feed', () => {
     expect(result.posts.map((post) => post.id)).toEqual(['100', '101']);
     expect(result.posts[0]).toMatchObject({
       author: { username: 'alice' },
+      repostedBy: {
+        key: 'username:reposter',
+        username: 'reposter',
+        name: 'Reposter',
+        profileUrl: 'https://x.com/reposter',
+        profileImageUrl: null,
+        verified: null,
+      },
       sourceIds: ['favorites'],
       relationships: [
         {

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -96,6 +96,24 @@ function parseJson(value: string | null, fallback: unknown): unknown {
   }
 }
 
+function publicRepostAuthor(value: string | null) {
+  const parsed = parseJson(value, null);
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const author = parsed as Record<string, unknown>;
+  if (typeof author.username !== 'string' || typeof author.name !== 'string') return null;
+  const id = typeof author.id === 'string' && author.id ? author.id : null;
+
+  return {
+    key: id ? `id:${id}` : `username:${author.username.toLocaleLowerCase()}`,
+    username: author.username,
+    name: author.name,
+    profileUrl: typeof author.profileUrl === 'string' ? author.profileUrl : null,
+    profileImageUrl: typeof author.profileImageUrl === 'string' ? author.profileImageUrl : null,
+    verified: typeof author.verified === 'boolean' ? author.verified : null,
+  };
+}
+
 function localDate(value: Date, timezone = DEFAULT_TIMEZONE): string {
   const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: timezone,
@@ -143,7 +161,7 @@ function publicPost(
     metrics: parseJson(row.metrics_json, {}),
     relationships,
     presentation: row.presentation ?? row.kind,
-    repostedBy: parseJson(row.reposted_by_json, null),
+    repostedBy: publicRepostAuthor(row.reposted_by_json),
     sourceIds,
   };
 }


### PR DESCRIPTION
## Summary

- normalize archived repost metadata into the Daily View author contract expected by the shipped native app
- synthesize the same stable `id:` or `username:` key used by the X archive and make missing optional profile/verification fields explicit
- fix the production Swift decode failure at `posts[*].repostedBy.key` without requiring another native build

## Validation

- `bun run --cwd apps/worker lint`
- `bun run --cwd apps/worker typecheck`
- `bun run --cwd apps/worker vitest run src/lib/daily-feed.test.ts src/routes/api-v1.test.ts` (78 tests passed)
- live payload compatibility replay through shipped Swift models (`feed=500`, `today=1`, `week=26`)
- repository pre-push gates (format, design-system, monorepo typecheck, 75 web tests, 1,680 Worker tests)