### PR TITLE
feat(ios): refine native article reader

### DIFF
--- a/apps/ios/ZineNative/Core/Models/ArticleBody.swift
+++ b/apps/ios/ZineNative/Core/Models/ArticleBody.swift
@@ -65,6 +65,7 @@ struct ArticleReaderMetadata: Equatable {
     let bookmarkID: String
     let title: String
     let creator: String
+    let creatorImageURL: URL?
     let canonicalURL: URL
     let readingTimeMinutes: Int?
     let initialProgress: BookmarkProgress?

--- a/apps/ios/ZineNative/Core/Models/Bookmark.swift
+++ b/apps/ios/ZineNative/Core/Models/Bookmark.swift
@@ -42,6 +42,10 @@ enum Provider: String, Codable, CaseIterable, Identifiable {
         case .x: "X"
         }
     }
+
+    func opensInZineReader(contentType: ContentType) -> Bool {
+        contentType == .article && self != .substack
+    }
 }
 
 struct BookmarkTag: Codable, Hashable, Identifiable {
@@ -53,6 +57,11 @@ struct BookmarkProgress: Codable, Hashable {
     let position: Double
     let duration: Double
     let percent: Double
+
+    var fraction: Double {
+        let value = duration > 0 ? position / duration : percent / 100
+        return min(max(value, 0), 1)
+    }
 }
 
 struct Bookmark: Codable, Hashable, Identifiable {

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -35,9 +35,6 @@ struct HomeView: View {
                 .navigationTitle("Home")
                 .navigationDestination(for: HomeNavigationRoute.self) { route in
                     destination(for: route)
-                        .navigationTransition(
-                            .zoom(sourceID: route.sourceID, in: bookmarkTransition)
-                        )
                 }
                 .navigationDestination(for: HomeSectionRoute.self) { route in
                     switch route {

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -216,6 +216,7 @@ struct BookmarkDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarVisibility(.hidden, for: .tabBar)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task(id: content.id) {
@@ -286,13 +287,14 @@ struct BookmarkDetailView: View {
 
             Spacer(minLength: 0)
 
-            if content.contentType == .article {
+            if content.provider.opensInZineReader(contentType: content.contentType) {
                 NavigationLink {
                     ArticleReaderView(
                         metadata: ArticleReaderMetadata(
                             bookmarkID: content.id,
                             title: content.title,
                             creator: content.creator,
+                            creatorImageURL: content.creatorImageUrl,
                             canonicalURL: content.canonicalUrl,
                             readingTimeMinutes: content.readingTimeMinutes,
                             initialProgress: content.progress,
@@ -304,12 +306,21 @@ struct BookmarkDetailView: View {
                         onFinishedChanged: updateFinishedState
                     )
                 } label: {
-                    Label("Read", systemImage: "book.pages")
-                        .font(.subheadline.weight(.semibold))
+                    Image(systemName: "book.pages")
+                        .resizable()
+                        .scaledToFit()
+                        .symbolRenderingMode(.monochrome)
+                        .frame(
+                            width: ProviderOpenButton.iconSize,
+                            height: ProviderOpenButton.iconSize
+                        )
+                        .frame(
+                            width: ProviderOpenButton.controlSize,
+                            height: ProviderOpenButton.controlSize
+                        )
+                        .background(Color("AccentColor"), in: Circle())
                         .foregroundStyle(.white)
-                        .padding(.horizontal, 18)
-                        .frame(minHeight: 48)
-                        .background(Color.accentColor, in: Capsule())
+                        .accessibilityHidden(true)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Read in Zine")

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -11,7 +11,6 @@ struct LibraryView: View {
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
-    @Namespace private var bookmarkTransition
 
     init(
         client: APIClient,
@@ -68,9 +67,6 @@ struct LibraryView: View {
                             store.setBookmarked(changed, isBookmarked: isBookmarked)
                         },
                         onExternalOpen: onExternalOpen
-                    )
-                    .navigationTransition(
-                        .zoom(sourceID: bookmark.id, in: bookmarkTransition)
                     )
                 }
         }
@@ -131,7 +127,6 @@ struct LibraryView: View {
                 }
                 .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
                 .listRowSeparator(.hidden)
-                .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
                     if !bookmark.isFinished {
                         Button {

--- a/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
+++ b/apps/ios/ZineNative/Features/Library/ProviderOpenButton.swift
@@ -156,6 +156,9 @@ struct ProviderLinkButton: View {
 }
 
 struct ProviderOpenButton: View {
+    static let iconSize: CGFloat = 27
+    static let controlSize: CGFloat = 56
+
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.openURL) private var openURL
 
@@ -181,8 +184,8 @@ struct ProviderOpenButton: View {
             openURL(destination)
         } label: {
             providerLogo
-                .frame(width: 27, height: 27)
-                .frame(width: 56, height: 56)
+                .frame(width: Self.iconSize, height: Self.iconSize)
+                .frame(width: Self.controlSize, height: Self.controlSize)
                 .background(action.backgroundColor, in: Circle())
                 .foregroundStyle(action.foregroundColor)
                 .accessibilityHidden(true)

--- a/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
@@ -1,15 +1,122 @@
 import SwiftUI
 import WebKit
 
+enum ArticleReaderFontSize: String, CaseIterable, Identifiable {
+    static let storageKey = "articleReaderFontSize"
+
+    case small
+    case standard
+    case large
+    case extraLarge
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .small: "Small"
+        case .standard: "Default"
+        case .large: "Large"
+        case .extraLarge: "Extra Large"
+        }
+    }
+
+    var scale: Double {
+        switch self {
+        case .small: 0.9
+        case .standard: 1
+        case .large: 1.15
+        case .extraLarge: 1.3
+        }
+    }
+}
+
+private final class ArticleReaderWebView: WKWebView {
+    var onNavigationControllerAvailable: ((UINavigationController) -> Void)?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self,
+                  let navigationController = nearestNavigationController()
+            else { return }
+            onNavigationControllerAvailable?(navigationController)
+        }
+    }
+
+    private func nearestNavigationController() -> UINavigationController? {
+        var responder: UIResponder? = self
+        while let next = responder?.next {
+            if let navigationController = next as? UINavigationController {
+                return navigationController
+            }
+            if let viewController = next as? UIViewController,
+               let navigationController = viewController.navigationController
+            {
+                return navigationController
+            }
+            responder = next
+        }
+        return nil
+    }
+}
+
+struct ArticleReaderChromeOffsetTracker {
+    static let maximumOffset: CGFloat = 56
+
+    private(set) var offset: CGFloat = 0
+    private var lastScrollOffset: CGFloat?
+
+    mutating func begin(at scrollOffset: CGFloat) {
+        lastScrollOffset = max(scrollOffset, 0)
+    }
+
+    mutating func update(scrollOffset: CGFloat) -> CGFloat? {
+        let scrollOffset = max(scrollOffset, 0)
+
+        if scrollOffset == 0 {
+            lastScrollOffset = 0
+            return setOffset(0)
+        }
+
+        guard let lastScrollOffset else {
+            self.lastScrollOffset = scrollOffset
+            return nil
+        }
+
+        self.lastScrollOffset = scrollOffset
+        return setOffset(offset + scrollOffset - lastScrollOffset)
+    }
+
+    mutating func end() {
+        lastScrollOffset = nil
+    }
+
+    private mutating func setOffset(_ value: CGFloat) -> CGFloat? {
+        let value = min(max(value, 0), Self.maximumOffset)
+        guard value != offset else { return nil }
+        offset = value
+        return value
+    }
+}
+
 enum ArticleHTMLDocumentBuilder {
-    static func makeHTML(for document: ArticleReaderDocument) -> String {
+    static func makeHTML(
+        for document: ArticleReaderDocument,
+        fontScale: Double = ArticleReaderFontSize.standard.scale
+    ) -> String {
         let metadata = document.metadata
         let readingTime = metadata.readingTimeMinutes.map { "\($0) min read" }
-        let meta = [metadata.creator, readingTime]
+        let creatorAvatar = avatarHTML(for: metadata.creatorImageURL)
+        let creatorMeta = """
+        <span class="creator">\(creatorAvatar)<span>\(escape(metadata.creator))</span></span>
+        """
+        let meta = [creatorMeta, readingTime.map { "<span>\(escape($0))</span>" }]
             .compactMap { $0 }
-            .map(escape)
-            .joined(separator: " · ")
+            .joined(separator: "<span aria-hidden=\"true\">·</span>")
         let body = document.response.readableContent ?? ""
+        let topPadding = 32 + ArticleReaderChromeOffsetTracker.maximumOffset
 
         return """
         <!doctype html>
@@ -19,31 +126,59 @@ enum ArticleHTMLDocumentBuilder {
           <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
           <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https: http: data:; style-src 'unsafe-inline'; script-src 'none'; connect-src 'none'; frame-src 'none'; media-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
           <style>
-            :root { color-scheme: light dark; }
+            :root {
+              color-scheme: light dark;
+              --reader-font-scale: \(fontScale);
+            }
             * { box-sizing: border-box; }
             html { -webkit-text-size-adjust: 100%; }
             body {
               margin: 0 auto;
               max-width: 760px;
-              padding: 32px 22px 96px;
+              padding: \(topPadding)px 22px 96px;
               background: #ffffff;
               color: #1c1c1e;
               font: -apple-system-body;
+              font-size: calc(17px * var(--reader-font-scale));
               line-height: 1.66;
               overflow-wrap: anywhere;
             }
-            header { margin: 6px 0 34px; }
+            header { margin: 6px 0 24px; }
             h1 {
-              margin: 0 0 12px;
+              margin: 0 0 14px;
               font: -apple-system-title1;
+              font-size: calc(34px * var(--reader-font-scale));
               font-weight: 750;
               line-height: 1.12;
               letter-spacing: -0.02em;
             }
+            .title-rule {
+              margin: 14px 0 0;
+              border: 0;
+              border-top: 1px solid #d1d1d6;
+            }
             .meta {
+              display: flex;
+              align-items: center;
+              gap: 8px;
               color: #636366;
               font: -apple-system-subheadline;
+              font-size: calc(15px * var(--reader-font-scale));
               line-height: 1.4;
+            }
+            .creator {
+              display: inline-flex;
+              align-items: center;
+              gap: 8px;
+            }
+            .creator-avatar {
+              width: 24px;
+              height: 24px;
+              margin: 0;
+              border-radius: 50%;
+              object-fit: cover;
+              flex: 0 0 auto;
+              background: #e5e5ea;
             }
             main > :first-child { margin-top: 0; }
             p, ul, ol, blockquote, pre, figure { margin: 0 0 1.25em; }
@@ -52,9 +187,20 @@ enum ArticleHTMLDocumentBuilder {
               line-height: 1.2;
               letter-spacing: -0.012em;
             }
-            h2 { font: -apple-system-title2; font-weight: 700; }
-            h3 { font: -apple-system-title3; font-weight: 700; }
-            h4 { font: -apple-system-headline; }
+            h2 {
+              font: -apple-system-title2;
+              font-size: calc(22px * var(--reader-font-scale));
+              font-weight: 700;
+            }
+            h3 {
+              font: -apple-system-title3;
+              font-size: calc(20px * var(--reader-font-scale));
+              font-weight: 700;
+            }
+            h4 {
+              font: -apple-system-headline;
+              font-size: calc(17px * var(--reader-font-scale));
+            }
             ul, ol { padding-left: 1.4em; }
             li { margin-bottom: 0.45em; }
             img, video {
@@ -69,7 +215,7 @@ enum ArticleHTMLDocumentBuilder {
             figcaption {
               margin-top: -0.8em;
               color: #6e6e73;
-              font-size: 14px;
+              font-size: calc(14px * var(--reader-font-scale));
               line-height: 1.45;
               text-align: center;
             }
@@ -109,6 +255,7 @@ enum ArticleHTMLDocumentBuilder {
           <header>
             <h1>\(escape(metadata.title))</h1>
             <div class="meta">\(meta)</div>
+            <hr class="title-rule" aria-hidden="true">
           </header>
           <main>\(body)</main>
         </body>
@@ -124,18 +271,33 @@ enum ArticleHTMLDocumentBuilder {
             .replacingOccurrences(of: "\"", with: "&quot;")
             .replacingOccurrences(of: "'", with: "&#39;")
     }
+
+    private static func avatarHTML(for url: URL?) -> String {
+        guard let url,
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http"
+        else { return "" }
+
+        return "<img class=\"creator-avatar\" src=\"\(escape(url.absoluteString))\" alt=\"\">"
+    }
 }
 
 struct ArticleHTMLView: UIViewRepresentable {
     let document: ArticleReaderDocument
     let initialProgress: Double
+    let fontScale: Double
     let onProgressChanged: (Double) -> Void
+    let onScrollSettled: (Double) -> Void
+    let onChromeOffsetChanged: (CGFloat) -> Void
     let onOpenURL: (URL) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             initialProgress: initialProgress,
+            fontScale: fontScale,
             onProgressChanged: onProgressChanged,
+            onScrollSettled: onScrollSettled,
+            onChromeOffsetChanged: onChromeOffsetChanged,
             onOpenURL: onOpenURL
         )
     }
@@ -148,7 +310,7 @@ struct ArticleHTMLView: UIViewRepresentable {
         configuration.defaultWebpagePreferences = preferences
         configuration.websiteDataStore = .nonPersistent()
 
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        let webView = ArticleReaderWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.scrollView.delegate = context.coordinator
         webView.scrollView.contentInsetAdjustmentBehavior = .never
@@ -156,54 +318,144 @@ struct ArticleHTMLView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
-        context.coordinator.load(document, in: webView)
+        webView.onNavigationControllerAvailable = { [weak coordinator = context.coordinator, weak webView] navigationController in
+            guard let webView else { return }
+            coordinator?.enableInteractivePop(
+                in: navigationController,
+                alongside: webView.scrollView.panGestureRecognizer
+            )
+        }
+        context.coordinator.loadInitial(document, in: webView)
         return webView
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
-        guard context.coordinator.loadedContentHash != document.contentHash else { return }
-        context.coordinator.load(document, in: webView)
+        context.coordinator.update(document, fontScale: fontScale, in: webView)
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        coordinator.restoreInteractivePopConfiguration()
+        (webView as? ArticleReaderWebView)?.onNavigationControllerAvailable = nil
+        webView.navigationDelegate = nil
+        webView.scrollView.delegate = nil
     }
 
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate {
+        private struct PopGestureConfiguration {
+            let gesture: UIGestureRecognizer
+            let originalDelegate: (any UIGestureRecognizerDelegate)?
+            let wasEnabled: Bool
+        }
+
         private let initialProgress: Double
+        private var fontScale: Double
         private let onProgressChanged: (Double) -> Void
+        private let onScrollSettled: (Double) -> Void
+        private let onChromeOffsetChanged: (CGFloat) -> Void
         private let onOpenURL: (URL) -> Void
         private var isRestoringProgress = false
+        private var chromeOffsetTracker = ArticleReaderChromeOffsetTracker()
+        private var popGestureConfigurations: [PopGestureConfiguration] = []
         fileprivate var loadedContentHash: String?
 
         init(
             initialProgress: Double,
+            fontScale: Double,
             onProgressChanged: @escaping (Double) -> Void,
+            onScrollSettled: @escaping (Double) -> Void,
+            onChromeOffsetChanged: @escaping (CGFloat) -> Void,
             onOpenURL: @escaping (URL) -> Void
         ) {
             self.initialProgress = min(max(initialProgress, 0), 1)
+            self.fontScale = fontScale
             self.onProgressChanged = onProgressChanged
+            self.onScrollSettled = onScrollSettled
+            self.onChromeOffsetChanged = onChromeOffsetChanged
             self.onOpenURL = onOpenURL
         }
 
-        func load(_ document: ArticleReaderDocument, in webView: WKWebView) {
+        func enableInteractivePop(
+            in navigationController: UINavigationController,
+            alongside scrollGesture: UIPanGestureRecognizer
+        ) {
+            var popGestures = [navigationController.interactivePopGestureRecognizer]
+            if #available(iOS 26.0, *) {
+                popGestures.append(navigationController.interactiveContentPopGestureRecognizer)
+            }
+
+            for popGesture in popGestures.compactMap({ $0 }) {
+                guard !popGestureConfigurations.contains(where: { $0.gesture === popGesture })
+                else { continue }
+
+                popGestureConfigurations.append(
+                    PopGestureConfiguration(
+                        gesture: popGesture,
+                        originalDelegate: popGesture.delegate,
+                        wasEnabled: popGesture.isEnabled
+                    )
+                )
+                popGesture.delegate = nil
+                popGesture.isEnabled = navigationController.viewControllers.count > 1
+                scrollGesture.require(toFail: popGesture)
+            }
+        }
+
+        func restoreInteractivePopConfiguration() {
+            for configuration in popGestureConfigurations {
+                if configuration.gesture.delegate == nil {
+                    configuration.gesture.delegate = configuration.originalDelegate
+                }
+                configuration.gesture.isEnabled = configuration.wasEnabled
+            }
+            popGestureConfigurations.removeAll()
+        }
+
+        func loadInitial(_ document: ArticleReaderDocument, in webView: WKWebView) {
             loadedContentHash = document.contentHash
+            pendingRestoreProgress = initialProgress
+            isRestoringProgress = initialProgress > 0
             webView.loadHTMLString(
-                ArticleHTMLDocumentBuilder.makeHTML(for: document),
+                ArticleHTMLDocumentBuilder.makeHTML(for: document, fontScale: fontScale),
+                baseURL: document.metadata.canonicalURL
+            )
+        }
+
+        func update(
+            _ document: ArticleReaderDocument,
+            fontScale newFontScale: Double,
+            in webView: WKWebView
+        ) {
+            let contentChanged = loadedContentHash != document.contentHash
+            let fontScaleChanged = fontScale != newFontScale
+            guard contentChanged || fontScaleChanged else { return }
+
+            let restoreProgress: Double
+            if contentChanged {
+                restoreProgress = initialProgress
+            } else if isRestoringProgress, let pendingRestoreProgress {
+                restoreProgress = pendingRestoreProgress
+            } else {
+                restoreProgress = progress(in: webView.scrollView)
+            }
+            pendingRestoreProgress = restoreProgress
+            isRestoringProgress = restoreProgress > 0
+            loadedContentHash = document.contentHash
+            fontScale = newFontScale
+            webView.loadHTMLString(
+                ArticleHTMLDocumentBuilder.makeHTML(for: document, fontScale: newFontScale),
                 baseURL: document.metadata.canonicalURL
             )
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
-            guard initialProgress > 0 else { return }
-            isRestoringProgress = true
-            DispatchQueue.main.async { [weak self, weak webView] in
-                guard let self, let webView else { return }
-                let scrollView = webView.scrollView
-                let maximumOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 0)
-                scrollView.setContentOffset(
-                    CGPoint(x: 0, y: maximumOffset * initialProgress),
-                    animated: false
-                )
+            let progress = pendingRestoreProgress ?? 0
+            pendingRestoreProgress = nil
+            guard progress > 0 else {
                 isRestoringProgress = false
+                return
             }
+            restoreProgress(progress, in: webView)
         }
 
         func webView(
@@ -226,6 +478,85 @@ struct ArticleHTMLView: UIViewRepresentable {
             let maximumOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 1)
             let fraction = min(max(scrollView.contentOffset.y / maximumOffset, 0), 1)
             onProgressChanged(fraction)
+
+            guard scrollView.isDragging || scrollView.isDecelerating else { return }
+            if let offset = chromeOffsetTracker.update(scrollOffset: scrollView.contentOffset.y) {
+                onChromeOffsetChanged(offset)
+            }
+        }
+
+        func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+            progressRestorationGeneration += 1
+            progressRestorationTask?.cancel()
+            progressRestorationTask = nil
+            isRestoringProgress = false
+            chromeOffsetTracker.begin(at: scrollView.contentOffset.y)
+        }
+
+        func scrollViewDidEndDragging(
+            _ scrollView: UIScrollView,
+            willDecelerate decelerate: Bool
+        ) {
+            if !decelerate {
+                chromeOffsetTracker.end()
+                onScrollSettled(progress(in: scrollView))
+            }
+        }
+
+        func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+            chromeOffsetTracker.end()
+            onScrollSettled(progress(in: scrollView))
+        }
+
+        private var pendingRestoreProgress: Double?
+        private var progressRestorationTask: Task<Void, Never>?
+        private var progressRestorationGeneration = 0
+
+        private func restoreProgress(_ progress: Double, in webView: WKWebView) {
+            progressRestorationGeneration += 1
+            let generation = progressRestorationGeneration
+            progressRestorationTask?.cancel()
+            isRestoringProgress = true
+            progressRestorationTask = Task { @MainActor [weak self, weak webView] in
+                guard let self, let webView else { return }
+                defer {
+                    if generation == progressRestorationGeneration {
+                        isRestoringProgress = false
+                        progressRestorationTask = nil
+                    }
+                }
+
+                for delayMilliseconds in [0, 120, 300, 600] {
+                    if delayMilliseconds > 0 {
+                        do {
+                            try await Task.sleep(for: .milliseconds(delayMilliseconds))
+                        } catch {
+                            return
+                        }
+                    } else {
+                        await Task.yield()
+                    }
+
+                    guard !Task.isCancelled,
+                          generation == progressRestorationGeneration
+                    else { return }
+                    let scrollView = webView.scrollView
+                    let maximumOffset = max(
+                        scrollView.contentSize.height - scrollView.bounds.height,
+                        0
+                    )
+                    scrollView.setContentOffset(
+                        CGPoint(x: 0, y: maximumOffset * progress),
+                        animated: false
+                    )
+                    chromeOffsetTracker.end()
+                }
+            }
+        }
+
+        private func progress(in scrollView: UIScrollView) -> Double {
+            let maximumOffset = max(scrollView.contentSize.height - scrollView.bounds.height, 1)
+            return min(max(scrollView.contentOffset.y / maximumOffset, 0), 1)
         }
     }
 }

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
@@ -10,6 +10,29 @@ enum ArticleReaderPhase: Equatable {
 }
 
 @MainActor
+final class ArticleProgressWriteQueue {
+    typealias Write = @MainActor (Double) async -> Bool
+
+    private let write: Write
+    private var tail: Task<Bool, Never>?
+
+    init(write: @escaping Write) {
+        self.write = write
+    }
+
+    func enqueue(_ fraction: Double) async -> Bool {
+        let previous = tail
+        let write = self.write
+        let task = Task { @MainActor in
+            _ = await previous?.value
+            return await write(fraction)
+        }
+        tail = task
+        return await task.value
+    }
+}
+
+@MainActor
 @Observable
 final class ArticleReaderStore {
     private(set) var phase: ArticleReaderPhase
@@ -19,6 +42,7 @@ final class ArticleReaderStore {
     let initialProgressFraction: Double
 
     private let client: APIClient
+    private let progressWriteQueue: ArticleProgressWriteQueue
     private var loadGeneration = 0
 
     init(
@@ -28,12 +52,26 @@ final class ArticleReaderStore {
     ) {
         self.metadata = metadata
         self.client = client
+        let bookmarkID = metadata.bookmarkID
+        progressWriteQueue = ArticleProgressWriteQueue { fraction in
+            do {
+                try await client.updateProgress(id: bookmarkID, fraction: fraction)
+                return true
+            } catch is CancellationError {
+                return false
+            } catch {
+                do {
+                    try await Task.sleep(for: .milliseconds(500))
+                    try await client.updateProgress(id: bookmarkID, fraction: fraction)
+                    return true
+                } catch {
+                    return false
+                }
+            }
+        }
         phase = initialPhase
         isFinished = metadata.isFinished
-        initialProgressFraction = min(
-            max((metadata.initialProgress?.percent ?? 0) / 100, 0),
-            1
-        )
+        initialProgressFraction = metadata.initialProgress?.fraction ?? 0
     }
 
     var readyDocument: ArticleReaderDocument? {
@@ -80,18 +118,7 @@ final class ArticleReaderStore {
 
     func persistProgress(_ fraction: Double) async -> BookmarkProgress? {
         let clamped = min(max(fraction, 0), 1)
-        do {
-            try await client.updateProgress(id: metadata.bookmarkID, fraction: clamped)
-        } catch is CancellationError {
-            return nil
-        } catch {
-            do {
-                try await Task.sleep(for: .milliseconds(500))
-                try await client.updateProgress(id: metadata.bookmarkID, fraction: clamped)
-            } catch {
-                return nil
-            }
-        }
+        guard await progressWriteQueue.enqueue(clamped) else { return nil }
 
         return BookmarkProgress(
             position: clamped,

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 
 struct ArticleReaderView: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    @AppStorage(ArticleReaderFontSize.storageKey) private var storedFontSize =
+        ArticleReaderFontSize.standard.rawValue
 
     @State private var store: ArticleReaderStore
     @State private var scrollProgress: Double
     @State private var lastPersistedProgress: Double
     @State private var hasRecordedOpen = false
     @State private var isUpdatingFinished = false
+    @State private var readerChromeOffset: CGFloat = 0
 
     private let onRead: () -> Void
     private let onProgressSaved: (BookmarkProgress) -> Void
@@ -25,7 +29,7 @@ struct ArticleReaderView: View {
         onProgressSaved: @escaping (BookmarkProgress) -> Void = { _ in },
         onFinishedChanged: @escaping (Bool) -> Void = { _ in }
     ) {
-        let initialProgress = min(max((metadata.initialProgress?.percent ?? 0) / 100, 0), 1)
+        let initialProgress = metadata.initialProgress?.fraction ?? 0
         _store = State(
             initialValue: ArticleReaderStore(
                 metadata: metadata,
@@ -42,30 +46,31 @@ struct ArticleReaderView: View {
     }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .top) {
             Color(uiColor: .systemBackground)
                 .ignoresSafeArea()
 
             phaseContent
+
+            readerChromeViewport
         }
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationTitle(dynamicTypeSize.isAccessibilitySize ? "" : "Reader")
-        .toolbar { readerToolbar }
+        .toolbarVisibility(.hidden, for: .navigationBar)
         .task(id: store.metadata.bookmarkID) {
             guard loadsOnAppear else { return }
             await store.load()
         }
         .task(id: progressWriteKey) {
             guard store.readyDocument != nil,
-                  scrollProgress > 0,
                   abs(scrollProgress - lastPersistedProgress) >= 0.01
             else { return }
+            let progress = scrollProgress
             do {
                 try await Task.sleep(for: .seconds(2))
             } catch {
                 return
             }
-            await persistProgress()
+            guard abs(progress - lastPersistedProgress) >= 0.0001 else { return }
+            await persistProgress(progress)
         }
         .onChange(of: store.readyDocument?.contentHash, initial: true) { _, hash in
             guard hash != nil else { return }
@@ -76,6 +81,7 @@ struct ArticleReaderView: View {
             flushProgress()
         }
         .onDisappear {
+            readerChromeOffset = 0
             flushProgress()
         }
     }
@@ -113,36 +119,16 @@ struct ArticleReaderView: View {
 
     @ViewBuilder
     private func reader(_ document: ArticleReaderDocument) -> some View {
-        VStack(spacing: 0) {
-            if document.isDegraded {
-                degradedNotice
-            }
-
-            ArticleHTMLView(
-                document: document,
-                initialProgress: store.initialProgressFraction,
-                onProgressChanged: { scrollProgress = $0 },
-                onOpenURL: { openURL($0) }
-            )
-            .accessibilityIdentifier("article-reader-content")
-        }
-    }
-
-    private var degradedNotice: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
-            Text("This article may be incomplete.")
-                .font(.subheadline.weight(.medium))
-            Spacer(minLength: 8)
-            Button("View Original") {
-                openOriginal()
-            }
-            .font(.subheadline.weight(.semibold))
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(.orange.opacity(0.1))
+        ArticleHTMLView(
+            document: document,
+            initialProgress: store.initialProgressFraction,
+            fontScale: readerFontSize.scale,
+            onProgressChanged: { scrollProgress = $0 },
+            onScrollSettled: persistSettledProgress,
+            onChromeOffsetChanged: { readerChromeOffset = $0 },
+            onOpenURL: { openURL($0) }
+        )
+        .accessibilityIdentifier("article-reader-content")
     }
 
     private func unavailableView(message: String, retryable: Bool) -> some View {
@@ -164,34 +150,78 @@ struct ArticleReaderView: View {
         }
     }
 
-    @ToolbarContentBuilder
-    private var readerToolbar: some ToolbarContent {
-        ToolbarItemGroup(placement: .topBarTrailing) {
-            ShareLink(item: store.metadata.canonicalURL) {
-                Image(systemName: "square.and.arrow.up")
-            }
-            .accessibilityLabel("Share article")
-
+    private var readerChrome: some View {
+        HStack(spacing: 10) {
             Button {
-                openOriginal()
+                dismiss()
             } label: {
-                Image(systemName: "safari")
+                Image(systemName: "chevron.left")
+                    .font(.headline.weight(.semibold))
+                    .frame(width: 44, height: 44)
             }
-            .accessibilityLabel("Open original article")
+            .buttonStyle(.plain)
+            .background(.thinMaterial, in: Circle())
+            .accessibilityLabel("Back")
 
-            Button {
-                Task { await toggleFinished() }
-            } label: {
-                Image(systemName: store.isFinished ? "checkmark.circle.fill" : "checkmark.circle")
-                    .foregroundStyle(store.isFinished ? .green : .primary)
+            Spacer(minLength: 8)
+
+            HStack(spacing: 0) {
+                Menu {
+                    ForEach(ArticleReaderFontSize.allCases) { fontSize in
+                        Button {
+                            storedFontSize = fontSize.rawValue
+                        } label: {
+                            if fontSize == readerFontSize {
+                                Label(fontSize.title, systemImage: "checkmark")
+                            } else {
+                                Text(fontSize.title)
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "textformat.size")
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Reader text size")
+
+                ShareLink(item: store.metadata.canonicalURL) {
+                    Image(systemName: "square.and.arrow.up")
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Share article")
+
+                Button {
+                    openOriginal()
+                } label: {
+                    Image(systemName: "safari")
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Open original article")
             }
-            .disabled(isUpdatingFinished)
-            .accessibilityLabel(store.isFinished ? "Mark unfinished" : "Mark finished")
+            .background(.thinMaterial, in: Capsule())
         }
+        .padding(.horizontal, 12)
+        .frame(height: ArticleReaderChromeOffsetTracker.maximumOffset)
+        .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("article-reader-chrome")
+    }
+
+    private var readerChromeViewport: some View {
+        ZStack(alignment: .top) {
+            readerChrome
+                .offset(y: -readerChromeOffset)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: ArticleReaderChromeOffsetTracker.maximumOffset, alignment: .top)
+        .clipped()
     }
 
     private var progressWriteKey: Int {
         Int((scrollProgress * 100).rounded(.down))
+    }
+
+    private var readerFontSize: ArticleReaderFontSize {
+        ArticleReaderFontSize(rawValue: storedFontSize) ?? .standard
     }
 
     private func recordOpenIfNeeded() {
@@ -205,25 +235,26 @@ struct ArticleReaderView: View {
         openURL(store.metadata.canonicalURL)
     }
 
-    private func persistProgress() async {
-        guard let progress = await store.persistProgress(scrollProgress) else { return }
-        lastPersistedProgress = scrollProgress
+    private func persistSettledProgress(_ progress: Double) {
+        scrollProgress = progress
+        guard store.readyDocument != nil,
+              abs(progress - lastPersistedProgress) >= 0.0001
+        else { return }
+        Task { await persistProgress(progress) }
+    }
+
+    private func persistProgress(_ fraction: Double) async {
+        guard let progress = await store.persistProgress(fraction) else { return }
+        lastPersistedProgress = progress.fraction
         onProgressSaved(progress)
     }
 
     private func flushProgress() {
         guard store.readyDocument != nil,
-              scrollProgress > 0,
-              abs(scrollProgress - lastPersistedProgress) >= 0.005
+              abs(scrollProgress - lastPersistedProgress) >= 0.0001
         else { return }
         let progress = scrollProgress
-        Task {
-            guard let saved = await store.persistProgress(progress) else { return }
-            await MainActor.run {
-                lastPersistedProgress = progress
-                onProgressSaved(saved)
-            }
-        }
+        Task { await persistProgress(progress) }
     }
 
     private func toggleFinished() async {

--- a/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
@@ -1,12 +1,19 @@
 import SwiftUI
 
 struct ScreenshotArticleReaderView: View {
+    private enum Destination: Hashable {
+        case reader
+    }
+
     let unavailable: Bool
+
+    @State private var path: [Destination] = [.reader]
 
     private let metadata = ArticleReaderMetadata(
         bookmarkID: "fixture-reader",
         title: "Designing Calm Software in a Noisy World",
         creator: "Mina Park",
+        creatorImageURL: URL(string: "https://avatars.githubusercontent.com/u/7396?v=4"),
         canonicalURL: URL(string: "https://example.com/calm-software")!,
         readingTimeMinutes: 7,
         initialProgress: BookmarkProgress(position: 0.18, duration: 1, percent: 18),
@@ -19,15 +26,22 @@ struct ScreenshotArticleReaderView: View {
     )
 
     var body: some View {
-        NavigationStack {
-            ArticleReaderView(
-                metadata: metadata,
-                client: client,
-                initialPhase: unavailable ? .unavailable(
-                    "This page doesn’t contain a dependable article body, so Zine won’t show an incomplete version."
-                ) : .ready(document),
-                loadsOnAppear: false
-            )
+        NavigationStack(path: $path) {
+            Text("Reader fixture root")
+                .accessibilityIdentifier("article-reader-fixture-root")
+                .navigationDestination(for: Destination.self) { destination in
+                    switch destination {
+                    case .reader:
+                        ArticleReaderView(
+                            metadata: metadata,
+                            client: client,
+                            initialPhase: unavailable ? .unavailable(
+                                "This page doesn’t contain a dependable article body, so Zine won’t show an incomplete version."
+                            ) : .ready(document),
+                            loadsOnAppear: false
+                        )
+                    }
+                }
         }
     }
 

--- a/apps/ios/ZineNativeTests/ArticleReaderTests.swift
+++ b/apps/ios/ZineNativeTests/ArticleReaderTests.swift
@@ -31,6 +31,137 @@ final class ArticleReaderTests: XCTestCase {
         XCTAssertTrue(html.contains("<article><p>Readable body</p></article>"))
     }
 
+    func testHTMLDocumentAppliesReaderFontScaleToTypographyOnly() throws {
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let html = ArticleHTMLDocumentBuilder.makeHTML(
+            for: ArticleReaderDocument(metadata: Self.metadata(), response: response),
+            fontScale: ArticleReaderFontSize.extraLarge.scale
+        )
+
+        XCTAssertTrue(html.contains("--reader-font-scale: 1.3"))
+        XCTAssertTrue(html.contains("font-size: calc(17px * var(--reader-font-scale))"))
+        XCTAssertTrue(html.contains("padding: 88.0px 22px 96px"))
+        XCTAssertFalse(html.contains("zoom:"))
+    }
+
+    func testHTMLDocumentPlacesCreatorAvatarBeforeCreatorName() throws {
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let html = ArticleHTMLDocumentBuilder.makeHTML(
+            for: ArticleReaderDocument(
+                metadata: Self.metadata(
+                    creatorImageURL: URL(string: "https://example.com/avatar.jpg?size=48&fit=crop")
+                ),
+                response: response
+            )
+        )
+
+        let avatar = "<img class=\"creator-avatar\" src=\"https://example.com/avatar.jpg?size=48&amp;fit=crop\" alt=\"\">"
+        XCTAssertTrue(html.contains(avatar))
+        XCTAssertLessThan(html.range(of: avatar)!.lowerBound, html.range(of: "<span>Author</span>")!.lowerBound)
+    }
+
+    func testHTMLDocumentPlacesRuleBetweenCreatorMetadataAndBody() throws {
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let html = ArticleHTMLDocumentBuilder.makeHTML(
+            for: ArticleReaderDocument(metadata: Self.metadata(), response: response)
+        )
+
+        let title = "<h1>A dependable reader</h1>"
+        let rule = "<hr class=\"title-rule\" aria-hidden=\"true\">"
+        let metadata = "<div class=\"meta\">"
+        let body = "<main>"
+        XCTAssertLessThan(html.range(of: title)!.lowerBound, html.range(of: metadata)!.lowerBound)
+        XCTAssertLessThan(html.range(of: metadata)!.lowerBound, html.range(of: rule)!.lowerBound)
+        XCTAssertLessThan(html.range(of: rule)!.lowerBound, html.range(of: body)!.lowerBound)
+    }
+
+    func testReaderFontSizePresetsHaveStableIncreasingScales() {
+        XCTAssertEqual(ArticleReaderFontSize.allCases.map(\.title), [
+            "Small", "Default", "Large", "Extra Large",
+        ])
+        XCTAssertEqual(ArticleReaderFontSize.allCases.map(\.scale), [0.9, 1, 1.15, 1.3])
+    }
+
+    @MainActor
+    func testReaderUsesPreciseStoredProgressInsteadOfRoundedPercent() {
+        let progress = BookmarkProgress(position: 0.2574, duration: 1, percent: 26)
+        let store = ArticleReaderStore(
+            metadata: Self.metadata(initialProgress: progress),
+            client: Self.client { _ in (500, "{}") }
+        )
+
+        XCTAssertEqual(progress.fraction, 0.2574, accuracy: 0.000_001)
+        XCTAssertEqual(store.initialProgressFraction, 0.2574, accuracy: 0.000_001)
+        XCTAssertEqual(
+            BookmarkProgress(position: 4, duration: 0, percent: 37).fraction,
+            0.37,
+            accuracy: 0.000_001
+        )
+    }
+
+    @MainActor
+    func testProgressWritesRemainOrderedWhenTheFirstRequestIsSlow() async {
+        var writes: [Double] = []
+        var activeWrites = 0
+        var maximumActiveWrites = 0
+        let queue = ArticleProgressWriteQueue { fraction in
+            activeWrites += 1
+            maximumActiveWrites = max(maximumActiveWrites, activeWrites)
+            if fraction == 0.2 {
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            writes.append(fraction)
+            activeWrites -= 1
+            return true
+        }
+
+        let first = Task { @MainActor in await queue.enqueue(0.2) }
+        await Task.yield()
+        let second = Task { @MainActor in await queue.enqueue(0.8) }
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        XCTAssertTrue(firstResult)
+        XCTAssertTrue(secondResult)
+        XCTAssertEqual(writes, [0.2, 0.8])
+        XCTAssertEqual(maximumActiveWrites, 1)
+    }
+
+    func testReaderChromeOffsetDirectlyTracksBothScrollDirections() {
+        var tracker = ArticleReaderChromeOffsetTracker()
+
+        tracker.begin(at: 100)
+        XCTAssertEqual(tracker.update(scrollOffset: 120), 20)
+        XCTAssertEqual(tracker.update(scrollOffset: 150), 50)
+        XCTAssertNil(tracker.update(scrollOffset: 150))
+        XCTAssertEqual(tracker.offset, 50)
+
+        XCTAssertEqual(tracker.update(scrollOffset: 138), 38)
+        XCTAssertEqual(tracker.update(scrollOffset: 100), 0)
+    }
+
+    func testReaderChromeOffsetStaysPutAcrossAPause() {
+        var tracker = ArticleReaderChromeOffsetTracker()
+
+        tracker.begin(at: 0)
+        XCTAssertEqual(tracker.update(scrollOffset: 80), 56)
+        tracker.end()
+        XCTAssertEqual(tracker.offset, 56)
+
+        tracker.begin(at: 80)
+        XCTAssertNil(tracker.update(scrollOffset: 80))
+        XCTAssertEqual(tracker.update(scrollOffset: 66), 42)
+    }
+
     func testCachePersistsOnlyReadableDocumentsPerUser() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: "article-cache-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -98,14 +229,23 @@ final class ArticleReaderTests: XCTestCase {
         XCTAssertEqual(ArticleReaderURLProtocol.requests.map(\.httpMethod), ["GET", "POST"])
     }
 
-    private static func metadata(title: String = "A dependable reader") -> ArticleReaderMetadata {
+    private static func metadata(
+        title: String = "A dependable reader",
+        creatorImageURL: URL? = nil,
+        initialProgress: BookmarkProgress? = BookmarkProgress(
+            position: 0.25,
+            duration: 1,
+            percent: 25
+        )
+    ) -> ArticleReaderMetadata {
         ArticleReaderMetadata(
             bookmarkID: "bookmark-1",
             title: title,
             creator: "Author",
+            creatorImageURL: creatorImageURL,
             canonicalURL: URL(string: "https://example.com/article")!,
             readingTimeMinutes: 4,
-            initialProgress: BookmarkProgress(position: 0.25, duration: 1, percent: 25),
+            initialProgress: initialProgress,
             isFinished: false
         )
     }

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -93,4 +93,11 @@ final class BookmarkTests: XCTestCase {
         XCTAssertEqual(Provider.substack.creatorActionTitle, "View on Substack")
         XCTAssertEqual(Provider.x.creatorActionTitle, "View on X")
     }
+
+    func testSubstackArticlesKeepTheirNativeProviderDestination() {
+        XCTAssertTrue(Provider.web.opensInZineReader(contentType: .article))
+        XCTAssertTrue(Provider.rss.opensInZineReader(contentType: .article))
+        XCTAssertFalse(Provider.substack.opensInZineReader(contentType: .article))
+        XCTAssertFalse(Provider.substack.opensInZineReader(contentType: .post))
+    }
 }


### PR DESCRIPTION
## Summary

- refine the native reader chrome with scroll-aware controls, font sizing, native swipe-back, and hidden tab navigation
- improve article presentation with creator avatars, a header divider, external Substack handling, and a correctly sized high-contrast Read action
- make reading-progress restoration and persistence precise and ordered, with expanded model and reader tests

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `xcodebuild test -quiet -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=78C1C044-D74D-4188-8C42-6743A1919C0D" -derivedDataPath /tmp/zine-reader-pr-native-tests CODE_SIGNING_ALLOWED=NO` (49 tests passed)
- manually verified reader chrome, scroll-direction behavior, swipe-back, font menu, creator avatar, header divider, and Read FAB on simulator and physical iPhone