### PR TITLE
feat(today): add Favorites conversation daily view

### DIFF
--- a/.codex/skills/zine-x-timeline-collector/SKILL.md
+++ b/.codex/skills/zine-x-timeline-collector/SKILL.md
@@ -16,13 +16,14 @@ Collect top-to-bottom Following or configured-list timeline entries without expo
 
 ## Workflow
 
-1. Resolve the source and requested count. Default to `500`. Following uses source `FOLLOWING/following`; a configured Favorites list uses `FAVORITES/x-list:<id>` and its stable `https://x.com/i/lists/<id>` URL.
+1. Resolve the source and collection policy. Following is count-bounded and defaults to `500`. A configured Favorites list is time-bounded to the rolling previous `24` hours, uses `FAVORITES/x-list:<id>` and its stable `https://x.com/i/lists/<id>` URL, and defaults to a separate `5000`-post safety guard. The safety guard is not the Favorites target: reaching it before the time boundary makes the run partial.
 2. Start the local receiver in a PTY and keep the session alive:
 
    ```bash
-   bun run --cwd apps/x-collector receive --count <N> \
+   bun run --cwd apps/x-collector receive [--count <N>] \
      --source-type <FOLLOWING|FAVORITES|LIST> --source-id <id> \
-     --source-name <name> [--source-url <url>]
+     --source-name <name> [--source-url <url>] \
+     [--window-hours 24] [--safety-limit 5000]
    ```
 
    Wait for its one-line JSON readiness response. Record `receiverUrl` and `runId`.
@@ -35,7 +36,7 @@ Collect top-to-bottom Following or configured-list timeline entries without expo
    - Import `apps/x-collector/src/browser-extractor.mjs` and `apps/x-collector/src/browser-session.mjs` by absolute path.
    - GET `<receiverUrl>/checkpoint` and pass it to `createCollectionSession`. For a new receiver, the empty checkpoint starts positions at zero; after a browser-control restart, it restores accepted tweet IDs, accepted ad keys, and the next position.
    - Call `extractVisibleTimelineBatch` through the documented Playwright page-evaluation API, passing the session's accepted ad keys as its argument.
-   - Pass the result, session state, and N to `prepareTimelineBatch`. It removes accepted primary posts, assigns stable positions, keeps quoted canonical posts, and produces the exact receiver payload.
+   - Pass the result, session state, and the receiver's requested count/safety limit to `prepareTimelineBatch`. It removes accepted primary posts, assigns stable positions, keeps quoted canonical posts, excludes Favorites posts older than the persisted cutoff, and produces the exact receiver payload plus rolling-window completion state.
    - POST each non-empty prepared payload directly from the JavaScript session to `<receiverUrl>/batch`. Do not emit raw post bodies through `nodeRepl.write` or copy them into the conversation.
    - Scroll roughly one viewport, wait for X to settle, and repeat.
    - For Favorite posts marked as replies or quotes, use `reserveContextExpansion(state, tweetId, 40)` before opening their permalink. If allowed, call the same extractor on the focused thread, pass the result to `prepareContextBatch`, POST the payload to `/batch`, then call `finishContextExpansion` and POST its returned record to `/context-status`. Use `COMPLETE`, `TRUNCATED`, or `FAILED` honestly. If the 40-permalink budget is reached, POST the returned `TRUNCATED/context_budget_reached` record without opening another permalink. Context posts have no timeline item and never count toward N.
@@ -43,20 +44,25 @@ Collect top-to-bottom Following or configured-list timeline entries without expo
 6. Recover transient stalls without splitting the logical capture:
    - After five consecutive scrolls add no new primary entries, keep the receiver alive and perform one recovery cycle: wait three seconds, scroll up roughly one viewport, wait briefly, scroll down roughly two viewports, wait three seconds, then extract again.
    - If recovery adds an entry, reset the stall and failed-recovery counters and continue the same run.
-   - If recovery adds nothing, increment the failed-recovery counter and repeat the cycle. Finalize as `PARTIAL` with `timeline_stalled` only after three consecutive recovery cycles fail.
+   - If recovery adds nothing, increment the failed-recovery counter and repeat the cycle. Finalize as `PARTIAL` with `timeline_stalled` and termination reason `TIMELINE_STALLED` only after three consecutive recovery cycles fail.
    - If browser control disconnects, reconnect, GET `/checkpoint`, rebuild the browser session state, and continue the same receiver/run when possible.
 
 7. Stop when one of these occurs:
-   - N unique organic primary timeline entries have been accepted: complete as `COMPLETE`.
+   - Following: N unique organic primary timeline entries have been accepted; complete as `COMPLETE` with `COUNT_REACHED`.
+   - Favorites/List: three distinct primary entries older than the persisted 24-hour cutoff have been observed; complete as `COMPLETE` with `WINDOW_BOUNDARY_REACHED`. Those boundary-evidence posts are not uploaded.
+   - Favorites/List: the 5000-post safety guard is reached before the time boundary; complete as `PARTIAL` with `safety_limit_reached` and `SAFETY_LIMIT_REACHED`.
+   - Any rolling-window item lacks a publication timestamp: keep collecting, but the run cannot be complete; finalize as `PARTIAL` with the missing-timestamp count and `COLLECTOR_FAILED`.
    - Three stall-recovery cycles fail: complete as `PARTIAL` with `timeline_stalled`.
    - X blocks loading or the connection fails after supported recovery: complete as `PARTIAL` with a concise reason.
 
-8. POST the completion state to `<receiverUrl>/complete`. The receiver validates, chunks, uploads, finalizes the manifest, and reads the run back from the archive. Large uploads may outlive the browser request timeout; treat the receiver process result as authoritative.
+8. POST the completion state and explicit `terminationReason` to `<receiverUrl>/complete`. The receiver validates the termination against count/window coverage, chunks, uploads, finalizes the manifest, and reads the run back from the archive. Large uploads may outlive the browser request timeout; treat the receiver process result as authoritative.
 9. Wait for the receiver process to exit successfully. Report the run ID, requested count, collected count, excluded-ad count, recovery count, and verification result.
 
 ## Invariants
 
-- “Latest N” means the first N unique organic entries observed top-to-bottom in the verified source.
+- For Following, “Latest N” means the first N unique organic entries observed top-to-bottom in the verified source.
+- For Favorites, the product boundary is the persisted rolling 24-hour cutoff. The numeric safety guard must never be described as the requested Favorites count.
+- A repost card exposes the original post timestamp, not a reliable repost-event timestamp. Before the boundary is proven, retain reposts according to verified list activity order; never use an old reposted original as boundary evidence. Preserve the reposter provenance so the API can disclose this distinction.
 - Never collect from For You. A source verification failure stops or pauses extraction rather than silently changing provenance.
 - A Favorites run and its membership snapshot are primary Daily View inputs; Following remains a separate run and secondary context.
 - Context expansion is capped at 40 Favorite permalinks per run. Every attempted, failed, or budget-truncated expansion is recorded in run provenance.

--- a/.codex/skills/zine-x-timeline-collector/SKILL.md
+++ b/.codex/skills/zine-x-timeline-collector/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: zine-x-timeline-collector
-description: Collect the latest configurable number of organic entries from the authenticated X Following timeline in Chrome or the integrated Codex browser and upload them to Zine's Cloudflare X archive. Use when the user asks to collect, crawl, capture, sync, or archive their X following feed or latest N timeline posts.
+description: Collect source-aware organic entries from the authenticated X Following timeline or a configured X List, capture list membership, and upload them to Zine's Cloudflare X archive.
 ---
 
 # Zine X Timeline Collector
 
-Collect top-to-bottom Following timeline entries without exposing browser credentials or large tweet payloads to the conversation. Keep replies, reposts, and quote posts. Exclude ads.
+Collect top-to-bottom Following or configured-list timeline entries without exposing browser credentials or large tweet payloads to the conversation. Keep replies, reposts, and quote posts. Exclude ads.
 
 ## Requirements
 
@@ -16,18 +16,21 @@ Collect top-to-bottom Following timeline entries without exposing browser creden
 
 ## Workflow
 
-1. Resolve the requested count. Default to `500`; accept larger values as requested.
+1. Resolve the source and requested count. Default to `500`. Following uses source `FOLLOWING/following`; a configured Favorites list uses `FAVORITES/x-list:<id>` and its stable `https://x.com/i/lists/<id>` URL.
 2. Start the local receiver in a PTY and keep the session alive:
 
    ```bash
-   bun run --cwd apps/x-collector receive --count <N>
+   bun run --cwd apps/x-collector receive --count <N> \
+     --source-type <FOLLOWING|FAVORITES|LIST> --source-id <id> \
+     --source-name <name> [--source-url <url>]
    ```
 
    Wait for its one-line JSON readiness response. Record `receiverUrl` and `runId`.
    If browser control restarts while the receiver is alive, reconnect to the same receiver and GET `<receiverUrl>/checkpoint`; do not start a second run.
 
 3. Follow the selected browser skill's bootstrap exactly, including reading its complete browser documentation. Reuse or claim an existing authenticated X tab when available.
-4. Navigate to `https://x.com/home`. If signed out, ask the user to sign in. Select the **Following** timeline and verify it is active before extracting.
+4. Navigate to the configured source. If signed out, ask the user to sign in. For Following, select **Following** and verify it is active. For a list, verify the exact list ID remains in the URL and the expected list name is visible before every extraction.
+   - For list sources, visit the list's Members view, import `list-members-extractor.mjs`, collect unique mounted member usernames through bounded scrolling, and POST small batches to `<receiverUrl>/source-members`. When the roster reaches its visible total or exhausts three stall-recovery cycles, send a final empty batch with `status: COMPLETE`, or `status: PARTIAL` plus `failureReason`. Until that final marker arrives, the receiver deliberately records membership as partial.
 5. In the persistent browser-control JavaScript session:
    - Import `apps/x-collector/src/browser-extractor.mjs` and `apps/x-collector/src/browser-session.mjs` by absolute path.
    - GET `<receiverUrl>/checkpoint` and pass it to `createCollectionSession`. For a new receiver, the empty checkpoint starts positions at zero; after a browser-control restart, it restores accepted tweet IDs, accepted ad keys, and the next position.
@@ -35,6 +38,7 @@ Collect top-to-bottom Following timeline entries without exposing browser creden
    - Pass the result, session state, and N to `prepareTimelineBatch`. It removes accepted primary posts, assigns stable positions, keeps quoted canonical posts, and produces the exact receiver payload.
    - POST each non-empty prepared payload directly from the JavaScript session to `<receiverUrl>/batch`. Do not emit raw post bodies through `nodeRepl.write` or copy them into the conversation.
    - Scroll roughly one viewport, wait for X to settle, and repeat.
+   - For Favorite posts marked as replies or quotes, use `reserveContextExpansion(state, tweetId, 40)` before opening their permalink. If allowed, call the same extractor on the focused thread, pass the result to `prepareContextBatch`, POST the payload to `/batch`, then call `finishContextExpansion` and POST its returned record to `/context-status`. Use `COMPLETE`, `TRUNCATED`, or `FAILED` honestly. If the 40-permalink budget is reached, POST the returned `TRUNCATED/context_budget_reached` record without opening another permalink. Context posts have no timeline item and never count toward N.
 
 6. Recover transient stalls without splitting the logical capture:
    - After five consecutive scrolls add no new primary entries, keep the receiver alive and perform one recovery cycle: wait three seconds, scroll up roughly one viewport, wait briefly, scroll down roughly two viewports, wait three seconds, then extract again.
@@ -52,7 +56,10 @@ Collect top-to-bottom Following timeline entries without exposing browser creden
 
 ## Invariants
 
-- “Latest N” means the first N unique organic entries observed top-to-bottom in Following.
+- “Latest N” means the first N unique organic entries observed top-to-bottom in the verified source.
+- Never collect from For You. A source verification failure stops or pauses extraction rather than silently changing provenance.
+- A Favorites run and its membership snapshot are primary Daily View inputs; Following remains a separate run and secondary context.
+- Context expansion is capped at 40 Favorite permalinks per run. Every attempted, failed, or budget-truncated expansion is recorded in run provenance.
 - Never upload cookies, local storage, request headers, CSRF values, or authentication data from X.
 - Never include promoted or sponsored entries.
 - Treat a repost as a timeline presentation pointing to the original canonical tweet; do not manufacture a duplicate tweet.

--- a/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
+++ b/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
@@ -34,13 +34,15 @@ The extractor rejects cards with promoted, sponsored, or ad markers outside the 
 
 ## Partial completion
 
-Use `PARTIAL` only when the requested number cannot be reached after supported recovery. Valid concise reasons include:
+Use `PARTIAL` when Following cannot reach its requested count, or when a Favorites run cannot prove the rolling-window boundary. Valid concise reasons include:
 
 - `timeline_stalled`
 - `x_rate_limited`
 - `browser_disconnected`
 - `x_auth_required`
 - `collector_error: <short message>`
+- `safety_limit_reached`
+- `missing_published_at: <count>`
 
 The receiver retains and uploads every successfully collected item before the failure.
 
