### PR TITLE
fix(x-collector): scope list member capture

### DIFF
--- a/apps/x-collector/src/list-members-extractor.mjs
+++ b/apps/x-collector/src/list-members-extractor.mjs
@@ -5,8 +5,10 @@
  * Invoke through browser page evaluation; keep deduplication in the caller.
  */
 export function extractVisibleListMembers() {
+  const timeline = document.querySelector('[aria-label="Timeline: List members"]');
+  const root = timeline ?? document;
   const usernames = [];
-  for (const cell of document.querySelectorAll('[data-testid="UserCell"]')) {
+  for (const cell of root.querySelectorAll('[data-testid="UserCell"]')) {
     const links = [...cell.querySelectorAll('a[href^="/"]')];
     const profileLink = links.find((link) => {
       const href = link.getAttribute('href') || '';

--- a/apps/x-collector/src/list-members-extractor.test.mjs
+++ b/apps/x-collector/src/list-members-extractor.test.mjs
@@ -16,4 +16,22 @@ describe('list member extractor', () => {
 
     expect(extractVisibleListMembers()).toEqual(['alice', 'bob']);
   });
+
+  it('ignores user cells outside the list-members timeline', () => {
+    const { document, window } = parseHTML(`
+      <main>
+        <div aria-label="Timeline: List members">
+          <div data-testid="UserCell"><a href="/Alice">Alice</a></div>
+          <div data-testid="UserCell"><a href="/bob">Bob</a></div>
+        </div>
+      </main>
+      <aside>
+        <div data-testid="UserCell"><a href="/suggested">Suggested</a></div>
+      </aside>
+    `);
+    globalThis.document = document;
+    globalThis.window = window;
+
+    expect(extractVisibleListMembers()).toEqual(['alice', 'bob']);
+  });
 });


### PR DESCRIPTION
## Summary
- scope Favorites membership extraction to X's `Timeline: List members` container
- prevent unrelated sidebar suggestions from entering immutable list-membership snapshots
- retain the existing document fallback for extractor fixtures and explicit partial behavior

## Validation
- `bunx prettier --check apps/x-collector/src/list-members-extractor.mjs apps/x-collector/src/list-members-extractor.test.mjs`
- `bun run --cwd apps/x-collector lint`
- `bun run --cwd apps/x-collector typecheck`
- `bun run --cwd apps/x-collector test` (25 passed)
- `bun run --cwd apps/x-collector build`
- full pre-push gates passed, including format, design-system, typecheck, web tests, and worker tests (1,690 passed)