### PR TITLE
fix(x-collector): report network collector provenance

### DIFF
--- a/apps/x-collector/src/cli.ts
+++ b/apps/x-collector/src/cli.ts
@@ -81,7 +81,7 @@ try {
       apiUrl,
       token,
       port,
-      collectorVersion: 'browser-dom-v4',
+      collectorVersion: 'browser-network-v4',
       source,
       startedAt,
       collectionPolicy: collection.collectionPolicy,


### PR DESCRIPTION
## Summary

- label receiver-created runs as `browser-network-v4` so archived provenance matches the network-first extraction path shipped in #354

## Validation

- `bun run format:check`
- `bun run --cwd apps/x-collector lint`
- `bun run --cwd apps/x-collector typecheck`
- `bun run --cwd apps/x-collector test` (24 tests passed)
- `bun run --cwd apps/x-collector build`