@@ -52,9 +54,9 @@ Use `createCollectionSession(checkpoint)` and `prepareTimelineBatch(rawBatch, st
 
 - `GET /session` returns run identity and current counts.
 - `GET /checkpoint` returns accepted tweet IDs, accepted ad keys, and the next position for reconnecting browser control.
-- `POST /batch` accepts `{ posts, items, adKeys, excludedAds }`; stable ad keys make retries idempotent.
+- `POST /batch` accepts `{ posts, items, adKeys, excludedAds, windowEvidence }`; stable ad keys and boundary tweet IDs make retries idempotent.
 - `POST /source-members` accepts small `{ usernames }` batches plus a final independent `status`/`failureReason` marker for list membership snapshots.
 - `POST /context-status` accepts `{ rootTweetId, status, reason }` for each bounded permalink expansion.
-- `POST /complete` accepts `{ status, failureReason }` and performs the verified Cloudflare upload.
+- `POST /complete` accepts `{ status, failureReason, terminationReason }`, validates it against persisted count/window coverage, and performs the verified Cloudflare upload.
 
 The receiver binds only to `127.0.0.1` and keeps the Zine PAT out of the X page context.

--- a/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
+++ b/.codex/skills/zine-x-timeline-collector/references/extraction-contract.md
@@ -1,6 +1,6 @@
 # Extraction contract
 
-Use the repository extractor at `apps/x-collector/src/browser-extractor.mjs`. It reads currently mounted `article[data-testid="tweet"]` elements and returns:
+Use the repository extractor at `apps/x-collector/src/browser-extractor.mjs`. It reads currently mounted `article[data-testid="tweet"]` elements from a verified Following or List source and returns:
 
 ```js
 {
@@ -13,7 +13,7 @@ Use the repository extractor at `apps/x-collector/src/browser-extractor.mjs`. It
 
 ## Browser state
 
-- Collect only after the X Home page visibly shows the active Following tab.
+- Collect only after the configured source is verified: active Following tab or exact X List ID/name.
 - X virtualizes the timeline. Extract visible/mounted cards before every scroll.
 - Keep deduplication state outside the page because mounted cards are recycled.
 - Pass the previously returned ad keys into the next extractor call so recycled ads are counted once.
@@ -46,13 +46,15 @@ The receiver retains and uploads every successfully collected item before the fa
 
 ## Resumable browser session
 
-Use `createCollectionSession(checkpoint)` and `prepareTimelineBatch(rawBatch, state, requestedCount)` from `apps/x-collector/src/browser-session.mjs`. The receiver owns the authoritative in-progress data; browser state can be rebuilt from its checkpoint without changing the run ID or item positions.
+Use `createCollectionSession(checkpoint)` and `prepareTimelineBatch(rawBatch, state, requestedCount)` from `apps/x-collector/src/browser-session.mjs`. Use `reserveContextExpansion` and `finishContextExpansion` for bounded Favorite-thread expansion. The receiver owns the authoritative in-progress data; browser state can be rebuilt from its checkpoint without changing the run ID, item positions, or recorded context status.
 
 ## Local receiver API
 
 - `GET /session` returns run identity and current counts.
 - `GET /checkpoint` returns accepted tweet IDs, accepted ad keys, and the next position for reconnecting browser control.
 - `POST /batch` accepts `{ posts, items, adKeys, excludedAds }`; stable ad keys make retries idempotent.
+- `POST /source-members` accepts small `{ usernames }` batches plus a final independent `status`/`failureReason` marker for list membership snapshots.
+- `POST /context-status` accepts `{ rootTweetId, status, reason }` for each bounded permalink expansion.
 - `POST /complete` accepts `{ status, failureReason }` and performs the verified Cloudflare upload.
 
 The receiver binds only to `127.0.0.1` and keeps the Zine PAT out of the X page context.

--- a/apps/ios/ContractReplay/main.swift
+++ b/apps/ios/ContractReplay/main.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+guard CommandLine.arguments.count == 2 else {
+    fatalError("usage: daily-feed-contract-replay <fixture.json>")
+}
+
+let data = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
+let response = try JSONDecoder().decode(DailyFeedResponse.self, from: data)
+
+guard response.variant.id == "people-first-v2",
+      response.inputs?.favorites != nil,
+      response.sections != nil
+else {
+    fatalError("fixture did not contain the people-first-v2 contract")
+}
+
+print(
+    "native-decode=ok variant=\(response.variant.id) posts=\(response.posts.count) conversations=\(response.conversations.count)"
+)

--- a/apps/ios/Fixtures/daily-feed-v2.json
+++ b/apps/ios/Fixtures/daily-feed-v2.json
@@ -1,0 +1,157 @@
+{
+  "schemaVersion": 1,
+  "variant": { "id": "people-first-v2", "mode": "REVIEW" },
+  "date": "2026-07-25",
+  "timezone": "America/Chicago",
+  "frozenAt": "2026-07-25T10:15:00.000Z",
+  "freshness": { "isCurrent": true, "status": "COMPLETE", "warnings": [] },
+  "coverage": {
+    "status": "COMPLETE",
+    "archiveStatus": "COMPLETE",
+    "selectionStatus": "COMPLETE",
+    "runId": "favorites-run",
+    "requestedCount": 500,
+    "collectedCount": 500,
+    "message": "Frozen Favorites, Following, and membership coverage are complete for this review slice."
+  },
+  "sources": [
+    {
+      "id": "x-list:123",
+      "type": "FAVORITES",
+      "name": "Favorites",
+      "selected": true,
+      "capturedAt": "2026-07-25T10:15:00.000Z",
+      "authorCount": 2,
+      "status": "COMPLETE",
+      "snapshotId": "snapshot-1",
+      "runId": "favorites-run",
+      "unresolvedCount": 0,
+      "failureReason": null
+    },
+    {
+      "id": "following",
+      "type": "FOLLOWING",
+      "name": "Following",
+      "selected": true,
+      "capturedAt": "2026-07-25T10:30:00.000Z",
+      "authorCount": 250
+    }
+  ],
+  "conversations": [
+    {
+      "id": "topic:1:2",
+      "evidenceType": "TOPIC_SIMILARITY",
+      "label": "Shared topic · swiftdata",
+      "evidence": "2 Favorite posts share multiple explicit terms.",
+      "postIds": ["1", "2"],
+      "authors": ["alice", "bob"],
+      "relationshipTypes": [],
+      "favoritePostIds": ["1"],
+      "contextPostIds": ["2"],
+      "favoriteAuthors": ["alice"],
+      "latestActivityAt": "2026-07-25T10:00:00.000Z",
+      "coverageWarnings": []
+    }
+  ],
+  "posts": [
+    {
+      "id": "1",
+      "url": "https://x.com/alice/status/1",
+      "text": "Favorite post",
+      "publishedAt": "2026-07-25T10:00:00.000Z",
+      "observedAt": "2026-07-25T10:01:00.000Z",
+      "kind": "POST",
+      "author": {
+        "key": "id:alice",
+        "username": "alice",
+        "name": "Alice",
+        "profileUrl": null,
+        "profileImageUrl": null,
+        "verified": false
+      },
+      "media": [],
+      "links": [],
+      "metrics": { "replies": 1, "reposts": 0, "likes": 2, "views": 10, "bookmarks": 0 },
+      "relationships": [],
+      "presentation": "POST",
+      "repostedBy": null,
+      "sourceIds": ["x-list:123"],
+      "sourcePosition": 0
+    },
+    {
+      "id": "2",
+      "url": "https://x.com/bob/status/2",
+      "text": "Following context",
+      "publishedAt": "2026-07-25T09:55:00.000Z",
+      "observedAt": "2026-07-25T10:02:00.000Z",
+      "kind": "REPLY",
+      "author": {
+        "key": "id:bob",
+        "username": "bob",
+        "name": "Bob",
+        "profileUrl": null,
+        "profileImageUrl": null,
+        "verified": false
+      },
+      "media": [],
+      "links": [],
+      "metrics": { "replies": 0, "reposts": 0, "likes": 1, "views": 5, "bookmarks": 0 },
+      "relationships": [],
+      "presentation": "POST",
+      "repostedBy": null,
+      "sourceIds": ["following"],
+      "sourcePosition": 0
+    }
+  ],
+  "sections": { "favoritePostIds": [], "followingPostIds": [] },
+  "inputs": {
+    "favorites": {
+      "runId": "favorites-run",
+      "sourceId": "x-list:123",
+      "sourceName": "Favorites",
+      "sourceUrl": "https://x.com/i/lists/123",
+      "status": "COMPLETE",
+      "requestedCount": 500,
+      "collectedCount": 500,
+      "contextCoverage": {
+        "budget": 40,
+        "attempted": 1,
+        "completed": 1,
+        "truncated": 0,
+        "failed": 0,
+        "warnings": []
+      },
+      "frozenAt": "2026-07-25T10:15:00.000Z"
+    },
+    "following": {
+      "runId": "following-run",
+      "sourceId": "following",
+      "sourceName": "Following",
+      "sourceUrl": "https://x.com/home",
+      "status": "COMPLETE",
+      "requestedCount": 500,
+      "collectedCount": 500,
+      "contextCoverage": {
+        "budget": 0,
+        "attempted": 0,
+        "completed": 0,
+        "truncated": 0,
+        "failed": 0,
+        "warnings": []
+      },
+      "frozenAt": "2026-07-25T10:30:00.000Z"
+    },
+    "membership": {
+      "snapshotId": "snapshot-1",
+      "runId": "favorites-run",
+      "sourceId": "x-list:123",
+      "capturedAt": "2026-07-25T10:15:00.000Z",
+      "status": "COMPLETE",
+      "resolvedCount": 2,
+      "unresolvedCount": 0,
+      "failureReason": null
+    }
+  },
+  "requestId": "fixture-request",
+  "traceId": "fixture-trace"
+}

--- a/apps/ios/Fixtures/daily-feed-v2.json
+++ b/apps/ios/Fixtures/daily-feed-v2.json
@@ -10,9 +10,13 @@
     "archiveStatus": "COMPLETE",
     "selectionStatus": "COMPLETE",
     "runId": "favorites-run",
-    "requestedCount": 500,
-    "collectedCount": 500,
-    "message": "Frozen Favorites, Following, and membership coverage are complete for this review slice."
+    "requestedCount": 5000,
+    "collectedCount": 2,
+    "message": "Frozen Favorites from the last 24 hours, Following, and membership coverage are complete for this review slice.",
+    "collectionMode": "ROLLING_WINDOW",
+    "windowHours": 24,
+    "safetyLimit": 5000,
+    "terminationReason": "WINDOW_BOUNDARY_REACHED"
   },
   "sources": [
     {
@@ -111,8 +115,21 @@
       "sourceName": "Favorites",
       "sourceUrl": "https://x.com/i/lists/123",
       "status": "COMPLETE",
-      "requestedCount": 500,
-      "collectedCount": 500,
+      "requestedCount": 5000,
+      "collectedCount": 2,
+      "collectionPolicy": {
+        "mode": "ROLLING_WINDOW",
+        "windowHours": 24,
+        "cutoffAt": "2026-07-24T10:15:00.000Z",
+        "boundaryEvidenceRequired": 3
+      },
+      "terminationReason": "WINDOW_BOUNDARY_REACHED",
+      "windowCoverage": {
+        "outsideWindow": 3,
+        "missingPublishedAt": 0,
+        "boundaryEvidenceRequired": 3,
+        "boundaryReached": true
+      },
       "contextCoverage": {
         "budget": 40,
         "attempted": 1,
@@ -131,6 +148,14 @@
       "status": "COMPLETE",
       "requestedCount": 500,
       "collectedCount": 500,
+      "collectionPolicy": { "mode": "COUNT" },
+      "terminationReason": "COUNT_REACHED",
+      "windowCoverage": {
+        "outsideWindow": 0,
+        "missingPublishedAt": 0,
+        "boundaryEvidenceRequired": 0,
+        "boundaryReached": false
+      },
       "contextCoverage": {
         "budget": 0,
         "attempted": 0,

--- a/apps/ios/ZineNative/Core/Models/DailyFeed.swift
+++ b/apps/ios/ZineNative/Core/Models/DailyFeed.swift
@@ -53,6 +53,10 @@ struct DailyFeedCoverage: Decodable, Hashable {
     let requestedCount: Int
     let collectedCount: Int
     let message: String
+    let collectionMode: String?
+    let windowHours: Int?
+    let safetyLimit: Int?
+    let terminationReason: String?
 }
 
 struct DailyFeedSource: Decodable, Hashable, Identifiable {
@@ -116,8 +120,25 @@ struct DailyFeedInputRun: Decodable, Hashable {
     let status: String
     let requestedCount: Int
     let collectedCount: Int
+    let collectionPolicy: DailyCollectionPolicy?
+    let terminationReason: String?
+    let windowCoverage: DailyWindowCoverage?
     let contextCoverage: DailyContextCoverage?
     let frozenAt: String?
+}
+
+struct DailyCollectionPolicy: Decodable, Hashable {
+    let mode: String
+    let windowHours: Int?
+    let cutoffAt: String?
+    let boundaryEvidenceRequired: Int?
+}
+
+struct DailyWindowCoverage: Decodable, Hashable {
+    let outsideWindow: Int
+    let missingPublishedAt: Int
+    let boundaryEvidenceRequired: Int
+    let boundaryReached: Bool
 }
 
 struct DailyContextCoverage: Decodable, Hashable {

--- a/apps/ios/ZineNative/Core/Models/DailyFeed.swift
+++ b/apps/ios/ZineNative/Core/Models/DailyFeed.swift
@@ -11,6 +11,8 @@ struct DailyFeedResponse: Decodable, Hashable {
     let sources: [DailyFeedSource]
     let conversations: [DailyConversation]
     let posts: [DailyPost]
+    let sections: DailyFeedSections?
+    let inputs: DailyFeedInputs?
     let requestId: String
     let traceId: String
 }
@@ -57,6 +59,7 @@ struct DailyFeedSource: Decodable, Hashable, Identifiable {
     enum SourceType: String, Decodable, Hashable {
         case favorites = "FAVORITES"
         case list = "LIST"
+        case following = "FOLLOWING"
         case followingFallback = "FOLLOWING_FALLBACK"
     }
 
@@ -66,12 +69,18 @@ struct DailyFeedSource: Decodable, Hashable, Identifiable {
     let selected: Bool
     let capturedAt: String?
     let authorCount: Int
+    let status: DailyCoverageStatus?
+    let snapshotId: String?
+    let runId: String?
+    let unresolvedCount: Int?
+    let failureReason: String?
 }
 
 struct DailyConversation: Decodable, Hashable, Identifiable {
     enum EvidenceType: String, Decodable, Hashable {
         case directRelationship = "DIRECT_RELATIONSHIP"
         case sharedLink = "SHARED_LINK"
+        case topicSimilarity = "TOPIC_SIMILARITY"
     }
 
     let id: String
@@ -81,6 +90,54 @@ struct DailyConversation: Decodable, Hashable, Identifiable {
     let postIds: [String]
     let authors: [String]
     let relationshipTypes: [String]
+    let favoritePostIds: [String]?
+    let contextPostIds: [String]?
+    let favoriteAuthors: [String]?
+    let latestActivityAt: String?
+    let coverageWarnings: [String]?
+}
+
+struct DailyFeedSections: Decodable, Hashable {
+    let favoritePostIds: [String]
+    let followingPostIds: [String]
+}
+
+struct DailyFeedInputs: Decodable, Hashable {
+    let favorites: DailyFeedInputRun?
+    let following: DailyFeedInputRun?
+    let membership: DailyFeedMembershipInput?
+}
+
+struct DailyFeedInputRun: Decodable, Hashable {
+    let runId: String
+    let sourceId: String
+    let sourceName: String
+    let sourceUrl: String?
+    let status: String
+    let requestedCount: Int
+    let collectedCount: Int
+    let contextCoverage: DailyContextCoverage?
+    let frozenAt: String?
+}
+
+struct DailyContextCoverage: Decodable, Hashable {
+    let budget: Int
+    let attempted: Int
+    let completed: Int
+    let truncated: Int
+    let failed: Int
+    let warnings: [String]
+}
+
+struct DailyFeedMembershipInput: Decodable, Hashable {
+    let snapshotId: String?
+    let runId: String?
+    let sourceId: String
+    let capturedAt: String?
+    let status: DailyCoverageStatus
+    let resolvedCount: Int
+    let unresolvedCount: Int
+    let failureReason: String?
 }
 
 struct DailyPost: Decodable, Hashable, Identifiable {
@@ -98,6 +155,7 @@ struct DailyPost: Decodable, Hashable, Identifiable {
     let presentation: String
     let repostedBy: DailyAuthor?
     let sourceIds: [String]
+    let sourcePosition: Int?
 
     var postURL: URL? { URL(string: url) }
 

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -9,7 +9,6 @@ struct DailyFeedReviewView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var store: DailyFeedStore
-    @State private var selectedSourceID: String?
 
     private let client: APIClient
 
@@ -59,10 +58,7 @@ struct DailyFeedReviewView: View {
                 Button("Try again") { Task { await store.load() } }
             }
         } else if let response = store.response {
-            DailyFeedContent(
-                response: response,
-                selectedSourceID: $selectedSourceID
-            )
+            DailyFeedContent(response: response)
             .refreshable { await store.load() }
         }
     }
@@ -70,28 +66,39 @@ struct DailyFeedReviewView: View {
 
 private struct DailyFeedContent: View {
     let response: DailyFeedResponse
-    @Binding var selectedSourceID: String?
 
-    private var filteredPosts: [DailyPost] {
-        guard let selectedSourceID else { return response.posts }
-        return response.posts.filter { $0.sourceIds.contains(selectedSourceID) }
+    private var postsByID: [String: DailyPost] {
+        Dictionary(uniqueKeysWithValues: response.posts.map { ($0.id, $0) })
     }
 
     private var sourceNames: [String: String] {
         Dictionary(uniqueKeysWithValues: response.sources.map { ($0.id, $0.name) })
     }
 
-    private var peopleSectionTitle: String {
-        switch response.coverage.selectionStatus {
-        case .complete:
-            return "Real posts from Favorites and lists"
-        case .stale:
-            return "Real posts; source membership may be stale"
-        case .fallback:
-            return "Real posts from an explicit Following fallback"
-        case .missing:
-            return "Real posts; source membership unavailable"
-        }
+    private var favoritePosts: [DailyPost] {
+        let ids = response.sections?.favoritePostIds
+            ?? response.posts.filter {
+                $0.sourceIds.contains(where: isFavoriteSource) && !conversationPostIDs.contains($0.id)
+            }.map(\.id)
+        return ids.compactMap { postsByID[$0] }
+    }
+
+    private var followingPosts: [DailyPost] {
+        let ids = response.sections?.followingPostIds
+            ?? response.posts.filter {
+                !$0.sourceIds.contains(where: isFavoriteSource) && !conversationPostIDs.contains($0.id)
+            }.map(\.id)
+        return ids.compactMap { postsByID[$0] }
+    }
+
+    private var conversationPostIDs: Set<String> {
+        Set(response.conversations.flatMap(\.postIds))
+    }
+
+    private func isFavoriteSource(_ sourceID: String) -> Bool {
+        response.sources.first(where: { $0.id == sourceID }).map {
+            $0.type == .favorites || $0.type == .list
+        } ?? false
     }
 
     var body: some View {
@@ -105,12 +112,12 @@ private struct DailyFeedContent: View {
                     .padding(.horizontal, 18)
                     .padding(.top, 16)
 
-                sectionTitle("IN CONVERSATION", "Only what the posts show")
+                sectionTitle("FAVORITES", "Conversations from Favorites")
                     .padding(.horizontal, 18)
                     .padding(.top, 30)
 
                 if response.conversations.isEmpty {
-                    Text("No multi-author reply, quote, repost, or shared-link convergence was found in this slice.")
+                    Text("No evidence-backed Favorite conversations were found in this frozen slice.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 18)
@@ -121,7 +128,7 @@ private struct DailyFeedContent: View {
                             DailyConversationCard(
                                 conversation: conversation,
                                 posts: conversation.postIds.compactMap { id in
-                                    response.posts.first { $0.id == id }
+                                    postsByID[id]
                                 },
                                 date: response.date
                             )
@@ -131,26 +138,45 @@ private struct DailyFeedContent: View {
                     .padding(.top, 14)
                 }
 
-                sectionTitle("YOUR PEOPLE", peopleSectionTitle)
+                sectionTitle("FAVORITES", "More from Favorites")
                     .padding(.horizontal, 18)
                     .padding(.top, 34)
 
-                DailySourceFilter(
-                    sources: response.sources,
-                    selectedSourceID: $selectedSourceID
-                )
-                .padding(.top, 12)
-
-                if filteredPosts.isEmpty {
+                if favoritePosts.isEmpty {
                     ContentUnavailableView(
-                        "No posts in this source",
+                        "No additional Favorite posts",
                         systemImage: "person.2.slash",
-                        description: Text("The frozen run has no matching posts for this filter.")
+                        description: Text("Favorite posts in this slice are either grouped above or unavailable under the disclosed coverage.")
                     )
                     .padding(.top, 34)
                 } else {
                     LazyVStack(spacing: 14) {
-                        ForEach(filteredPosts) { post in
+                        ForEach(favoritePosts) { post in
+                            DailyFeedPostCard(
+                                post: post,
+                                sourceNames: sourceNames,
+                                authorDestinationDate: response.date
+                            )
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.top, 16)
+                    .padding(.bottom, 38)
+                }
+
+                sectionTitle("FOLLOWING", "More from Following")
+                    .padding(.horizontal, 18)
+                    .padding(.top, 34)
+
+                if followingPosts.isEmpty {
+                    Text("No additional Following posts remain after conversation context and deduplication.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 18)
+                        .padding(.top, 10)
+                } else {
+                    LazyVStack(spacing: 14) {
+                        ForEach(followingPosts) { post in
                             DailyFeedPostCard(
                                 post: post,
                                 sourceNames: sourceNames,
@@ -266,60 +292,20 @@ private struct DailyCoverageNotice: View {
     }
 }
 
-private struct DailySourceFilter: View {
-    let sources: [DailyFeedSource]
-    @Binding var selectedSourceID: String?
-
-    var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                filterButton(title: "All", sourceID: nil, count: nil)
-                ForEach(sources) { source in
-                    filterButton(
-                        title: source.name,
-                        sourceID: source.id,
-                        count: source.authorCount
-                    )
-                }
-            }
-            .padding(.horizontal, 18)
-        }
-    }
-
-    private func filterButton(title: String, sourceID: String?, count: Int?) -> some View {
-        let isSelected = selectedSourceID == sourceID
-        return Button {
-            selectedSourceID = sourceID
-        } label: {
-            HStack(spacing: 5) {
-                Text(title)
-                if let count {
-                    Text("\(count)")
-                        .foregroundStyle(isSelected ? .white.opacity(0.72) : .secondary)
-                }
-            }
-            .font(.caption.weight(.semibold))
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .foregroundStyle(isSelected ? Color.white : Color.primary)
-            .background(
-                isSelected ? Color.accentColor : Color.secondary.opacity(0.12),
-                in: Capsule()
-            )
-        }
-        .buttonStyle(.plain)
-    }
-}
-
 private struct DailyConversationCard: View {
     let conversation: DailyConversation
     let posts: [DailyPost]
     let date: String
+    @State private var isExpanded = false
+
+    private var visiblePosts: [DailyPost] {
+        isExpanded ? posts : Array(posts.prefix(2))
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 10) {
-                Image(systemName: conversation.evidenceType == .directRelationship ? "arrow.triangle.branch" : "link")
+                Image(systemName: evidenceIcon)
                     .foregroundStyle(Color.accentColor)
                 VStack(alignment: .leading, spacing: 3) {
                     Text(conversation.label)
@@ -327,12 +313,18 @@ private struct DailyConversationCard: View {
                     Text(conversation.evidence)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    ForEach(conversation.coverageWarnings ?? [], id: \.self) { warning in
+                        Label(warning, systemImage: "exclamationmark.circle")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 
             Divider()
 
-            ForEach(posts) { post in
+            ForEach(visiblePosts) { post in
                 NavigationLink(value: DailyAuthorRoute(author: post.author, date: date)) {
                     HStack(alignment: .top, spacing: 9) {
                         DailyAuthorAvatar(author: post.author, size: 30)
@@ -345,15 +337,37 @@ private struct DailyConversationCard: View {
                                 .foregroundStyle(.primary)
                                 .lineLimit(3)
                                 .multilineTextAlignment(.leading)
+                            Text(isFavorite(post) ? "Favorite source" : "Conversation context")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(isFavorite(post) ? Color.accentColor : .secondary)
                         }
                         Spacer(minLength: 0)
                     }
                 }
                 .buttonStyle(.plain)
             }
+
+            if posts.count > 2 {
+                Button(isExpanded ? "Show less" : "Show all \(posts.count) posts") {
+                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                }
+                .font(.caption.weight(.semibold))
+            }
         }
         .padding(14)
         .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func isFavorite(_ post: DailyPost) -> Bool {
+        conversation.favoritePostIds?.contains(post.id) ?? false
+    }
+
+    private var evidenceIcon: String {
+        switch conversation.evidenceType {
+        case .directRelationship: "arrow.triangle.branch"
+        case .sharedLink: "link"
+        case .topicSimilarity: "text.magnifyingglass"
+        }
     }
 }
 
@@ -667,6 +681,7 @@ private extension DailyPost {
         relationships: [],
         presentation: "POST",
         repostedBy: nil,
-        sourceIds: ["favorites"]
+        sourceIds: ["favorites"],
+        sourcePosition: 0
     )
 }

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -254,7 +254,7 @@ private struct DailyCoverageNotice: View {
                 Text(statusTitle)
                     .font(.subheadline.weight(.semibold))
                 Spacer()
-                Text("\(response.coverage.collectedCount)/\(response.coverage.requestedCount)")
+                Text(scopeSummary)
                     .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
             }
@@ -285,6 +285,13 @@ private struct DailyCoverageNotice: View {
 
     private var statusIcon: String {
         response.coverage.status == .complete ? "checkmark.seal.fill" : "exclamationmark.triangle.fill"
+    }
+
+    private var scopeSummary: String {
+        if let windowHours = response.coverage.windowHours {
+            return "Last \(windowHours)h · \(response.coverage.collectedCount) posts"
+        }
+        return "\(response.coverage.collectedCount)/\(response.coverage.requestedCount)"
     }
 
     private var statusColor: Color {

--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -16,6 +16,7 @@ function postRow(input: {
   kind?: string;
   links?: unknown[];
   repostedBy?: unknown;
+  presentation?: string;
 }) {
   const timestamp = Date.parse(input.publishedAt);
   return {
@@ -38,7 +39,7 @@ function postRow(input: {
     last_seen_at: timestamp,
     position: input.position ?? null,
     observed_at: Date.parse('2026-07-24T13:00:00.000Z'),
-    presentation: 'POST',
+    presentation: input.presentation ?? 'POST',
     reposted_by_json: input.repostedBy ? JSON.stringify(input.repostedBy) : null,
   };
 }
@@ -111,6 +112,9 @@ function fakeArchiveDb(
     favoritesRequestedCount?: number;
     favoritesCollectedCount?: number;
     favoritesContextCoverage?: Record<string, unknown>;
+    favoritesCollectionPolicy?: Record<string, unknown>;
+    favoritesTerminationReason?: string;
+    favoritesWindowCoverage?: Record<string, unknown>;
     sourceStatus?: 'COMPLETE' | 'PARTIAL';
     sourceFailureReason?: string | null;
     sourceUnresolvedUsernames?: string[];
@@ -137,7 +141,7 @@ function fakeArchiveDb(
                   ? [
                       {
                         id: 'favorites-run',
-                        requested_count: options.favoritesRequestedCount ?? 2,
+                        requested_count: options.favoritesRequestedCount ?? 5_000,
                         collected_count: options.favoritesCollectedCount ?? 2,
                         status: options.favoritesStatus ?? 'COMPLETE',
                         started_at: Date.parse('2026-07-24T12:30:00.000Z'),
@@ -156,6 +160,24 @@ function fakeArchiveDb(
                             truncated: 0,
                             failed: 0,
                             warnings: [],
+                          }
+                        ),
+                        collection_policy_json: JSON.stringify(
+                          options.favoritesCollectionPolicy ?? {
+                            mode: 'ROLLING_WINDOW',
+                            windowHours: 24,
+                            cutoffAt: '2026-07-23T12:30:00.000Z',
+                            boundaryEvidenceRequired: 3,
+                          }
+                        ),
+                        termination_reason:
+                          options.favoritesTerminationReason ?? 'WINDOW_BOUNDARY_REACHED',
+                        window_coverage_json: JSON.stringify(
+                          options.favoritesWindowCoverage ?? {
+                            outsideWindow: 3,
+                            missingPublishedAt: 0,
+                            boundaryEvidenceRequired: 3,
+                            boundaryReached: true,
                           }
                         ),
                       },
@@ -181,6 +203,14 @@ function fakeArchiveDb(
                     truncated: 0,
                     failed: 0,
                     warnings: [],
+                  }),
+                  collection_policy_json: JSON.stringify({ mode: 'COUNT' }),
+                  termination_reason: 'COUNT_REACHED',
+                  window_coverage_json: JSON.stringify({
+                    outsideWindow: 0,
+                    missingPublishedAt: 0,
+                    boundaryEvidenceRequired: 0,
+                    boundaryReached: false,
                   }),
                 },
               ],
@@ -612,8 +642,9 @@ describe('people-first daily feed', () => {
     const result = await getDailyFeed(
       fakeArchiveDb({
         favoritesStatus: 'PARTIAL',
-        favoritesRequestedCount: 500,
+        favoritesRequestedCount: 5_000,
         favoritesCollectedCount: 120,
+        favoritesTerminationReason: 'TIMELINE_STALLED',
         favoritesContextCoverage: {
           budget: 40,
           attempted: 40,
@@ -628,7 +659,9 @@ describe('people-first daily feed', () => {
     );
 
     expect(result.coverage.status).toBe('PARTIAL');
-    expect(result.freshness.warnings.join(' ')).toContain('120/500 requested posts');
+    expect(result.freshness.warnings.join(' ')).toContain(
+      'did not prove complete 24-hour coverage'
+    );
     expect(result.freshness.warnings).toContain('1 Favorite thread expansion was truncated.');
     expect(result.conversations[0]?.coverageWarnings).toContain('context_budget_reached');
     expect(result.inputs.favorites?.contextCoverage).toMatchObject({ truncated: 1, failed: 1 });
@@ -639,8 +672,9 @@ describe('people-first daily feed', () => {
       fakeArchiveDb({
         favoritePostRows: [],
         favoritesStatus: 'PARTIAL',
-        favoritesRequestedCount: 500,
+        favoritesRequestedCount: 5_000,
         favoritesCollectedCount: 0,
+        favoritesTerminationReason: 'TIMELINE_STALLED',
       }),
       USER_ID,
       { now: NOW }
@@ -650,6 +684,83 @@ describe('people-first daily feed', () => {
     expect(result.sections.favoritePostIds).toEqual([]);
     expect(result.sections.followingPostIds).toEqual(['100', '101', '102']);
     expect(result.coverage.selectionStatus).not.toBe('FALLBACK');
+  });
+
+  it('defensively excludes Favorites posts outside the rolling 24-hour window', async () => {
+    const inside = postRow({
+      id: 'inside-window',
+      authorKey: 'id:alice',
+      username: 'alice',
+      name: 'Alice',
+      text: 'Inside the window',
+      publishedAt: '2026-07-24T12:00:00.000Z',
+      position: 0,
+    });
+    const outside = postRow({
+      id: 'outside-window',
+      authorKey: 'id:bob',
+      username: 'bob',
+      name: 'Bob',
+      text: 'Outside the window',
+      publishedAt: '2026-07-23T12:00:00.000Z',
+      position: 1,
+    });
+    const recentRepostOfOlderMaterial = postRow({
+      id: 'recent-repost',
+      authorKey: 'id:carol',
+      username: 'carol',
+      name: 'Carol',
+      text: 'Older original, recently reposted by a Favorite',
+      publishedAt: '2025-01-01T12:00:00.000Z',
+      position: 1,
+      presentation: 'REPOST',
+    });
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        favoritePostRows: [inside, recentRepostOfOlderMaterial, outside],
+        postRows: [],
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.posts.map((post) => post.id)).toEqual(['inside-window', 'recent-repost']);
+    expect(result.freshness.warnings.join(' ')).toContain(
+      'outside the rolling 24-hour window and excluded'
+    );
+    expect(result.freshness.warnings.join(' ')).toContain(
+      'rolling-window inclusion follows the verified list activity order'
+    );
+    expect(result.coverage).toMatchObject({
+      collectionMode: 'ROLLING_WINDOW',
+      windowHours: 24,
+      safetyLimit: 5_000,
+      terminationReason: 'WINDOW_BOUNDARY_REACHED',
+    });
+  });
+
+  it('reports the high numeric guard as partial instead of treating it as the Favorites target', async () => {
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        favoritesRequestedCount: 5_000,
+        favoritesCollectedCount: 5_000,
+        favoritesStatus: 'PARTIAL',
+        favoritesTerminationReason: 'SAFETY_LIMIT_REACHED',
+        favoritesWindowCoverage: {
+          outsideWindow: 0,
+          missingPublishedAt: 0,
+          boundaryEvidenceRequired: 3,
+          boundaryReached: false,
+        },
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.coverage.status).toBe('PARTIAL');
+    expect(result.freshness.warnings.join(' ')).toContain(
+      '5000-post safety guard before reaching the 24-hour boundary'
+    );
   });
 
   it('returns all available author posts for today and the past week with context', async () => {

--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -100,14 +100,27 @@ const earlierAlice = postRow({
 function fakeArchiveDb(
   options: {
     configuredSources?: boolean;
+    favoritesRun?: boolean;
     sourceCapturedAt?: number;
     postRows?: ReturnType<typeof postRow>[];
+    favoritePostRows?: ReturnType<typeof postRow>[];
+    contextPostRows?: ReturnType<typeof postRow>[];
+    relationshipRows?: Array<Record<string, unknown>>;
     relationshipBindingCounts?: number[];
+    favoritesStatus?: 'COMPLETE' | 'PARTIAL';
+    favoritesRequestedCount?: number;
+    favoritesCollectedCount?: number;
+    favoritesContextCoverage?: Record<string, unknown>;
+    sourceStatus?: 'COMPLETE' | 'PARTIAL';
+    sourceFailureReason?: string | null;
+    sourceUnresolvedUsernames?: string[];
   } = {}
 ): D1Database {
   const configuredSources = options.configuredSources ?? true;
+  const favoritesRun = options.favoritesRun ?? configuredSources;
   const sourceCapturedAt = options.sourceCapturedAt ?? NOW.getTime();
   const rowsForRun = options.postRows ?? todayRows;
+  const favoriteRowsForRun = options.favoritePostRows ?? rowsForRun.slice(0, 2);
   return {
     prepare(sql: string) {
       let bindings: unknown[] = [];
@@ -120,8 +133,36 @@ function fakeArchiveDb(
           if (sql.includes('FROM x_timeline_runs')) {
             return {
               results: [
+                ...(favoritesRun
+                  ? [
+                      {
+                        id: 'favorites-run',
+                        requested_count: options.favoritesRequestedCount ?? 2,
+                        collected_count: options.favoritesCollectedCount ?? 2,
+                        status: options.favoritesStatus ?? 'COMPLETE',
+                        started_at: Date.parse('2026-07-24T12:30:00.000Z'),
+                        completed_at: Date.parse('2026-07-24T13:00:00.000Z'),
+                        excluded_ads: 0,
+                        failure_reason: null,
+                        source_type: 'FAVORITES',
+                        source_id: 'favorites',
+                        source_name: 'Favorites',
+                        source_url: 'https://x.com/i/lists/123',
+                        context_coverage_json: JSON.stringify(
+                          options.favoritesContextCoverage ?? {
+                            budget: 40,
+                            attempted: 0,
+                            completed: 0,
+                            truncated: 0,
+                            failed: 0,
+                            warnings: [],
+                          }
+                        ),
+                      },
+                    ]
+                  : []),
                 {
-                  id: 'run-1',
+                  id: 'following-run',
                   requested_count: 3,
                   collected_count: 3,
                   status: 'COMPLETE',
@@ -129,52 +170,91 @@ function fakeArchiveDb(
                   completed_at: Date.parse('2026-07-24T13:00:00.000Z'),
                   excluded_ads: 0,
                   failure_reason: null,
+                  source_type: 'FOLLOWING',
+                  source_id: 'following',
+                  source_name: 'Following',
+                  source_url: 'https://x.com/home',
+                  context_coverage_json: JSON.stringify({
+                    budget: 0,
+                    attempted: 0,
+                    completed: 0,
+                    truncated: 0,
+                    failed: 0,
+                    warnings: [],
+                  }),
                 },
               ],
             };
           }
           if (sql.includes('FROM x_timeline_run_items i')) {
-            return { results: rowsForRun };
+            return { results: bindings[1] === 'favorites-run' ? favoriteRowsForRun : rowsForRun };
+          }
+          if (sql.includes('FROM x_timeline_run_context_posts')) {
+            return {
+              results: bindings[1] === 'favorites-run' ? (options.contextPostRows ?? []) : [],
+            };
           }
           if (sql.includes('FROM x_post_relationships r')) {
             options.relationshipBindingCounts?.push(bindings.length);
             const sourceIds = new Set(bindings.slice(1));
             return {
-              results: sourceIds.has('100')
-                ? [
-                    {
-                      source_tweet_id: '100',
-                      relationship_type: 'REPLY_TO',
-                      target_tweet_id: '101',
-                      target_url: 'https://x.com/i/status/101',
-                      target_text: 'Bob starts the thread.',
-                      target_author_key: 'id:bob',
-                      target_username: 'bob',
-                      target_author_name: 'Bob',
-                      target_profile_image_url: 'https://example.com/bob.jpg',
-                    },
-                  ]
-                : [],
+              results: options.relationshipRows
+                ? options.relationshipRows.filter((row) =>
+                    sourceIds.has(String(row.source_tweet_id))
+                  )
+                : sourceIds.has('100')
+                  ? [
+                      {
+                        source_tweet_id: '100',
+                        relationship_type: 'REPLY_TO',
+                        target_tweet_id: '101',
+                        target_url: 'https://x.com/i/status/101',
+                        target_text: 'Bob starts the thread.',
+                        target_author_key: 'id:bob',
+                        target_username: 'bob',
+                        target_author_name: 'Bob',
+                        target_profile_image_url: 'https://example.com/bob.jpg',
+                      },
+                    ]
+                  : [],
             };
           }
-          if (sql.includes('FROM x_daily_sources s')) {
+          if (sql.includes('FROM x_daily_source_snapshots')) {
             return {
               results: configuredSources
                 ? [
                     {
                       source_id: 'favorites',
+                      snapshot_id: 'snapshot-1',
+                      run_id: 'favorites-run',
                       source_type: 'FAVORITES',
                       name: 'Favorites',
                       is_selected: 1,
                       captured_at: sourceCapturedAt,
+                      status: options.sourceStatus ?? 'COMPLETE',
+                      failure_reason: options.sourceFailureReason ?? null,
+                      supplied_count: 2,
+                      resolved_count: 2,
+                      unresolved_usernames_json: JSON.stringify(
+                        options.sourceUnresolvedUsernames ?? []
+                      ),
                       author_key: 'id:alice',
                     },
                     {
                       source_id: 'favorites',
+                      snapshot_id: 'snapshot-1',
+                      run_id: 'favorites-run',
                       source_type: 'FAVORITES',
                       name: 'Favorites',
                       is_selected: 1,
                       captured_at: sourceCapturedAt,
+                      status: options.sourceStatus ?? 'COMPLETE',
+                      failure_reason: options.sourceFailureReason ?? null,
+                      supplied_count: 2,
+                      resolved_count: 2,
+                      unresolved_usernames_json: JSON.stringify(
+                        options.sourceUnresolvedUsernames ?? []
+                      ),
                       author_key: 'id:bob',
                     },
                   ]
@@ -202,9 +282,9 @@ describe('people-first daily feed', () => {
       status: 'COMPLETE',
       archiveStatus: 'COMPLETE',
       selectionStatus: 'COMPLETE',
-      collectedCount: 3,
+      collectedCount: 2,
     });
-    expect(result.posts.map((post) => post.id)).toEqual(['100', '101']);
+    expect(result.posts.map((post) => post.id)).toEqual(['100', '101', '102']);
     expect(result.posts[0]).toMatchObject({
       author: { username: 'alice' },
       repostedBy: {
@@ -226,10 +306,17 @@ describe('people-first daily feed', () => {
     expect(result.conversations).toEqual([
       expect.objectContaining({
         evidenceType: 'DIRECT_RELATIONSHIP',
-        postIds: ['100', '101'],
-        authors: ['alice', 'bob'],
+        postIds: ['101', '100'],
+        authors: ['bob', 'alice'],
+        favoriteAuthors: ['bob', 'reposter'],
       }),
     ]);
+    expect(result.sections).toEqual({ favoritePostIds: [], followingPostIds: ['102'] });
+    expect(result.inputs).toMatchObject({
+      favorites: { runId: 'favorites-run', sourceId: 'favorites' },
+      following: { runId: 'following-run' },
+      membership: { snapshotId: 'snapshot-1', runId: 'favorites-run', resolvedCount: 2 },
+    });
   });
 
   it('labels Following as a partial fallback instead of claiming favorites', async () => {
@@ -243,9 +330,60 @@ describe('people-first daily feed', () => {
       expect.objectContaining({ id: 'following-fallback', type: 'FOLLOWING_FALLBACK' }),
     ]);
     expect(result.freshness.warnings.join(' ')).toContain(
-      'Favorite and selected-list membership has not been captured'
+      'No frozen Favorites list run is available'
     );
     expect(result.posts).toHaveLength(3);
+  });
+
+  it('groups a Favorite reply with immutable run context without adding context to streams', async () => {
+    const favoriteReply = postRow({
+      id: '200',
+      authorKey: 'id:alice',
+      username: 'alice',
+      name: 'Alice',
+      text: 'Part two of my thread.',
+      publishedAt: '2026-07-24T12:15:00.000Z',
+      kind: 'REPLY',
+    });
+    const threadParent = postRow({
+      id: '199',
+      authorKey: 'id:alice',
+      username: 'alice',
+      name: 'Alice',
+      text: 'Part one of my thread.',
+      publishedAt: '2026-07-24T12:00:00.000Z',
+    });
+    const db = fakeArchiveDb({
+      postRows: [],
+      favoritePostRows: [favoriteReply],
+      contextPostRows: [threadParent],
+      relationshipRows: [
+        {
+          source_tweet_id: '200',
+          relationship_type: 'REPLY_TO',
+          target_tweet_id: '199',
+          target_url: 'https://x.com/alice/status/199',
+          target_text: 'Part one of my thread.',
+          target_author_key: 'id:alice',
+          target_username: 'alice',
+          target_author_name: 'Alice',
+          target_profile_image_url: null,
+        },
+      ],
+    });
+
+    const result = await getDailyFeed(db, USER_ID, { now: NOW });
+
+    expect(result.conversations).toEqual([
+      expect.objectContaining({
+        evidenceType: 'DIRECT_RELATIONSHIP',
+        favoritePostIds: ['200'],
+        contextPostIds: ['199'],
+        postIds: ['199', '200'],
+      }),
+    ]);
+    expect(result.sections).toEqual({ favoritePostIds: [], followingPostIds: [] });
+    expect(result.posts.find((post) => post.id === '199')?.sourceIds).toEqual([]);
   });
 
   it('marks source membership captured on another day as stale', async () => {
@@ -258,8 +396,35 @@ describe('people-first daily feed', () => {
     expect(result.coverage.selectionStatus).toBe('STALE');
     expect(result.coverage.status).toBe('PARTIAL');
     expect(result.freshness.warnings).toContain(
-      'Favorite/list membership was captured on a different day than the frozen post run.'
+      'Favorites membership was captured on a different day than the frozen post run.'
     );
+  });
+
+  it('discloses a partial roster and unresolved member resolution', async () => {
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        sourceStatus: 'PARTIAL',
+        sourceFailureReason: 'membership_stalled',
+        sourceUnresolvedUsernames: ['missing'],
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.coverage.selectionStatus).toBe('STALE');
+    expect(result.coverage.status).toBe('PARTIAL');
+    expect(result.freshness.warnings).toEqual(
+      expect.arrayContaining([
+        'Favorites membership capture is partial.',
+        'membership_stalled',
+        'Favorites membership has 1 unresolved username.',
+      ])
+    );
+    expect(result.inputs.membership).toMatchObject({
+      status: 'PARTIAL',
+      unresolvedCount: 1,
+      failureReason: 'membership_stalled',
+    });
   });
 
   it('batches relationship lookups below the production D1 bind-variable limit', async () => {
@@ -288,6 +453,203 @@ describe('people-first daily feed', () => {
 
     expect(result.posts).toHaveLength(205);
     expect(relationshipBindingCounts).toEqual([91, 91, 26]);
+  });
+
+  it('keeps Favorites posts that are absent from the Following slice and groups strong topics', async () => {
+    const favoriteOnly = [
+      postRow({
+        id: 'favorite-only-1',
+        authorKey: 'id:alice',
+        username: 'alice',
+        name: 'Alice',
+        text: '#SwiftData migration performance indexing',
+        publishedAt: '2026-07-24T12:30:00.000Z',
+        position: 0,
+      }),
+      postRow({
+        id: 'favorite-only-2',
+        authorKey: 'id:bob',
+        username: 'bob',
+        name: 'Bob',
+        text: '#SwiftData migration performance benchmarks',
+        publishedAt: '2026-07-24T12:20:00.000Z',
+        position: 1,
+      }),
+    ];
+    const result = await getDailyFeed(
+      fakeArchiveDb({ favoritePostRows: favoriteOnly, postRows: [todayRows[2]] }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.posts.map((post) => post.id)).toEqual([
+      'favorite-only-1',
+      'favorite-only-2',
+      '102',
+    ]);
+    expect(result.conversations).toEqual([
+      expect.objectContaining({
+        evidenceType: 'TOPIC_SIMILARITY',
+        favoritePostIds: ['favorite-only-1', 'favorite-only-2'],
+        contextPostIds: [],
+      }),
+    ]);
+    expect(result.sections.followingPostIds).toEqual(['102']);
+  });
+
+  it('groups Favorite quote context and preserves its explicit evidence', async () => {
+    const quote = postRow({
+      id: 'quote-2',
+      authorKey: 'id:alice',
+      username: 'alice',
+      name: 'Alice',
+      text: 'Quoting this for context.',
+      publishedAt: '2026-07-24T12:30:00.000Z',
+      kind: 'QUOTE',
+      position: 0,
+    });
+    const quoted = postRow({
+      id: 'quote-1',
+      authorKey: 'id:outside',
+      username: 'outside',
+      name: 'Outside',
+      text: 'The quoted post.',
+      publishedAt: '2026-07-24T12:00:00.000Z',
+    });
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        postRows: [],
+        favoritePostRows: [quote],
+        contextPostRows: [quoted],
+        relationshipRows: [
+          {
+            source_tweet_id: 'quote-2',
+            relationship_type: 'QUOTE_OF',
+            target_tweet_id: 'quote-1',
+            target_url: 'https://x.com/outside/status/quote-1',
+            target_text: 'The quoted post.',
+            target_author_key: 'id:outside',
+            target_username: 'outside',
+            target_author_name: 'Outside',
+            target_profile_image_url: null,
+          },
+        ],
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.conversations[0]).toMatchObject({
+      evidenceType: 'DIRECT_RELATIONSHIP',
+      relationshipTypes: ['QUOTE_OF'],
+      favoritePostIds: ['quote-2'],
+      contextPostIds: ['quote-1'],
+    });
+  });
+
+  it('groups a shared normalized link but leaves weak topic overlap ungrouped', async () => {
+    const sharedLink = {
+      url: 'https://example.com/report',
+      normalizedUrl: 'https://example.com/report',
+      source: 'TEXT',
+    };
+    const favorites = [
+      postRow({
+        id: 'link-1',
+        authorKey: 'id:alice',
+        username: 'alice',
+        name: 'Alice',
+        text: '#AI cats',
+        publishedAt: '2026-07-24T12:30:00.000Z',
+        position: 0,
+        links: [sharedLink],
+      }),
+      postRow({
+        id: 'link-2',
+        authorKey: 'id:bob',
+        username: 'bob',
+        name: 'Bob',
+        text: '#AI dogs',
+        publishedAt: '2026-07-24T12:20:00.000Z',
+        position: 1,
+        links: [sharedLink],
+      }),
+      postRow({
+        id: 'weak-1',
+        authorKey: 'id:carol',
+        username: 'carol',
+        name: 'Carol',
+        text: '#Robotics gardens',
+        publishedAt: '2026-07-24T12:10:00.000Z',
+        position: 2,
+      }),
+      postRow({
+        id: 'weak-2',
+        authorKey: 'id:dave',
+        username: 'dave',
+        name: 'Dave',
+        text: '#Robotics kitchens',
+        publishedAt: '2026-07-24T12:00:00.000Z',
+        position: 3,
+      }),
+    ];
+    const result = await getDailyFeed(
+      fakeArchiveDb({ postRows: [], favoritePostRows: favorites, relationshipRows: [] }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.conversations).toEqual([
+      expect.objectContaining({
+        evidenceType: 'SHARED_LINK',
+        favoritePostIds: ['link-1', 'link-2'],
+      }),
+    ]);
+    expect(result.sections.favoritePostIds).toEqual(['weak-1', 'weak-2']);
+  });
+
+  it('surfaces partial timeline and truncated context coverage', async () => {
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        favoritesStatus: 'PARTIAL',
+        favoritesRequestedCount: 500,
+        favoritesCollectedCount: 120,
+        favoritesContextCoverage: {
+          budget: 40,
+          attempted: 40,
+          completed: 38,
+          truncated: 1,
+          failed: 1,
+          warnings: ['context_budget_reached', 'thread_unavailable'],
+        },
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.coverage.status).toBe('PARTIAL');
+    expect(result.freshness.warnings.join(' ')).toContain('120/500 requested posts');
+    expect(result.freshness.warnings).toContain('1 Favorite thread expansion was truncated.');
+    expect(result.conversations[0]?.coverageWarnings).toContain('context_budget_reached');
+    expect(result.inputs.favorites?.contextCoverage).toMatchObject({ truncated: 1, failed: 1 });
+  });
+
+  it('shows an honest empty Favorites section without substituting Following', async () => {
+    const result = await getDailyFeed(
+      fakeArchiveDb({
+        favoritePostRows: [],
+        favoritesStatus: 'PARTIAL',
+        favoritesRequestedCount: 500,
+        favoritesCollectedCount: 0,
+      }),
+      USER_ID,
+      { now: NOW }
+    );
+
+    expect(result.sources[0]).toMatchObject({ type: 'FAVORITES' });
+    expect(result.sections.favoritePostIds).toEqual([]);
+    expect(result.sections.followingPostIds).toEqual(['100', '101', '102']);
+    expect(result.coverage.selectionStatus).not.toBe('FALLBACK');
   });
 
   it('returns all available author posts for today and the past week with context', async () => {

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -1,5 +1,5 @@
 const DEFAULT_TIMEZONE = 'America/Chicago';
-const MAX_RUN_POSTS = 500;
+const MAX_RUN_POSTS = 5_000;
 const RELATIONSHIP_QUERY_POST_LIMIT = 90;
 const MAX_AUTHOR_POSTS = 500;
 
@@ -17,6 +17,9 @@ type ArchiveRunRow = {
   source_name: string;
   source_url: string | null;
   context_coverage_json: string;
+  collection_policy_json: string;
+  termination_reason: string;
+  window_coverage_json: string;
 };
 
 type ContextCoverage = {
@@ -26,6 +29,22 @@ type ContextCoverage = {
   truncated: number;
   failed: number;
   warnings: string[];
+};
+
+type CollectionPolicy =
+  | { mode: 'COUNT' }
+  | {
+      mode: 'ROLLING_WINDOW';
+      windowHours: number;
+      cutoffAt: string;
+      boundaryEvidenceRequired: number;
+    };
+
+type WindowCoverage = {
+  outsideWindow: number;
+  missingPublishedAt: number;
+  boundaryEvidenceRequired: number;
+  boundaryReached: boolean;
 };
 
 type ArchivePostRow = {
@@ -198,7 +217,7 @@ async function archiveRuns(db: D1Database, userId: string): Promise<ArchiveRunRo
     .prepare(
       `SELECT id, requested_count, collected_count, status, started_at, completed_at,
         excluded_ads, failure_reason, source_type, source_id, source_name, source_url,
-        context_coverage_json
+        context_coverage_json, collection_policy_json, termination_reason, window_coverage_json
        FROM x_timeline_runs
        WHERE user_id = ? AND status IN ('COMPLETE', 'PARTIAL') AND completed_at IS NOT NULL
        ORDER BY completed_at DESC, id DESC LIMIT 60`
@@ -219,6 +238,21 @@ function contextCoverage(run: ArchiveRunRow): ContextCoverage {
     warnings: Array.isArray(parsed.warnings)
       ? parsed.warnings.filter((warning): warning is string => typeof warning === 'string')
       : [],
+  };
+}
+
+function collectionPolicy(run: ArchiveRunRow): CollectionPolicy {
+  const parsed = parseJson(run.collection_policy_json, { mode: 'COUNT' }) as CollectionPolicy;
+  return parsed.mode === 'ROLLING_WINDOW' ? parsed : { mode: 'COUNT' };
+}
+
+function windowCoverage(run: ArchiveRunRow): WindowCoverage {
+  const parsed = parseJson(run.window_coverage_json, {}) as Partial<WindowCoverage>;
+  return {
+    outsideWindow: parsed.outsideWindow ?? 0,
+    missingPublishedAt: parsed.missingPublishedAt ?? 0,
+    boundaryEvidenceRequired: parsed.boundaryEvidenceRequired ?? 0,
+    boundaryReached: parsed.boundaryReached ?? false,
   };
 }
 
@@ -734,7 +768,34 @@ export async function getDailyFeed(
 
   const frozenAt = new Date(primaryRun.completed_at ?? primaryRun.started_at);
   const date = localDate(frozenAt, timezone);
-  const favoriteRows = favoritesRun ? await postsForRun(db, userId, favoritesRun.id) : [];
+  const favoritePolicy = favoritesRun ? collectionPolicy(favoritesRun) : null;
+  const favoriteCutoff = favoritesRun
+    ? Date.parse(
+        favoritePolicy?.mode === 'ROLLING_WINDOW'
+          ? favoritePolicy.cutoffAt
+          : new Date(favoritesRun.started_at - 24 * 60 * 60 * 1_000).toISOString()
+      )
+    : null;
+  const rawFavoriteRows = favoritesRun ? await postsForRun(db, userId, favoritesRun.id) : [];
+  const favoriteRows = rawFavoriteRows.filter(
+    (row) =>
+      (favoritePolicy?.mode === 'ROLLING_WINDOW' && row.presentation === 'REPOST') ||
+      (row.published_at !== null && favoriteCutoff !== null && row.published_at >= favoriteCutoff)
+  );
+  const favoriteRowsWithoutTimestamp = rawFavoriteRows.filter(
+    (row) =>
+      row.published_at === null &&
+      !(favoritePolicy?.mode === 'ROLLING_WINDOW' && row.presentation === 'REPOST')
+  ).length;
+  const favoriteRowsOutsideWindow =
+    rawFavoriteRows.length - favoriteRows.length - favoriteRowsWithoutTimestamp;
+  const favoriteRepostsUsingTimelinePosition = favoriteRows.filter(
+    (row) =>
+      row.presentation === 'REPOST' &&
+      favoriteCutoff !== null &&
+      row.published_at !== null &&
+      row.published_at < favoriteCutoff
+  ).length;
   const followingRows = followingRun ? await postsForRun(db, userId, followingRun.id) : [];
   const contextRows = [
     ...(favoritesRun ? await contextPostsForRun(db, userId, favoritesRun.id) : []),
@@ -764,6 +825,26 @@ export async function getDailyFeed(
   });
   const warnings: string[] = [];
   if (sourceResult.warning) warnings.push(sourceResult.warning);
+  if (favoritesRun && favoritePolicy?.mode !== 'ROLLING_WINDOW') {
+    warnings.push(
+      'This Favorites run used a legacy count target; Daily View defensively limited it to the 24 hours before capture.'
+    );
+  }
+  if (favoriteRowsOutsideWindow > 0) {
+    warnings.push(
+      `${favoriteRowsOutsideWindow} Favorites post${favoriteRowsOutsideWindow === 1 ? ' was' : 's were'} outside the rolling 24-hour window and excluded.`
+    );
+  }
+  if (favoriteRowsWithoutTimestamp > 0) {
+    warnings.push(
+      `${favoriteRowsWithoutTimestamp} Favorites post${favoriteRowsWithoutTimestamp === 1 ? ' has' : 's have'} no publication timestamp and ${favoriteRowsWithoutTimestamp === 1 ? 'was' : 'were'} excluded.`
+    );
+  }
+  if (favoriteRepostsUsingTimelinePosition > 0) {
+    warnings.push(
+      `${favoriteRepostsUsingTimelinePosition} recent Favorite repost${favoriteRepostsUsingTimelinePosition === 1 ? '' : 's'} ${favoriteRepostsUsingTimelinePosition === 1 ? 'contains' : 'contain'} older original material; rolling-window inclusion follows the verified list activity order.`
+    );
+  }
   const membershipSource = favoritesRun
     ? (sourceResult.sources.find((source) => source.id === favoritesRun.source_id) ??
       sourceResult.sources.find((source) => source.type === 'FAVORITES'))
@@ -815,7 +896,19 @@ export async function getDailyFeed(
   );
   const posts = [...favoritePosts, ...followingPosts, ...contextPosts];
   const favoriteContextCoverage = favoritesRun ? contextCoverage(favoritesRun) : null;
+  const favoriteWindowCoverage = favoritesRun ? windowCoverage(favoritesRun) : null;
   const contextWarnings: string[] = [];
+  const missingWindowTimestampCount = favoriteWindowCoverage?.missingPublishedAt ?? 0;
+  if (missingWindowTimestampCount > 0) {
+    warnings.push(
+      `${missingWindowTimestampCount} Favorites timeline item${missingWindowTimestampCount === 1 ? '' : 's'} could not be classified into the rolling window because publication timestamps were missing.`
+    );
+  }
+  if (favoritesRun?.termination_reason === 'SAFETY_LIMIT_REACHED') {
+    warnings.push(
+      `Favorites collection hit its ${favoritesRun.requested_count}-post safety guard before reaching the 24-hour boundary.`
+    );
+  }
   if (favoriteContextCoverage?.truncated) {
     contextWarnings.push(
       `${favoriteContextCoverage.truncated} Favorite thread expansion${favoriteContextCoverage.truncated === 1 ? ' was' : 's were'} truncated.`
@@ -837,8 +930,20 @@ export async function getDailyFeed(
   const followingSectionIds = followingPosts
     .filter((post) => !conversationPostIds.has(post.id))
     .map((post) => post.id);
-  const runComplete = (run: ArchiveRunRow | null) =>
-    !run || (run.status === 'COMPLETE' && run.collected_count >= run.requested_count);
+  const runComplete = (run: ArchiveRunRow | null) => {
+    if (!run) return true;
+    const policy = collectionPolicy(run);
+    if (policy.mode === 'ROLLING_WINDOW') {
+      const coverage = windowCoverage(run);
+      return (
+        run.status === 'COMPLETE' &&
+        run.termination_reason === 'WINDOW_BOUNDARY_REACHED' &&
+        coverage.boundaryReached &&
+        coverage.missingPublishedAt === 0
+      );
+    }
+    return run.status === 'COMPLETE' && run.collected_count >= run.requested_count;
+  };
   const archiveComplete = runComplete(favoritesRun) && runComplete(followingRun);
   const contextComplete =
     !favoriteContextCoverage ||
@@ -847,8 +952,11 @@ export async function getDailyFeed(
   warnings.push(...contextWarnings);
   for (const run of [favoritesRun, followingRun].filter(Boolean) as ArchiveRunRow[]) {
     if (!runComplete(run)) {
+      const policy = collectionPolicy(run);
       warnings.push(
-        `X ${run.source_name} run ${run.id} is ${run.status.toLocaleLowerCase()} (${run.collected_count}/${run.requested_count} requested posts).`
+        policy.mode === 'ROLLING_WINDOW'
+          ? `X ${run.source_name} run ${run.id} did not prove complete ${policy.windowHours}-hour coverage (${run.termination_reason.toLocaleLowerCase()}).`
+          : `X ${run.source_name} run ${run.id} is ${run.status.toLocaleLowerCase()} (${run.collected_count}/${run.requested_count} requested posts).`
       );
     }
     if (run.failure_reason) warnings.push(run.failure_reason);
@@ -877,8 +985,13 @@ export async function getDailyFeed(
       collectedCount: primaryRun.collected_count,
       message:
         status === 'COMPLETE'
-          ? 'Frozen Favorites, Following, and membership coverage are complete for this review slice.'
+          ? `Frozen Favorites from the last ${favoritePolicy?.mode === 'ROLLING_WINDOW' ? favoritePolicy.windowHours : 24} hours, Following, and membership coverage are complete for this review slice.`
           : 'This review slice is usable with the coverage limits shown above.',
+      collectionMode: favoritePolicy?.mode ?? 'COUNT',
+      windowHours: favoritePolicy?.mode === 'ROLLING_WINDOW' ? favoritePolicy.windowHours : null,
+      safetyLimit: favoritePolicy?.mode === 'ROLLING_WINDOW' ? favoritesRun?.requested_count : null,
+      terminationReason:
+        favoritesRun?.termination_reason ?? followingRun?.termination_reason ?? null,
     },
     sources: [
       ...(favoritesRun
@@ -931,6 +1044,9 @@ export async function getDailyFeed(
             status: favoritesRun.status,
             requestedCount: favoritesRun.requested_count,
             collectedCount: favoritesRun.collected_count,
+            collectionPolicy: favoritePolicy,
+            terminationReason: favoritesRun.termination_reason,
+            windowCoverage: favoriteWindowCoverage,
             contextCoverage: favoriteContextCoverage,
             frozenAt: favoritesRun.completed_at
               ? new Date(favoritesRun.completed_at).toISOString()
@@ -946,6 +1062,9 @@ export async function getDailyFeed(
             status: followingRun.status,
             requestedCount: followingRun.requested_count,
             collectedCount: followingRun.collected_count,
+            collectionPolicy: collectionPolicy(followingRun),
+            terminationReason: followingRun.termination_reason,
+            windowCoverage: windowCoverage(followingRun),
             contextCoverage: contextCoverage(followingRun),
             frozenAt: followingRun.completed_at
               ? new Date(followingRun.completed_at).toISOString()

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -12,6 +12,20 @@ type ArchiveRunRow = {
   completed_at: number | null;
   excluded_ads: number;
   failure_reason: string | null;
+  source_type: 'FOLLOWING' | 'FAVORITES' | 'LIST';
+  source_id: string;
+  source_name: string;
+  source_url: string | null;
+  context_coverage_json: string;
+};
+
+type ContextCoverage = {
+  budget: number;
+  attempted: number;
+  completed: number;
+  truncated: number;
+  failed: number;
+  warnings: string[];
 };
 
 type ArchivePostRow = {
@@ -51,21 +65,33 @@ type RelationshipRow = {
 };
 
 type DailySourceRow = {
+  snapshot_id: string;
+  run_id: string;
   source_id: string;
   source_type: 'FAVORITES' | 'LIST';
   name: string;
   is_selected: number;
   captured_at: number;
+  status: 'COMPLETE' | 'PARTIAL';
+  failure_reason: string | null;
+  supplied_count: number;
+  resolved_count: number;
+  unresolved_usernames_json: string;
   author_key: string | null;
 };
 
 type DailySource = {
   id: string;
-  type: 'FAVORITES' | 'LIST' | 'FOLLOWING_FALLBACK';
+  type: 'FAVORITES' | 'LIST' | 'FOLLOWING' | 'FOLLOWING_FALLBACK';
   name: string;
   selected: boolean;
   capturedAt: string | null;
   authorCount: number;
+  status?: 'COMPLETE' | 'PARTIAL';
+  snapshotId?: string | null;
+  runId?: string | null;
+  unresolvedCount?: number;
+  failureReason?: string | null;
 };
 
 type DailyRelationship = {
@@ -163,6 +189,7 @@ function publicPost(
     presentation: row.presentation ?? row.kind,
     repostedBy: publicRepostAuthor(row.reposted_by_json),
     sourceIds,
+    sourcePosition: row.position,
   };
 }
 
@@ -170,7 +197,8 @@ async function archiveRuns(db: D1Database, userId: string): Promise<ArchiveRunRo
   const rows = await db
     .prepare(
       `SELECT id, requested_count, collected_count, status, started_at, completed_at,
-        excluded_ads, failure_reason
+        excluded_ads, failure_reason, source_type, source_id, source_name, source_url,
+        context_coverage_json
        FROM x_timeline_runs
        WHERE user_id = ? AND status IN ('COMPLETE', 'PARTIAL') AND completed_at IS NOT NULL
        ORDER BY completed_at DESC, id DESC LIMIT 60`
@@ -180,16 +208,32 @@ async function archiveRuns(db: D1Database, userId: string): Promise<ArchiveRunRo
   return rows.results;
 }
 
+function contextCoverage(run: ArchiveRunRow): ContextCoverage {
+  const parsed = parseJson(run.context_coverage_json, {}) as Partial<ContextCoverage>;
+  return {
+    budget: parsed.budget ?? 0,
+    attempted: parsed.attempted ?? 0,
+    completed: parsed.completed ?? 0,
+    truncated: parsed.truncated ?? 0,
+    failed: parsed.failed ?? 0,
+    warnings: Array.isArray(parsed.warnings)
+      ? parsed.warnings.filter((warning): warning is string => typeof warning === 'string')
+      : [],
+  };
+}
+
 async function selectRun(
   db: D1Database,
   userId: string,
   date: string | undefined,
-  timezone: string
+  timezone: string,
+  sourceTypes: ArchiveRunRow['source_type'][] = ['FOLLOWING']
 ): Promise<ArchiveRunRow | null> {
   const runs = await archiveRuns(db, userId);
-  if (!date) return runs[0] ?? null;
+  const eligible = runs.filter((run) => sourceTypes.includes(run.source_type ?? 'FOLLOWING'));
+  if (!date) return eligible[0] ?? null;
   return (
-    runs.find(
+    eligible.find(
       (run) => localDate(new Date(run.completed_at ?? run.started_at), timezone) === date
     ) ?? null
   );
@@ -211,6 +255,30 @@ async function postsForRun(
        JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
        WHERE i.user_id = ? AND i.run_id = ?
        ORDER BY i.position ASC LIMIT ?`
+    )
+    .bind(userId, runId, MAX_RUN_POSTS)
+    .all<ArchivePostRow>();
+  return rows.results;
+}
+
+async function contextPostsForRun(
+  db: D1Database,
+  userId: string,
+  runId: string
+): Promise<ArchivePostRow[]> {
+  const rows = await db
+    .prepare(
+      `SELECT NULL AS position, c.observed_at, 'CONTEXT' AS presentation,
+        NULL AS reposted_by_json, p.tweet_id, p.url, p.text, p.published_at, p.lang,
+        p.kind, p.author_key, a.username, a.name AS author_name, a.profile_url,
+        a.profile_image_url, a.verified, p.media_json, p.links_json, p.metrics_json,
+        p.first_seen_at, p.last_seen_at
+       FROM x_timeline_run_context_posts c
+       JOIN x_posts p ON p.user_id = c.user_id AND p.tweet_id = c.tweet_id
+       JOIN x_authors a ON a.user_id = p.user_id AND a.author_key = p.author_key
+       WHERE c.user_id = ? AND c.run_id = ?
+       ORDER BY COALESCE(p.published_at, c.observed_at) ASC, p.tweet_id ASC
+       LIMIT ?`
     )
     .bind(userId, runId, MAX_RUN_POSTS)
     .all<ArchivePostRow>();
@@ -273,23 +341,43 @@ async function relationshipsForPosts(
 
 async function dailySources(
   db: D1Database,
-  userId: string
+  userId: string,
+  options: { runId?: string; referenceAt?: number } = {}
 ): Promise<{
   sources: DailySource[];
   authorsBySource: Map<string, Set<string>>;
   warning: string | null;
 }> {
   try {
+    const byRun = options.runId !== undefined;
     const rows = await db
       .prepare(
-        `SELECT s.source_id, s.source_type, s.name, s.is_selected, s.captured_at, m.author_key
-         FROM x_daily_sources s
-         LEFT JOIN x_daily_source_members m
-           ON m.user_id = s.user_id AND m.source_id = s.source_id
-         WHERE s.user_id = ? AND s.is_selected = 1
-         ORDER BY CASE s.source_type WHEN 'FAVORITES' THEN 0 ELSE 1 END, s.name`
+        byRun
+          ? `SELECT s.id AS snapshot_id, s.run_id, s.source_id, s.source_type, s.name,
+               s.is_selected, s.captured_at, s.status, s.failure_reason, s.supplied_count, s.resolved_count,
+               s.unresolved_usernames_json, m.author_key
+             FROM x_daily_source_snapshots s
+             LEFT JOIN x_daily_source_snapshot_members m
+               ON m.user_id = s.user_id AND m.snapshot_id = s.id
+             WHERE s.user_id = ? AND s.run_id = ? AND s.is_selected = 1
+             ORDER BY m.author_key`
+          : `WITH latest AS (
+               SELECT *, ROW_NUMBER() OVER (
+                 PARTITION BY source_id ORDER BY captured_at DESC, id DESC
+               ) AS source_rank
+               FROM x_daily_source_snapshots
+               WHERE user_id = ? AND is_selected = 1 AND captured_at <= ?
+             )
+             SELECT s.id AS snapshot_id, s.run_id, s.source_id, s.source_type, s.name,
+               s.is_selected, s.captured_at, s.status, s.failure_reason, s.supplied_count, s.resolved_count,
+               s.unresolved_usernames_json, m.author_key
+             FROM latest s
+             LEFT JOIN x_daily_source_snapshot_members m
+               ON m.user_id = s.user_id AND m.snapshot_id = s.id
+             WHERE s.source_rank = 1
+             ORDER BY CASE s.source_type WHEN 'FAVORITES' THEN 0 ELSE 1 END, s.name`
       )
-      .bind(userId)
+      .bind(userId, byRun ? options.runId : (options.referenceAt ?? Date.now()))
       .all<DailySourceRow>();
     const sourceMap = new Map<string, DailySource>();
     const authorsBySource = new Map<string, Set<string>>();
@@ -303,7 +391,12 @@ async function dailySources(
         name: row.name,
         selected: true,
         capturedAt: new Date(row.captured_at).toISOString(),
-        authorCount: authors.size,
+        authorCount: row.resolved_count,
+        status: row.status,
+        snapshotId: row.snapshot_id,
+        runId: row.run_id,
+        unresolvedCount: (parseJson(row.unresolved_usernames_json, []) as unknown[]).length,
+        failureReason: row.failure_reason,
       });
     }
     return { sources: [...sourceMap.values()], authorsBySource, warning: null };
@@ -332,8 +425,72 @@ function uniqueAuthors(posts: DailyPost[]): string[] {
   return [...new Set(posts.map((post) => post.author.username))];
 }
 
-function conversationGroups(posts: DailyPost[]) {
+function uniquePresentationAuthors(posts: DailyPost[]): string[] {
+  return [...new Set(posts.map((post) => post.repostedBy?.username ?? post.author.username))];
+}
+
+const TOPIC_STOP_WORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'also',
+  'because',
+  'before',
+  'being',
+  'from',
+  'have',
+  'into',
+  'just',
+  'more',
+  'that',
+  'their',
+  'there',
+  'these',
+  'they',
+  'this',
+  'those',
+  'through',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'with',
+  'would',
+  'your',
+  'https',
+  'http',
+]);
+
+function topicTokens(post: DailyPost): Set<string> {
+  const values = post.text.toLocaleLowerCase().match(/[#@]?[\p{L}\p{N}_-]{4,}/gu) ?? [];
+  return new Set(values.filter((value) => !TOPIC_STOP_WORDS.has(value)));
+}
+
+function sharedTopicTerms(leftTokens: Set<string>, rightTokens: Set<string>): string[] {
+  return [...leftTokens].filter((token) => rightTokens.has(token)).sort();
+}
+
+function dailyPostTimestamp(post: DailyPost): number {
+  return Date.parse(post.publishedAt ?? post.observedAt ?? '') || 0;
+}
+
+function conversationLatestActivity(posts: DailyPost[]): string | null {
+  const latest = Math.max(...posts.map(dailyPostTimestamp));
+  return latest > 0 ? new Date(latest).toISOString() : null;
+}
+
+function firstSourcePosition(posts: DailyPost[]): number {
+  return Math.min(...posts.map((post) => post.sourcePosition ?? Number.MAX_SAFE_INTEGER));
+}
+
+function conversationGroups(
+  posts: DailyPost[],
+  favoritePostIds = new Set(posts.map((post) => post.id)),
+  contextWarnings: string[] = []
+) {
   const postById = new Map(posts.map((post) => [post.id, post]));
+  const topicTokensByPost = new Map(posts.map((post) => [post.id, topicTokens(post)]));
   const parents = new Map(posts.map((post) => [post.id, post.id]));
   const find = (id: string): string => {
     const parent = parents.get(id) ?? id;
@@ -362,16 +519,31 @@ function conversationGroups(posts: DailyPost[]) {
 
   const candidates: Array<{
     id: string;
-    evidenceType: 'DIRECT_RELATIONSHIP' | 'SHARED_LINK';
+    evidenceType: 'DIRECT_RELATIONSHIP' | 'SHARED_LINK' | 'TOPIC_SIMILARITY';
     label: string;
     evidence: string;
     postIds: string[];
     authors: string[];
     relationshipTypes: string[];
+    favoritePostIds: string[];
+    contextPostIds: string[];
+    favoriteAuthors: string[];
+    latestActivityAt: string | null;
+    coverageWarnings: string[];
+    firstFavoritePosition: number;
   }> = [];
   for (const groupPosts of direct.values()) {
-    const authors = uniqueAuthors(groupPosts);
-    if (groupPosts.length < 2 || authors.length < 2) continue;
+    const orderedPosts = [...groupPosts].sort(
+      (left, right) => dailyPostTimestamp(left) - dailyPostTimestamp(right)
+    );
+    const selectedPosts = orderedPosts.slice(0, 8);
+    if (!selectedPosts.some((post) => favoritePostIds.has(post.id))) {
+      const favoriteAnchor = orderedPosts.find((post) => favoritePostIds.has(post.id));
+      if (favoriteAnchor) selectedPosts.splice(-1, 1, favoriteAnchor);
+    }
+    const authors = uniqueAuthors(selectedPosts);
+    const favoritePosts = selectedPosts.filter((post) => favoritePostIds.has(post.id));
+    if (groupPosts.length < 2 || favoritePosts.length === 0) continue;
     const relationshipTypes = [
       ...new Set(
         groupPosts.flatMap((post) =>
@@ -391,12 +563,20 @@ function conversationGroups(posts: DailyPost[]) {
         .slice(0, 3)
         .map((author) => `@${author}`)
         .join(', ')}`,
-      evidence: `${groupPosts.length} posts are connected by ${relationshipTypes
+      evidence: `${selectedPosts.length} posts are connected by ${relationshipTypes
         .map((type) => type.toLocaleLowerCase().replaceAll('_', ' '))
         .join(', ')} metadata.`,
-      postIds: groupPosts.slice(0, 4).map((post) => post.id),
+      postIds: selectedPosts.map((post) => post.id),
       authors,
       relationshipTypes,
+      favoritePostIds: favoritePosts.map((post) => post.id),
+      contextPostIds: selectedPosts
+        .filter((post) => !favoritePostIds.has(post.id))
+        .map((post) => post.id),
+      favoriteAuthors: uniquePresentationAuthors(favoritePosts),
+      latestActivityAt: conversationLatestActivity(selectedPosts),
+      coverageWarnings: contextWarnings,
+      firstFavoritePosition: firstSourcePosition(favoritePosts),
     });
   }
 
@@ -411,11 +591,18 @@ function conversationGroups(posts: DailyPost[]) {
     }
   }
   for (const [url, linkedPosts] of linkGroups) {
-    const uniquePosts = [...new Map(linkedPosts.map((post) => [post.id, post])).values()];
+    const uniquePosts = [...new Map(linkedPosts.map((post) => [post.id, post])).values()]
+      .filter((post) => !candidates.some((candidate) => candidate.postIds.includes(post.id)))
+      .sort(
+        (left, right) =>
+          firstSourcePosition([left]) - firstSourcePosition([right]) ||
+          dailyPostTimestamp(right) - dailyPostTimestamp(left)
+      )
+      .slice(0, 8);
     const authors = uniqueAuthors(uniquePosts);
-    if (uniquePosts.length < 2 || authors.length < 2) continue;
+    const favoritePosts = uniquePosts.filter((post) => favoritePostIds.has(post.id));
+    if (uniquePosts.length < 2 || authors.length < 2 || favoritePosts.length === 0) continue;
     const ids = uniquePosts.map((post) => post.id);
-    if (candidates.some((candidate) => ids.every((id) => candidate.postIds.includes(id)))) continue;
     let domain = url;
     try {
       domain = new URL(url).hostname.replace(/^www\./, '');
@@ -430,18 +617,72 @@ function conversationGroups(posts: DailyPost[]) {
       postIds: ids.slice(0, 4),
       authors,
       relationshipTypes: [],
+      favoritePostIds: favoritePosts.map((post) => post.id),
+      contextPostIds: uniquePosts
+        .filter((post) => !favoritePostIds.has(post.id))
+        .map((post) => post.id),
+      favoriteAuthors: uniquePresentationAuthors(favoritePosts),
+      latestActivityAt: conversationLatestActivity(uniquePosts),
+      coverageWarnings: [],
+      firstFavoritePosition: firstSourcePosition(favoritePosts),
+    });
+  }
+
+  const favoritePosts = posts.filter((post) => favoritePostIds.has(post.id));
+  for (let leftIndex = 0; leftIndex < favoritePosts.length; leftIndex++) {
+    const left = favoritePosts[leftIndex]!;
+    if (candidates.some((candidate) => candidate.postIds.includes(left.id))) continue;
+    const related = [left];
+    const evidenceTerms = new Set<string>();
+    for (let rightIndex = leftIndex + 1; rightIndex < favoritePosts.length; rightIndex++) {
+      const right = favoritePosts[rightIndex]!;
+      if (candidates.some((candidate) => candidate.postIds.includes(right.id))) continue;
+      const terms = sharedTopicTerms(
+        topicTokensByPost.get(left.id) ?? new Set(),
+        topicTokensByPost.get(right.id) ?? new Set()
+      );
+      const hasStrongMarker = terms.some((term) => term.startsWith('#') || term.startsWith('@'));
+      if (terms.length < 3 && !(hasStrongMarker && terms.length >= 2)) continue;
+      related.push(right);
+      terms.slice(0, 4).forEach((term) => evidenceTerms.add(term));
+      if (related.length === 4) break;
+    }
+    if (related.length < 2 || uniqueAuthors(related).length < 2) continue;
+    const terms = [...evidenceTerms].slice(0, 3);
+    candidates.push({
+      id: `topic:${related
+        .map((post) => post.id)
+        .sort()
+        .join(':')}`,
+      evidenceType: 'TOPIC_SIMILARITY',
+      label: `Shared topic · ${terms.join(' · ')}`,
+      evidence: `${related.length} Favorite posts share multiple explicit terms: ${terms.join(', ')}.`,
+      postIds: related.map((post) => post.id),
+      authors: uniqueAuthors(related),
+      relationshipTypes: [],
+      favoritePostIds: related.map((post) => post.id),
+      contextPostIds: [],
+      favoriteAuthors: uniquePresentationAuthors(related),
+      latestActivityAt: conversationLatestActivity(related),
+      coverageWarnings: [],
+      firstFavoritePosition: firstSourcePosition(related),
     });
   }
 
   return candidates
     .sort(
       (a, b) =>
-        (a.evidenceType === 'DIRECT_RELATIONSHIP' ? 0 : 1) -
-          (b.evidenceType === 'DIRECT_RELATIONSHIP' ? 0 : 1) ||
+        (({ DIRECT_RELATIONSHIP: 0, SHARED_LINK: 1, TOPIC_SIMILARITY: 2 })[a.evidenceType] ?? 3) -
+          ({ DIRECT_RELATIONSHIP: 0, SHARED_LINK: 1, TOPIC_SIMILARITY: 2 }[b.evidenceType] ?? 3) ||
+        b.favoriteAuthors.length - a.favoriteAuthors.length ||
+        b.favoritePostIds.length - a.favoritePostIds.length ||
         b.authors.length - a.authors.length ||
-        b.postIds.length - a.postIds.length
+        (Date.parse(b.latestActivityAt ?? '') || 0) - (Date.parse(a.latestActivityAt ?? '') || 0) ||
+        a.firstFavoritePosition - b.firstFavoritePosition ||
+        a.id.localeCompare(b.id)
     )
-    .slice(0, 3);
+    .slice(0, 3)
+    .map(({ firstFavoritePosition: _firstFavoritePosition, ...conversation }) => conversation);
 }
 
 export async function getDailyFeed(
@@ -452,11 +693,24 @@ export async function getDailyFeed(
   const timezone = options.timezone ?? DEFAULT_TIMEZONE;
   const now = options.now ?? new Date();
   const expectedDate = localDate(now, timezone);
-  const run = await selectRun(db, userId, options.date, timezone);
-  if (!run) {
+  const requestedDate = options.date ?? expectedDate;
+  let favoritesRun = await selectRun(db, userId, requestedDate, timezone, ['FAVORITES', 'LIST']);
+  let followingRun = await selectRun(db, userId, requestedDate, timezone, ['FOLLOWING']);
+  if (!options.date && !favoritesRun && !followingRun) {
+    favoritesRun = await selectRun(db, userId, undefined, timezone, ['FAVORITES', 'LIST']);
+    const fallbackDate = favoritesRun
+      ? localDate(new Date(favoritesRun.completed_at ?? favoritesRun.started_at), timezone)
+      : undefined;
+    followingRun = await selectRun(db, userId, fallbackDate, timezone, ['FOLLOWING']);
+    if (!favoritesRun && !followingRun) {
+      followingRun = await selectRun(db, userId, undefined, timezone, ['FOLLOWING']);
+    }
+  }
+  const primaryRun = favoritesRun ?? followingRun;
+  if (!primaryRun) {
     return {
       schemaVersion: 1,
-      variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+      variant: { id: 'people-first-v2', mode: 'REVIEW' as const },
       date: options.date ?? expectedDate,
       timezone,
       frozenAt: null,
@@ -473,88 +727,143 @@ export async function getDailyFeed(
       sources: [] as DailySource[],
       conversations: [] as ReturnType<typeof conversationGroups>,
       posts: [] as DailyPost[],
+      sections: { favoritePostIds: [], followingPostIds: [] },
+      inputs: { favorites: null, following: null, membership: null },
     };
   }
 
-  const frozenAt = new Date(run.completed_at ?? run.started_at);
+  const frozenAt = new Date(primaryRun.completed_at ?? primaryRun.started_at);
   const date = localDate(frozenAt, timezone);
-  const archivePosts = await postsForRun(db, userId, run.id);
+  const favoriteRows = favoritesRun ? await postsForRun(db, userId, favoritesRun.id) : [];
+  const followingRows = followingRun ? await postsForRun(db, userId, followingRun.id) : [];
+  const contextRows = [
+    ...(favoritesRun ? await contextPostsForRun(db, userId, favoritesRun.id) : []),
+    ...(followingRun ? await contextPostsForRun(db, userId, followingRun.id) : []),
+  ];
+  const primaryRows = [
+    ...favoriteRows,
+    ...followingRows.filter(
+      (row) => !favoriteRows.some((favorite) => favorite.tweet_id === row.tweet_id)
+    ),
+  ];
+  const primaryIds = new Set(primaryRows.map((row) => row.tweet_id));
+  const uniqueContextRows = [
+    ...new Map(
+      contextRows.filter((row) => !primaryIds.has(row.tweet_id)).map((row) => [row.tweet_id, row])
+    ).values(),
+  ];
+  const archivePosts = [...primaryRows, ...uniqueContextRows];
   const relationships = await relationshipsForPosts(
     db,
     userId,
     archivePosts.map((post) => post.tweet_id)
   );
-  const sourceResult = await dailySources(db, userId);
-  let sources = sourceResult.sources;
-  let selectionStatus: 'COMPLETE' | 'STALE' | 'FALLBACK' | 'MISSING' =
-    sources.length > 0 ? 'COMPLETE' : 'MISSING';
-  let selectedRows = archivePosts
-    .map((row) => ({
-      row,
-      sourceIds: sourceIdsForAuthor(row.author_key, sources, sourceResult.authorsBySource),
-    }))
-    .filter((entry) => entry.sourceIds.length > 0);
+  const sourceResult = await dailySources(db, userId, {
+    runId: favoritesRun?.id,
+    referenceAt: frozenAt.getTime(),
+  });
   const warnings: string[] = [];
   if (sourceResult.warning) warnings.push(sourceResult.warning);
-  if (sources.length === 0 || selectedRows.length === 0) {
+  const membershipSource = favoritesRun
+    ? (sourceResult.sources.find((source) => source.id === favoritesRun.source_id) ??
+      sourceResult.sources.find((source) => source.type === 'FAVORITES'))
+    : null;
+  let selectionStatus: 'COMPLETE' | 'STALE' | 'FALLBACK' | 'MISSING';
+  if (!favoritesRun) {
     selectionStatus = 'FALLBACK';
-    sources = [
-      {
-        id: 'following-fallback',
-        type: 'FOLLOWING_FALLBACK',
-        name: 'Following',
-        selected: true,
-        capturedAt: frozenAt.toISOString(),
-        authorCount: new Set(archivePosts.map((post) => post.author_key)).size,
-      },
-    ];
-    selectedRows = archivePosts.map((row) => ({ row, sourceIds: ['following-fallback'] }));
     warnings.push(
-      sourceResult.sources.length === 0
-        ? 'Favorite and selected-list membership has not been captured; showing the frozen Following run.'
-        : 'No posts in the frozen run matched the selected Favorite/list sources; showing Following as an explicit fallback.'
+      'No frozen Favorites list run is available; showing Following as an explicit fallback.'
+    );
+  } else if (!membershipSource) {
+    selectionStatus = 'MISSING';
+    warnings.push(
+      'The Favorites timeline was captured, but its membership snapshot is unavailable.'
     );
   } else if (
-    sources.some(
-      (source) => source.capturedAt && localDate(new Date(source.capturedAt), timezone) !== date
-    )
+    membershipSource.status !== 'COMPLETE' ||
+    (membershipSource.capturedAt &&
+      localDate(new Date(membershipSource.capturedAt), timezone) !== date)
   ) {
     selectionStatus = 'STALE';
     warnings.push(
-      'Favorite/list membership was captured on a different day than the frozen post run.'
+      membershipSource.status !== 'COMPLETE'
+        ? 'Favorites membership capture is partial.'
+        : 'Favorites membership was captured on a different day than the frozen post run.'
+    );
+  } else {
+    selectionStatus = 'COMPLETE';
+  }
+  if (membershipSource?.failureReason) warnings.push(membershipSource.failureReason);
+  const unresolvedMembershipCount = membershipSource?.unresolvedCount ?? 0;
+  if (unresolvedMembershipCount > 0) {
+    warnings.push(
+      `Favorites membership has ${unresolvedMembershipCount} unresolved username${unresolvedMembershipCount === 1 ? '' : 's'}.`
     );
   }
 
-  const sourceRank = new Map(
-    sources.map((source, index) => [source.id, source.type === 'FAVORITES' ? -1 : index])
+  const favoriteSourceId = favoritesRun?.source_id ?? 'favorites';
+  const followingSourceId = favoritesRun ? 'following' : 'following-fallback';
+  const favoritePosts = favoriteRows.map((row) =>
+    publicPost(row, [favoriteSourceId], relationships.get(row.tweet_id) ?? [])
   );
-  selectedRows.sort(
-    (a, b) =>
-      Math.min(...a.sourceIds.map((id) => sourceRank.get(id) ?? 100)) -
-        Math.min(...b.sourceIds.map((id) => sourceRank.get(id) ?? 100)) ||
-      (a.row.position ?? 10_000) - (b.row.position ?? 10_000)
+  const favoritePostIds = new Set(favoritePosts.map((post) => post.id));
+  const followingPosts = followingRows
+    .filter((row) => !favoritePostIds.has(row.tweet_id))
+    .map((row) => publicPost(row, [followingSourceId], relationships.get(row.tweet_id) ?? []));
+  const contextPosts = uniqueContextRows.map((row) =>
+    publicPost(row, [], relationships.get(row.tweet_id) ?? [])
   );
-  const posts = selectedRows.map(({ row, sourceIds }) =>
-    publicPost(row, sourceIds, relationships.get(row.tweet_id) ?? [])
-  );
-  const archiveComplete = run.status === 'COMPLETE' && run.collected_count >= run.requested_count;
-  if (!archiveComplete) {
-    warnings.push(
-      `X run ${run.id} is ${run.status.toLocaleLowerCase()} (${run.collected_count}/${run.requested_count} requested posts).`
+  const posts = [...favoritePosts, ...followingPosts, ...contextPosts];
+  const favoriteContextCoverage = favoritesRun ? contextCoverage(favoritesRun) : null;
+  const contextWarnings: string[] = [];
+  if (favoriteContextCoverage?.truncated) {
+    contextWarnings.push(
+      `${favoriteContextCoverage.truncated} Favorite thread expansion${favoriteContextCoverage.truncated === 1 ? ' was' : 's were'} truncated.`
     );
   }
-  if (run.failure_reason) warnings.push(run.failure_reason);
+  if (favoriteContextCoverage?.failed) {
+    contextWarnings.push(
+      `${favoriteContextCoverage.failed} Favorite thread expansion${favoriteContextCoverage.failed === 1 ? '' : 's'} failed.`
+    );
+  }
+  contextWarnings.push(...(favoriteContextCoverage?.warnings ?? []));
+  const conversations = conversationGroups(posts, favoritePostIds, contextWarnings);
+  const conversationPostIds = new Set(
+    conversations.flatMap((conversation) => conversation.postIds)
+  );
+  const favoriteUngroupedIds = favoritePosts
+    .filter((post) => !conversationPostIds.has(post.id))
+    .map((post) => post.id);
+  const followingSectionIds = followingPosts
+    .filter((post) => !conversationPostIds.has(post.id))
+    .map((post) => post.id);
+  const runComplete = (run: ArchiveRunRow | null) =>
+    !run || (run.status === 'COMPLETE' && run.collected_count >= run.requested_count);
+  const archiveComplete = runComplete(favoritesRun) && runComplete(followingRun);
+  const contextComplete =
+    !favoriteContextCoverage ||
+    (favoriteContextCoverage.truncated === 0 && favoriteContextCoverage.failed === 0);
+  const membershipComplete = selectionStatus === 'COMPLETE' && unresolvedMembershipCount === 0;
+  warnings.push(...contextWarnings);
+  for (const run of [favoritesRun, followingRun].filter(Boolean) as ArchiveRunRow[]) {
+    if (!runComplete(run)) {
+      warnings.push(
+        `X ${run.source_name} run ${run.id} is ${run.status.toLocaleLowerCase()} (${run.collected_count}/${run.requested_count} requested posts).`
+      );
+    }
+    if (run.failure_reason) warnings.push(run.failure_reason);
+  }
   if (date !== expectedDate) {
     warnings.push(`Frozen review data is from ${date}; the current local date is ${expectedDate}.`);
   }
   const status =
-    archiveComplete && selectionStatus === 'COMPLETE'
+    archiveComplete && contextComplete && favoritesRun && membershipComplete
       ? ('COMPLETE' as const)
       : ('PARTIAL' as const);
 
   return {
     schemaVersion: 1,
-    variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+    variant: { id: 'people-first-v2', mode: 'REVIEW' as const },
     date,
     timezone,
     frozenAt: frozenAt.toISOString(),
@@ -563,17 +872,99 @@ export async function getDailyFeed(
       status,
       archiveStatus: archiveComplete ? ('COMPLETE' as const) : ('PARTIAL' as const),
       selectionStatus,
-      runId: run.id,
-      requestedCount: run.requested_count,
-      collectedCount: run.collected_count,
+      runId: primaryRun.id,
+      requestedCount: primaryRun.requested_count,
+      collectedCount: primaryRun.collected_count,
       message:
         status === 'COMPLETE'
-          ? 'Frozen archive coverage and Favorite/list membership are complete for this review slice.'
+          ? 'Frozen Favorites, Following, and membership coverage are complete for this review slice.'
           : 'This review slice is usable with the coverage limits shown above.',
     },
-    sources,
-    conversations: conversationGroups(posts),
+    sources: [
+      ...(favoritesRun
+        ? [
+            membershipSource ?? {
+              id: favoriteSourceId,
+              type: favoritesRun.source_type as 'FAVORITES' | 'LIST',
+              name: favoritesRun.source_name,
+              selected: true,
+              capturedAt: favoritesRun.completed_at
+                ? new Date(favoritesRun.completed_at).toISOString()
+                : null,
+              authorCount: new Set(favoriteRows.map((row) => row.author_key)).size,
+              status: 'PARTIAL' as const,
+              snapshotId: null,
+              runId: favoritesRun.id,
+              unresolvedCount: 0,
+              failureReason: 'membership_snapshot_unavailable',
+            },
+          ]
+        : []),
+      ...(followingRun
+        ? [
+            {
+              id: followingSourceId,
+              type: favoritesRun ? ('FOLLOWING' as const) : ('FOLLOWING_FALLBACK' as const),
+              name: 'Following',
+              selected: true,
+              capturedAt: followingRun.completed_at
+                ? new Date(followingRun.completed_at).toISOString()
+                : null,
+              authorCount: new Set(followingRows.map((row) => row.author_key)).size,
+            },
+          ]
+        : []),
+    ],
+    conversations,
     posts,
+    sections: {
+      favoritePostIds: favoriteUngroupedIds,
+      followingPostIds: followingSectionIds,
+    },
+    inputs: {
+      favorites: favoritesRun
+        ? {
+            runId: favoritesRun.id,
+            sourceId: favoritesRun.source_id,
+            sourceName: favoritesRun.source_name,
+            sourceUrl: favoritesRun.source_url,
+            status: favoritesRun.status,
+            requestedCount: favoritesRun.requested_count,
+            collectedCount: favoritesRun.collected_count,
+            contextCoverage: favoriteContextCoverage,
+            frozenAt: favoritesRun.completed_at
+              ? new Date(favoritesRun.completed_at).toISOString()
+              : null,
+          }
+        : null,
+      following: followingRun
+        ? {
+            runId: followingRun.id,
+            sourceId: followingRun.source_id,
+            sourceName: followingRun.source_name,
+            sourceUrl: followingRun.source_url,
+            status: followingRun.status,
+            requestedCount: followingRun.requested_count,
+            collectedCount: followingRun.collected_count,
+            contextCoverage: contextCoverage(followingRun),
+            frozenAt: followingRun.completed_at
+              ? new Date(followingRun.completed_at).toISOString()
+              : null,
+          }
+        : null,
+      membership: membershipSource
+        ? {
+            snapshotId: membershipSource.snapshotId ?? null,
+            runId: membershipSource.runId ?? favoritesRun?.id ?? null,
+            sourceId: membershipSource.id,
+            capturedAt: membershipSource.capturedAt,
+            status: membershipSource.status ?? 'PARTIAL',
+            resolvedCount: membershipSource.authorCount,
+            unresolvedCount: membershipSource.unresolvedCount ?? 0,
+            failureReason: membershipSource.failureReason ?? null,
+          }
+        : null,
+    },
   };
 }
 
@@ -622,7 +1013,14 @@ export async function getDailyAuthorActivity(
     userId,
     rows.map((row) => row.tweet_id)
   );
-  const sourceResult = await dailySources(db, userId);
+  const activityFavoritesRun = await selectRun(db, userId, options.date, timezone, [
+    'FAVORITES',
+    'LIST',
+  ]);
+  const sourceResult = await dailySources(db, userId, {
+    runId: activityFavoritesRun?.id,
+    referenceAt: Date.parse(`${options.date}T23:59:59.999Z`),
+  });
   const posts = rows.map((row) =>
     publicPost(
       row,
@@ -637,7 +1035,7 @@ export async function getDailyAuthorActivity(
     return runDate >= startDate && runDate <= options.date;
   });
   const warnings = [
-    'Shows every post available in the X Following archive, which is a sampled timeline rather than a complete author export.',
+    'Shows every post available in the frozen Favorites and Following archives, which are sampled timelines rather than a complete author export.',
   ];
   if (sourceResult.warning) warnings.push(sourceResult.warning);
   if (relevantRuns.some((run) => run.status !== 'COMPLETE')) {
@@ -646,7 +1044,7 @@ export async function getDailyAuthorActivity(
 
   return {
     schemaVersion: 1,
-    variant: { id: 'people-first-v1', mode: 'REVIEW' as const },
+    variant: { id: 'people-first-v2', mode: 'REVIEW' as const },
     date: options.date,
     range: options.range,
     startDate,

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -1048,7 +1048,7 @@
         "tags": ["Editorial"],
         "operationId": "getPeopleFirstDailyFeed",
         "summary": "Get the frozen people-first Today review feed",
-        "description": "Returns real X posts from Favorite and selected-list source snapshots, explicit relationship/shared-link conversation groups, and archive coverage. This review route does not replace the live editorial Today issue.",
+        "description": "Returns a frozen Favorites-list timeline first, evidence-backed reply/quote/shared-link/topic conversation groups, ungrouped Favorite posts, and a deduplicated secondary Following stream with immutable source, membership, run-context, and context-budget provenance. This review route does not replace the live editorial Today issue.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "experimental",

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -1048,7 +1048,7 @@
         "tags": ["Editorial"],
         "operationId": "getPeopleFirstDailyFeed",
         "summary": "Get the frozen people-first Today review feed",
-        "description": "Returns a frozen Favorites-list timeline first, evidence-backed reply/quote/shared-link/topic conversation groups, ungrouped Favorite posts, and a deduplicated secondary Following stream with immutable source, membership, run-context, and context-budget provenance. This review route does not replace the live editorial Today issue.",
+        "description": "Returns a frozen rolling-24-hour Favorites-list timeline first, evidence-backed reply/quote/shared-link/topic conversation groups, ungrouped Favorite posts, and a deduplicated secondary count-bounded Following stream with immutable source, membership, collection-policy, window, run-context, and context-budget provenance. This review route does not replace the live editorial Today issue.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "experimental",

--- a/apps/x-archive/src/db/migrations/0003_source_aware_runs.sql
+++ b/apps/x-archive/src/db/migrations/0003_source_aware_runs.sql
@@ -1,0 +1,57 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE x_timeline_runs ADD COLUMN source_type TEXT NOT NULL DEFAULT 'FOLLOWING';
+ALTER TABLE x_timeline_runs ADD COLUMN source_id TEXT NOT NULL DEFAULT 'following';
+ALTER TABLE x_timeline_runs ADD COLUMN source_name TEXT NOT NULL DEFAULT 'Following';
+ALTER TABLE x_timeline_runs ADD COLUMN source_url TEXT;
+ALTER TABLE x_timeline_runs ADD COLUMN context_coverage_json TEXT NOT NULL DEFAULT '{"budget":0,"attempted":0,"completed":0,"truncated":0,"failed":0,"warnings":[]}';
+
+CREATE INDEX IF NOT EXISTS x_timeline_runs_user_source_completed_idx
+  ON x_timeline_runs(user_id, source_type, source_id, completed_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS x_timeline_run_context_posts (
+  run_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  tweet_id TEXT NOT NULL,
+  observed_at INTEGER NOT NULL,
+  PRIMARY KEY (run_id, tweet_id),
+  FOREIGN KEY (run_id) REFERENCES x_timeline_runs(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id, tweet_id) REFERENCES x_posts(user_id, tweet_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS x_timeline_run_context_posts_user_tweet_idx
+  ON x_timeline_run_context_posts(user_id, tweet_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS x_daily_source_snapshots (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_type TEXT NOT NULL CHECK (source_type IN ('FAVORITES', 'LIST')),
+  name TEXT NOT NULL,
+  is_selected INTEGER NOT NULL DEFAULT 1,
+  captured_at INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('COMPLETE', 'PARTIAL')),
+  failure_reason TEXT,
+  supplied_count INTEGER NOT NULL,
+  resolved_count INTEGER NOT NULL,
+  unresolved_usernames_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (run_id) REFERENCES x_timeline_runs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS x_daily_source_snapshots_user_source_captured_idx
+  ON x_daily_source_snapshots(user_id, source_id, captured_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS x_daily_source_snapshot_members (
+  snapshot_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  author_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (snapshot_id, author_key),
+  FOREIGN KEY (snapshot_id) REFERENCES x_daily_source_snapshots(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id, author_key) REFERENCES x_authors(user_id, author_key) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS x_daily_source_snapshot_members_author_idx
+  ON x_daily_source_snapshot_members(user_id, author_key, snapshot_id);

--- a/apps/x-archive/src/db/migrations/0003_source_aware_runs.sql
+++ b/apps/x-archive/src/db/migrations/0003_source_aware_runs.sql
@@ -5,6 +5,9 @@ ALTER TABLE x_timeline_runs ADD COLUMN source_id TEXT NOT NULL DEFAULT 'followin
 ALTER TABLE x_timeline_runs ADD COLUMN source_name TEXT NOT NULL DEFAULT 'Following';
 ALTER TABLE x_timeline_runs ADD COLUMN source_url TEXT;
 ALTER TABLE x_timeline_runs ADD COLUMN context_coverage_json TEXT NOT NULL DEFAULT '{"budget":0,"attempted":0,"completed":0,"truncated":0,"failed":0,"warnings":[]}';
+ALTER TABLE x_timeline_runs ADD COLUMN collection_policy_json TEXT NOT NULL DEFAULT '{"mode":"COUNT"}';
+ALTER TABLE x_timeline_runs ADD COLUMN termination_reason TEXT NOT NULL DEFAULT 'COUNT_REACHED';
+ALTER TABLE x_timeline_runs ADD COLUMN window_coverage_json TEXT NOT NULL DEFAULT '{"outsideWindow":0,"missingPublishedAt":0,"boundaryEvidenceRequired":0,"boundaryReached":false}';
 
 CREATE INDEX IF NOT EXISTS x_timeline_runs_user_source_completed_idx
   ON x_timeline_runs(user_id, source_type, source_id, completed_at DESC, id DESC);

--- a/apps/x-archive/src/index.test.ts
+++ b/apps/x-archive/src/index.test.ts
@@ -66,6 +66,12 @@ async function insertCapturedRunForDailySources() {
       requestedCount: 1,
       startedAt: '2026-07-11T13:00:00.000Z',
       collectorVersion: 'test-v1',
+      source: {
+        type: 'FAVORITES',
+        id: 'favorites',
+        name: 'Favorites',
+        url: 'https://x.com/i/lists/123',
+      },
     }),
   });
   await api('/api/v1/x-timeline/runs/run-daily-sources/chunks/0', {
@@ -97,7 +103,7 @@ async function insertCapturedRunForDailySources() {
 beforeEach(async () => {
   await testEnv.AUTH_DB.exec('DELETE FROM api_tokens;');
   await testEnv.ARCHIVE_DB.exec(
-    'DELETE FROM x_daily_source_members; DELETE FROM x_daily_sources; DELETE FROM x_ingest_chunks; DELETE FROM x_timeline_run_items; DELETE FROM x_post_links; DELETE FROM x_post_relationships; DELETE FROM x_posts; DELETE FROM x_authors; DELETE FROM x_timeline_runs;'
+    'DELETE FROM x_daily_source_snapshot_members; DELETE FROM x_daily_source_snapshots; DELETE FROM x_daily_source_members; DELETE FROM x_daily_sources; DELETE FROM x_ingest_chunks; DELETE FROM x_timeline_run_context_posts; DELETE FROM x_timeline_run_items; DELETE FROM x_post_links; DELETE FROM x_post_relationships; DELETE FROM x_posts; DELETE FROM x_authors; DELETE FROM x_timeline_runs;'
   );
   await testEnv.AUTH_DB.prepare(
     `INSERT INTO api_tokens
@@ -128,9 +134,12 @@ describe('X archive worker', () => {
       }),
     });
     expect(create.status).toBe(201);
+    expect(await create.clone().json()).toMatchObject({
+      run: { source: { type: 'FOLLOWING', id: 'following', name: 'Following' } },
+    });
 
     const chunkBody = {
-      posts: [post('100')],
+      posts: [post('100'), { ...post('099'), links: [] }],
       items: [
         {
           tweetId: '100',
@@ -148,7 +157,7 @@ describe('X archive worker', () => {
     expect(chunk.status).toBe(200);
     expect(await chunk.json()).toMatchObject({
       duplicateChunk: false,
-      canonicalPosts: { created: 1, updated: 0, unchanged: 0 },
+      canonicalPosts: { created: 2, updated: 0, unchanged: 0 },
     });
 
     const retry = await api('/api/v1/x-timeline/runs/run-00000001/chunks/0', {
@@ -165,11 +174,25 @@ describe('X archive worker', () => {
         excludedAds: 2,
         status: 'COMPLETE',
         failureReason: null,
+        contextCoverage: {
+          budget: 40,
+          attempted: 1,
+          completed: 0,
+          truncated: 1,
+          failed: 0,
+          warnings: ['context_budget_reached'],
+        },
       }),
     });
     expect(complete.status).toBe(200);
     expect(await complete.json()).toMatchObject({
-      run: { id: 'run-00000001', collectedCount: 1, excludedAds: 2, status: 'COMPLETE' },
+      run: {
+        id: 'run-00000001',
+        collectedCount: 1,
+        excludedAds: 2,
+        status: 'COMPLETE',
+        contextCoverage: { attempted: 1, truncated: 1 },
+      },
     });
 
     const read = await api('/api/v1/x-timeline/runs/run-00000001');
@@ -216,6 +239,13 @@ describe('X archive worker', () => {
       .first<{ count: number }>();
     expect(indexedLinks?.count).toBe(1);
 
+    const contextPosts = await testEnv.ARCHIVE_DB.prepare(
+      'SELECT tweet_id FROM x_timeline_run_context_posts WHERE run_id = ?'
+    )
+      .bind('run-00000001')
+      .all<{ tweet_id: string }>();
+    expect(contextPosts.results).toEqual([{ tweet_id: '099' }]);
+
     expect(await testEnv.ARCHIVE_BUCKET.head('users/user_test/posts/100.json.gz')).not.toBeNull();
     const exported = await api('/api/v1/x-timeline/runs/run-00000001/export');
     expect(exported.status).toBe(200);
@@ -227,17 +257,28 @@ describe('X archive worker', () => {
     const put = await api('/api/v1/x-timeline/daily-sources/favorites', {
       method: 'PUT',
       body: JSON.stringify({
+        runId: 'run-daily-sources',
         sourceType: 'FAVORITES',
         name: 'Favorites',
         selected: true,
         capturedAt: '2026-07-11T13:02:00.000Z',
+        status: 'PARTIAL',
+        failureReason: 'membership_stalled',
         usernames: ['example', 'missing'],
       }),
     });
     expect(put.status).toBe(200);
     expect(await put.json()).toMatchObject({
-      source: { id: 'favorites', type: 'FAVORITES', authorCount: 1 },
+      source: {
+        id: 'favorites',
+        runId: 'run-daily-sources',
+        type: 'FAVORITES',
+        status: 'PARTIAL',
+        failureReason: 'membership_stalled',
+        authorCount: 1,
+      },
       unresolvedUsernames: ['missing'],
+      created: true,
     });
 
     const read = await api('/api/v1/x-timeline/daily-sources');
@@ -245,11 +286,71 @@ describe('X archive worker', () => {
       sources: [
         {
           id: 'favorites',
+          runId: 'run-daily-sources',
           type: 'FAVORITES',
           selected: true,
+          status: 'PARTIAL',
+          failureReason: 'membership_stalled',
+          suppliedCount: 2,
+          resolvedCount: 1,
+          unresolvedUsernames: ['missing'],
           authors: [{ username: 'example' }],
         },
       ],
+    });
+
+    const retry = await api('/api/v1/x-timeline/daily-sources/favorites', {
+      method: 'PUT',
+      body: JSON.stringify({
+        runId: 'run-daily-sources',
+        sourceType: 'FAVORITES',
+        name: 'Favorites',
+        selected: true,
+        capturedAt: '2026-07-11T13:02:00.000Z',
+        status: 'PARTIAL',
+        failureReason: 'membership_stalled',
+        usernames: ['example', 'missing'],
+      }),
+    });
+    expect(await retry.json()).toMatchObject({
+      source: { snapshotId: expect.any(String), runId: 'run-daily-sources' },
+      created: false,
+    });
+    const snapshotCount = await testEnv.ARCHIVE_DB.prepare(
+      'SELECT COUNT(*) AS count FROM x_daily_source_snapshots WHERE run_id = ?'
+    )
+      .bind('run-daily-sources')
+      .first<{ count: number }>();
+    expect(snapshotCount?.count).toBe(1);
+  });
+
+  it('stores source provenance on list timeline runs', async () => {
+    const create = await api('/api/v1/x-timeline/runs', {
+      method: 'POST',
+      body: JSON.stringify({
+        runId: 'run-favorites-list',
+        requestedCount: 500,
+        startedAt: '2026-07-11T13:00:00.000Z',
+        collectorVersion: 'browser-dom-v4',
+        source: {
+          type: 'FAVORITES',
+          id: 'x-list:123',
+          name: 'Favorites',
+          url: 'https://x.com/i/lists/123',
+        },
+      }),
+    });
+
+    expect(create.status).toBe(201);
+    expect(await create.json()).toMatchObject({
+      run: {
+        source: {
+          type: 'FAVORITES',
+          id: 'x-list:123',
+          name: 'Favorites',
+          url: 'https://x.com/i/lists/123',
+        },
+      },
     });
   });
 

--- a/apps/x-archive/src/index.test.ts
+++ b/apps/x-archive/src/index.test.ts
@@ -329,7 +329,7 @@ describe('X archive worker', () => {
       method: 'POST',
       body: JSON.stringify({
         runId: 'run-favorites-list',
-        requestedCount: 500,
+        requestedCount: 5_000,
         startedAt: '2026-07-11T13:00:00.000Z',
         collectorVersion: 'browser-dom-v4',
         source: {
@@ -337,6 +337,12 @@ describe('X archive worker', () => {
           id: 'x-list:123',
           name: 'Favorites',
           url: 'https://x.com/i/lists/123',
+        },
+        collectionPolicy: {
+          mode: 'ROLLING_WINDOW',
+          windowHours: 24,
+          cutoffAt: '2026-07-10T13:00:00.000Z',
+          boundaryEvidenceRequired: 3,
         },
       }),
     });
@@ -350,6 +356,52 @@ describe('X archive worker', () => {
           name: 'Favorites',
           url: 'https://x.com/i/lists/123',
         },
+        requestedCount: 5_000,
+        collectionPolicy: {
+          mode: 'ROLLING_WINDOW',
+          windowHours: 24,
+          cutoffAt: '2026-07-10T13:00:00.000Z',
+        },
+      },
+    });
+
+    const invalidCompletion = await api('/api/v1/x-timeline/runs/run-favorites-list/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        collectedCount: 0,
+        excludedAds: 0,
+        status: 'COMPLETE',
+        terminationReason: 'WINDOW_BOUNDARY_REACHED',
+        windowCoverage: {
+          outsideWindow: 0,
+          missingPublishedAt: 0,
+          boundaryEvidenceRequired: 3,
+          boundaryReached: false,
+        },
+      }),
+    });
+    expect(invalidCompletion.status).toBe(409);
+
+    const complete = await api('/api/v1/x-timeline/runs/run-favorites-list/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        collectedCount: 0,
+        excludedAds: 0,
+        status: 'COMPLETE',
+        terminationReason: 'WINDOW_BOUNDARY_REACHED',
+        windowCoverage: {
+          outsideWindow: 3,
+          missingPublishedAt: 0,
+          boundaryEvidenceRequired: 3,
+          boundaryReached: true,
+        },
+      }),
+    });
+    expect(complete.status).toBe(200);
+    expect(await complete.json()).toMatchObject({
+      run: {
+        terminationReason: 'WINDOW_BOUNDARY_REACHED',
+        windowCoverage: { boundaryReached: true, outsideWindow: 3 },
       },
     });
   });

--- a/apps/x-archive/src/index.ts
+++ b/apps/x-archive/src/index.ts
@@ -65,6 +65,9 @@ type RunRow = {
   source_name: string;
   source_url: string | null;
   context_coverage_json: string;
+  collection_policy_json: string;
+  termination_reason: string;
+  window_coverage_json: string;
   created_at: number;
   updated_at: number;
 };
@@ -234,6 +237,14 @@ function publicRun(row: RunRow) {
       failed: 0,
       warnings: [],
     }),
+    collectionPolicy: parseJson(row.collection_policy_json, { mode: 'COUNT' }),
+    terminationReason: row.termination_reason ?? 'COUNT_REACHED',
+    windowCoverage: parseJson(row.window_coverage_json, {
+      outsideWindow: 0,
+      missingPublishedAt: 0,
+      boundaryEvidenceRequired: 0,
+      boundaryReached: false,
+    }),
     createdAt: new Date(row.created_at).toISOString(),
     updatedAt: new Date(row.updated_at).toISOString(),
   };
@@ -371,8 +382,8 @@ app.post('/api/v1/x-timeline/runs', async (c) => {
   await c.env.ARCHIVE_DB.prepare(
     `INSERT INTO x_timeline_runs
       (id, user_id, requested_count, status, started_at, collector_version, schema_version,
-       source_type, source_id, source_name, source_url, created_at, updated_at)
-     VALUES (?, ?, ?, 'CAPTURING', ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       source_type, source_id, source_name, source_url, collection_policy_json, created_at, updated_at)
+     VALUES (?, ?, ?, 'CAPTURING', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       input.runId,
@@ -385,6 +396,7 @@ app.post('/api/v1/x-timeline/runs', async (c) => {
       input.source.id,
       input.source.name,
       input.source.url ?? null,
+      JSON.stringify(input.collectionPolicy),
       now,
       now
     )
@@ -697,6 +709,26 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
     .bind(runId, userId)
     .first<RunRow>();
   if (!run) return c.json({ error: 'Run not found', code: 'NOT_FOUND' }, 404);
+  const collectionPolicy = parseJson(run.collection_policy_json, { mode: 'COUNT' }) as {
+    mode?: string;
+  };
+  if (
+    parsed.data.status === 'COMPLETE' &&
+    ((collectionPolicy.mode === 'ROLLING_WINDOW' &&
+      (parsed.data.terminationReason !== 'WINDOW_BOUNDARY_REACHED' ||
+        !parsed.data.windowCoverage.boundaryReached ||
+        parsed.data.windowCoverage.missingPublishedAt > 0)) ||
+      (collectionPolicy.mode !== 'ROLLING_WINDOW' &&
+        parsed.data.terminationReason !== 'COUNT_REACHED'))
+  ) {
+    return c.json(
+      {
+        error: 'Completion reason does not satisfy the run collection policy',
+        code: 'COLLECTION_POLICY_INCOMPLETE',
+      },
+      409
+    );
+  }
 
   const items = await c.env.ARCHIVE_DB.prepare(
     `SELECT tweet_id, position, observed_at, presentation, reposted_by_json
@@ -736,6 +768,9 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
       collectorVersion: run.collector_version,
       failureReason: parsed.data.failureReason ?? null,
       contextCoverage: parsed.data.contextCoverage,
+      collectionPolicy: parseJson(run.collection_policy_json, { mode: 'COUNT' }),
+      terminationReason: parsed.data.terminationReason,
+      windowCoverage: parsed.data.windowCoverage,
       items: items.results.map((item) => ({
         tweetId: item.tweet_id,
         position: item.position,
@@ -753,7 +788,8 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
   await c.env.ARCHIVE_DB.prepare(
     `UPDATE x_timeline_runs SET
       collected_count = ?, status = ?, completed_at = ?, excluded_ads = ?, manifest_key = ?,
-      failure_reason = ?, context_coverage_json = ?, updated_at = ?
+      failure_reason = ?, context_coverage_json = ?, termination_reason = ?,
+      window_coverage_json = ?, updated_at = ?
      WHERE id = ? AND user_id = ?`
   )
     .bind(
@@ -764,6 +800,8 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
       key,
       parsed.data.failureReason ?? null,
       JSON.stringify(parsed.data.contextCoverage),
+      parsed.data.terminationReason,
+      JSON.stringify(parsed.data.windowCoverage),
       Date.now(),
       runId,
       userId

--- a/apps/x-archive/src/index.ts
+++ b/apps/x-archive/src/index.ts
@@ -19,13 +19,25 @@ const MAX_PAGE_SIZE = 100;
 
 const DailySourceSnapshotSchema = z
   .object({
+    runId: z.string().trim().min(1).max(120),
     sourceType: z.enum(['FAVORITES', 'LIST']),
     name: z.string().trim().min(1).max(120),
     selected: z.boolean().default(true),
     capturedAt: z.string().datetime(),
+    status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
+    failureReason: z.string().trim().min(1).max(500).nullable().optional(),
     usernames: z.array(z.string().trim().min(1).max(64)).max(5_000),
   })
-  .strict();
+  .strict()
+  .superRefine((snapshot, ctx) => {
+    if (snapshot.status === 'COMPLETE' && snapshot.failureReason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['failureReason'],
+        message: 'Complete membership snapshots cannot include a failure reason',
+      });
+    }
+  });
 
 type TokenRow = {
   id: string;
@@ -48,6 +60,11 @@ type RunRow = {
   schema_version: number;
   manifest_key: string | null;
   failure_reason: string | null;
+  source_type: 'FOLLOWING' | 'FAVORITES' | 'LIST';
+  source_id: string;
+  source_name: string;
+  source_url: string | null;
+  context_coverage_json: string;
   created_at: number;
   updated_at: number;
 };
@@ -153,6 +170,15 @@ function parsePostLinks(value: string | null | undefined): XPostLink[] {
   }
 }
 
+function parseJson(value: string | null | undefined, fallback: unknown): unknown {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return fallback;
+  }
+}
+
 function mergePostLinks(previous: XPostLink[], incoming: XPostLink[]): XPostLink[] {
   const links = new Map(previous.map((link) => [link.normalizedUrl, link]));
   for (const link of incoming) {
@@ -194,6 +220,20 @@ function publicRun(row: RunRow) {
     collectorVersion: row.collector_version,
     schemaVersion: row.schema_version,
     failureReason: row.failure_reason,
+    source: {
+      type: row.source_type ?? 'FOLLOWING',
+      id: row.source_id ?? 'following',
+      name: row.source_name ?? 'Following',
+      url: row.source_url ?? null,
+    },
+    contextCoverage: parseJson(row.context_coverage_json, {
+      budget: 0,
+      attempted: 0,
+      completed: 0,
+      truncated: 0,
+      failed: 0,
+      warnings: [],
+    }),
     createdAt: new Date(row.created_at).toISOString(),
     updatedAt: new Date(row.updated_at).toISOString(),
   };
@@ -330,8 +370,9 @@ app.post('/api/v1/x-timeline/runs', async (c) => {
   const now = Date.now();
   await c.env.ARCHIVE_DB.prepare(
     `INSERT INTO x_timeline_runs
-      (id, user_id, requested_count, status, started_at, collector_version, schema_version, created_at, updated_at)
-     VALUES (?, ?, ?, 'CAPTURING', ?, ?, ?, ?, ?)`
+      (id, user_id, requested_count, status, started_at, collector_version, schema_version,
+       source_type, source_id, source_name, source_url, created_at, updated_at)
+     VALUES (?, ?, ?, 'CAPTURING', ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       input.runId,
@@ -340,6 +381,10 @@ app.post('/api/v1/x-timeline/runs', async (c) => {
       Date.parse(input.startedAt),
       input.collectorVersion,
       X_ARCHIVE_SCHEMA_VERSION,
+      input.source.type,
+      input.source.id,
+      input.source.name,
+      input.source.url ?? null,
       now,
       now
     )
@@ -458,6 +503,7 @@ app.put('/api/v1/x-timeline/runs/:runId/chunks/:chunkIndex', async (c) => {
 
   const now = Date.now();
   const statements: D1PreparedStatement[] = [];
+  const primaryTweetIds = new Set(input.items.map((item) => item.tweetId));
   for (const post of postsById.values()) {
     const key = authorKey(post);
     const seenAt = Date.parse(post.capturedAt);
@@ -577,6 +623,16 @@ app.put('/api/v1/x-timeline/runs/:runId/chunks/:chunkIndex', async (c) => {
         )
       );
     }
+    if (!primaryTweetIds.has(post.tweetId)) {
+      statements.push(
+        c.env.ARCHIVE_DB.prepare(
+          `INSERT INTO x_timeline_run_context_posts (run_id, user_id, tweet_id, observed_at)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(run_id, tweet_id) DO UPDATE SET
+             observed_at = MIN(x_timeline_run_context_posts.observed_at, excluded.observed_at)`
+        ).bind(runId, userId, post.tweetId, seenAt)
+      );
+    }
   }
   for (const item of input.items) {
     statements.push(
@@ -679,6 +735,7 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
       excludedAds: parsed.data.excludedAds,
       collectorVersion: run.collector_version,
       failureReason: parsed.data.failureReason ?? null,
+      contextCoverage: parsed.data.contextCoverage,
       items: items.results.map((item) => ({
         tweetId: item.tweet_id,
         position: item.position,
@@ -696,7 +753,7 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
   await c.env.ARCHIVE_DB.prepare(
     `UPDATE x_timeline_runs SET
       collected_count = ?, status = ?, completed_at = ?, excluded_ads = ?, manifest_key = ?,
-      failure_reason = ?, updated_at = ?
+      failure_reason = ?, context_coverage_json = ?, updated_at = ?
      WHERE id = ? AND user_id = ?`
   )
     .bind(
@@ -706,6 +763,7 @@ app.post('/api/v1/x-timeline/runs/:runId/complete', async (c) => {
       parsed.data.excludedAds,
       key,
       parsed.data.failureReason ?? null,
+      JSON.stringify(parsed.data.contextCoverage),
       Date.now(),
       runId,
       userId
@@ -732,23 +790,37 @@ app.get('/api/v1/x-timeline/runs', async (c) => {
 app.get('/api/v1/x-timeline/daily-sources', async (c) => {
   const userId = c.get('userId');
   const rows = await c.env.ARCHIVE_DB.prepare(
-    `SELECT s.source_id, s.source_type, s.name, s.is_selected, s.captured_at,
-      a.author_key, a.username, a.name AS author_name
-     FROM x_daily_sources s
-     LEFT JOIN x_daily_source_members m
-       ON m.user_id = s.user_id AND m.source_id = s.source_id
+    `WITH latest AS (
+       SELECT *, ROW_NUMBER() OVER (
+         PARTITION BY source_id ORDER BY captured_at DESC, id DESC
+       ) AS source_rank
+       FROM x_daily_source_snapshots WHERE user_id = ?
+     )
+     SELECT s.id AS snapshot_id, s.run_id, s.source_id, s.source_type, s.name, s.is_selected,
+       s.captured_at, s.status, s.failure_reason, s.supplied_count, s.resolved_count,
+       s.unresolved_usernames_json, a.author_key, a.username, a.name AS author_name
+     FROM latest s
+     LEFT JOIN x_daily_source_snapshot_members m
+       ON m.user_id = s.user_id AND m.snapshot_id = s.id
      LEFT JOIN x_authors a
        ON a.user_id = m.user_id AND a.author_key = m.author_key
-     WHERE s.user_id = ?
+     WHERE s.source_rank = 1
      ORDER BY CASE s.source_type WHEN 'FAVORITES' THEN 0 ELSE 1 END, s.name, a.username`
   )
     .bind(userId)
     .all<{
       source_id: string;
+      snapshot_id: string;
+      run_id: string;
       source_type: 'FAVORITES' | 'LIST';
       name: string;
       is_selected: number;
       captured_at: number;
+      status: 'COMPLETE' | 'PARTIAL';
+      failure_reason: string | null;
+      supplied_count: number;
+      resolved_count: number;
+      unresolved_usernames_json: string;
       author_key: string | null;
       username: string | null;
       author_name: string | null;
@@ -757,20 +829,34 @@ app.get('/api/v1/x-timeline/daily-sources', async (c) => {
     string,
     {
       id: string;
+      snapshotId: string;
+      runId: string;
       type: 'FAVORITES' | 'LIST';
       name: string;
       selected: boolean;
       capturedAt: string;
+      status: 'COMPLETE' | 'PARTIAL';
+      failureReason: string | null;
+      suppliedCount: number;
+      resolvedCount: number;
+      unresolvedUsernames: string[];
       authors: Array<{ key: string; username: string; name: string }>;
     }
   >();
   for (const row of rows.results) {
     const source = sources.get(row.source_id) ?? {
       id: row.source_id,
+      snapshotId: row.snapshot_id,
+      runId: row.run_id,
       type: row.source_type,
       name: row.name,
       selected: Boolean(row.is_selected),
       capturedAt: new Date(row.captured_at).toISOString(),
+      status: row.status,
+      failureReason: row.failure_reason,
+      suppliedCount: row.supplied_count,
+      resolvedCount: row.resolved_count,
+      unresolvedUsernames: JSON.parse(row.unresolved_usernames_json) as string[],
       authors: [],
     };
     if (row.author_key && row.username && row.author_name) {
@@ -804,6 +890,58 @@ app.put('/api/v1/x-timeline/daily-sources/:sourceId', async (c) => {
 
   const userId = c.get('userId');
   const input = parsed.data;
+  const run = await c.env.ARCHIVE_DB.prepare(
+    'SELECT * FROM x_timeline_runs WHERE id = ? AND user_id = ?'
+  )
+    .bind(input.runId, userId)
+    .first<RunRow>();
+  if (!run) return c.json({ error: 'Run not found', code: 'NOT_FOUND' }, 404);
+  if (
+    run.source_id !== sourceId ||
+    run.source_type !== input.sourceType ||
+    (run.status !== 'COMPLETE' && run.status !== 'PARTIAL')
+  ) {
+    return c.json(
+      { error: 'Snapshot provenance does not match a finalized source run', code: 'RUN_CONFLICT' },
+      409
+    );
+  }
+
+  const existingSnapshot = await c.env.ARCHIVE_DB.prepare(
+    `SELECT id, name, is_selected, captured_at, status, failure_reason, resolved_count,
+       unresolved_usernames_json
+     FROM x_daily_source_snapshots WHERE user_id = ? AND run_id = ?`
+  )
+    .bind(userId, input.runId)
+    .first<{
+      id: string;
+      name: string;
+      is_selected: number;
+      captured_at: number;
+      status: 'COMPLETE' | 'PARTIAL';
+      failure_reason: string | null;
+      resolved_count: number;
+      unresolved_usernames_json: string;
+    }>();
+  if (existingSnapshot) {
+    return c.json({
+      source: {
+        id: sourceId,
+        snapshotId: existingSnapshot.id,
+        runId: input.runId,
+        type: input.sourceType,
+        name: existingSnapshot.name,
+        selected: Boolean(existingSnapshot.is_selected),
+        capturedAt: new Date(existingSnapshot.captured_at).toISOString(),
+        status: existingSnapshot.status,
+        failureReason: existingSnapshot.failure_reason,
+        authorCount: existingSnapshot.resolved_count,
+      },
+      unresolvedUsernames: JSON.parse(existingSnapshot.unresolved_usernames_json) as string[],
+      created: false,
+    });
+  }
+
   const usernames = [...new Set(input.usernames.map((value) => value.toLocaleLowerCase()))];
   const placeholders = usernames.map(() => '?').join(',');
   const authors = usernames.length
@@ -816,6 +954,42 @@ app.put('/api/v1/x-timeline/daily-sources/:sourceId', async (c) => {
     : { results: [] as Array<{ author_key: string; username: string }> };
   const resolved = new Set(authors.results.map((author) => author.username.toLocaleLowerCase()));
   const now = Date.now();
+  const unresolvedUsernames = usernames.filter((username) => !resolved.has(username));
+  const snapshotId = crypto.randomUUID();
+
+  await c.env.ARCHIVE_DB.prepare(
+    `INSERT INTO x_daily_source_snapshots
+      (id, run_id, user_id, source_id, source_type, name, is_selected, captured_at, status,
+       failure_reason, supplied_count, resolved_count, unresolved_usernames_json, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      snapshotId,
+      input.runId,
+      userId,
+      sourceId,
+      input.sourceType,
+      input.name,
+      input.selected ? 1 : 0,
+      Date.parse(input.capturedAt),
+      input.status,
+      input.failureReason ?? null,
+      usernames.length,
+      authors.results.length,
+      JSON.stringify(unresolvedUsernames),
+      now
+    )
+    .run();
+  if (authors.results.length > 0) {
+    await c.env.ARCHIVE_DB.batch(
+      authors.results.map((author) =>
+        c.env.ARCHIVE_DB.prepare(
+          `INSERT INTO x_daily_source_snapshot_members
+            (snapshot_id, user_id, author_key, created_at) VALUES (?, ?, ?, ?)`
+        ).bind(snapshotId, userId, author.author_key, now)
+      )
+    );
+  }
 
   await c.env.ARCHIVE_DB.prepare(
     `INSERT INTO x_daily_sources
@@ -857,13 +1031,18 @@ app.put('/api/v1/x-timeline/daily-sources/:sourceId', async (c) => {
   return c.json({
     source: {
       id: sourceId,
+      runId: input.runId,
       type: input.sourceType,
       name: input.name,
       selected: input.selected,
       capturedAt: input.capturedAt,
+      snapshotId,
+      status: input.status,
+      failureReason: input.failureReason ?? null,
       authorCount: authors.results.length,
     },
-    unresolvedUsernames: usernames.filter((username) => !resolved.has(username)),
+    unresolvedUsernames,
+    created: true,
   });
 });
 

--- a/apps/x-collector/README.md
+++ b/apps/x-collector/README.md
@@ -1,7 +1,7 @@
 # X Collector
 
-The browser collector reads visible organic posts from the authenticated X Following timeline and
-sends validated batches to the local receiver. Collector version `browser-dom-v3` also captures
+The browser collector reads visible organic posts from the authenticated X Following timeline or a configured X List and
+sends validated batches to the local receiver. Collector version `browser-dom-v4` also captures source provenance, immutable run-linked list membership, and bounded context-only thread posts with explicit completion/truncation status. It retains
 outbound links from tweet text and X link cards.
 
 For each destination, the extractor prefers an expanded URL exposed by the DOM, preserves the

--- a/apps/x-collector/README.md
+++ b/apps/x-collector/README.md
@@ -4,6 +4,8 @@ The browser collector reads visible organic posts from the authenticated X Follo
 sends validated batches to the local receiver. Collector version `browser-dom-v4` also captures source provenance, immutable run-linked list membership, and bounded context-only thread posts with explicit completion/truncation status. It retains
 outbound links from tweet text and X link cards.
 
+Following is collected to an explicit count target. Favorites/List collection instead uses a persisted rolling 24-hour cutoff and stops only after three older timeline entries prove the boundary. Its default 5000-post limit is a safety guard; reaching it before the boundary produces a partial run rather than a false complete result.
+
 For each destination, the extractor prefers an expanded URL exposed by the DOM, preserves the
 observed redirect URL, removes fragments and common tracking parameters for `normalizedUrl`, and
 deduplicates text/card appearances within the same post. Card title, description, domain, and image

--- a/apps/x-collector/src/browser-extractor.mjs
+++ b/apps/x-collector/src/browser-extractor.mjs
@@ -306,7 +306,9 @@ export function extractVisibleTimelineBatch(seenAdKeys = []) {
     const knownAdKeys = new Set(Array.isArray(seenAdKeys) ? seenAdKeys : []);
     const adKeys = [];
 
-    for (const article of document.querySelectorAll('article[data-testid="tweet"]')) {
+    const articles = [...document.querySelectorAll('article[data-testid="tweet"]')];
+    const threadMode = /\/status\/\d+/.test(globalThis.location?.pathname || '');
+    for (const [articleIndex, article] of articles.entries()) {
       if (isPromoted(article)) {
         const adKey =
           article.querySelector('a[href*="/status/"]')?.getAttribute('href') ||
@@ -332,6 +334,18 @@ export function extractVisibleTimelineBatch(seenAdKeys = []) {
       const relationships = [];
       if (quoted)
         relationships.push({ type: 'QUOTE_OF', tweetId: quoted.tweetId, url: quoted.url });
+      if (reply && threadMode && articleIndex > 0) {
+        const parentArticle = articles[articleIndex - 1];
+        const parentLink = parentArticle?.querySelector('a[href*="/status/"]:has(time)');
+        const parentIdentity = statusIdentity(parentLink?.getAttribute('href'));
+        if (parentIdentity && parentIdentity.tweetId !== identity.tweetId) {
+          relationships.push({
+            type: 'REPLY_TO',
+            tweetId: parentIdentity.tweetId,
+            url: parentIdentity.url,
+          });
+        }
+      }
       const post = {
         tweetId: identity.tweetId,
         url: identity.url,

--- a/apps/x-collector/src/browser-extractor.test.mjs
+++ b/apps/x-collector/src/browser-extractor.test.mjs
@@ -4,6 +4,7 @@ import { extractVisibleTimelineBatch } from './browser-extractor.mjs';
 
 afterEach(() => {
   delete globalThis.document;
+  delete globalThis.location;
 });
 
 describe('X browser extractor', () => {
@@ -94,5 +95,30 @@ describe('X browser extractor', () => {
     const repeated = extractVisibleTimelineBatch(result.adKeys);
     expect(repeated.excludedAds).toBe(0);
     expect(repeated.adKeys).toEqual([]);
+  });
+
+  it('captures reply ancestry when extracting a focused thread', () => {
+    const { document } = parseHTML(`
+      <article data-testid="tweet">
+        <div data-testid="User-Name"><span>Parent</span><span>@parent</span><a href="/parent"></a></div>
+        <a href="/parent/status/400"><time datetime="2026-07-11T12:00:00.000Z"></time></a>
+        <div data-testid="tweetText">Parent post</div>
+      </article>
+      <article data-testid="tweet">
+        <div data-testid="User-Name"><span>Reply</span><span>@reply</span><a href="/reply"></a></div>
+        <a href="/reply/status/401"><time datetime="2026-07-11T12:01:00.000Z"></time></a>
+        <div>Replying to @parent</div>
+        <div data-testid="tweetText">Reply post</div>
+      </article>
+    `);
+    globalThis.document = document;
+    globalThis.location = { pathname: '/reply/status/401' };
+
+    const result = extractVisibleTimelineBatch();
+    expect(result.posts[1]).toMatchObject({
+      tweetId: '401',
+      kind: 'REPLY',
+      relationships: [{ type: 'REPLY_TO', tweetId: '400' }],
+    });
   });
 });

--- a/apps/x-collector/src/browser-session.mjs
+++ b/apps/x-collector/src/browser-session.mjs
@@ -1,11 +1,44 @@
 export function createCollectionSession(checkpoint = {}) {
   const acceptedTweetIds = new Set(checkpoint.acceptedTweetIds || []);
+  const acceptedPostIds = new Set(checkpoint.acceptedPostIds || checkpoint.acceptedTweetIds || []);
   const acceptedAdKeys = new Set(checkpoint.acceptedAdKeys || []);
   const nextPosition = Number.isInteger(checkpoint.nextPosition)
     ? checkpoint.nextPosition
     : acceptedTweetIds.size;
+  const contextRecords = new Map(
+    (checkpoint.contextRecords || []).map((record) => [record.rootTweetId, record])
+  );
 
-  return { acceptedTweetIds, acceptedAdKeys, nextPosition };
+  return { acceptedTweetIds, acceptedPostIds, acceptedAdKeys, contextRecords, nextPosition };
+}
+
+export function reserveContextExpansion(state, rootTweetId, budget = 40) {
+  const existing = state.contextRecords.get(rootTweetId);
+  if (existing) return { allowed: false, duplicate: true, status: existing };
+  const attempted = [...state.contextRecords.values()].filter(
+    (record) => record.status !== 'SKIPPED'
+  ).length;
+  if (attempted >= budget) {
+    const status = {
+      rootTweetId,
+      status: 'TRUNCATED',
+      reason: 'context_budget_reached',
+    };
+    state.contextRecords.set(rootTweetId, status);
+    return { allowed: false, duplicate: false, status };
+  }
+  const status = { rootTweetId, status: 'PENDING', reason: null };
+  state.contextRecords.set(rootTweetId, status);
+  return { allowed: true, duplicate: false, status };
+}
+
+export function finishContextExpansion(state, rootTweetId, status, reason = null) {
+  if (!['COMPLETE', 'TRUNCATED', 'FAILED'].includes(status)) {
+    throw new Error(`Unsupported context status ${status}`);
+  }
+  const record = { rootTweetId, status, reason };
+  state.contextRecords.set(rootTweetId, record);
+  return record;
 }
 
 export function prepareTimelineBatch(rawBatch, state, requestedCount) {
@@ -33,9 +66,11 @@ export function prepareTimelineBatch(rawBatch, state, requestedCount) {
   }
 
   const hasStableAdKeys = Array.isArray(rawBatch.adKeys);
+  const posts = (rawBatch.posts || []).filter((post) => neededPostIds.has(post.tweetId));
+  for (const post of posts) state.acceptedPostIds.add(post.tweetId);
   return {
     payload: {
-      posts: (rawBatch.posts || []).filter((post) => neededPostIds.has(post.tweetId)),
+      posts,
       items,
       adKeys: newAdKeys,
       excludedAds: hasStableAdKeys ? newAdKeys.length : rawBatch.excludedAds || 0,
@@ -43,5 +78,18 @@ export function prepareTimelineBatch(rawBatch, state, requestedCount) {
     addedItems: items.length,
     totalAccepted: state.acceptedTweetIds.size,
     complete: state.acceptedTweetIds.size >= requestedCount,
+  };
+}
+
+export function prepareContextBatch(rawBatch, state) {
+  const posts = [];
+  for (const post of rawBatch.posts || []) {
+    if (state.acceptedPostIds.has(post.tweetId)) continue;
+    state.acceptedPostIds.add(post.tweetId);
+    posts.push(post);
+  }
+  return {
+    payload: { posts, items: [], adKeys: [], excludedAds: 0 },
+    addedPosts: posts.length,
   };
 }

--- a/apps/x-collector/src/browser-session.mjs
+++ b/apps/x-collector/src/browser-session.mjs
@@ -8,8 +8,20 @@ export function createCollectionSession(checkpoint = {}) {
   const contextRecords = new Map(
     (checkpoint.contextRecords || []).map((record) => [record.rootTweetId, record])
   );
+  const outsideWindowTweetIds = new Set(checkpoint.outsideWindowTweetIds || []);
+  const missingTimestampTweetIds = new Set(checkpoint.missingTimestampTweetIds || []);
+  const collectionPolicy = checkpoint.collectionPolicy || { mode: 'COUNT' };
 
-  return { acceptedTweetIds, acceptedPostIds, acceptedAdKeys, contextRecords, nextPosition };
+  return {
+    acceptedTweetIds,
+    acceptedPostIds,
+    acceptedAdKeys,
+    contextRecords,
+    outsideWindowTweetIds,
+    missingTimestampTweetIds,
+    collectionPolicy,
+    nextPosition,
+  };
 }
 
 export function reserveContextExpansion(state, rootTweetId, budget = 40) {
@@ -50,9 +62,30 @@ export function prepareTimelineBatch(rawBatch, state, requestedCount) {
     newAdKeys.push(adKey);
   }
 
+  const postsById = new Map((rawBatch.posts || []).map((post) => [post.tweetId, post]));
+  const newOutsideWindowTweetIds = [];
+  const newMissingTimestampTweetIds = [];
   const items = [];
   for (const item of rawBatch.items || []) {
-    if (items.length >= remaining || state.acceptedTweetIds.has(item.tweetId)) continue;
+    if (state.acceptedTweetIds.has(item.tweetId)) continue;
+    if (state.collectionPolicy.mode === 'ROLLING_WINDOW' && item.presentation !== 'REPOST') {
+      const publishedAt = Date.parse(postsById.get(item.tweetId)?.publishedAt || '');
+      if (!Number.isFinite(publishedAt)) {
+        if (!state.missingTimestampTweetIds.has(item.tweetId)) {
+          state.missingTimestampTweetIds.add(item.tweetId);
+          newMissingTimestampTweetIds.push(item.tweetId);
+        }
+        continue;
+      }
+      if (publishedAt < Date.parse(state.collectionPolicy.cutoffAt)) {
+        if (!state.outsideWindowTweetIds.has(item.tweetId)) {
+          state.outsideWindowTweetIds.add(item.tweetId);
+          newOutsideWindowTweetIds.push(item.tweetId);
+        }
+        continue;
+      }
+    }
+    if (items.length >= remaining) continue;
     state.acceptedTweetIds.add(item.tweetId);
     items.push({ ...item, position: state.nextPosition++ });
   }
@@ -74,10 +107,32 @@ export function prepareTimelineBatch(rawBatch, state, requestedCount) {
       items,
       adKeys: newAdKeys,
       excludedAds: hasStableAdKeys ? newAdKeys.length : rawBatch.excludedAds || 0,
+      windowEvidence: {
+        outsideWindowTweetIds: newOutsideWindowTweetIds,
+        missingTimestampTweetIds: newMissingTimestampTweetIds,
+      },
     },
     addedItems: items.length,
     totalAccepted: state.acceptedTweetIds.size,
-    complete: state.acceptedTweetIds.size >= requestedCount,
+    complete:
+      state.collectionPolicy.mode === 'ROLLING_WINDOW'
+        ? state.outsideWindowTweetIds.size >= state.collectionPolicy.boundaryEvidenceRequired
+        : state.acceptedTweetIds.size >= requestedCount,
+    safetyLimitReached:
+      state.collectionPolicy.mode === 'ROLLING_WINDOW' &&
+      state.acceptedTweetIds.size >= requestedCount &&
+      state.outsideWindowTweetIds.size < state.collectionPolicy.boundaryEvidenceRequired,
+    windowCoverage: {
+      outsideWindow: state.outsideWindowTweetIds.size,
+      missingPublishedAt: state.missingTimestampTweetIds.size,
+      boundaryEvidenceRequired:
+        state.collectionPolicy.mode === 'ROLLING_WINDOW'
+          ? state.collectionPolicy.boundaryEvidenceRequired
+          : 0,
+      boundaryReached:
+        state.collectionPolicy.mode === 'ROLLING_WINDOW' &&
+        state.outsideWindowTweetIds.size >= state.collectionPolicy.boundaryEvidenceRequired,
+    },
   };
 }
 
@@ -89,7 +144,13 @@ export function prepareContextBatch(rawBatch, state) {
     posts.push(post);
   }
   return {
-    payload: { posts, items: [], adKeys: [], excludedAds: 0 },
+    payload: {
+      posts,
+      items: [],
+      adKeys: [],
+      excludedAds: 0,
+      windowEvidence: { outsideWindowTweetIds: [], missingTimestampTweetIds: [] },
+    },
     addedPosts: posts.length,
   };
 }

--- a/apps/x-collector/src/browser-session.test.mjs
+++ b/apps/x-collector/src/browser-session.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { createCollectionSession, prepareTimelineBatch } from './browser-session.mjs';
+import {
+  createCollectionSession,
+  finishContextExpansion,
+  prepareContextBatch,
+  prepareTimelineBatch,
+  reserveContextExpansion,
+} from './browser-session.mjs';
 
 describe('X browser collection session', () => {
   it('resumes positions and filters accepted posts and ads from a receiver checkpoint', () => {
@@ -47,6 +53,49 @@ describe('X browser collection session', () => {
       addedItems: 0,
       totalAccepted: 2,
       payload: { items: [], posts: [], adKeys: [], excludedAds: 0 },
+    });
+  });
+
+  it('prepares canonical thread context without manufacturing timeline items', () => {
+    const state = createCollectionSession({
+      acceptedTweetIds: ['100'],
+      acceptedPostIds: ['100'],
+    });
+    const prepared = prepareContextBatch(
+      {
+        posts: [
+          { tweetId: '100', text: 'already captured' },
+          { tweetId: '200', text: 'thread parent' },
+        ],
+      },
+      state
+    );
+
+    expect(prepared).toMatchObject({
+      addedPosts: 1,
+      payload: { posts: [{ tweetId: '200' }], items: [] },
+    });
+  });
+
+  it('enforces and resumes a bounded context expansion budget', () => {
+    const state = createCollectionSession({
+      contextRecords: [{ rootTweetId: '100', status: 'COMPLETE', reason: null }],
+    });
+
+    expect(reserveContextExpansion(state, '100', 2)).toMatchObject({
+      allowed: false,
+      duplicate: true,
+    });
+    expect(reserveContextExpansion(state, '200', 2)).toMatchObject({ allowed: true });
+    expect(finishContextExpansion(state, '200', 'FAILED', 'thread_unavailable')).toEqual({
+      rootTweetId: '200',
+      status: 'FAILED',
+      reason: 'thread_unavailable',
+    });
+    expect(reserveContextExpansion(state, '300', 2)).toMatchObject({
+      allowed: false,
+      duplicate: false,
+      status: { status: 'TRUNCATED', reason: 'context_budget_reached' },
     });
   });
 });

--- a/apps/x-collector/src/browser-session.test.mjs
+++ b/apps/x-collector/src/browser-session.test.mjs
@@ -98,4 +98,84 @@ describe('X browser collection session', () => {
       status: { status: 'TRUNCATED', reason: 'context_budget_reached' },
     });
   });
+
+  it('collects Favorites inside the rolling window and completes only after boundary evidence', () => {
+    const state = createCollectionSession({
+      collectionPolicy: {
+        mode: 'ROLLING_WINDOW',
+        windowHours: 24,
+        cutoffAt: '2026-07-24T18:00:00.000Z',
+        boundaryEvidenceRequired: 3,
+      },
+    });
+    const result = prepareTimelineBatch(
+      {
+        posts: [
+          { tweetId: 'new', publishedAt: '2026-07-25T17:00:00.000Z', relationships: [] },
+          { tweetId: 'fresh-repost', publishedAt: '2025-01-01T00:00:00.000Z', relationships: [] },
+          { tweetId: 'old-1', publishedAt: '2026-07-24T17:00:00.000Z', relationships: [] },
+          { tweetId: 'old-2', publishedAt: '2026-07-24T16:00:00.000Z', relationships: [] },
+          { tweetId: 'old-3', publishedAt: '2026-07-24T15:00:00.000Z', relationships: [] },
+        ],
+        items: [
+          { tweetId: 'new' },
+          { tweetId: 'fresh-repost', presentation: 'REPOST' },
+          { tweetId: 'old-1' },
+          { tweetId: 'old-2' },
+          { tweetId: 'old-3' },
+        ],
+        adKeys: [],
+      },
+      state,
+      5_000
+    );
+
+    expect(result).toMatchObject({
+      addedItems: 2,
+      totalAccepted: 2,
+      complete: true,
+      safetyLimitReached: false,
+      windowCoverage: {
+        outsideWindow: 3,
+        missingPublishedAt: 0,
+        boundaryEvidenceRequired: 3,
+        boundaryReached: true,
+      },
+      payload: {
+        items: [
+          { tweetId: 'new', position: 0 },
+          { tweetId: 'fresh-repost', presentation: 'REPOST', position: 1 },
+        ],
+        windowEvidence: {
+          outsideWindowTweetIds: ['old-1', 'old-2', 'old-3'],
+          missingTimestampTweetIds: [],
+        },
+      },
+    });
+    expect(result.payload.posts.map((post) => post.tweetId)).toEqual(['new', 'fresh-repost']);
+  });
+
+  it('does not call a rolling-window run complete when the safety guard is reached', () => {
+    const state = createCollectionSession({
+      collectionPolicy: {
+        mode: 'ROLLING_WINDOW',
+        windowHours: 24,
+        cutoffAt: '2026-07-24T18:00:00.000Z',
+        boundaryEvidenceRequired: 3,
+      },
+    });
+    const result = prepareTimelineBatch(
+      {
+        posts: [
+          { tweetId: '1', publishedAt: '2026-07-25T17:00:00.000Z', relationships: [] },
+          { tweetId: '2', publishedAt: '2026-07-25T16:00:00.000Z', relationships: [] },
+        ],
+        items: [{ tweetId: '1' }, { tweetId: '2' }],
+      },
+      state,
+      2
+    );
+
+    expect(result).toMatchObject({ complete: false, safetyLimitReached: true });
+  });
 });

--- a/apps/x-collector/src/cli.ts
+++ b/apps/x-collector/src/cli.ts
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { XTimelineCaptureSchema } from '@zine/x-archive-schema';
 import { startReceiver } from './receiver';
-import { resolveCollectorSource } from './source-config';
+import { resolveCollectionConfig, resolveCollectorSource } from './source-config';
 import { uploadCapture } from './upload';
 
 type Args = { _: string[]; [key: string]: string | boolean | string[] };
@@ -37,8 +37,9 @@ function usage(): never {
   console.error(`Usage:
   bun run --cwd apps/x-collector validate [--file capture.json]
   bun run --cwd apps/x-collector upload [--file capture.json] [--api-url URL] [--token TOKEN]
-  bun run --cwd apps/x-collector receive --count 500 [--source-type FOLLOWING|FAVORITES|LIST]
+  bun run --cwd apps/x-collector receive [--count 500] [--source-type FOLLOWING|FAVORITES|LIST]
     [--source-id ID] [--source-name NAME] [--source-url URL]
+    [--window-hours 24] [--safety-limit 5000]
     [--port 4319] [--api-url URL] [--token TOKEN]
 
 Environment:
@@ -56,10 +57,6 @@ try {
     const token =
       (typeof args.token === 'string' ? args.token : undefined) ?? process.env.ZINE_X_ARCHIVE_TOKEN;
     if (!token) throw new Error('ZINE_X_ARCHIVE_TOKEN or --token is required');
-    const requestedCount = typeof args.count === 'string' ? Number.parseInt(args.count, 10) : 500;
-    if (!Number.isFinite(requestedCount) || requestedCount < 1 || requestedCount > 100_000) {
-      throw new Error('--count must be between 1 and 100000');
-    }
     const port = typeof args.port === 'string' ? Number.parseInt(args.port, 10) : 4319;
     const apiUrl =
       (typeof args['api-url'] === 'string' ? args['api-url'] : undefined) ??
@@ -71,20 +68,31 @@ try {
       name: typeof args['source-name'] === 'string' ? args['source-name'] : undefined,
       url: typeof args['source-url'] === 'string' ? args['source-url'] : undefined,
     });
+    const startedAt = new Date().toISOString();
+    const collection = resolveCollectionConfig({
+      source,
+      count: typeof args.count === 'string' ? args.count : undefined,
+      safetyLimit: typeof args['safety-limit'] === 'string' ? args['safety-limit'] : undefined,
+      windowHours: typeof args['window-hours'] === 'string' ? args['window-hours'] : undefined,
+      startedAt,
+    });
     const receiver = startReceiver({
-      requestedCount,
+      requestedCount: collection.requestedCount,
       apiUrl,
       token,
       port,
       collectorVersion: 'browser-dom-v4',
       source,
+      startedAt,
+      collectionPolicy: collection.collectionPolicy,
     });
     console.log(
       JSON.stringify({
         ready: true,
         receiverUrl: receiver.url,
         runId: receiver.runId,
-        requestedCount,
+        requestedCount: collection.requestedCount,
+        collectionPolicy: collection.collectionPolicy,
         source,
       })
     );

--- a/apps/x-collector/src/cli.ts
+++ b/apps/x-collector/src/cli.ts
@@ -3,6 +3,7 @@
 import { readFile } from 'node:fs/promises';
 import { XTimelineCaptureSchema } from '@zine/x-archive-schema';
 import { startReceiver } from './receiver';
+import { resolveCollectorSource } from './source-config';
 import { uploadCapture } from './upload';
 
 type Args = { _: string[]; [key: string]: string | boolean | string[] };
@@ -36,7 +37,9 @@ function usage(): never {
   console.error(`Usage:
   bun run --cwd apps/x-collector validate [--file capture.json]
   bun run --cwd apps/x-collector upload [--file capture.json] [--api-url URL] [--token TOKEN]
-  bun run --cwd apps/x-collector receive --count 500 [--port 4319] [--api-url URL] [--token TOKEN]
+  bun run --cwd apps/x-collector receive --count 500 [--source-type FOLLOWING|FAVORITES|LIST]
+    [--source-id ID] [--source-name NAME] [--source-url URL]
+    [--port 4319] [--api-url URL] [--token TOKEN]
 
 Environment:
   ZINE_X_ARCHIVE_API_URL   defaults to https://x-archive-api.myzine.app
@@ -62,13 +65,27 @@ try {
       (typeof args['api-url'] === 'string' ? args['api-url'] : undefined) ??
       process.env.ZINE_X_ARCHIVE_API_URL ??
       'https://x-archive-api.myzine.app';
-    const receiver = startReceiver({ requestedCount, apiUrl, token, port });
+    const source = resolveCollectorSource({
+      type: typeof args['source-type'] === 'string' ? args['source-type'] : undefined,
+      id: typeof args['source-id'] === 'string' ? args['source-id'] : undefined,
+      name: typeof args['source-name'] === 'string' ? args['source-name'] : undefined,
+      url: typeof args['source-url'] === 'string' ? args['source-url'] : undefined,
+    });
+    const receiver = startReceiver({
+      requestedCount,
+      apiUrl,
+      token,
+      port,
+      collectorVersion: 'browser-dom-v4',
+      source,
+    });
     console.log(
       JSON.stringify({
         ready: true,
         receiverUrl: receiver.url,
         runId: receiver.runId,
         requestedCount,
+        source,
       })
     );
     const result = await receiver.completed;

--- a/apps/x-collector/src/list-members-extractor.mjs
+++ b/apps/x-collector/src/list-members-extractor.mjs
@@ -1,0 +1,19 @@
+/* global document */
+
+/**
+ * Extract visible X List member usernames from mounted UserCell elements.
+ * Invoke through browser page evaluation; keep deduplication in the caller.
+ */
+export function extractVisibleListMembers() {
+  const usernames = [];
+  for (const cell of document.querySelectorAll('[data-testid="UserCell"]')) {
+    const links = [...cell.querySelectorAll('a[href^="/"]')];
+    const profileLink = links.find((link) => {
+      const href = link.getAttribute('href') || '';
+      return /^\/[A-Za-z0-9_]{1,64}$/.test(href);
+    });
+    const username = profileLink?.getAttribute('href')?.slice(1);
+    if (username) usernames.push(username);
+  }
+  return [...new Set(usernames.map((username) => username.toLocaleLowerCase()))];
+}

--- a/apps/x-collector/src/list-members-extractor.test.mjs
+++ b/apps/x-collector/src/list-members-extractor.test.mjs
@@ -1,0 +1,19 @@
+import { parseHTML } from 'linkedom';
+import { describe, expect, it } from 'vitest';
+
+import { extractVisibleListMembers } from './list-members-extractor.mjs';
+
+describe('list member extractor', () => {
+  it('extracts unique usernames only from mounted user cells', () => {
+    const { document, window } = parseHTML(`
+      <div data-testid="UserCell"><a href="/Alice">Alice</a></div>
+      <div data-testid="UserCell"><a href="/bob">Bob</a><a href="/bob/status/1">post</a></div>
+      <div data-testid="UserCell"><a href="/Alice">Alice again</a></div>
+      <article data-testid="tweet"><a href="/not-a-member">Ignore</a></article>
+    `);
+    globalThis.document = document;
+    globalThis.window = window;
+
+    expect(extractVisibleListMembers()).toEqual(['alice', 'bob']);
+  });
+});

--- a/apps/x-collector/src/receiver.test.ts
+++ b/apps/x-collector/src/receiver.test.ts
@@ -13,17 +13,24 @@ afterEach(() => {
 
 describe('local browser receiver', () => {
   it('accumulates browser batches and performs a verified upload', async () => {
+    let completionBody: Record<string, unknown> | null = null;
+    let membershipBody: Record<string, unknown> | null = null;
     apiServer = Bun.serve({
       hostname: '127.0.0.1',
       port: 0,
-      fetch(request) {
+      async fetch(request) {
         const url = new URL(request.url);
         if (url.pathname.endsWith('/runs') && request.method === 'POST') {
           return Response.json({ run: { id: 'receiver-run-001' } }, { status: 201 });
         }
         if (url.pathname.includes('/chunks/')) return Response.json({ accepted: true });
         if (url.pathname.endsWith('/complete')) {
+          completionBody = (await request.json()) as Record<string, unknown>;
           return Response.json({ run: { id: 'receiver-run-001', collectedCount: 2 } });
+        }
+        if (url.pathname.includes('/daily-sources/')) {
+          membershipBody = (await request.json()) as Record<string, unknown>;
+          return Response.json({ source: { snapshotId: 'snapshot-1' }, created: true });
         }
         return Response.json({ run: { id: 'receiver-run-001', collectedCount: 2 } });
       },
@@ -35,6 +42,12 @@ describe('local browser receiver', () => {
       port: 0,
       runId: 'receiver-run-001',
       startedAt: '2026-07-11T13:00:00.000Z',
+      source: {
+        type: 'FAVORITES',
+        id: 'x-list:123',
+        name: 'Favorites',
+        url: 'https://x.com/i/lists/123',
+      },
     });
 
     const batch = await fetch(`${receiver.url}/batch`, {
@@ -149,6 +162,34 @@ describe('local browser receiver', () => {
     });
     expect(await resumedBatch.json()).toMatchObject({ timelineItems: 2, excludedAds: 2 });
 
+    const sourceMembers = await fetch(`${receiver.url}/source-members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ usernames: ['example'], status: 'COMPLETE' }),
+    });
+    expect(await sourceMembers.json()).toMatchObject({
+      sourceMemberCount: 1,
+      sourceMembershipStatus: 'COMPLETE',
+      sourceMembershipFailureReason: null,
+    });
+
+    const contextStatus = await fetch(`${receiver.url}/context-status`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        rootTweetId: '100',
+        status: 'TRUNCATED',
+        reason: 'context_budget_reached',
+      }),
+    });
+    expect(await contextStatus.json()).toMatchObject({
+      contextCoverage: {
+        attempted: 1,
+        truncated: 1,
+        warnings: ['context_budget_reached'],
+      },
+    });
+
     const complete = await fetch(`${receiver.url}/complete`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -159,6 +200,22 @@ describe('local browser receiver', () => {
       runId: 'receiver-run-001',
       timelineItemsSubmitted: 2,
       verified: true,
+    });
+    expect(completionBody).toMatchObject({
+      contextCoverage: {
+        attempted: 1,
+        completed: 0,
+        truncated: 1,
+        failed: 0,
+        warnings: ['context_budget_reached'],
+      },
+    });
+    expect(membershipBody).toMatchObject({
+      runId: 'receiver-run-001',
+      sourceType: 'FAVORITES',
+      status: 'COMPLETE',
+      failureReason: null,
+      usernames: ['example'],
     });
   });
 });

--- a/apps/x-collector/src/receiver.test.ts
+++ b/apps/x-collector/src/receiver.test.ts
@@ -218,4 +218,93 @@ describe('local browser receiver', () => {
       usernames: ['example'],
     });
   });
+
+  it('requires persisted boundary evidence before completing a rolling-window run', async () => {
+    let completionBody: Record<string, unknown> | null = null;
+    apiServer = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname.endsWith('/runs') && request.method === 'POST') {
+          return Response.json({ run: { id: 'receiver-window-001' } }, { status: 201 });
+        }
+        if (url.pathname.endsWith('/complete')) {
+          completionBody = (await request.json()) as Record<string, unknown>;
+          return Response.json({ run: { id: 'receiver-window-001', collectedCount: 0 } });
+        }
+        if (url.pathname.includes('/daily-sources/')) {
+          return Response.json({ source: { snapshotId: 'snapshot-window' }, created: true });
+        }
+        return Response.json({ run: { id: 'receiver-window-001', collectedCount: 0 } });
+      },
+    });
+    receiver = startReceiver({
+      requestedCount: 5_000,
+      apiUrl: `http://${apiServer.hostname}:${apiServer.port}`,
+      token: 'zine_pat_receiver-test',
+      port: 0,
+      runId: 'receiver-window-001',
+      startedAt: '2026-07-25T18:00:00.000Z',
+      source: {
+        type: 'FAVORITES',
+        id: 'x-list:123',
+        name: 'Favorites',
+        url: 'https://x.com/i/lists/123',
+      },
+      collectionPolicy: {
+        mode: 'ROLLING_WINDOW',
+        windowHours: 24,
+        cutoffAt: '2026-07-24T18:00:00.000Z',
+        boundaryEvidenceRequired: 3,
+      },
+    });
+
+    const missingReason = await fetch(`${receiver.url}/complete`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'COMPLETE' }),
+    });
+    expect(missingReason.status).toBe(400);
+
+    await fetch(`${receiver.url}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        posts: [],
+        items: [],
+        windowEvidence: {
+          outsideWindowTweetIds: ['old-1', 'old-2', 'old-3'],
+          missingTimestampTweetIds: [],
+        },
+      }),
+    });
+    const checkpoint = await fetch(`${receiver.url}/checkpoint`).then((response) =>
+      response.json()
+    );
+    expect(checkpoint).toMatchObject({
+      collectionPolicy: { mode: 'ROLLING_WINDOW', windowHours: 24 },
+      outsideWindowTweetIds: ['old-1', 'old-2', 'old-3'],
+    });
+
+    const complete = await fetch(`${receiver.url}/complete`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        status: 'COMPLETE',
+        terminationReason: 'WINDOW_BOUNDARY_REACHED',
+      }),
+    });
+    expect(complete.status).toBe(200);
+    await expect(receiver.completed).resolves.toMatchObject({ verified: true });
+    expect(completionBody).toMatchObject({
+      terminationReason: 'WINDOW_BOUNDARY_REACHED',
+      windowCoverage: {
+        outsideWindow: 3,
+        missingPublishedAt: 0,
+        boundaryEvidenceRequired: 3,
+        boundaryReached: true,
+      },
+    });
+  });
 });

--- a/apps/x-collector/src/receiver.ts
+++ b/apps/x-collector/src/receiver.ts
@@ -6,7 +6,7 @@ import {
   type XTimelineItem,
 } from '@zine/x-archive-schema';
 import { z } from 'zod';
-import { uploadCapture, type UploadResult } from './upload';
+import { uploadCapture, uploadDailySourceSnapshot, type UploadResult } from './upload';
 
 const BatchSchema = z
   .object({
@@ -24,6 +24,22 @@ const CompleteSchema = z
   })
   .strict();
 
+const SourceMembersSchema = z
+  .object({
+    usernames: z.array(z.string().trim().min(1).max(64)).max(500),
+    status: z.enum(['CAPTURING', 'COMPLETE', 'PARTIAL']).optional(),
+    failureReason: z.string().trim().min(1).max(500).nullable().optional(),
+  })
+  .strict();
+
+const ContextStatusSchema = z
+  .object({
+    rootTweetId: z.string().min(1).max(64),
+    status: z.enum(['COMPLETE', 'TRUNCATED', 'FAILED']),
+    reason: z.string().trim().min(1).max(500).nullable().optional(),
+  })
+  .strict();
+
 export type ReceiverOptions = {
   requestedCount: number;
   apiUrl: string;
@@ -32,6 +48,13 @@ export type ReceiverOptions = {
   collectorVersion?: string;
   runId?: string;
   startedAt?: string;
+  contextBudget?: number;
+  source?: {
+    type: 'FOLLOWING' | 'FAVORITES' | 'LIST';
+    id: string;
+    name: string;
+    url?: string | null;
+  };
 };
 
 export type ReceiverHandle = {
@@ -49,12 +72,53 @@ function corsHeaders() {
   };
 }
 
+function summarizeContextCoverage(
+  budget: number,
+  records: Map<string, { status: 'COMPLETE' | 'TRUNCATED' | 'FAILED'; reason: string | null }>
+) {
+  const values = [...records.values()];
+  return {
+    budget,
+    attempted: values.length,
+    completed: values.filter((record) => record.status === 'COMPLETE').length,
+    truncated: values.filter((record) => record.status === 'TRUNCATED').length,
+    failed: values.filter((record) => record.status === 'FAILED').length,
+    warnings: [
+      ...new Set(
+        values
+          .filter((record) => record.status !== 'COMPLETE')
+          .map(
+            (record) =>
+              record.reason ??
+              (record.status === 'TRUNCATED'
+                ? 'context_expansion_truncated'
+                : 'context_expansion_failed')
+          )
+      ),
+    ],
+  };
+}
+
 export function startReceiver(options: ReceiverOptions): ReceiverHandle {
   const runId = options.runId ?? crypto.randomUUID();
   const startedAt = options.startedAt ?? new Date().toISOString();
   const posts = new Map<string, XPost>();
   const items = new Map<string, XTimelineItem>();
   const acceptedAdKeys = new Set<string>();
+  const sourceMembers = new Set<string>();
+  let sourceMembershipStatus: 'COMPLETE' | 'PARTIAL' =
+    options.source?.type === 'FAVORITES' || options.source?.type === 'LIST'
+      ? 'PARTIAL'
+      : 'COMPLETE';
+  let sourceMembershipFailureReason: string | null =
+    sourceMembershipStatus === 'PARTIAL' ? 'membership_not_finalized' : null;
+  const contextRecords = new Map<
+    string,
+    { status: 'COMPLETE' | 'TRUNCATED' | 'FAILED'; reason: string | null }
+  >();
+  const contextBudget =
+    options.contextBudget ??
+    (options.source?.type === 'FAVORITES' || options.source?.type === 'LIST' ? 40 : 0);
   let legacyExcludedAds = 0;
   let resolveCompleted!: (result: UploadResult) => void;
   let rejectCompleted!: (error: unknown) => void;
@@ -77,9 +141,14 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             startedAt,
             requestedCount: options.requestedCount,
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
+            source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
             posts: posts.size,
             items: items.size,
             excludedAds,
+            sourceMemberCount: sourceMembers.size,
+            sourceMembershipStatus,
+            sourceMembershipFailureReason,
+            contextCoverage: summarizeContextCoverage(contextBudget, contextRecords),
             nextPosition:
               items.size === 0
                 ? 0
@@ -98,7 +167,9 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             startedAt,
             requestedCount: options.requestedCount,
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
+            source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
             acceptedTweetIds: orderedItems.map((item) => item.tweetId),
+            acceptedPostIds: [...posts.keys()],
             acceptedAdKeys: [...acceptedAdKeys],
             nextPosition:
               orderedItems.length === 0
@@ -106,6 +177,13 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
                 : Math.max(...orderedItems.map((item) => item.position)) + 1,
             canonicalPosts: posts.size,
             excludedAds,
+            sourceMembers: [...sourceMembers],
+            sourceMembershipStatus,
+            sourceMembershipFailureReason,
+            contextRecords: [...contextRecords].map(([rootTweetId, record]) => ({
+              rootTweetId,
+              ...record,
+            })),
           },
           { headers: corsHeaders() }
         );
@@ -138,6 +216,54 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
           { headers: corsHeaders() }
         );
       }
+      if (request.method === 'POST' && url.pathname === '/source-members') {
+        const parsed = SourceMembersSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+          return Response.json(
+            { error: 'Invalid source member batch', issues: parsed.error.issues },
+            { status: 400, headers: corsHeaders() }
+          );
+        }
+        for (const username of parsed.data.usernames) {
+          sourceMembers.add(username.toLocaleLowerCase());
+        }
+        if (parsed.data.status === 'COMPLETE') {
+          sourceMembershipStatus = 'COMPLETE';
+          sourceMembershipFailureReason = null;
+        } else if (parsed.data.status === 'PARTIAL') {
+          sourceMembershipStatus = 'PARTIAL';
+          sourceMembershipFailureReason = parsed.data.failureReason ?? 'membership_capture_partial';
+        }
+        return Response.json(
+          {
+            accepted: true,
+            sourceMemberCount: sourceMembers.size,
+            sourceMembershipStatus,
+            sourceMembershipFailureReason,
+          },
+          { headers: corsHeaders() }
+        );
+      }
+      if (request.method === 'POST' && url.pathname === '/context-status') {
+        const parsed = ContextStatusSchema.safeParse(await request.json().catch(() => null));
+        if (!parsed.success) {
+          return Response.json(
+            { error: 'Invalid context status', issues: parsed.error.issues },
+            { status: 400, headers: corsHeaders() }
+          );
+        }
+        contextRecords.set(parsed.data.rootTweetId, {
+          status: parsed.data.status,
+          reason: parsed.data.reason ?? null,
+        });
+        return Response.json(
+          {
+            accepted: true,
+            contextCoverage: summarizeContextCoverage(contextBudget, contextRecords),
+          },
+          { headers: corsHeaders() }
+        );
+      }
       if (request.method === 'POST' && url.pathname === '/complete') {
         const parsed = CompleteSchema.safeParse(await request.json().catch(() => null));
         if (!parsed.success) {
@@ -153,9 +279,11 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             startedAt,
             completedAt: new Date().toISOString(),
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
+            source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
             excludedAds: legacyExcludedAds + acceptedAdKeys.size,
             status: parsed.data.status,
             failureReason: parsed.data.failureReason ?? null,
+            contextCoverage: summarizeContextCoverage(contextBudget, contextRecords),
             posts: [...posts.values()],
             items: [...items.values()].sort((left, right) => left.position - right.position),
           });
@@ -164,6 +292,22 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             token: options.token,
             verify: true,
           });
+          if (options.source?.type === 'FAVORITES' || options.source?.type === 'LIST') {
+            await uploadDailySourceSnapshot(
+              {
+                runId,
+                sourceId: options.source.id,
+                sourceType: options.source.type,
+                name: options.source.name,
+                selected: true,
+                capturedAt: new Date().toISOString(),
+                status: sourceMembershipStatus,
+                failureReason: sourceMembershipFailureReason,
+                usernames: [...sourceMembers],
+              },
+              { apiUrl: options.apiUrl, token: options.token }
+            );
+          }
           resolveCompleted(result);
           setTimeout(() => server.stop(), 100);
           return Response.json({ success: true, ...result }, { headers: corsHeaders() });

--- a/apps/x-collector/src/receiver.ts
+++ b/apps/x-collector/src/receiver.ts
@@ -2,6 +2,8 @@ import {
   XPostSchema,
   XTimelineCaptureSchema,
   XTimelineItemSchema,
+  type XCollectionPolicy,
+  type XCollectionTerminationReason,
   type XPost,
   type XTimelineItem,
 } from '@zine/x-archive-schema';
@@ -14,6 +16,13 @@ const BatchSchema = z
     items: z.array(XTimelineItemSchema).max(100),
     adKeys: z.array(z.string().min(1).max(1_000)).max(200).default([]),
     excludedAds: z.number().int().nonnegative().default(0),
+    windowEvidence: z
+      .object({
+        outsideWindowTweetIds: z.array(z.string().min(1).max(64)).max(200).default([]),
+        missingTimestampTweetIds: z.array(z.string().min(1).max(64)).max(200).default([]),
+      })
+      .strict()
+      .default({}),
   })
   .strict();
 
@@ -21,6 +30,15 @@ const CompleteSchema = z
   .object({
     status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
     failureReason: z.string().max(2_000).nullable().optional(),
+    terminationReason: z
+      .enum([
+        'COUNT_REACHED',
+        'WINDOW_BOUNDARY_REACHED',
+        'SAFETY_LIMIT_REACHED',
+        'TIMELINE_STALLED',
+        'COLLECTOR_FAILED',
+      ])
+      .optional(),
   })
   .strict();
 
@@ -49,6 +67,7 @@ export type ReceiverOptions = {
   runId?: string;
   startedAt?: string;
   contextBudget?: number;
+  collectionPolicy?: XCollectionPolicy;
   source?: {
     type: 'FOLLOWING' | 'FAVORITES' | 'LIST';
     id: string;
@@ -99,6 +118,22 @@ function summarizeContextCoverage(
   };
 }
 
+function summarizeWindowCoverage(
+  policy: XCollectionPolicy,
+  outsideWindowTweetIds: Set<string>,
+  missingTimestampTweetIds: Set<string>
+) {
+  const boundaryEvidenceRequired =
+    policy.mode === 'ROLLING_WINDOW' ? policy.boundaryEvidenceRequired : 0;
+  return {
+    outsideWindow: outsideWindowTweetIds.size,
+    missingPublishedAt: missingTimestampTweetIds.size,
+    boundaryEvidenceRequired,
+    boundaryReached:
+      policy.mode === 'ROLLING_WINDOW' && outsideWindowTweetIds.size >= boundaryEvidenceRequired,
+  };
+}
+
 export function startReceiver(options: ReceiverOptions): ReceiverHandle {
   const runId = options.runId ?? crypto.randomUUID();
   const startedAt = options.startedAt ?? new Date().toISOString();
@@ -116,9 +151,12 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
     string,
     { status: 'COMPLETE' | 'TRUNCATED' | 'FAILED'; reason: string | null }
   >();
+  const outsideWindowTweetIds = new Set<string>();
+  const missingTimestampTweetIds = new Set<string>();
   const contextBudget =
     options.contextBudget ??
     (options.source?.type === 'FAVORITES' || options.source?.type === 'LIST' ? 40 : 0);
+  const collectionPolicy = options.collectionPolicy ?? { mode: 'COUNT' as const };
   let legacyExcludedAds = 0;
   let resolveCompleted!: (result: UploadResult) => void;
   let rejectCompleted!: (error: unknown) => void;
@@ -142,6 +180,7 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             requestedCount: options.requestedCount,
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
             source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
+            collectionPolicy,
             posts: posts.size,
             items: items.size,
             excludedAds,
@@ -149,6 +188,11 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             sourceMembershipStatus,
             sourceMembershipFailureReason,
             contextCoverage: summarizeContextCoverage(contextBudget, contextRecords),
+            windowCoverage: summarizeWindowCoverage(
+              collectionPolicy,
+              outsideWindowTweetIds,
+              missingTimestampTweetIds
+            ),
             nextPosition:
               items.size === 0
                 ? 0
@@ -168,6 +212,7 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             requestedCount: options.requestedCount,
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
             source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
+            collectionPolicy,
             acceptedTweetIds: orderedItems.map((item) => item.tweetId),
             acceptedPostIds: [...posts.keys()],
             acceptedAdKeys: [...acceptedAdKeys],
@@ -184,6 +229,8 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
               rootTweetId,
               ...record,
             })),
+            outsideWindowTweetIds: [...outsideWindowTweetIds],
+            missingTimestampTweetIds: [...missingTimestampTweetIds],
           },
           { headers: corsHeaders() }
         );
@@ -205,6 +252,12 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
         } else {
           legacyExcludedAds += parsed.data.excludedAds;
         }
+        for (const tweetId of parsed.data.windowEvidence.outsideWindowTweetIds) {
+          outsideWindowTweetIds.add(tweetId);
+        }
+        for (const tweetId of parsed.data.windowEvidence.missingTimestampTweetIds) {
+          missingTimestampTweetIds.add(tweetId);
+        }
         const updatedExcludedAds = legacyExcludedAds + acceptedAdKeys.size;
         return Response.json(
           {
@@ -212,6 +265,11 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             canonicalPosts: posts.size,
             timelineItems: items.size,
             excludedAds: updatedExcludedAds,
+            windowCoverage: summarizeWindowCoverage(
+              collectionPolicy,
+              outsideWindowTweetIds,
+              missingTimestampTweetIds
+            ),
           },
           { headers: corsHeaders() }
         );
@@ -273,6 +331,25 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
           );
         }
         try {
+          const terminationReason: XCollectionTerminationReason | null =
+            parsed.data.terminationReason ??
+            (collectionPolicy.mode === 'COUNT' && parsed.data.status === 'COMPLETE'
+              ? ('COUNT_REACHED' as const)
+              : null);
+          if (!terminationReason) {
+            return Response.json(
+              {
+                success: false,
+                error: 'terminationReason is required for rolling-window and partial runs',
+              },
+              { status: 400, headers: corsHeaders() }
+            );
+          }
+          const windowCoverage = summarizeWindowCoverage(
+            collectionPolicy,
+            outsideWindowTweetIds,
+            missingTimestampTweetIds
+          );
           const capture = XTimelineCaptureSchema.parse({
             runId,
             requestedCount: options.requestedCount,
@@ -280,10 +357,13 @@ export function startReceiver(options: ReceiverOptions): ReceiverHandle {
             completedAt: new Date().toISOString(),
             collectorVersion: options.collectorVersion ?? 'browser-dom-v3',
             source: options.source ?? { type: 'FOLLOWING', id: 'following', name: 'Following' },
+            collectionPolicy,
+            terminationReason,
             excludedAds: legacyExcludedAds + acceptedAdKeys.size,
             status: parsed.data.status,
             failureReason: parsed.data.failureReason ?? null,
             contextCoverage: summarizeContextCoverage(contextBudget, contextRecords),
+            windowCoverage,
             posts: [...posts.values()],
             items: [...items.values()].sort((left, right) => left.position - right.position),
           });

--- a/apps/x-collector/src/source-config.test.ts
+++ b/apps/x-collector/src/source-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { resolveCollectorSource } from './source-config';
+import { resolveCollectionConfig, resolveCollectorSource } from './source-config';
 
 describe('collector source configuration', () => {
   it('uses an explicit Following source by default', () => {
@@ -40,5 +40,47 @@ describe('collector source configuration', () => {
     expect(() =>
       resolveCollectorSource({ type: 'FAVORITES', url: 'https://example.com/i/lists/123' })
     ).toThrow('x.com/i/lists');
+  });
+
+  it('uses a count target for Following and a rolling 24-hour window for Favorites', () => {
+    const startedAt = '2026-07-25T18:00:00.000Z';
+    expect(
+      resolveCollectionConfig({
+        source: resolveCollectorSource({}),
+        count: '500',
+        startedAt,
+      })
+    ).toEqual({ requestedCount: 500, collectionPolicy: { mode: 'COUNT' } });
+
+    expect(
+      resolveCollectionConfig({
+        source: resolveCollectorSource({
+          type: 'FAVORITES',
+          url: 'https://x.com/i/lists/123',
+        }),
+        startedAt,
+      })
+    ).toEqual({
+      requestedCount: 5_000,
+      collectionPolicy: {
+        mode: 'ROLLING_WINDOW',
+        windowHours: 24,
+        cutoffAt: '2026-07-24T18:00:00.000Z',
+        boundaryEvidenceRequired: 3,
+      },
+    });
+  });
+
+  it('rejects a count-limited Favorites collection', () => {
+    expect(() =>
+      resolveCollectionConfig({
+        source: resolveCollectorSource({
+          type: 'FAVORITES',
+          url: 'https://x.com/i/lists/123',
+        }),
+        count: '500',
+        startedAt: '2026-07-25T18:00:00.000Z',
+      })
+    ).toThrow('uses --window-hours and --safety-limit');
   });
 });

--- a/apps/x-collector/src/source-config.test.ts
+++ b/apps/x-collector/src/source-config.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { resolveCollectorSource } from './source-config';
+
+describe('collector source configuration', () => {
+  it('uses an explicit Following source by default', () => {
+    expect(resolveCollectorSource({})).toEqual({
+      type: 'FOLLOWING',
+      id: 'following',
+      name: 'Following',
+      url: 'https://x.com/home',
+    });
+  });
+
+  it('derives and validates a stable X list id from the source URL', () => {
+    expect(
+      resolveCollectorSource({
+        type: 'favorites',
+        name: 'Favorites',
+        url: 'https://x.com/i/lists/123/',
+      })
+    ).toEqual({
+      type: 'FAVORITES',
+      id: 'x-list:123',
+      name: 'Favorites',
+      url: 'https://x.com/i/lists/123',
+    });
+    expect(() =>
+      resolveCollectorSource({
+        type: 'FAVORITES',
+        id: 'x-list:456',
+        url: 'https://x.com/i/lists/123',
+      })
+    ).toThrow('must match the list URL');
+  });
+
+  it('rejects non-list and non-X URLs for list collection', () => {
+    expect(() => resolveCollectorSource({ type: 'FAVORITES', url: 'https://x.com/home' })).toThrow(
+      'x.com/i/lists'
+    );
+    expect(() =>
+      resolveCollectorSource({ type: 'FAVORITES', url: 'https://example.com/i/lists/123' })
+    ).toThrow('x.com/i/lists');
+  });
+});

--- a/apps/x-collector/src/source-config.ts
+++ b/apps/x-collector/src/source-config.ts
@@ -5,6 +5,63 @@ export type CollectorSource = {
   url: string;
 };
 
+export type CollectorCollectionConfig = {
+  requestedCount: number;
+  collectionPolicy:
+    | { mode: 'COUNT' }
+    | {
+        mode: 'ROLLING_WINDOW';
+        windowHours: number;
+        cutoffAt: string;
+        boundaryEvidenceRequired: number;
+      };
+};
+
+function positiveInteger(value: string | undefined, fallback: number, label: string): number {
+  const parsed = value === undefined ? fallback : Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 100_000) {
+    throw new Error(`${label} must be between 1 and 100000`);
+  }
+  return parsed;
+}
+
+export function resolveCollectionConfig(input: {
+  source: CollectorSource;
+  count?: string;
+  safetyLimit?: string;
+  windowHours?: string;
+  startedAt: string;
+}): CollectorCollectionConfig {
+  if (input.source.type === 'FOLLOWING') {
+    if (input.safetyLimit !== undefined || input.windowHours !== undefined) {
+      throw new Error('Following collection uses --count, not rolling-window options');
+    }
+    return {
+      requestedCount: positiveInteger(input.count, 500, '--count'),
+      collectionPolicy: { mode: 'COUNT' },
+    };
+  }
+
+  if (input.count !== undefined) {
+    throw new Error(
+      'Favorites/List collection uses --window-hours and --safety-limit, not --count'
+    );
+  }
+  const windowHours = positiveInteger(input.windowHours, 24, '--window-hours');
+  if (windowHours > 168) throw new Error('--window-hours must be between 1 and 168');
+  const startedAt = Date.parse(input.startedAt);
+  if (!Number.isFinite(startedAt)) throw new Error('startedAt must be an ISO timestamp');
+  return {
+    requestedCount: positiveInteger(input.safetyLimit, 5_000, '--safety-limit'),
+    collectionPolicy: {
+      mode: 'ROLLING_WINDOW',
+      windowHours,
+      cutoffAt: new Date(startedAt - windowHours * 60 * 60 * 1_000).toISOString(),
+      boundaryEvidenceRequired: 3,
+    },
+  };
+}
+
 export function resolveCollectorSource(input: {
   type?: string;
   id?: string;

--- a/apps/x-collector/src/source-config.ts
+++ b/apps/x-collector/src/source-config.ts
@@ -1,0 +1,58 @@
+export type CollectorSource = {
+  type: 'FOLLOWING' | 'FAVORITES' | 'LIST';
+  id: string;
+  name: string;
+  url: string;
+};
+
+export function resolveCollectorSource(input: {
+  type?: string;
+  id?: string;
+  name?: string;
+  url?: string;
+}): CollectorSource {
+  const type = (input.type ?? 'FOLLOWING').toUpperCase();
+  if (type !== 'FOLLOWING' && type !== 'FAVORITES' && type !== 'LIST') {
+    throw new Error('--source-type must be FOLLOWING, FAVORITES, or LIST');
+  }
+
+  if (type === 'FOLLOWING') {
+    if (input.id && input.id !== 'following') {
+      throw new Error('Following source id must be following');
+    }
+    if (input.url) {
+      const sourceURL = new URL(input.url);
+      if (
+        sourceURL.protocol !== 'https:' ||
+        !['x.com', 'www.x.com'].includes(sourceURL.hostname) ||
+        sourceURL.pathname !== '/home'
+      ) {
+        throw new Error('Following source URL must be https://x.com/home');
+      }
+    }
+    return {
+      type,
+      id: 'following',
+      name: input.name ?? 'Following',
+      url: 'https://x.com/home',
+    };
+  }
+
+  if (!input.url) throw new Error('--source-url is required for list sources');
+  const sourceURL = new URL(input.url);
+  if (sourceURL.protocol !== 'https:' || !['x.com', 'www.x.com'].includes(sourceURL.hostname)) {
+    throw new Error('--source-url must be an https://x.com/i/lists/<id> URL');
+  }
+  const match = sourceURL.pathname.match(/^\/i\/lists\/(\d+)\/?$/);
+  if (!match) throw new Error('--source-url must be an https://x.com/i/lists/<id> URL');
+  const id = `x-list:${match[1]}`;
+  if (input.id && input.id !== id) {
+    throw new Error(`--source-id must match the list URL (${id})`);
+  }
+  return {
+    type,
+    id,
+    name: input.name ?? (type === 'FAVORITES' ? 'Favorites' : `List ${match[1]}`),
+    url: `https://x.com/i/lists/${match[1]}`,
+  };
+}

--- a/apps/x-collector/src/upload.test.ts
+++ b/apps/x-collector/src/upload.test.ts
@@ -30,6 +30,8 @@ function capture(count = 26) {
     completedAt: '2026-07-11T13:05:00.000Z',
     collectorVersion: 'test-v1',
     source: { type: 'FOLLOWING' as const, id: 'following', name: 'Following' },
+    collectionPolicy: { mode: 'COUNT' as const },
+    terminationReason: 'COUNT_REACHED' as const,
     excludedAds: 0,
     status: 'COMPLETE' as const,
     contextCoverage: {
@@ -39,6 +41,12 @@ function capture(count = 26) {
       truncated: 0,
       failed: 0,
       warnings: [],
+    },
+    windowCoverage: {
+      outsideWindow: 0,
+      missingPublishedAt: 0,
+      boundaryEvidenceRequired: 0,
+      boundaryReached: false,
     },
     posts,
     items: posts.map((post, position) => ({

--- a/apps/x-collector/src/upload.test.ts
+++ b/apps/x-collector/src/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildUploadChunks, uploadCapture } from './upload';
+import { buildUploadChunks, uploadCapture, uploadDailySourceSnapshot } from './upload';
 
 function capture(count = 26) {
   const posts = Array.from({ length: count }, (_, index) => ({
@@ -29,8 +29,17 @@ function capture(count = 26) {
     startedAt: '2026-07-11T13:00:00.000Z',
     completedAt: '2026-07-11T13:05:00.000Z',
     collectorVersion: 'test-v1',
+    source: { type: 'FOLLOWING' as const, id: 'following', name: 'Following' },
     excludedAds: 0,
     status: 'COMPLETE' as const,
+    contextCoverage: {
+      budget: 0,
+      attempted: 0,
+      completed: 0,
+      truncated: 0,
+      failed: 0,
+      warnings: [],
+    },
     posts,
     items: posts.map((post, position) => ({
       tweetId: post.tweetId,
@@ -81,5 +90,33 @@ describe('X collector uploader', () => {
       'POST',
       'GET',
     ]);
+  });
+
+  it('links an immutable membership snapshot to its Favorites run', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body));
+      return Response.json({ source: { snapshotId: 'snapshot-1' }, created: true });
+    }) as unknown as typeof fetch;
+
+    await uploadDailySourceSnapshot(
+      {
+        runId: 'favorites-run',
+        sourceId: 'x-list:123',
+        sourceType: 'FAVORITES',
+        name: 'Favorites',
+        selected: true,
+        capturedAt: '2026-07-25T10:15:00.000Z',
+        status: 'COMPLETE',
+        usernames: ['alice', 'bob'],
+      },
+      { apiUrl: 'https://archive.example.com', token: 'zine_pat_test', fetchImpl }
+    );
+
+    expect(requestBody).toMatchObject({
+      runId: 'favorites-run',
+      sourceType: 'FAVORITES',
+      usernames: ['alice', 'bob'],
+    });
   });
 });

--- a/apps/x-collector/src/upload.ts
+++ b/apps/x-collector/src/upload.ts
@@ -23,6 +23,18 @@ export type UploadResult = {
   run: unknown;
 };
 
+export type DailySourceSnapshotInput = {
+  runId: string;
+  sourceId: string;
+  sourceType: 'FAVORITES' | 'LIST';
+  name: string;
+  selected: boolean;
+  capturedAt: string;
+  status: 'COMPLETE' | 'PARTIAL';
+  failureReason?: string | null;
+  usernames: string[];
+};
+
 type Chunk = { posts: XPost[]; items: XTimelineItem[] };
 
 export function buildUploadChunks(capture: XTimelineCapture, requestedChunkSize = 25): Chunk[] {
@@ -100,6 +112,7 @@ export async function uploadCapture(
         requestedCount: capture.requestedCount,
         startedAt: capture.startedAt,
         collectorVersion: capture.collectorVersion,
+        source: capture.source,
       }),
     },
     fetchImpl
@@ -133,6 +146,7 @@ export async function uploadCapture(
         excludedAds: capture.excludedAds,
         status: capture.status,
         failureReason: capture.failureReason ?? null,
+        contextCoverage: capture.contextCoverage,
       }),
     },
     fetchImpl
@@ -165,4 +179,32 @@ export async function uploadCapture(
     verified,
     run: completed.run ?? create.run,
   };
+}
+
+export async function uploadDailySourceSnapshot(
+  input: DailySourceSnapshotInput,
+  options: Pick<UploadOptions, 'apiUrl' | 'token' | 'fetchImpl'>
+): Promise<unknown> {
+  const apiUrl = options.apiUrl.replace(/\/$/, '');
+  return requestJson(
+    `${apiUrl}/api/v1/x-timeline/daily-sources/${encodeURIComponent(input.sourceId)}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${options.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        runId: input.runId,
+        sourceType: input.sourceType,
+        name: input.name,
+        selected: input.selected,
+        capturedAt: input.capturedAt,
+        status: input.status,
+        failureReason: input.failureReason ?? null,
+        usernames: input.usernames,
+      }),
+    },
+    options.fetchImpl ?? fetch
+  );
 }

--- a/apps/x-collector/src/upload.ts
+++ b/apps/x-collector/src/upload.ts
@@ -113,6 +113,7 @@ export async function uploadCapture(
         startedAt: capture.startedAt,
         collectorVersion: capture.collectorVersion,
         source: capture.source,
+        collectionPolicy: capture.collectionPolicy,
       }),
     },
     fetchImpl
@@ -147,6 +148,8 @@ export async function uploadCapture(
         status: capture.status,
         failureReason: capture.failureReason ?? null,
         contextCoverage: capture.contextCoverage,
+        windowCoverage: capture.windowCoverage,
+        terminationReason: capture.terminationReason,
       }),
     },
     fetchImpl

--- a/docs/x-timeline-archive.md
+++ b/docs/x-timeline-archive.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The X archive captures a configurable number of organic entries from the authenticated X Following timeline. It retains posts, replies, repost presentations, quotes, ordering, authors, relationships, metrics, and media links. It excludes ads and does not download media.
+The X archive captures source-aware organic entries from the authenticated X Following timeline and configured X Lists. It retains posts, replies, repost presentations, quotes, ordering, authors, relationships, metrics, and media links. It excludes ads and does not download media.
 
 Collection is intentionally separate from Zine Inbox, bookmarks, enrichment, and analysis.
 
@@ -18,6 +18,8 @@ Collection is intentionally separate from Zine Inbox, bookmarks, enrichment, and
 ## Identity and deduplication
 
 Canonical post identity is `(Zine user ID, X tweet ID)`. Repeated collection updates `last_seen_at` and the single canonical payload; it does not create another post. Each run stores lightweight ordered pointers to canonical posts.
+
+Permalink-expanded thread posts are associated with the frozen run in a separate immutable context table. They never receive a primary timeline position or count toward the requested source total. Each run also stores bounded context coverage, including attempted, completed, truncated, and failed expansion counts.
 
 Reposts are modeled as run-item presentation metadata pointing to the original canonical tweet. Quote, reply, and repost relationships point to target tweet IDs instead of embedding duplicate post records.
 
@@ -53,6 +55,8 @@ bun run --cwd apps/x-collector validate --file capture.json
 bun run --cwd apps/x-collector upload --file capture.json
 ```
 
+Favorites-first Daily View collection uses two immutable runs: a `FAVORITES` run for the configured list and a separate `FOLLOWING` run for secondary context. The Favorites receiver also accepts list-member batches at `/source-members` and per-thread coverage records at `/context-status`; completion stores an immutable roster snapshot linked directly to its run. Roster status is finalized independently, so a complete timeline cannot hide a partial member capture. Run metadata records the exact source type, stable list ID, name, URL, and context coverage. Never substitute For You for either source.
+
 ## API
 
 All `/api/*` routes require a Zine PAT.
@@ -62,6 +66,7 @@ All `/api/*` routes require a Zine PAT.
 - `POST /api/v1/x-timeline/runs`
 - `PUT /api/v1/x-timeline/runs/{runId}/chunks/{chunkIndex}`
 - `POST /api/v1/x-timeline/runs/{runId}/complete`
+- `PUT /api/v1/x-timeline/daily-sources/{sourceId}`
 
 Chunk indexes are idempotent. Reusing an index with the same body succeeds; reusing it with different data returns `409`.
 
@@ -72,6 +77,7 @@ Chunk indexes are idempotent. Reusing an index with the same body succeeds; reus
 - `GET /api/v1/x-timeline/runs/{runId}/export`
 - `GET /api/v1/x-timeline/posts`
 - `GET /api/v1/x-timeline/posts/{tweetId}`
+- `GET /api/v1/x-timeline/daily-sources`
 
 Post listing uses an opaque keyset cursor.
 

--- a/docs/x-timeline-archive.md
+++ b/docs/x-timeline-archive.md
@@ -46,6 +46,16 @@ Ask Codex to use the `zine-x-timeline-collector` skill, or start its receiver ex
 bun run x:archive:receive -- --count 500
 ```
 
+That command is for Following. A Favorites list uses a rolling window instead of a post target:
+
+```bash
+bun run --cwd apps/x-collector receive \
+  --source-type FAVORITES \
+  --source-url https://x.com/i/lists/<id> \
+  --window-hours 24 \
+  --safety-limit 5000
+```
+
 The receiver listens only on `127.0.0.1`, accepts small browser-extracted batches, and exposes a checkpoint that lets browser control reconnect without changing the run or item positions. The collector performs bounded up/down recovery after transient X stalls before falling back to a partial run. On completion, the receiver uploads chunks of at most 25 primary timeline entries, finalizes the R2 run manifest, then reads the run back for verification.
 
 For an existing capture JSON file:
@@ -55,7 +65,7 @@ bun run --cwd apps/x-collector validate --file capture.json
 bun run --cwd apps/x-collector upload --file capture.json
 ```
 
-Favorites-first Daily View collection uses two immutable runs: a `FAVORITES` run for the configured list and a separate `FOLLOWING` run for secondary context. The Favorites receiver also accepts list-member batches at `/source-members` and per-thread coverage records at `/context-status`; completion stores an immutable roster snapshot linked directly to its run. Roster status is finalized independently, so a complete timeline cannot hide a partial member capture. Run metadata records the exact source type, stable list ID, name, URL, and context coverage. Never substitute For You for either source.
+Favorites-first Daily View collection uses two immutable runs: a rolling-24-hour `FAVORITES` run for the configured list and a separate 500-post `FOLLOWING` run for secondary context. The Favorites receiver also accepts list-member batches at `/source-members`, rolling-window evidence with each `/batch`, and per-thread coverage records at `/context-status`; completion stores an immutable roster snapshot linked directly to its run. Roster status is finalized independently, so a complete timeline cannot hide a partial member capture. A Favorites run is complete only after it records enough older non-repost entries to prove the time boundary, with no missing publication timestamps. Reposts are retained according to their verified list activity position because X exposes the original post timestamp rather than a reliable repost-event timestamp; the reposter remains explicit. The numeric guard is recorded separately and produces partial coverage if reached first. Run metadata records the exact source type, stable list ID, name, URL, collection policy, termination reason, window coverage, and context coverage. Never substitute For You for either source.
 
 ## API
 

--- a/packages/x-archive-schema/src/index.ts
+++ b/packages/x-archive-schema/src/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const X_ARCHIVE_SCHEMA_VERSION = 2;
+export const X_ARCHIVE_SCHEMA_VERSION = 3;
 export const X_ARCHIVE_MAX_TIMELINE_ITEMS_PER_CHUNK = 25;
 export const X_ARCHIVE_MAX_POSTS_PER_CHUNK = 75;
 
@@ -15,6 +15,39 @@ const OptionalHttpUrlSchema = HttpUrlSchema.nullable().optional();
 
 export const XPostKindSchema = z.enum(['POST', 'REPLY', 'REPOST', 'QUOTE']);
 export type XPostKind = z.infer<typeof XPostKindSchema>;
+
+export const XTimelineSourceTypeSchema = z.enum(['FOLLOWING', 'FAVORITES', 'LIST']);
+export type XTimelineSourceType = z.infer<typeof XTimelineSourceTypeSchema>;
+
+export const XTimelineSourceSchema = z
+  .object({
+    type: XTimelineSourceTypeSchema.default('FOLLOWING'),
+    id: z.string().trim().min(1).max(120).default('following'),
+    name: z.string().trim().min(1).max(160).default('Following'),
+    url: HttpUrlSchema.nullable().optional(),
+  })
+  .strict();
+export type XTimelineSource = z.infer<typeof XTimelineSourceSchema>;
+
+export const XContextCoverageSchema = z
+  .object({
+    budget: z.number().int().nonnegative().default(0),
+    attempted: z.number().int().nonnegative().default(0),
+    completed: z.number().int().nonnegative().default(0),
+    truncated: z.number().int().nonnegative().default(0),
+    failed: z.number().int().nonnegative().default(0),
+    warnings: z.array(z.string().trim().min(1).max(500)).max(50).default([]),
+  })
+  .strict()
+  .superRefine((coverage, ctx) => {
+    if (coverage.completed + coverage.truncated + coverage.failed !== coverage.attempted) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Context outcome counts must equal attempted expansions',
+      });
+    }
+  });
+export type XContextCoverage = z.infer<typeof XContextCoverageSchema>;
 
 export const XPostRelationshipTypeSchema = z.enum(['REPLY_TO', 'REPOST_OF', 'QUOTE_OF']);
 export type XPostRelationshipType = z.infer<typeof XPostRelationshipTypeSchema>;
@@ -141,9 +174,15 @@ export const XTimelineCaptureSchema = z
     startedAt: z.string().datetime(),
     completedAt: z.string().datetime().nullable().optional(),
     collectorVersion: z.string().min(1).max(80),
+    source: XTimelineSourceSchema.default({
+      type: 'FOLLOWING',
+      id: 'following',
+      name: 'Following',
+    }),
     excludedAds: z.number().int().nonnegative().default(0),
     status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
     failureReason: z.string().max(2_000).nullable().optional(),
+    contextCoverage: XContextCoverageSchema.default({}),
     posts: z.array(XPostSchema),
     items: z.array(XTimelineItemSchema),
   })
@@ -183,6 +222,11 @@ export const CreateXTimelineRunSchema = z
     requestedCount: z.number().int().positive().max(100_000),
     startedAt: z.string().datetime(),
     collectorVersion: z.string().min(1).max(80),
+    source: XTimelineSourceSchema.default({
+      type: 'FOLLOWING',
+      id: 'following',
+      name: 'Following',
+    }),
   })
   .strict();
 export type CreateXTimelineRun = z.infer<typeof CreateXTimelineRunSchema>;
@@ -214,6 +258,7 @@ export const CompleteXTimelineRunSchema = z
     status: z.enum(['COMPLETE', 'PARTIAL']),
     failureReason: z.string().max(2_000).nullable().optional(),
     collectedCount: z.number().int().nonnegative(),
+    contextCoverage: XContextCoverageSchema.default({}),
   })
   .strict();
 export type CompleteXTimelineRun = z.infer<typeof CompleteXTimelineRunSchema>;

--- a/packages/x-archive-schema/src/index.ts
+++ b/packages/x-archive-schema/src/index.ts
@@ -29,6 +29,32 @@ export const XTimelineSourceSchema = z
   .strict();
 export type XTimelineSource = z.infer<typeof XTimelineSourceSchema>;
 
+export const XCollectionPolicySchema = z.discriminatedUnion('mode', [
+  z
+    .object({
+      mode: z.literal('COUNT'),
+    })
+    .strict(),
+  z
+    .object({
+      mode: z.literal('ROLLING_WINDOW'),
+      windowHours: z.number().int().positive().max(168),
+      cutoffAt: z.string().datetime(),
+      boundaryEvidenceRequired: z.number().int().positive().max(20).default(3),
+    })
+    .strict(),
+]);
+export type XCollectionPolicy = z.infer<typeof XCollectionPolicySchema>;
+
+export const XCollectionTerminationReasonSchema = z.enum([
+  'COUNT_REACHED',
+  'WINDOW_BOUNDARY_REACHED',
+  'SAFETY_LIMIT_REACHED',
+  'TIMELINE_STALLED',
+  'COLLECTOR_FAILED',
+]);
+export type XCollectionTerminationReason = z.infer<typeof XCollectionTerminationReasonSchema>;
+
 export const XContextCoverageSchema = z
   .object({
     budget: z.number().int().nonnegative().default(0),
@@ -48,6 +74,16 @@ export const XContextCoverageSchema = z
     }
   });
 export type XContextCoverage = z.infer<typeof XContextCoverageSchema>;
+
+export const XWindowCoverageSchema = z
+  .object({
+    outsideWindow: z.number().int().nonnegative().default(0),
+    missingPublishedAt: z.number().int().nonnegative().default(0),
+    boundaryEvidenceRequired: z.number().int().nonnegative().default(0),
+    boundaryReached: z.boolean().default(false),
+  })
+  .strict();
+export type XWindowCoverage = z.infer<typeof XWindowCoverageSchema>;
 
 export const XPostRelationshipTypeSchema = z.enum(['REPLY_TO', 'REPOST_OF', 'QUOTE_OF']);
 export type XPostRelationshipType = z.infer<typeof XPostRelationshipTypeSchema>;
@@ -179,15 +215,58 @@ export const XTimelineCaptureSchema = z
       id: 'following',
       name: 'Following',
     }),
+    collectionPolicy: XCollectionPolicySchema.default({ mode: 'COUNT' }),
+    terminationReason: XCollectionTerminationReasonSchema.default('COUNT_REACHED'),
     excludedAds: z.number().int().nonnegative().default(0),
     status: z.enum(['COMPLETE', 'PARTIAL']).default('COMPLETE'),
     failureReason: z.string().max(2_000).nullable().optional(),
     contextCoverage: XContextCoverageSchema.default({}),
+    windowCoverage: XWindowCoverageSchema.default({}),
     posts: z.array(XPostSchema),
     items: z.array(XTimelineItemSchema),
   })
   .strict()
   .superRefine((capture, ctx) => {
+    if (capture.collectionPolicy.mode === 'ROLLING_WINDOW' && capture.source.type === 'FOLLOWING') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['collectionPolicy'],
+        message: 'Rolling-window collection is only supported for configured X lists',
+      });
+    }
+    if (
+      capture.collectionPolicy.mode === 'ROLLING_WINDOW' &&
+      capture.status === 'COMPLETE' &&
+      capture.terminationReason !== 'WINDOW_BOUNDARY_REACHED'
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['terminationReason'],
+        message: 'A complete rolling-window run must reach the window boundary',
+      });
+    }
+    if (
+      capture.collectionPolicy.mode === 'ROLLING_WINDOW' &&
+      capture.status === 'COMPLETE' &&
+      (!capture.windowCoverage.boundaryReached || capture.windowCoverage.missingPublishedAt > 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['windowCoverage'],
+        message: 'A complete rolling-window run needs boundary evidence and no missing timestamps',
+      });
+    }
+    if (
+      capture.collectionPolicy.mode === 'COUNT' &&
+      capture.status === 'COMPLETE' &&
+      capture.terminationReason !== 'COUNT_REACHED'
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['terminationReason'],
+        message: 'A complete count-bounded run must reach its count target',
+      });
+    }
     const postIds = new Set(capture.posts.map((post) => post.tweetId));
     const itemIds = new Set<string>();
     const positions = new Set<number>();
@@ -227,6 +306,7 @@ export const CreateXTimelineRunSchema = z
       id: 'following',
       name: 'Following',
     }),
+    collectionPolicy: XCollectionPolicySchema.default({ mode: 'COUNT' }),
   })
   .strict();
 export type CreateXTimelineRun = z.infer<typeof CreateXTimelineRunSchema>;
@@ -259,6 +339,8 @@ export const CompleteXTimelineRunSchema = z
     failureReason: z.string().max(2_000).nullable().optional(),
     collectedCount: z.number().int().nonnegative(),
     contextCoverage: XContextCoverageSchema.default({}),
+    windowCoverage: XWindowCoverageSchema.default({}),
+    terminationReason: XCollectionTerminationReasonSchema.default('COUNT_REACHED'),
   })
   .strict();
 export type CompleteXTimelineRun = z.infer<typeof CompleteXTimelineRunSchema>;


### PR DESCRIPTION
## Summary

- collect two independent, source-identified X archive runs: an exact Favorites List as the primary source and Following as secondary, with no For You collection path
- define Favorites as a rolling previous-24-hour source, anchored at collection start; completion requires boundary evidence from three distinct older non-repost posts
- keep 5,000 posts only as a safety guard: reaching it before the time boundary produces explicit partial coverage, never a false complete run
- keep Following as the separate count-bounded 500-post source
- persist immutable run-linked Favorites membership snapshots, collection policy, termination reason, window coverage, and bounded reply/thread context
- build the review-only `people-first-v2` API contract: evidence-backed direct-thread, quote, reply, shared-link, and strong-topic conversations, followed by deduplicated More Favorites and More Following streams
- defensively enforce the 24-hour Favorites cutoff in the Worker while retaining reposts by verified Favorites timeline position and disclosing that X exposes the original post timestamp rather than a reliable repost-event timestamp
- preserve author activity for Today and the past week, including reply, quote, repost, and link context
- update the canonical SwiftUI client to show Last 24h coverage and add an exact JSON-to-Swift contract replay fixture

This remains isolated as a `REVIEW` variant. It does not replace or auto-promote the live editorial Today experience.

After merge, release still requires applying the X archive D1 migration, deploying the X archive and Worker backends, configuring the exact Favorites List URL, collecting a fresh rolling-24-hour Favorites run plus an independent Following 500 run, reading the production API back, and rebuilding/installing the native app on the paired iPhone.

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run test`
- collector source, browser extraction/session, receiver, and upload tests: 18 passed
- X archive policy/provenance tests: 6 passed
- Daily View grouping/ranking, rolling-window, and author activity tests: 14 passed
- Worker full suite: 86 files / 1,710 tests passed
- Worker pre-push subset: 85 files / 1,689 tests passed
- API v1 tests: 73 passed
- generic iOS Simulator build for `apps/ios/ZineNative.xcodeproj`: `BUILD SUCCEEDED`
- exact `daily-feed-v2.json` replay through shipped Swift models: `native-decode=ok variant=people-first-v2 posts=2 conversations=1`

No production migration, deployment, capture, device installation, or launch was attempted from this unmerged branch.
