### PR TITLE
feat(today): cluster Daily View into topics and threads

### DIFF
--- a/apps/ios/ContractReplay/main.swift
+++ b/apps/ios/ContractReplay/main.swift
@@ -7,13 +7,17 @@ guard CommandLine.arguments.count == 2 else {
 let data = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
 let response = try JSONDecoder().decode(DailyFeedResponse.self, from: data)
 
-guard response.variant.id == "people-first-v2",
+guard response.schemaVersion == 2,
+      response.variant.id == "people-first-v3",
       response.inputs?.favorites != nil,
-      response.sections != nil
+      response.sections != nil,
+      response.clustering?.method == "THREAD_FIRST_EVIDENCE_CLUSTERING",
+      response.threadUnits?.isEmpty == false,
+      response.topicClusters?.isEmpty == false
 else {
-    fatalError("fixture did not contain the people-first-v2 contract")
+    fatalError("fixture did not contain the people-first-v3 thread-first contract")
 }
 
 print(
-    "native-decode=ok variant=\(response.variant.id) posts=\(response.posts.count) conversations=\(response.conversations.count)"
+    "native-decode=ok variant=\(response.variant.id) posts=\(response.posts.count) threads=\(response.threadUnits?.count ?? 0) topics=\(response.topicClusters?.count ?? 0)"
 )

--- a/apps/ios/Fixtures/daily-feed-v2.json
+++ b/apps/ios/Fixtures/daily-feed-v2.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "variant": { "id": "people-first-v2", "mode": "REVIEW" },
+  "schemaVersion": 2,
+  "variant": { "id": "people-first-v3", "mode": "REVIEW" },
   "date": "2026-07-25",
   "timezone": "America/Chicago",
   "frozenAt": "2026-07-25T10:15:00.000Z",
@@ -46,17 +46,92 @@
       "id": "topic:1:2",
       "evidenceType": "TOPIC_SIMILARITY",
       "label": "Shared topic · swiftdata",
-      "evidence": "2 Favorite posts share multiple explicit terms.",
+      "evidence": "2 Favorite conversations from 2 authors share explicit evidence.",
       "postIds": ["1", "2"],
       "authors": ["alice", "bob"],
       "relationshipTypes": [],
-      "favoritePostIds": ["1"],
-      "contextPostIds": ["2"],
-      "favoriteAuthors": ["alice"],
+      "favoritePostIds": ["1", "2"],
+      "contextPostIds": [],
+      "favoriteAuthors": ["alice", "bob"],
       "latestActivityAt": "2026-07-25T10:00:00.000Z",
       "coverageWarnings": []
     }
   ],
+  "topicClusters": [
+    {
+      "id": "topic:daily-topics-v1:swiftdata",
+      "label": "SwiftData migrations",
+      "labelSource": "EXTRACTED_PHRASE",
+      "labelTerms": ["SwiftData migrations"],
+      "evidence": "2 Favorite conversations from 2 authors share explicit evidence.",
+      "evidenceSignals": [
+        {
+          "type": "SHARED_PHRASE",
+          "value": "SwiftData migrations",
+          "threadUnitIds": ["post:1", "post:2"]
+        }
+      ],
+      "threadUnitIds": ["post:1", "post:2"],
+      "favoriteThreadUnitIds": ["post:1", "post:2"],
+      "supportingThreadUnitIds": [],
+      "postIds": ["1", "2"],
+      "favoritePostIds": ["1", "2"],
+      "contextPostIds": [],
+      "favoriteAuthors": ["alice", "bob"],
+      "supportingAuthors": [],
+      "score": 260,
+      "latestActivityAt": "2026-07-25T10:00:00.000Z",
+      "coverageWarnings": []
+    }
+  ],
+  "threadUnits": [
+    {
+      "id": "post:1",
+      "conversationId": "1",
+      "rootPostId": "1",
+      "postIds": ["1"],
+      "favoritePostIds": ["1"],
+      "followingPostIds": [],
+      "contextPostIds": [],
+      "authorKeys": ["id:alice"],
+      "favoriteAuthorKeys": ["id:alice"],
+      "authors": ["alice"],
+      "favoriteAuthors": ["alice"],
+      "relationshipTypes": [],
+      "structureStatus": "EXACT",
+      "latestActivityAt": "2026-07-25T10:00:00.000Z",
+      "firstSourcePosition": 0,
+      "coverageWarnings": []
+    },
+    {
+      "id": "post:2",
+      "conversationId": "2",
+      "rootPostId": "2",
+      "postIds": ["2"],
+      "favoritePostIds": ["2"],
+      "followingPostIds": [],
+      "contextPostIds": [],
+      "authorKeys": ["id:bob"],
+      "favoriteAuthorKeys": ["id:bob"],
+      "authors": ["bob"],
+      "favoriteAuthors": ["bob"],
+      "relationshipTypes": [],
+      "structureStatus": "EXACT",
+      "latestActivityAt": "2026-07-25T09:55:00.000Z",
+      "firstSourcePosition": 1,
+      "coverageWarnings": []
+    }
+  ],
+  "clustering": {
+    "version": "daily-topics-v1",
+    "method": "THREAD_FIRST_EVIDENCE_CLUSTERING",
+    "semanticStatus": "COMPLETE",
+    "embeddingModel": "@cf/qwen/qwen3-embedding-0.6b",
+    "maxTopics": 5,
+    "minimumFavoriteAuthors": 2,
+    "candidateLimit": 40,
+    "semanticUnitLimit": 256
+  },
   "posts": [
     {
       "id": "1",
@@ -65,6 +140,16 @@
       "publishedAt": "2026-07-25T10:00:00.000Z",
       "observedAt": "2026-07-25T10:01:00.000Z",
       "kind": "POST",
+      "conversationId": "1",
+      "structure": {
+        "status": "EXACT",
+        "source": "NETWORK_LIST_LATEST",
+        "operation": "ListLatestTweetsTimeline",
+        "moduleId": null,
+        "moduleTweetIds": [],
+        "modulePosition": null,
+        "warnings": []
+      },
       "author": {
         "key": "id:alice",
         "username": "alice",
@@ -85,10 +170,20 @@
     {
       "id": "2",
       "url": "https://x.com/bob/status/2",
-      "text": "Following context",
+      "text": "SwiftData migration notes from another Favorite",
       "publishedAt": "2026-07-25T09:55:00.000Z",
       "observedAt": "2026-07-25T10:02:00.000Z",
       "kind": "REPLY",
+      "conversationId": "2",
+      "structure": {
+        "status": "EXACT",
+        "source": "NETWORK_LIST_LATEST",
+        "operation": "ListLatestTweetsTimeline",
+        "moduleId": null,
+        "moduleTweetIds": [],
+        "modulePosition": null,
+        "warnings": []
+      },
       "author": {
         "key": "id:bob",
         "username": "bob",
@@ -103,11 +198,16 @@
       "relationships": [],
       "presentation": "POST",
       "repostedBy": null,
-      "sourceIds": ["following"],
-      "sourcePosition": 0
+      "sourceIds": ["x-list:123"],
+      "sourcePosition": 1
     }
   ],
-  "sections": { "favoritePostIds": [], "followingPostIds": [] },
+  "sections": {
+    "favoritePostIds": [],
+    "followingPostIds": [],
+    "favoriteThreadUnitIds": [],
+    "followingThreadUnitIds": []
+  },
   "inputs": {
     "favorites": {
       "runId": "favorites-run",

--- a/apps/ios/ZineNative/Core/Models/DailyFeed.swift
+++ b/apps/ios/ZineNative/Core/Models/DailyFeed.swift
@@ -10,6 +10,9 @@ struct DailyFeedResponse: Decodable, Hashable {
     let coverage: DailyFeedCoverage
     let sources: [DailyFeedSource]
     let conversations: [DailyConversation]
+    let topicClusters: [DailyTopicCluster]?
+    let threadUnits: [DailyThreadUnit]?
+    let clustering: DailyTopicClustering?
     let posts: [DailyPost]
     let sections: DailyFeedSections?
     let inputs: DailyFeedInputs?
@@ -101,9 +104,71 @@ struct DailyConversation: Decodable, Hashable, Identifiable {
     let coverageWarnings: [String]?
 }
 
+struct DailyTopicClustering: Decodable, Hashable {
+    let version: String
+    let method: String
+    let semanticStatus: String
+    let embeddingModel: String?
+    let maxTopics: Int
+    let minimumFavoriteAuthors: Int
+    let candidateLimit: Int
+    let semanticUnitLimit: Int
+}
+
+struct DailyTopicSignal: Decodable, Hashable, Identifiable {
+    let type: String
+    let value: String
+    let threadUnitIds: [String]
+
+    var id: String { "\(type):\(value)" }
+}
+
+struct DailyTopicCluster: Decodable, Hashable, Identifiable {
+    let id: String
+    let label: String
+    let labelSource: String
+    let labelTerms: [String]
+    let evidence: String
+    let evidenceSignals: [DailyTopicSignal]
+    let threadUnitIds: [String]
+    let favoriteThreadUnitIds: [String]
+    let supportingThreadUnitIds: [String]
+    let postIds: [String]
+    let favoritePostIds: [String]
+    let contextPostIds: [String]
+    let favoriteAuthors: [String]
+    let supportingAuthors: [String]
+    let score: Int
+    let latestActivityAt: String?
+    let coverageWarnings: [String]
+}
+
+struct DailyThreadUnit: Decodable, Hashable, Identifiable {
+    let id: String
+    let conversationId: String?
+    let rootPostId: String
+    let postIds: [String]
+    let favoritePostIds: [String]
+    let followingPostIds: [String]
+    let contextPostIds: [String]
+    let authorKeys: [String]
+    let favoriteAuthorKeys: [String]
+    let authors: [String]
+    let favoriteAuthors: [String]
+    let relationshipTypes: [String]
+    let structureStatus: String
+    let latestActivityAt: String?
+    let firstSourcePosition: Int?
+    let coverageWarnings: [String]
+
+    var isThread: Bool { postIds.count > 1 }
+}
+
 struct DailyFeedSections: Decodable, Hashable {
     let favoritePostIds: [String]
     let followingPostIds: [String]
+    let favoriteThreadUnitIds: [String]?
+    let followingThreadUnitIds: [String]?
 }
 
 struct DailyFeedInputs: Decodable, Hashable {
@@ -168,6 +233,8 @@ struct DailyPost: Decodable, Hashable, Identifiable {
     let publishedAt: String?
     let observedAt: String?
     let kind: String
+    let conversationId: String?
+    let structure: DailyPostStructure?
     let author: DailyAuthor
     let media: [DailyPostMedia]
     let links: [DailyPostLink]
@@ -184,6 +251,12 @@ struct DailyPost: Decodable, Hashable, Identifiable {
         let value = publishedAt ?? observedAt
         return value.flatMap { try? Date($0, strategy: .iso8601) }
     }
+}
+
+struct DailyPostStructure: Decodable, Hashable {
+    let status: String
+    let source: String
+    let observedAt: String?
 }
 
 struct DailyAuthor: Decodable, Hashable {
@@ -242,6 +315,7 @@ struct DailyPostRelationship: Decodable, Hashable, Identifiable {
     let type: String
     let tweetId: String
     let url: String?
+    let evidenceSource: String?
     let target: DailyRelatedPost?
 
     var id: String { "\(type):\(tweetId)" }

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -75,30 +75,28 @@ private struct DailyFeedContent: View {
         Dictionary(uniqueKeysWithValues: response.sources.map { ($0.id, $0.name) })
     }
 
-    private var favoritePosts: [DailyPost] {
-        let ids = response.sections?.favoritePostIds
-            ?? response.posts.filter {
-                $0.sourceIds.contains(where: isFavoriteSource) && !conversationPostIDs.contains($0.id)
-            }.map(\.id)
-        return ids.compactMap { postsByID[$0] }
+    private var threadUnitsByID: [String: DailyThreadUnit] {
+        Dictionary(uniqueKeysWithValues: (response.threadUnits ?? []).map { ($0.id, $0) })
     }
 
-    private var followingPosts: [DailyPost] {
-        let ids = response.sections?.followingPostIds
-            ?? response.posts.filter {
-                !$0.sourceIds.contains(where: isFavoriteSource) && !conversationPostIDs.contains($0.id)
-            }.map(\.id)
-        return ids.compactMap { postsByID[$0] }
+    private var favoriteThreadUnits: [DailyThreadUnit] {
+        (response.sections?.favoriteThreadUnitIds ?? []).compactMap { threadUnitsByID[$0] }
     }
 
-    private var conversationPostIDs: Set<String> {
-        Set(response.conversations.flatMap(\.postIds))
+    private var followingThreadUnits: [DailyThreadUnit] {
+        (response.sections?.followingThreadUnitIds ?? []).compactMap { threadUnitsByID[$0] }
     }
 
-    private func isFavoriteSource(_ sourceID: String) -> Bool {
-        response.sources.first(where: { $0.id == sourceID }).map {
-            $0.type == .favorites || $0.type == .list
-        } ?? false
+    private var legacyFavoritePosts: [DailyPost] {
+        (response.sections?.favoritePostIds ?? []).compactMap { postsByID[$0] }
+    }
+
+    private var legacyFollowingPosts: [DailyPost] {
+        (response.sections?.followingPostIds ?? []).compactMap { postsByID[$0] }
+    }
+
+    private var usesThreadFirstContract: Bool {
+        response.topicClusters != nil && response.threadUnits != nil
     }
 
     var body: some View {
@@ -112,12 +110,34 @@ private struct DailyFeedContent: View {
                     .padding(.horizontal, 18)
                     .padding(.top, 16)
 
-                sectionTitle("FAVORITES", "Conversations from Favorites")
+                sectionTitle("FAVORITES", "What Favorites are talking about")
                     .padding(.horizontal, 18)
                     .padding(.top, 30)
 
-                if response.conversations.isEmpty {
-                    Text("No evidence-backed Favorite conversations were found in this frozen slice.")
+                if usesThreadFirstContract, let topics = response.topicClusters {
+                    if topics.isEmpty {
+                        Text("No topic has enough independent Favorite voices in this frozen slice.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 18)
+                            .padding(.top, 10)
+                    } else {
+                        LazyVStack(spacing: 14) {
+                            ForEach(topics) { topic in
+                                DailyTopicClusterCard(
+                                    topic: topic,
+                                    threadUnitsByID: threadUnitsByID,
+                                    postsByID: postsByID,
+                                    sourceNames: sourceNames,
+                                    date: response.date
+                                )
+                            }
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.top, 14)
+                    }
+                } else if response.conversations.isEmpty {
+                    Text("No evidence-backed Favorite topics were found in this frozen slice.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 18)
@@ -142,54 +162,75 @@ private struct DailyFeedContent: View {
                     .padding(.horizontal, 18)
                     .padding(.top, 34)
 
-                if favoritePosts.isEmpty {
+                if usesThreadFirstContract, favoriteThreadUnits.isEmpty {
                     ContentUnavailableView(
-                        "No additional Favorite posts",
+                        "No additional Favorite conversations",
                         systemImage: "person.2.slash",
-                        description: Text("Favorite posts in this slice are either grouped above or unavailable under the disclosed coverage.")
+                        description: Text("Favorite conversations in this slice are either grouped above or unavailable under the disclosed coverage.")
                     )
                     .padding(.top, 34)
-                } else {
+                } else if usesThreadFirstContract {
                     LazyVStack(spacing: 14) {
-                        ForEach(favoritePosts) { post in
-                            DailyFeedPostCard(
-                                post: post,
+                        ForEach(favoriteThreadUnits) { threadUnit in
+                            DailyThreadUnitCard(
+                                threadUnit: threadUnit,
+                                postsByID: postsByID,
                                 sourceNames: sourceNames,
-                                authorDestinationDate: response.date
+                                date: response.date
                             )
                         }
                     }
                     .padding(.horizontal, 18)
                     .padding(.top, 16)
                     .padding(.bottom, 38)
+                } else {
+                    legacyPostList(legacyFavoritePosts)
                 }
 
                 sectionTitle("FOLLOWING", "More from Following")
                     .padding(.horizontal, 18)
                     .padding(.top, 34)
 
-                if followingPosts.isEmpty {
-                    Text("No additional Following posts remain after conversation context and deduplication.")
+                if usesThreadFirstContract, followingThreadUnits.isEmpty {
+                    Text("No additional Following conversations remain after topic support and deduplication.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, 18)
                         .padding(.top, 10)
-                } else {
+                } else if usesThreadFirstContract {
                     LazyVStack(spacing: 14) {
-                        ForEach(followingPosts) { post in
-                            DailyFeedPostCard(
-                                post: post,
+                        ForEach(followingThreadUnits) { threadUnit in
+                            DailyThreadUnitCard(
+                                threadUnit: threadUnit,
+                                postsByID: postsByID,
                                 sourceNames: sourceNames,
-                                authorDestinationDate: response.date
+                                date: response.date
                             )
                         }
                     }
                     .padding(.horizontal, 18)
                     .padding(.top, 16)
                     .padding(.bottom, 38)
+                } else {
+                    legacyPostList(legacyFollowingPosts)
                 }
             }
         }
+    }
+
+    private func legacyPostList(_ posts: [DailyPost]) -> some View {
+        LazyVStack(spacing: 14) {
+            ForEach(posts) { post in
+                DailyFeedPostCard(
+                    post: post,
+                    sourceNames: sourceNames,
+                    authorDestinationDate: response.date
+                )
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+        .padding(.bottom, 38)
     }
 
     private func sectionTitle(_ eyebrow: String, _ title: String) -> some View {
@@ -263,6 +304,12 @@ private struct DailyCoverageNotice: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            if let clustering = response.clustering {
+                Label(topicMethod(clustering), systemImage: "point.3.connected.trianglepath.dotted")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             ForEach(response.freshness.warnings, id: \.self) { warning in
                 Label(warning, systemImage: "exclamationmark.circle")
                     .font(.caption)
@@ -296,6 +343,208 @@ private struct DailyCoverageNotice: View {
 
     private var statusColor: Color {
         response.coverage.status == .complete ? .green : .orange
+    }
+
+    private func topicMethod(_ clustering: DailyTopicClustering) -> String {
+        if let model = clustering.embeddingModel {
+            let scope = clustering.semanticStatus == "PARTIAL" ? "bounded" : "complete"
+            return "Topics use extracted evidence plus \(scope) pinned semantic similarity (\(model))."
+        }
+        return "Topics use deterministic extracted phrases, links, and relationships."
+    }
+}
+
+private struct DailyTopicClusterCard: View {
+    let topic: DailyTopicCluster
+    let threadUnitsByID: [String: DailyThreadUnit]
+    let postsByID: [String: DailyPost]
+    let sourceNames: [String: String]
+    let date: String
+
+    @State private var showsAllFavorites = false
+    @State private var showsFollowingSupport = false
+
+    private var favoriteUnits: [DailyThreadUnit] {
+        topic.favoriteThreadUnitIds.compactMap { threadUnitsByID[$0] }
+    }
+
+    private var supportingUnits: [DailyThreadUnit] {
+        topic.supportingThreadUnitIds.compactMap { threadUnitsByID[$0] }
+    }
+
+    private var visibleFavoriteUnits: [DailyThreadUnit] {
+        showsAllFavorites ? favoriteUnits : Array(favoriteUnits.prefix(3))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Image(systemName: "person.3.sequence.fill")
+                        .foregroundStyle(Color.accentColor)
+                    Text(topic.label)
+                        .font(.title3.weight(.bold))
+                    Spacer(minLength: 0)
+                }
+
+                Text(topic.evidence)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(Array(topic.evidenceSignals.prefix(4))) { signal in
+                            Label(signal.value, systemImage: signalIcon(signal.type))
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
+                                .background(Color.secondary.opacity(0.09), in: Capsule())
+                        }
+                    }
+                }
+
+                ForEach(topic.coverageWarnings, id: \.self) { warning in
+                    Label(warning, systemImage: "exclamationmark.circle")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            ForEach(visibleFavoriteUnits) { threadUnit in
+                DailyThreadUnitCard(
+                    threadUnit: threadUnit,
+                    postsByID: postsByID,
+                    sourceNames: sourceNames,
+                    date: date,
+                    isEmbedded: true
+                )
+            }
+
+            if favoriteUnits.count > visibleFavoriteUnits.count {
+                Button("Show all \(favoriteUnits.count) Favorite conversations") {
+                    withAnimation(.easeInOut(duration: 0.2)) { showsAllFavorites = true }
+                }
+                .font(.caption.weight(.semibold))
+            } else if showsAllFavorites, favoriteUnits.count > 3 {
+                Button("Show fewer Favorite conversations") {
+                    withAnimation(.easeInOut(duration: 0.2)) { showsAllFavorites = false }
+                }
+                .font(.caption.weight(.semibold))
+            }
+
+            if !supportingUnits.isEmpty {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { showsFollowingSupport.toggle() }
+                } label: {
+                    Label(
+                        showsFollowingSupport
+                            ? "Hide supporting context"
+                            : "Show \(supportingUnits.count) supporting context conversation\(supportingUnits.count == 1 ? "" : "s")",
+                        systemImage: showsFollowingSupport ? "chevron.up" : "chevron.down"
+                    )
+                }
+                .font(.caption.weight(.semibold))
+
+                if showsFollowingSupport {
+                    ForEach(supportingUnits) { threadUnit in
+                        DailyThreadUnitCard(
+                            threadUnit: threadUnit,
+                            postsByID: postsByID,
+                            sourceNames: sourceNames,
+                            date: date,
+                            isEmbedded: true
+                        )
+                    }
+                }
+            }
+        }
+        .padding(15)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func signalIcon(_ type: String) -> String {
+        switch type {
+        case "DIRECT_REFERENCE": "quote.bubble"
+        case "SHARED_LINK": "link"
+        case "SHARED_MARKER": "number"
+        case "SEMANTIC_SIMILARITY": "point.3.connected.trianglepath.dotted"
+        default: "text.quote"
+        }
+    }
+}
+
+private struct DailyThreadUnitCard: View {
+    let threadUnit: DailyThreadUnit
+    let postsByID: [String: DailyPost]
+    let sourceNames: [String: String]
+    let date: String
+    var isEmbedded = false
+
+    @State private var isExpanded = false
+
+    private var posts: [DailyPost] {
+        threadUnit.postIds.compactMap { postsByID[$0] }
+    }
+
+    private var visiblePosts: [DailyPost] {
+        isExpanded ? posts : Array(posts.prefix(threadUnit.isThread ? 2 : 1))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if threadUnit.isThread {
+                HStack(spacing: 8) {
+                    Label("\(posts.count)-post thread", systemImage: "arrow.triangle.branch")
+                        .font(.caption.weight(.semibold))
+                    Spacer()
+                    Text(threadUnit.structureStatus == "EXACT" ? "EXACT" : "PARTIAL")
+                        .font(.caption2.weight(.heavy))
+                        .tracking(0.6)
+                        .foregroundStyle(threadUnit.structureStatus == "EXACT" ? .green : .orange)
+                }
+
+                Text(threadUnit.authors.prefix(3).map { "@\($0)" }.joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(Array(visiblePosts.enumerated()), id: \.element.id) { index, post in
+                if index > 0 { Divider() }
+                DailyFeedPostCard(
+                    post: post,
+                    sourceNames: sourceNames,
+                    authorDestinationDate: date,
+                    isEmbedded: true
+                )
+            }
+
+            if posts.count > visiblePosts.count {
+                Button("Show complete \(posts.count)-post thread") {
+                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded = true }
+                }
+                .font(.caption.weight(.semibold))
+            } else if isExpanded, posts.count > 2 {
+                Button("Collapse thread") {
+                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded = false }
+                }
+                .font(.caption.weight(.semibold))
+            }
+
+            ForEach(threadUnit.coverageWarnings, id: \.self) { warning in
+                Label(warning, systemImage: "exclamationmark.circle")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(isEmbedded ? 11 : 14)
+        .background(
+            Color.secondary.opacity(isEmbedded ? 0.055 : 0.08),
+            in: RoundedRectangle(cornerRadius: isEmbedded ? 13 : 16)
+        )
     }
 }
 
@@ -382,15 +631,18 @@ struct DailyFeedPostCard: View {
     let post: DailyPost
     let sourceNames: [String: String]
     private let authorDestinationDate: String?
+    private let isEmbedded: Bool
 
     init(
         post: DailyPost,
         sourceNames: [String: String],
-        authorDestinationDate: String? = nil
+        authorDestinationDate: String? = nil,
+        isEmbedded: Bool = false
     ) {
         self.post = post
         self.sourceNames = sourceNames
         self.authorDestinationDate = authorDestinationDate
+        self.isEmbedded = isEmbedded
     }
 
     var body: some View {
@@ -447,8 +699,11 @@ struct DailyFeedPostCard: View {
                 }
             }
         }
-        .padding(14)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+        .padding(isEmbedded ? 0 : 14)
+        .background(
+            isEmbedded ? Color.clear : Color.secondary.opacity(0.08),
+            in: RoundedRectangle(cornerRadius: 16)
+        )
     }
 
     @ViewBuilder
@@ -681,6 +936,12 @@ private extension DailyPost {
         publishedAt: "2026-07-24T15:00:00.000Z",
         observedAt: "2026-07-24T15:01:00.000Z",
         kind: "POST",
+        conversationId: "123",
+        structure: DailyPostStructure(
+            status: "EXACT",
+            source: "X_WEB_GRAPHQL_LIST",
+            observedAt: "2026-07-24T15:01:00.000Z"
+        ),
         author: .preview,
         media: [],
         links: [],

--- a/apps/ios/ZineNativeTests/EditorialTests.swift
+++ b/apps/ios/ZineNativeTests/EditorialTests.swift
@@ -3,6 +3,82 @@ import XCTest
 @testable import ZineNative
 
 final class EditorialTests: XCTestCase {
+    func testDecodesPeopleFirstV3ThreadAndTopicContract() throws {
+        let response = try JSONDecoder().decode(
+            DailyFeedResponse.self,
+            from: Data(
+                """
+                {
+                  "schemaVersion":2,
+                  "variant":{"id":"people-first-v3","mode":"REVIEW"},
+                  "date":"2026-07-25",
+                  "timezone":"America/Chicago",
+                  "frozenAt":"2026-07-25T13:00:00.000Z",
+                  "freshness":{"isCurrent":true,"status":"COMPLETE","warnings":[]},
+                  "coverage":{
+                    "status":"COMPLETE","archiveStatus":"COMPLETE",
+                    "selectionStatus":"COMPLETE","runId":"run-1",
+                    "requestedCount":5000,"collectedCount":2,
+                    "message":"Complete rolling-window review slice."
+                  },
+                  "sources":[],
+                  "conversations":[],
+                  "topicClusters":[{
+                    "id":"topic:daily-topics-v1:one","label":"Open weight models",
+                    "labelSource":"EXTRACTED_PHRASE","labelTerms":["Open weight models"],
+                    "evidence":"2 Favorite conversations from 2 authors share explicit evidence.",
+                    "evidenceSignals":[{
+                      "type":"SHARED_PHRASE","value":"Open weight models",
+                      "threadUnitIds":["post:1","post:2"]
+                    }],
+                    "threadUnitIds":["post:1","post:2"],
+                    "favoriteThreadUnitIds":["post:1","post:2"],
+                    "supportingThreadUnitIds":[],"postIds":["1","2"],
+                    "favoritePostIds":["1","2"],"contextPostIds":[],
+                    "favoriteAuthors":["alice","bob"],"supportingAuthors":[],
+                    "score":250,"latestActivityAt":"2026-07-25T12:00:00.000Z",
+                    "coverageWarnings":[]
+                  }],
+                  "threadUnits":[{
+                    "id":"post:1","conversationId":"1","rootPostId":"1",
+                    "postIds":["1"],"favoritePostIds":["1"],"followingPostIds":[],
+                    "contextPostIds":[],"authorKeys":["id:alice"],
+                    "favoriteAuthorKeys":["id:alice"],"authors":["alice"],
+                    "favoriteAuthors":["alice"],"relationshipTypes":[],
+                    "structureStatus":"EXACT","latestActivityAt":"2026-07-25T12:00:00.000Z",
+                    "firstSourcePosition":0,"coverageWarnings":[]
+                  },{
+                    "id":"post:2","conversationId":"2","rootPostId":"2",
+                    "postIds":["2"],"favoritePostIds":["2"],"followingPostIds":[],
+                    "contextPostIds":[],"authorKeys":["id:bob"],
+                    "favoriteAuthorKeys":["id:bob"],"authors":["bob"],
+                    "favoriteAuthors":["bob"],"relationshipTypes":[],
+                    "structureStatus":"EXACT","latestActivityAt":"2026-07-25T11:00:00.000Z",
+                    "firstSourcePosition":1,"coverageWarnings":[]
+                  }],
+                  "clustering":{
+                    "version":"daily-topics-v1","method":"THREAD_FIRST_EVIDENCE_CLUSTERING",
+                    "semanticStatus":"COMPLETE","embeddingModel":"@cf/qwen/qwen3-embedding-0.6b",
+                    "maxTopics":5,"minimumFavoriteAuthors":2,
+                    "candidateLimit":40,"semanticUnitLimit":256
+                  },
+                  "posts":[],
+                  "sections":{
+                    "favoritePostIds":[],"followingPostIds":[],
+                    "favoriteThreadUnitIds":[],"followingThreadUnitIds":[]
+                  },
+                  "requestId":"request-1","traceId":"trace-1"
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(response.variant.id, "people-first-v3")
+        XCTAssertEqual(response.clustering?.version, "daily-topics-v1")
+        XCTAssertEqual(response.threadUnits?.count, 2)
+        XCTAssertEqual(response.topicClusters?.first?.favoriteThreadUnitIds, ["post:1", "post:2"])
+    }
+
     func testDecodesPeopleFirstDailyFeedWithEvidenceAndPostContext() throws {
         let response = try JSONDecoder().decode(
             DailyFeedResponse.self,

--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -312,7 +312,7 @@ function fakeArchiveDb(
 }
 
 describe('people-first daily feed', () => {
-  it('groups exact same-conversation posts even when an intermediate parent is unavailable', async () => {
+  it('collapses exact same-conversation posts even when an intermediate parent is unavailable', async () => {
     const conversationRows = [
       postRow({
         id: '500',
@@ -346,18 +346,29 @@ describe('people-first daily feed', () => {
       { now: NOW }
     );
 
-    expect(result.conversations).toEqual([
+    expect(result.conversations).toEqual([]);
+    expect(result.threadUnits).toEqual([
       expect.objectContaining({
-        evidenceType: 'DIRECT_RELATIONSHIP',
+        id: 'conversation:500',
         postIds: ['500', '502'],
         relationshipTypes: ['CONVERSATION_ID'],
       }),
     ]);
   });
 
-  it('filters to explicit sources and groups only relationship-backed conversations', async () => {
+  it('filters to explicit sources and keeps relationship-backed posts in one thread unit', async () => {
     const result = await getDailyFeed(fakeArchiveDb(), USER_ID, { now: NOW });
 
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      variant: { id: 'people-first-v3', mode: 'REVIEW' },
+      clustering: {
+        version: 'daily-topics-v1',
+        method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
+        maxTopics: 5,
+        minimumFavoriteAuthors: 2,
+      },
+    });
     expect(result.coverage).toMatchObject({
       status: 'COMPLETE',
       archiveStatus: 'COMPLETE',
@@ -383,15 +394,20 @@ describe('people-first daily feed', () => {
         },
       ],
     });
-    expect(result.conversations).toEqual([
-      expect.objectContaining({
-        evidenceType: 'DIRECT_RELATIONSHIP',
-        postIds: ['101', '100'],
-        authors: ['bob', 'alice'],
-        favoriteAuthors: ['bob', 'reposter'],
-      }),
-    ]);
-    expect(result.sections).toEqual({ favoritePostIds: [], followingPostIds: ['102'] });
+    expect(result.conversations).toEqual([]);
+    expect(result.threadUnits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          postIds: ['101', '100'],
+          authors: ['bob', 'alice'],
+          favoriteAuthors: ['bob', 'reposter'],
+        }),
+      ])
+    );
+    expect(result.sections).toMatchObject({
+      favoritePostIds: ['100', '101'],
+      followingPostIds: ['102'],
+    });
     expect(result.inputs).toMatchObject({
       favorites: { runId: 'favorites-run', sourceId: 'favorites' },
       following: { runId: 'following-run' },
@@ -415,7 +431,7 @@ describe('people-first daily feed', () => {
     expect(result.posts).toHaveLength(3);
   });
 
-  it('groups a Favorite reply with immutable run context without adding context to streams', async () => {
+  it('collapses a Favorite reply with immutable run context without adding context to streams', async () => {
     const favoriteReply = postRow({
       id: '200',
       authorKey: 'id:alice',
@@ -454,15 +470,15 @@ describe('people-first daily feed', () => {
 
     const result = await getDailyFeed(db, USER_ID, { now: NOW });
 
-    expect(result.conversations).toEqual([
+    expect(result.conversations).toEqual([]);
+    expect(result.threadUnits).toEqual([
       expect.objectContaining({
-        evidenceType: 'DIRECT_RELATIONSHIP',
         favoritePostIds: ['200'],
         contextPostIds: ['199'],
         postIds: ['199', '200'],
       }),
     ]);
-    expect(result.sections).toEqual({ favoritePostIds: [], followingPostIds: [] });
+    expect(result.sections).toMatchObject({ favoritePostIds: ['200'], followingPostIds: [] });
     expect(result.posts.find((post) => post.id === '199')?.sourceIds).toEqual([]);
   });
 
@@ -577,7 +593,7 @@ describe('people-first daily feed', () => {
     expect(result.sections.followingPostIds).toEqual(['102']);
   });
 
-  it('groups Favorite quote context and preserves its explicit evidence', async () => {
+  it('preserves Favorite quote context without treating a quote pair as a topic', async () => {
     const quote = postRow({
       id: 'quote-2',
       authorKey: 'id:alice',
@@ -619,12 +635,11 @@ describe('people-first daily feed', () => {
       { now: NOW }
     );
 
-    expect(result.conversations[0]).toMatchObject({
-      evidenceType: 'DIRECT_RELATIONSHIP',
-      relationshipTypes: ['QUOTE_OF'],
-      favoritePostIds: ['quote-2'],
-      contextPostIds: ['quote-1'],
-    });
+    expect(result.conversations).toEqual([]);
+    expect(result.sections.favoritePostIds).toEqual(['quote-2']);
+    expect(result.posts.find((post) => post.id === 'quote-2')?.relationships).toEqual([
+      expect.objectContaining({ type: 'QUOTE_OF', tweetId: 'quote-1' }),
+    ]);
   });
 
   it('groups a shared normalized link but leaves weak topic overlap ungrouped', async () => {
@@ -681,7 +696,7 @@ describe('people-first daily feed', () => {
 
     expect(result.conversations).toEqual([
       expect.objectContaining({
-        evidenceType: 'SHARED_LINK',
+        evidenceType: 'TOPIC_SIMILARITY',
         favoritePostIds: ['link-1', 'link-2'],
       }),
     ]);
@@ -713,7 +728,7 @@ describe('people-first daily feed', () => {
       'did not prove complete 24-hour coverage'
     );
     expect(result.freshness.warnings).toContain('1 Favorite thread expansion was truncated.');
-    expect(result.conversations[0]?.coverageWarnings).toContain('context_budget_reached');
+    expect(result.threadUnits[0]?.coverageWarnings).not.toContain('context_budget_reached');
     expect(result.inputs.favorites?.contextCoverage).toMatchObject({ truncated: 1, failed: 1 });
   });
 

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -1,3 +1,9 @@
+import {
+  buildDailyTopicClustering,
+  createWorkersAIDailyTopicEmbeddingProvider,
+  DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL,
+} from './daily-topic-clustering';
+
 const DEFAULT_TIMEZONE = 'America/Chicago';
 const MAX_RUN_POSTS = 5_000;
 const RELATIONSHIP_QUERY_POST_LIMIT = 90;
@@ -218,8 +224,13 @@ function publicPost(
       profileImageUrl: row.profile_image_url,
       verified: row.verified === null ? null : Boolean(row.verified),
     },
-    media: parseJson(row.media_json, []),
-    links: parseJson(row.links_json, []),
+    media: parseJson(row.media_json, []) as unknown[],
+    links: parseJson(row.links_json, []) as Array<{
+      url?: string;
+      normalizedUrl?: string;
+      displayUrl?: string | null;
+      card?: { domain?: string | null } | null;
+    }>,
     metrics: parseJson(row.metrics_json, {}),
     relationships,
     presentation: row.presentation ?? row.kind,
@@ -492,299 +503,16 @@ function sourceIdsForAuthor(
     .map((source) => source.id);
 }
 
-function uniqueAuthors(posts: DailyPost[]): string[] {
-  return [...new Set(posts.map((post) => post.author.username))];
-}
-
-function uniquePresentationAuthors(posts: DailyPost[]): string[] {
-  return [...new Set(posts.map((post) => post.repostedBy?.username ?? post.author.username))];
-}
-
-const TOPIC_STOP_WORDS = new Set([
-  'about',
-  'after',
-  'again',
-  'also',
-  'because',
-  'before',
-  'being',
-  'from',
-  'have',
-  'into',
-  'just',
-  'more',
-  'that',
-  'their',
-  'there',
-  'these',
-  'they',
-  'this',
-  'those',
-  'through',
-  'what',
-  'when',
-  'where',
-  'which',
-  'while',
-  'with',
-  'would',
-  'your',
-  'https',
-  'http',
-]);
-
-function topicTokens(post: DailyPost): Set<string> {
-  const values = post.text.toLocaleLowerCase().match(/[#@]?[\p{L}\p{N}_-]{4,}/gu) ?? [];
-  return new Set(values.filter((value) => !TOPIC_STOP_WORDS.has(value)));
-}
-
-function sharedTopicTerms(leftTokens: Set<string>, rightTokens: Set<string>): string[] {
-  return [...leftTokens].filter((token) => rightTokens.has(token)).sort();
-}
-
-function dailyPostTimestamp(post: DailyPost): number {
-  return Date.parse(post.publishedAt ?? post.observedAt ?? '') || 0;
-}
-
-function conversationLatestActivity(posts: DailyPost[]): string | null {
-  const latest = Math.max(...posts.map(dailyPostTimestamp));
-  return latest > 0 ? new Date(latest).toISOString() : null;
-}
-
-function firstSourcePosition(posts: DailyPost[]): number {
-  return Math.min(...posts.map((post) => post.sourcePosition ?? Number.MAX_SAFE_INTEGER));
-}
-
-function conversationGroups(
-  posts: DailyPost[],
-  favoritePostIds = new Set(posts.map((post) => post.id)),
-  contextWarnings: string[] = []
-) {
-  const postById = new Map(posts.map((post) => [post.id, post]));
-  const topicTokensByPost = new Map(posts.map((post) => [post.id, topicTokens(post)]));
-  const parents = new Map(posts.map((post) => [post.id, post.id]));
-  const find = (id: string): string => {
-    const parent = parents.get(id) ?? id;
-    if (parent === id) return id;
-    const root = find(parent);
-    parents.set(id, root);
-    return root;
-  };
-  const union = (a: string, b: string) => {
-    const left = find(a);
-    const right = find(b);
-    if (left !== right) parents.set(right, left);
-  };
-
-  for (const post of posts) {
-    for (const relationship of post.relationships) {
-      if (postById.has(relationship.tweetId)) union(post.id, relationship.tweetId);
-    }
-  }
-  const postsByConversation = new Map<string, DailyPost[]>();
-  for (const post of posts) {
-    if (!post.conversationId) continue;
-    postsByConversation.set(post.conversationId, [
-      ...(postsByConversation.get(post.conversationId) ?? []),
-      post,
-    ]);
-  }
-  for (const groupPosts of postsByConversation.values()) {
-    for (let index = 1; index < groupPosts.length; index++) {
-      union(groupPosts[0].id, groupPosts[index].id);
-    }
-  }
-
-  const direct = new Map<string, DailyPost[]>();
-  for (const post of posts) {
-    const root = find(post.id);
-    direct.set(root, [...(direct.get(root) ?? []), post]);
-  }
-
-  const candidates: Array<{
-    id: string;
-    evidenceType: 'DIRECT_RELATIONSHIP' | 'SHARED_LINK' | 'TOPIC_SIMILARITY';
-    label: string;
-    evidence: string;
-    postIds: string[];
-    authors: string[];
-    relationshipTypes: string[];
-    favoritePostIds: string[];
-    contextPostIds: string[];
-    favoriteAuthors: string[];
-    latestActivityAt: string | null;
-    coverageWarnings: string[];
-    firstFavoritePosition: number;
-  }> = [];
-  for (const groupPosts of direct.values()) {
-    const orderedPosts = [...groupPosts].sort(
-      (left, right) => dailyPostTimestamp(left) - dailyPostTimestamp(right)
-    );
-    const selectedPosts = orderedPosts.slice(0, 8);
-    if (!selectedPosts.some((post) => favoritePostIds.has(post.id))) {
-      const favoriteAnchor = orderedPosts.find((post) => favoritePostIds.has(post.id));
-      if (favoriteAnchor) selectedPosts.splice(-1, 1, favoriteAnchor);
-    }
-    const authors = uniqueAuthors(selectedPosts);
-    const favoritePosts = selectedPosts.filter((post) => favoritePostIds.has(post.id));
-    if (groupPosts.length < 2 || favoritePosts.length === 0) continue;
-    const relationshipTypes = [
-      ...new Set(
-        groupPosts.flatMap((post) =>
-          post.relationships
-            .filter((relationship) => postById.has(relationship.tweetId))
-            .map((relationship) => relationship.type)
-        )
-      ),
-    ];
-    if (
-      groupPosts.some(
-        (post, index) =>
-          post.conversationId &&
-          groupPosts.some(
-            (candidate, candidateIndex) =>
-              candidateIndex !== index && candidate.conversationId === post.conversationId
-          )
-      )
-    ) {
-      relationshipTypes.push('CONVERSATION_ID');
-    }
-    candidates.push({
-      id: `relationship:${groupPosts
-        .map((post) => post.id)
-        .sort()
-        .join(':')}`,
-      evidenceType: 'DIRECT_RELATIONSHIP',
-      label: `Direct conversation · ${authors
-        .slice(0, 3)
-        .map((author) => `@${author}`)
-        .join(', ')}`,
-      evidence: `${selectedPosts.length} posts are connected by ${[...new Set(relationshipTypes)]
-        .map((type) => type.toLocaleLowerCase().replaceAll('_', ' '))
-        .join(', ')} metadata.`,
-      postIds: selectedPosts.map((post) => post.id),
-      authors,
-      relationshipTypes: [...new Set(relationshipTypes)],
-      favoritePostIds: favoritePosts.map((post) => post.id),
-      contextPostIds: selectedPosts
-        .filter((post) => !favoritePostIds.has(post.id))
-        .map((post) => post.id),
-      favoriteAuthors: uniquePresentationAuthors(favoritePosts),
-      latestActivityAt: conversationLatestActivity(selectedPosts),
-      coverageWarnings: contextWarnings,
-      firstFavoritePosition: firstSourcePosition(favoritePosts),
-    });
-  }
-
-  const linkGroups = new Map<string, DailyPost[]>();
-  for (const post of posts) {
-    for (const link of post.links as Array<{
-      normalizedUrl?: string;
-      card?: { domain?: string | null } | null;
-    }>) {
-      if (!link.normalizedUrl) continue;
-      linkGroups.set(link.normalizedUrl, [...(linkGroups.get(link.normalizedUrl) ?? []), post]);
-    }
-  }
-  for (const [url, linkedPosts] of linkGroups) {
-    const uniquePosts = [...new Map(linkedPosts.map((post) => [post.id, post])).values()]
-      .filter((post) => !candidates.some((candidate) => candidate.postIds.includes(post.id)))
-      .sort(
-        (left, right) =>
-          firstSourcePosition([left]) - firstSourcePosition([right]) ||
-          dailyPostTimestamp(right) - dailyPostTimestamp(left)
-      )
-      .slice(0, 8);
-    const authors = uniqueAuthors(uniquePosts);
-    const favoritePosts = uniquePosts.filter((post) => favoritePostIds.has(post.id));
-    if (uniquePosts.length < 2 || authors.length < 2 || favoritePosts.length === 0) continue;
-    const ids = uniquePosts.map((post) => post.id);
-    let domain = url;
-    try {
-      domain = new URL(url).hostname.replace(/^www\./, '');
-    } catch {
-      // Keep the normalized URL as explicit evidence when it cannot be parsed.
-    }
-    candidates.push({
-      id: `link:${url}`,
-      evidenceType: 'SHARED_LINK',
-      label: `Shared link · ${domain}`,
-      evidence: `${authors.length} authors linked to the same normalized URL.`,
-      postIds: ids.slice(0, 4),
-      authors,
-      relationshipTypes: [],
-      favoritePostIds: favoritePosts.map((post) => post.id),
-      contextPostIds: uniquePosts
-        .filter((post) => !favoritePostIds.has(post.id))
-        .map((post) => post.id),
-      favoriteAuthors: uniquePresentationAuthors(favoritePosts),
-      latestActivityAt: conversationLatestActivity(uniquePosts),
-      coverageWarnings: [],
-      firstFavoritePosition: firstSourcePosition(favoritePosts),
-    });
-  }
-
-  const favoritePosts = posts.filter((post) => favoritePostIds.has(post.id));
-  for (let leftIndex = 0; leftIndex < favoritePosts.length; leftIndex++) {
-    const left = favoritePosts[leftIndex]!;
-    if (candidates.some((candidate) => candidate.postIds.includes(left.id))) continue;
-    const related = [left];
-    const evidenceTerms = new Set<string>();
-    for (let rightIndex = leftIndex + 1; rightIndex < favoritePosts.length; rightIndex++) {
-      const right = favoritePosts[rightIndex]!;
-      if (candidates.some((candidate) => candidate.postIds.includes(right.id))) continue;
-      const terms = sharedTopicTerms(
-        topicTokensByPost.get(left.id) ?? new Set(),
-        topicTokensByPost.get(right.id) ?? new Set()
-      );
-      const hasStrongMarker = terms.some((term) => term.startsWith('#') || term.startsWith('@'));
-      if (terms.length < 3 && !(hasStrongMarker && terms.length >= 2)) continue;
-      related.push(right);
-      terms.slice(0, 4).forEach((term) => evidenceTerms.add(term));
-      if (related.length === 4) break;
-    }
-    if (related.length < 2 || uniqueAuthors(related).length < 2) continue;
-    const terms = [...evidenceTerms].slice(0, 3);
-    candidates.push({
-      id: `topic:${related
-        .map((post) => post.id)
-        .sort()
-        .join(':')}`,
-      evidenceType: 'TOPIC_SIMILARITY',
-      label: `Shared topic · ${terms.join(' · ')}`,
-      evidence: `${related.length} Favorite posts share multiple explicit terms: ${terms.join(', ')}.`,
-      postIds: related.map((post) => post.id),
-      authors: uniqueAuthors(related),
-      relationshipTypes: [],
-      favoritePostIds: related.map((post) => post.id),
-      contextPostIds: [],
-      favoriteAuthors: uniquePresentationAuthors(related),
-      latestActivityAt: conversationLatestActivity(related),
-      coverageWarnings: [],
-      firstFavoritePosition: firstSourcePosition(related),
-    });
-  }
-
-  return candidates
-    .sort(
-      (a, b) =>
-        (({ DIRECT_RELATIONSHIP: 0, SHARED_LINK: 1, TOPIC_SIMILARITY: 2 })[a.evidenceType] ?? 3) -
-          ({ DIRECT_RELATIONSHIP: 0, SHARED_LINK: 1, TOPIC_SIMILARITY: 2 }[b.evidenceType] ?? 3) ||
-        b.favoriteAuthors.length - a.favoriteAuthors.length ||
-        b.favoritePostIds.length - a.favoritePostIds.length ||
-        b.authors.length - a.authors.length ||
-        (Date.parse(b.latestActivityAt ?? '') || 0) - (Date.parse(a.latestActivityAt ?? '') || 0) ||
-        a.firstFavoritePosition - b.firstFavoritePosition ||
-        a.id.localeCompare(b.id)
-    )
-    .slice(0, 3)
-    .map(({ firstFavoritePosition: _firstFavoritePosition, ...conversation }) => conversation);
-}
-
 export async function getDailyFeed(
   db: D1Database,
   userId: string,
-  options: { date?: string; timezone?: string; now?: Date } = {}
+  options: {
+    date?: string;
+    timezone?: string;
+    now?: Date;
+    ai?: { run(model: string, input: unknown): Promise<unknown> } | null;
+    embeddingModel?: string;
+  } = {}
 ) {
   const timezone = options.timezone ?? DEFAULT_TIMEZONE;
   const now = options.now ?? new Date();
@@ -805,8 +533,8 @@ export async function getDailyFeed(
   const primaryRun = favoritesRun ?? followingRun;
   if (!primaryRun) {
     return {
-      schemaVersion: 1,
-      variant: { id: 'people-first-v2', mode: 'REVIEW' as const },
+      schemaVersion: 2,
+      variant: { id: 'people-first-v3', mode: 'REVIEW' as const },
       date: options.date ?? expectedDate,
       timezone,
       frozenAt: null,
@@ -821,9 +549,26 @@ export async function getDailyFeed(
         message: 'No complete or partial X Following archive run is available for this day.',
       },
       sources: [] as DailySource[],
-      conversations: [] as ReturnType<typeof conversationGroups>,
+      conversations: [],
+      topicClusters: [],
+      threadUnits: [],
+      clustering: {
+        version: 'daily-topics-v1',
+        method: 'THREAD_FIRST_EVIDENCE_CLUSTERING' as const,
+        semanticStatus: 'FALLBACK' as const,
+        embeddingModel: null,
+        maxTopics: 5,
+        minimumFavoriteAuthors: 2,
+        candidateLimit: 40,
+        semanticUnitLimit: 256,
+      },
       posts: [] as DailyPost[],
-      sections: { favoritePostIds: [], followingPostIds: [] },
+      sections: {
+        favoritePostIds: [],
+        followingPostIds: [],
+        favoriteThreadUnitIds: [],
+        followingThreadUnitIds: [],
+      },
       inputs: { favorites: null, following: null, membership: null },
     };
   }
@@ -957,6 +702,7 @@ export async function getDailyFeed(
     publicPost(row, [], relationships.get(row.tweet_id) ?? [])
   );
   const posts = [...favoritePosts, ...followingPosts, ...contextPosts];
+  const followingPostIds = new Set(followingPosts.map((post) => post.id));
   const favoriteContextCoverage = favoritesRun ? contextCoverage(favoritesRun) : null;
   const favoriteWindowCoverage = favoritesRun ? windowCoverage(favoritesRun) : null;
   const favoriteStructureCoverage = favoritesRun ? structureCoverage(favoritesRun) : null;
@@ -984,15 +730,56 @@ export async function getDailyFeed(
   }
   contextWarnings.push(...(favoriteContextCoverage?.warnings ?? []));
   contextWarnings.push(...(favoriteStructureCoverage?.warnings ?? []));
-  const conversations = conversationGroups(posts, favoritePostIds, contextWarnings);
-  const conversationPostIds = new Set(
-    conversations.flatMap((conversation) => conversation.postIds)
+  const topicClustering = await buildDailyTopicClustering(
+    posts,
+    favoritePostIds,
+    followingPostIds,
+    {
+      embeddingProvider: createWorkersAIDailyTopicEmbeddingProvider(
+        options.ai,
+        options.embeddingModel ?? DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL
+      ),
+    }
+  );
+  const threadUnitsById = new Map(topicClustering.threadUnits.map((unit) => [unit.id, unit]));
+  const postById = new Map(posts.map((post) => [post.id, post]));
+  const conversations = topicClustering.topicClusters.map((topic) => {
+    const topicPosts = topic.postIds
+      .map((postId) => postById.get(postId))
+      .filter((post): post is DailyPost => Boolean(post));
+    return {
+      id: topic.id,
+      evidenceType: 'TOPIC_SIMILARITY' as const,
+      label: topic.label,
+      evidence: topic.evidence,
+      postIds: topic.postIds,
+      authors: [...new Set(topicPosts.map((post) => post.author.username))],
+      relationshipTypes: [
+        ...new Set(
+          topic.threadUnitIds.flatMap(
+            (threadUnitId) => threadUnitsById.get(threadUnitId)?.relationshipTypes ?? []
+          )
+        ),
+      ],
+      favoritePostIds: topic.favoritePostIds,
+      contextPostIds: topic.contextPostIds,
+      favoriteAuthors: topic.favoriteAuthors,
+      latestActivityAt: topic.latestActivityAt,
+      coverageWarnings: topic.coverageWarnings,
+    };
+  });
+  const favoriteUngroupedThreadIds = new Set(topicClustering.favoriteThreadUnitIds);
+  const followingUngroupedThreadIds = new Set(topicClustering.followingThreadUnitIds);
+  const unitIdByPostId = new Map(
+    topicClustering.threadUnits.flatMap((unit) =>
+      unit.postIds.map((postId) => [postId, unit.id] as const)
+    )
   );
   const favoriteUngroupedIds = favoritePosts
-    .filter((post) => !conversationPostIds.has(post.id))
+    .filter((post) => favoriteUngroupedThreadIds.has(unitIdByPostId.get(post.id) ?? ''))
     .map((post) => post.id);
   const followingSectionIds = followingPosts
-    .filter((post) => !conversationPostIds.has(post.id))
+    .filter((post) => followingUngroupedThreadIds.has(unitIdByPostId.get(post.id) ?? ''))
     .map((post) => post.id);
   const runComplete = (run: ArchiveRunRow | null) => {
     if (!run) return true;
@@ -1014,6 +801,7 @@ export async function getDailyFeed(
     (favoriteContextCoverage.truncated === 0 && favoriteContextCoverage.failed === 0);
   const membershipComplete = selectionStatus === 'COMPLETE' && unresolvedMembershipCount === 0;
   warnings.push(...contextWarnings);
+  warnings.push(...topicClustering.warnings);
   for (const run of [favoritesRun, followingRun].filter(Boolean) as ArchiveRunRow[]) {
     if (!runComplete(run)) {
       const policy = collectionPolicy(run);
@@ -1034,8 +822,8 @@ export async function getDailyFeed(
       : ('PARTIAL' as const);
 
   return {
-    schemaVersion: 1,
-    variant: { id: 'people-first-v2', mode: 'REVIEW' as const },
+    schemaVersion: 2,
+    variant: { id: 'people-first-v3', mode: 'REVIEW' as const },
     date,
     timezone,
     frozenAt: frozenAt.toISOString(),
@@ -1093,10 +881,15 @@ export async function getDailyFeed(
         : []),
     ],
     conversations,
+    topicClusters: topicClustering.topicClusters,
+    threadUnits: topicClustering.threadUnits,
+    clustering: topicClustering.algorithm,
     posts,
     sections: {
       favoritePostIds: favoriteUngroupedIds,
       followingPostIds: followingSectionIds,
+      favoriteThreadUnitIds: topicClustering.favoriteThreadUnitIds,
+      followingThreadUnitIds: topicClustering.followingThreadUnitIds,
     },
     inputs: {
       favorites: favoritesRun

--- a/apps/worker/src/lib/daily-topic-clustering.test.ts
+++ b/apps/worker/src/lib/daily-topic-clustering.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDailyThreadUnits,
+  buildDailyTopicClustering,
+  createWorkersAIDailyTopicEmbeddingProvider,
+  type DailyTopicPost,
+} from './daily-topic-clustering';
+
+function post(input: {
+  id: string;
+  username: string;
+  text: string;
+  position: number;
+  conversationId?: string;
+  parentId?: string;
+  quoteId?: string;
+  source?: 'favorites' | 'following' | 'context';
+  link?: string;
+}): DailyTopicPost {
+  return {
+    id: input.id,
+    text: input.text,
+    publishedAt: new Date(Date.UTC(2026, 6, 25, 12, input.position)).toISOString(),
+    observedAt: '2026-07-25T13:00:00.000Z',
+    kind: input.parentId ? 'REPLY' : 'POST',
+    conversationId: input.conversationId ?? input.id,
+    structure: { status: 'EXACT', source: 'X_WEB_GRAPHQL_LIST' },
+    author: { key: `id:${input.username}`, username: input.username, name: input.username },
+    repostedBy: null,
+    relationships: [
+      ...(input.parentId
+        ? [{ type: 'REPLY_TO', tweetId: input.parentId, evidenceSource: 'X_WEB_GRAPHQL_LIST' }]
+        : []),
+      ...(input.quoteId
+        ? [{ type: 'QUOTE_OF', tweetId: input.quoteId, evidenceSource: 'X_WEB_GRAPHQL_LIST' }]
+        : []),
+    ],
+    links: input.link ? [{ url: input.link, normalizedUrl: input.link }] : [],
+    sourcePosition: input.source === 'context' ? null : input.position,
+  };
+}
+
+describe('daily topic clustering', () => {
+  it('batches pinned Workers AI embeddings and accepts the production response shape', async () => {
+    const calls: unknown[] = [];
+    const provider = createWorkersAIDailyTopicEmbeddingProvider(
+      {
+        async run(_model, input) {
+          calls.push(input);
+          const texts = (input as { text: string[] }).text;
+          return { data: texts.map((_, index) => [index, 1]) };
+        },
+      },
+      'pinned-model'
+    );
+
+    const vectors = await provider?.embed(
+      Array.from({ length: 33 }, (_, index) => `post ${index}`)
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(vectors).toHaveLength(33);
+    expect(provider?.model).toBe('pinned-model');
+  });
+
+  it('collapses exact reply chains into stable thread units without folding quotes into threads', () => {
+    const posts = [
+      post({ id: 'root', username: 'alice', text: 'Root', position: 0, conversationId: 'root' }),
+      post({
+        id: 'reply',
+        username: 'bob',
+        text: 'Reply',
+        position: 1,
+        conversationId: 'root',
+        parentId: 'root',
+      }),
+      post({ id: 'other', username: 'carol', text: 'Other', position: 2 }),
+    ];
+    posts[2].relationships = [{ type: 'QUOTE_OF', tweetId: 'root' }];
+
+    const units = buildDailyThreadUnits(posts, new Set(posts.map((value) => value.id)), new Set());
+
+    expect(units).toHaveLength(2);
+    expect(units[0]).toMatchObject({
+      id: 'conversation:root',
+      rootPostId: 'root',
+      postIds: ['root', 'reply'],
+      relationshipTypes: ['REPLY_TO', 'CONVERSATION_ID'],
+      structureStatus: 'EXACT',
+    });
+    expect(units[1]).toMatchObject({ id: 'conversation:other', postIds: ['other'] });
+  });
+
+  it('groups generalized model and open-weight topics without hardcoded product names', async () => {
+    const posts = [
+      post({
+        id: 'open-1',
+        username: 'alice',
+        text: 'Open-weight models matter for a healthy ecosystem',
+        position: 0,
+      }),
+      post({
+        id: 'open-2',
+        username: 'bob',
+        text: 'We signed the open weight model letter',
+        position: 1,
+      }),
+      post({
+        id: 'model-1',
+        username: 'carol',
+        text: 'Aurora 7 is fast and token efficient',
+        position: 2,
+      }),
+      post({
+        id: 'model-2',
+        username: 'dave',
+        text: 'My first Aurora-7 coding benchmark',
+        position: 3,
+      }),
+      post({
+        id: 'unrelated',
+        username: 'erin',
+        text: 'A garden update from this morning',
+        position: 4,
+      }),
+    ];
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set()
+    );
+
+    expect(result.topicClusters).toHaveLength(2);
+    expect(
+      result.topicClusters.map((topic) => topic.label.toLocaleLowerCase()).join(' ')
+    ).toContain('open weight');
+    expect(
+      result.topicClusters.map((topic) => topic.label.toLocaleLowerCase()).join(' ')
+    ).toContain('aurora 7');
+    expect(result.favoriteThreadUnitIds).toEqual(['conversation:unrelated']);
+    expect(result.algorithm).toMatchObject({
+      method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
+      semanticStatus: 'FALLBACK',
+      maxTopics: 5,
+      minimumFavoriteAuthors: 2,
+    });
+  });
+
+  it('uses an exact quote target as topic evidence without collapsing it into the quoting thread', async () => {
+    const posts = [
+      post({
+        id: 'target',
+        username: 'alice',
+        text: 'Open weight models need durable distribution',
+        position: 0,
+      }),
+      post({
+        id: 'quote',
+        username: 'bob',
+        text: 'This is the right direction',
+        position: 1,
+        quoteId: 'target',
+      }),
+    ];
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set()
+    );
+
+    expect(result.threadUnits).toHaveLength(2);
+    expect(result.topicClusters).toHaveLength(1);
+    expect(result.topicClusters[0]).toMatchObject({
+      favoriteThreadUnitIds: ['conversation:target', 'conversation:quote'],
+    });
+    expect(result.topicClusters[0].evidenceSignals).toContainEqual(
+      expect.objectContaining({ type: 'DIRECT_REFERENCE' })
+    );
+  });
+
+  it('groups independent Favorites that quote the same context post', async () => {
+    const posts = [
+      post({
+        id: 'context-target',
+        username: 'source',
+        text: 'A new compiler architecture for local agents',
+        position: 0,
+        source: 'context',
+      }),
+      post({
+        id: 'quote-one',
+        username: 'alice',
+        text: 'Worth studying',
+        position: 1,
+        quoteId: 'context-target',
+      }),
+      post({
+        id: 'quote-two',
+        username: 'bob',
+        text: 'This design is promising',
+        position: 2,
+        quoteId: 'context-target',
+      }),
+    ];
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(['quote-one', 'quote-two']),
+      new Set()
+    );
+
+    expect(result.topicClusters).toHaveLength(1);
+    expect(result.topicClusters[0]).toMatchObject({
+      favoriteThreadUnitIds: ['conversation:quote-one', 'conversation:quote-two'],
+      supportingThreadUnitIds: ['conversation:context-target'],
+    });
+  });
+
+  it('keeps a complete Favorite thread intact inside a topic and uses Following only as support', async () => {
+    const posts = [
+      post({
+        id: 'gergely-root',
+        username: 'gergely',
+        text: 'Code reviews changed after Fable 5',
+        position: 0,
+        conversationId: 'gergely-root',
+      }),
+      post({
+        id: 'gergely-reply',
+        username: 'gergely',
+        text: 'Opus 5 is not as good as Fable 5 for this case',
+        position: 1,
+        conversationId: 'gergely-root',
+        parentId: 'gergely-root',
+      }),
+      post({ id: 'favorite-2', username: 'alice', text: 'Opus 5 is expensive', position: 2 }),
+      post({
+        id: 'following-1',
+        username: 'bob',
+        text: 'Initial thoughts on Opus 5',
+        position: 3,
+        source: 'following',
+      }),
+    ];
+    const favorites = new Set(['gergely-root', 'gergely-reply', 'favorite-2']);
+    const following = new Set(['following-1']);
+
+    const result = await buildDailyTopicClustering(posts, favorites, following);
+    const topic = result.topicClusters[0];
+
+    expect(topic.label.toLocaleLowerCase()).toContain('opus 5');
+    expect(topic.favoriteThreadUnitIds).toContain('conversation:gergely-root');
+    expect(topic.supportingThreadUnitIds).toEqual(['conversation:following-1']);
+    expect(topic.postIds).toEqual(
+      expect.arrayContaining(['gergely-root', 'gergely-reply', 'favorite-2', 'following-1'])
+    );
+    expect(
+      result.threadUnits.find((unit) => unit.id === 'conversation:gergely-root')?.postIds
+    ).toEqual(['gergely-root', 'gergely-reply']);
+  });
+
+  it('ranks by Favorite author convergence and returns fewer than five when evidence is thin', async () => {
+    const posts = [
+      post({ id: 'wide-1', username: 'one', text: 'Nimbus 9 launch', position: 0 }),
+      post({ id: 'wide-2', username: 'two', text: 'Nimbus 9 benchmark', position: 1 }),
+      post({ id: 'wide-3', username: 'three', text: 'Nimbus 9 pricing', position: 2 }),
+      post({ id: 'small-1', username: 'four', text: 'Copper 4 launch', position: 3 }),
+      post({ id: 'small-2', username: 'five', text: 'Copper 4 benchmark', position: 4 }),
+    ];
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set()
+    );
+
+    expect(result.topicClusters).toHaveLength(2);
+    expect(result.topicClusters[0].label.toLocaleLowerCase()).toContain('nimbus 9');
+    expect(result.topicClusters[0].score).toBeGreaterThan(result.topicClusters[1].score);
+  });
+
+  it('uses pinned embeddings only for expansion and records their provenance', async () => {
+    const posts = [
+      post({ id: 'seed-1', username: 'one', text: 'Robotics safety research', position: 0 }),
+      post({ id: 'seed-2', username: 'two', text: 'Robotics safety testing', position: 1 }),
+      post({ id: 'semantic', username: 'three', text: 'Machines operating safely', position: 2 }),
+    ];
+    const vectors: Record<string, number[]> = {
+      'Robotics safety research': [1, 0],
+      'Robotics safety testing': [0.99, 0.01],
+      'Machines operating safely': [0.98, 0.02],
+    };
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set(),
+      {
+        embeddingProvider: {
+          model: 'pinned-test-model',
+          embed: async (texts) => texts.map((text) => vectors[text]),
+        },
+      }
+    );
+
+    expect(result.algorithm).toMatchObject({
+      semanticStatus: 'COMPLETE',
+      embeddingModel: 'pinned-test-model',
+    });
+    expect(result.topicClusters[0].favoriteThreadUnitIds).toContain('conversation:semantic');
+    expect(result.topicClusters[0].evidenceSignals).toContainEqual(
+      expect.objectContaining({ type: 'SEMANTIC_SIMILARITY', value: 'pinned-test-model' })
+    );
+  });
+
+  it('bounds semantic work on large days and discloses partial semantic coverage', async () => {
+    const posts = Array.from({ length: 300 }, (_, index) =>
+      post({
+        id: `large-${index}`,
+        username: `author-${index}`,
+        text: `Common scalable signal ${index}`,
+        position: index,
+      })
+    );
+    const embeddedBatchSizes: number[] = [];
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set(),
+      {
+        embeddingProvider: {
+          model: 'pinned-test-model',
+          embed: async (texts) => {
+            embeddedBatchSizes.push(texts.length);
+            return texts.map(() => [1, 0]);
+          },
+        },
+      }
+    );
+
+    expect(embeddedBatchSizes).toEqual([256]);
+    expect(result.algorithm).toMatchObject({
+      semanticStatus: 'PARTIAL',
+      semanticUnitLimit: 256,
+      candidateLimit: 40,
+    });
+    expect(result.warnings.join(' ')).toContain('256/300 Favorite thread units');
+    expect(result.topicClusters).toHaveLength(1);
+  });
+});

--- a/apps/worker/src/lib/daily-topic-clustering.ts
+++ b/apps/worker/src/lib/daily-topic-clustering.ts
@@ -1,0 +1,994 @@
+export const DAILY_TOPIC_ALGORITHM_VERSION = 'daily-topics-v1';
+export const DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL = '@cf/qwen/qwen3-embedding-0.6b';
+
+const MAX_TOPICS = 5;
+const MAX_SUPPORTING_UNITS = 8;
+const MAX_TOPIC_CANDIDATES = 40;
+const MAX_SEMANTIC_UNITS = 256;
+const MAX_SEMANTIC_SEEDS = 8;
+const MAX_EMBEDDING_TEXT_LENGTH = 1_600;
+const SEMANTIC_EXPANSION_THRESHOLD = 0.8;
+const SEMANTIC_STRONG_THRESHOLD = 0.87;
+
+const TOPIC_STOP_WORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'against',
+  'also',
+  'another',
+  'because',
+  'before',
+  'being',
+  'below',
+  'could',
+  'does',
+  'doing',
+  'from',
+  'getting',
+  'have',
+  'here',
+  'into',
+  'just',
+  'like',
+  'looking',
+  'make',
+  'more',
+  'much',
+  'need',
+  'only',
+  'other',
+  'really',
+  'should',
+  'some',
+  'still',
+  'than',
+  'that',
+  'their',
+  'there',
+  'these',
+  'they',
+  'thing',
+  'think',
+  'this',
+  'those',
+  'through',
+  'today',
+  'very',
+  'want',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'with',
+  'would',
+  'your',
+  'https',
+  'http',
+]);
+
+type TopicPostRelationship = {
+  type: string;
+  tweetId: string;
+  evidenceSource?: string | null;
+  target?: { text?: string | null } | null;
+};
+
+type TopicPostLink = {
+  url?: string;
+  normalizedUrl?: string;
+  displayUrl?: string | null;
+  card?: { domain?: string | null } | null;
+};
+
+export type DailyTopicPost = {
+  id: string;
+  text: string;
+  publishedAt: string | null;
+  observedAt: string | null;
+  kind: string;
+  conversationId?: string | null;
+  structure?: unknown;
+  author: { key: string; username: string; name: string };
+  repostedBy?: { key: string; username: string; name: string } | null;
+  relationships: TopicPostRelationship[];
+  links: TopicPostLink[];
+  sourcePosition: number | null;
+};
+
+export type DailyThreadUnit = {
+  id: string;
+  conversationId: string | null;
+  rootPostId: string;
+  postIds: string[];
+  favoritePostIds: string[];
+  followingPostIds: string[];
+  contextPostIds: string[];
+  authorKeys: string[];
+  favoriteAuthorKeys: string[];
+  authors: string[];
+  favoriteAuthors: string[];
+  relationshipTypes: string[];
+  structureStatus: 'EXACT' | 'PARTIAL';
+  latestActivityAt: string | null;
+  firstSourcePosition: number | null;
+  coverageWarnings: string[];
+};
+
+export type DailyTopicSignal = {
+  type:
+    | 'DIRECT_REFERENCE'
+    | 'SHARED_PHRASE'
+    | 'SHARED_LINK'
+    | 'SHARED_MARKER'
+    | 'SEMANTIC_SIMILARITY';
+  value: string;
+  threadUnitIds: string[];
+};
+
+export type DailyTopicCluster = {
+  id: string;
+  label: string;
+  labelSource: 'EXTRACTED_PHRASE' | 'CANONICAL_LINK';
+  labelTerms: string[];
+  evidence: string;
+  evidenceSignals: DailyTopicSignal[];
+  threadUnitIds: string[];
+  favoriteThreadUnitIds: string[];
+  supportingThreadUnitIds: string[];
+  postIds: string[];
+  favoritePostIds: string[];
+  contextPostIds: string[];
+  favoriteAuthors: string[];
+  supportingAuthors: string[];
+  score: number;
+  latestActivityAt: string | null;
+  coverageWarnings: string[];
+};
+
+export type DailyTopicClusteringResult = {
+  algorithm: {
+    version: string;
+    method: 'THREAD_FIRST_EVIDENCE_CLUSTERING';
+    semanticStatus: 'COMPLETE' | 'PARTIAL' | 'FALLBACK';
+    embeddingModel: string | null;
+    maxTopics: number;
+    minimumFavoriteAuthors: number;
+    candidateLimit: number;
+    semanticUnitLimit: number;
+  };
+  threadUnits: DailyThreadUnit[];
+  topicClusters: DailyTopicCluster[];
+  favoriteThreadUnitIds: string[];
+  followingThreadUnitIds: string[];
+  warnings: string[];
+};
+
+export type DailyTopicEmbeddingProvider = {
+  model: string;
+  embed(texts: string[]): Promise<number[][]>;
+};
+
+type WorkersAIRunner = {
+  run(model: string, input: unknown): Promise<unknown>;
+};
+
+function embeddingBatchFromResponse(response: unknown): number[][] {
+  if (!response || typeof response !== 'object') {
+    throw new Error('embedding response was empty');
+  }
+  const record = response as Record<string, unknown>;
+  const direct = record.data;
+  if (Array.isArray(direct) && direct.every((value) => Array.isArray(value))) {
+    return direct as number[][];
+  }
+  if (
+    Array.isArray(direct) &&
+    direct.every(
+      (value) =>
+        value &&
+        typeof value === 'object' &&
+        Array.isArray((value as Record<string, unknown>).embedding)
+    )
+  ) {
+    return direct.map((value) => (value as { embedding: number[] }).embedding);
+  }
+  const result = record.result;
+  if (result && typeof result === 'object') {
+    const nested = (result as Record<string, unknown>).data;
+    if (Array.isArray(nested) && nested.every((value) => Array.isArray(value))) {
+      return nested as number[][];
+    }
+  }
+  throw new Error('embedding response did not contain a vector batch');
+}
+
+export function createWorkersAIDailyTopicEmbeddingProvider(
+  ai: WorkersAIRunner | null | undefined,
+  model = DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL
+): DailyTopicEmbeddingProvider | null {
+  if (!ai) return null;
+  return {
+    model,
+    async embed(texts: string[]) {
+      const values: number[][] = [];
+      for (let offset = 0; offset < texts.length; offset += 32) {
+        const batch = texts.slice(offset, offset + 32);
+        const response = await ai.run(model, { text: batch });
+        const vectors = embeddingBatchFromResponse(response);
+        if (vectors.length !== batch.length) {
+          throw new Error(`embedding batch returned ${vectors.length}/${batch.length} vectors`);
+        }
+        values.push(...vectors);
+      }
+      return values;
+    },
+  };
+}
+
+type FeatureKind = 'REFERENCE' | 'URL' | 'MODEL' | 'TRIGRAM' | 'BIGRAM' | 'MARKER' | 'TOKEN';
+
+type Feature = {
+  key: string;
+  kind: FeatureKind;
+  value: string;
+  surface: string;
+  weight: number;
+};
+
+type UnitProfile = {
+  unit: DailyThreadUnit;
+  features: Map<string, Feature>;
+  text: string;
+};
+
+type TopicCandidate = {
+  anchors: Feature[];
+  favoriteUnitIds: Set<string>;
+  supportingUnitIds: Set<string>;
+  semanticEvidence: Map<string, number>;
+};
+
+function timestamp(post: DailyTopicPost): number {
+  return Date.parse(post.publishedAt ?? post.observedAt ?? '') || 0;
+}
+
+function latestActivity(posts: DailyTopicPost[]): string | null {
+  const latest = Math.max(0, ...posts.map(timestamp));
+  return latest > 0 ? new Date(latest).toISOString() : null;
+}
+
+function structureStatus(post: DailyTopicPost): 'EXACT' | 'PARTIAL' {
+  if (!post.structure || typeof post.structure !== 'object') return 'PARTIAL';
+  return (post.structure as { status?: unknown }).status === 'EXACT' ? 'EXACT' : 'PARTIAL';
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function orderedPosts(posts: DailyTopicPost[]): DailyTopicPost[] {
+  const ids = new Set(posts.map((post) => post.id));
+  const parentById = new Map<string, string>();
+  for (const post of posts) {
+    const parent = post.relationships.find(
+      (relationship) => relationship.type === 'REPLY_TO' && ids.has(relationship.tweetId)
+    );
+    if (parent) parentById.set(post.id, parent.tweetId);
+  }
+  const depthMemo = new Map<string, number>();
+  const depth = (id: string, visiting = new Set<string>()): number => {
+    const cached = depthMemo.get(id);
+    if (cached !== undefined) return cached;
+    const parent = parentById.get(id);
+    if (!parent || visiting.has(id)) return 0;
+    visiting.add(id);
+    const value = depth(parent, visiting) + 1;
+    depthMemo.set(id, value);
+    return value;
+  };
+  return [...posts].sort(
+    (left, right) =>
+      depth(left.id) - depth(right.id) ||
+      timestamp(left) - timestamp(right) ||
+      left.id.localeCompare(right.id)
+  );
+}
+
+export function buildDailyThreadUnits(
+  posts: DailyTopicPost[],
+  favoritePostIds: Set<string>,
+  followingPostIds: Set<string>
+): DailyThreadUnit[] {
+  const postById = new Map(posts.map((post) => [post.id, post]));
+  const parents = new Map(posts.map((post) => [post.id, post.id]));
+  const find = (id: string): string => {
+    const parent = parents.get(id) ?? id;
+    if (parent === id) return id;
+    const root = find(parent);
+    parents.set(id, root);
+    return root;
+  };
+  const union = (leftId: string, rightId: string) => {
+    const left = find(leftId);
+    const right = find(rightId);
+    if (left === right) return;
+    const [first, second] = [left, right].sort();
+    parents.set(second, first);
+  };
+
+  const byConversation = new Map<string, string[]>();
+  for (const post of posts) {
+    if (post.conversationId) {
+      byConversation.set(post.conversationId, [
+        ...(byConversation.get(post.conversationId) ?? []),
+        post.id,
+      ]);
+    }
+    for (const relationship of post.relationships) {
+      if (relationship.type === 'REPLY_TO' && postById.has(relationship.tweetId)) {
+        union(post.id, relationship.tweetId);
+      }
+    }
+  }
+  for (const ids of byConversation.values()) {
+    for (let index = 1; index < ids.length; index++) union(ids[0], ids[index]);
+  }
+
+  const grouped = new Map<string, DailyTopicPost[]>();
+  for (const post of posts) {
+    const root = find(post.id);
+    grouped.set(root, [...(grouped.get(root) ?? []), post]);
+  }
+
+  return [...grouped.values()]
+    .map((groupPosts): DailyThreadUnit => {
+      const ordered = orderedPosts(groupPosts);
+      const ids = new Set(ordered.map((post) => post.id));
+      const conversationIds = unique(
+        ordered.flatMap((post) => (post.conversationId ? [post.conversationId] : []))
+      );
+      const conversationId = conversationIds.length === 1 ? conversationIds[0] : null;
+      const root =
+        ordered.find(
+          (post) =>
+            !post.relationships.some(
+              (relationship) => relationship.type === 'REPLY_TO' && ids.has(relationship.tweetId)
+            )
+        ) ?? ordered[0];
+      const favoritePosts = ordered.filter((post) => favoritePostIds.has(post.id));
+      const followingPosts = ordered.filter((post) => followingPostIds.has(post.id));
+      const contextPosts = ordered.filter(
+        (post) => !favoritePostIds.has(post.id) && !followingPostIds.has(post.id)
+      );
+      const exact = ordered.every((post) => structureStatus(post) === 'EXACT');
+      const relationshipTypes = unique(
+        ordered.flatMap((post) =>
+          post.relationships
+            .filter(
+              (relationship) => relationship.type === 'REPLY_TO' && ids.has(relationship.tweetId)
+            )
+            .map((relationship) => relationship.type)
+        )
+      );
+      if (conversationId && ordered.length > 1) relationshipTypes.push('CONVERSATION_ID');
+      const sourcePositions = [...favoritePosts, ...followingPosts]
+        .map((post) => post.sourcePosition)
+        .filter((position): position is number => position !== null);
+      const stableIdentity = conversationId ?? root.id;
+      return {
+        id: `${conversationId ? 'conversation' : 'post'}:${stableIdentity}`,
+        conversationId,
+        rootPostId: root.id,
+        postIds: ordered.map((post) => post.id),
+        favoritePostIds: favoritePosts.map((post) => post.id),
+        followingPostIds: followingPosts.map((post) => post.id),
+        contextPostIds: contextPosts.map((post) => post.id),
+        authorKeys: unique(ordered.map((post) => post.author.key)),
+        favoriteAuthorKeys: unique(
+          favoritePosts.map((post) => post.repostedBy?.key ?? post.author.key)
+        ),
+        authors: unique(ordered.map((post) => post.author.username)),
+        favoriteAuthors: unique(
+          favoritePosts.map((post) => post.repostedBy?.username ?? post.author.username)
+        ),
+        relationshipTypes: unique(relationshipTypes),
+        structureStatus: exact ? 'EXACT' : 'PARTIAL',
+        latestActivityAt: latestActivity(ordered),
+        firstSourcePosition: sourcePositions.length > 0 ? Math.min(...sourcePositions) : null,
+        coverageWarnings: exact ? [] : ['Some posts in this thread have partial structure.'],
+      };
+    })
+    .sort(
+      (left, right) =>
+        (left.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) -
+          (right.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) ||
+        (Date.parse(right.latestActivityAt ?? '') || 0) -
+          (Date.parse(left.latestActivityAt ?? '') || 0) ||
+        left.id.localeCompare(right.id)
+    );
+}
+
+function normalizedToken(value: string): string {
+  const normalized = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLocaleLowerCase()
+    .replace(/^[@#]/, '')
+    .replace(/[^a-z0-9_]/g, '');
+  if (normalized.length > 4 && normalized.endsWith('ies')) return `${normalized.slice(0, -3)}y`;
+  if (
+    normalized.length > 4 &&
+    normalized.endsWith('s') &&
+    !normalized.endsWith('ss') &&
+    !normalized.endsWith('us')
+  ) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function featureWeight(kind: FeatureKind): number {
+  switch (kind) {
+    case 'REFERENCE':
+      return 9;
+    case 'URL':
+      return 8;
+    case 'MODEL':
+      return 6;
+    case 'TRIGRAM':
+      return 4;
+    case 'BIGRAM':
+      return 2.5;
+    case 'MARKER':
+      return 3;
+    case 'TOKEN':
+      return 1;
+  }
+}
+
+function addFeature(
+  features: Map<string, Feature>,
+  kind: FeatureKind,
+  value: string,
+  surface: string
+) {
+  const key = `${kind.toLocaleLowerCase()}:${value}`;
+  if (!features.has(key)) {
+    features.set(key, { key, kind, value, surface, weight: featureWeight(kind) });
+  }
+}
+
+function contentTokens(
+  text: string
+): Array<{ value: string; surface: string; marker: string | null }> {
+  const prepared = text.replace(/[\u2010-\u2015-]/g, ' ');
+  const raw = prepared.match(/[@#]?[\p{L}\p{N}_]+/gu) ?? [];
+  return raw.flatMap((surface) => {
+    const marker = surface.startsWith('@') || surface.startsWith('#') ? surface[0] : null;
+    const value = normalizedToken(surface);
+    if (!value || TOPIC_STOP_WORDS.has(value)) return [];
+    if (value.length < 3 && !/\d/.test(value)) return [];
+    return [{ value, surface: surface.replace(/^[@#]/, ''), marker }];
+  });
+}
+
+function canonicalUrl(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!/^https?:$/.test(url.protocol)) return null;
+    url.hostname = url.hostname.replace(/^www\./, '').toLocaleLowerCase();
+    url.hash = '';
+    if (url.pathname !== '/') url.pathname = url.pathname.replace(/\/$/, '');
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function profileForUnit(
+  unit: DailyThreadUnit,
+  postsById: Map<string, DailyTopicPost>
+): UnitProfile {
+  const features = new Map<string, Feature>();
+  const textParts: string[] = [];
+  for (const postId of unit.postIds) {
+    const post = postsById.get(postId);
+    if (!post) continue;
+    const texts = [
+      post.text,
+      ...post.relationships.flatMap((relationship) =>
+        relationship.type === 'QUOTE_OF' || relationship.type === 'REPOST_OF'
+          ? [relationship.target?.text ?? '']
+          : []
+      ),
+    ].filter(Boolean);
+    for (const text of texts) {
+      textParts.push(text);
+      const tokens = contentTokens(text);
+      for (const token of tokens) {
+        addFeature(features, 'TOKEN', token.value, token.surface);
+        if (token.marker) {
+          addFeature(
+            features,
+            'MARKER',
+            `${token.marker}${token.value}`,
+            `${token.marker}${token.surface}`
+          );
+        }
+      }
+      for (let index = 0; index < tokens.length - 1; index++) {
+        const left = tokens[index];
+        const right = tokens[index + 1];
+        const value = `${left.value} ${right.value}`;
+        const surface = `${left.surface} ${right.surface}`;
+        addFeature(
+          features,
+          /\d/.test(left.value) || /\d/.test(right.value) ? 'MODEL' : 'BIGRAM',
+          value,
+          surface
+        );
+      }
+      for (let index = 0; index < tokens.length - 2; index++) {
+        const slice = tokens.slice(index, index + 3);
+        addFeature(
+          features,
+          'TRIGRAM',
+          slice.map((token) => token.value).join(' '),
+          slice.map((token) => token.surface).join(' ')
+        );
+      }
+    }
+    for (const link of post.links) {
+      const url = canonicalUrl(link.normalizedUrl ?? link.url);
+      if (!url) continue;
+      let surface = link.displayUrl ?? link.card?.domain ?? url;
+      try {
+        surface = new URL(url).hostname.replace(/^www\./, '');
+      } catch {
+        // The canonical URL remains explicit evidence when its host cannot be displayed.
+      }
+      addFeature(features, 'URL', url, surface);
+    }
+  }
+  return {
+    unit,
+    features,
+    text: textParts.join('\n\n').slice(0, MAX_EMBEDDING_TEXT_LENGTH),
+  };
+}
+
+function featureSimilarity(left: UnitProfile, right: UnitProfile): number {
+  const keys = new Set([...left.features.keys(), ...right.features.keys()]);
+  let intersection = 0;
+  let union = 0;
+  for (const key of keys) {
+    const leftWeight = left.features.get(key)?.weight ?? 0;
+    const rightWeight = right.features.get(key)?.weight ?? 0;
+    intersection += Math.min(leftWeight, rightWeight);
+    union += Math.max(leftWeight, rightWeight);
+  }
+  return union > 0 ? intersection / union : 0;
+}
+
+function cosine(left: number[] | undefined, right: number[] | undefined): number {
+  if (!left || !right || left.length === 0 || left.length !== right.length) return 0;
+  let dot = 0;
+  let leftMagnitude = 0;
+  let rightMagnitude = 0;
+  for (let index = 0; index < left.length; index++) {
+    dot += left[index] * right[index];
+    leftMagnitude += left[index] * left[index];
+    rightMagnitude += right[index] * right[index];
+  }
+  if (leftMagnitude === 0 || rightMagnitude === 0) return 0;
+  return dot / Math.sqrt(leftMagnitude * rightMagnitude);
+}
+
+function authorKeysForUnit(
+  unit: DailyThreadUnit,
+  postsById: Map<string, DailyTopicPost>
+): string[] {
+  return unique(
+    unit.favoritePostIds.flatMap((postId) => {
+      const post = postsById.get(postId);
+      return post ? [post.repostedBy?.key ?? post.author.key] : [];
+    })
+  );
+}
+
+function jaccard(left: Set<string>, right: Set<string>): number {
+  const intersection = [...left].filter((value) => right.has(value)).length;
+  const union = new Set([...left, ...right]).size;
+  return union > 0 ? intersection / union : 0;
+}
+
+function signalType(feature: Feature): DailyTopicSignal['type'] {
+  if (feature.kind === 'REFERENCE') return 'DIRECT_REFERENCE';
+  if (feature.kind === 'URL') return 'SHARED_LINK';
+  if (feature.kind === 'MARKER') return 'SHARED_MARKER';
+  return 'SHARED_PHRASE';
+}
+
+function labelForAnchors(anchors: Feature[]): {
+  label: string;
+  labelTerms: string[];
+  source: DailyTopicCluster['labelSource'];
+} {
+  const ordered = [...anchors].sort(
+    (left, right) =>
+      right.weight - left.weight ||
+      right.value.split(' ').length - left.value.split(' ').length ||
+      left.value.localeCompare(right.value)
+  );
+  const selected: Feature[] = [];
+  for (const anchor of ordered) {
+    if (
+      selected.some(
+        (existing) => existing.value.includes(anchor.value) || anchor.value.includes(existing.value)
+      )
+    ) {
+      continue;
+    }
+    selected.push(anchor);
+    if (selected.length === 2) break;
+  }
+  const labelTerms = selected.map((feature) => feature.surface.trim()).filter(Boolean);
+  const fallback = ordered[0]?.surface || 'Shared evidence';
+  return {
+    label: (labelTerms.length > 0 ? labelTerms : [fallback]).join(' · '),
+    labelTerms: labelTerms.length > 0 ? labelTerms : [fallback],
+    source: selected[0]?.kind === 'URL' ? 'CANONICAL_LINK' : 'EXTRACTED_PHRASE',
+  };
+}
+
+function quotedUnitIds(
+  unit: DailyThreadUnit,
+  postsById: Map<string, DailyTopicPost>,
+  unitIdByPostId: Map<string, string>
+): string[] {
+  return unique(
+    unit.postIds.flatMap((postId) => {
+      const post = postsById.get(postId);
+      return (
+        post?.relationships.flatMap((relationship) =>
+          relationship.type === 'QUOTE_OF' || relationship.type === 'REPOST_OF'
+            ? [unitIdByPostId.get(relationship.tweetId)].filter((value): value is string =>
+                Boolean(value)
+              )
+            : []
+        ) ?? []
+      );
+    })
+  );
+}
+
+export async function buildDailyTopicClustering(
+  posts: DailyTopicPost[],
+  favoritePostIds: Set<string>,
+  followingPostIds: Set<string>,
+  options: {
+    embeddingProvider?: DailyTopicEmbeddingProvider | null;
+  } = {}
+): Promise<DailyTopicClusteringResult> {
+  const postsById = new Map(posts.map((post) => [post.id, post]));
+  const threadUnits = buildDailyThreadUnits(posts, favoritePostIds, followingPostIds);
+  const unitsById = new Map(threadUnits.map((unit) => [unit.id, unit]));
+  const unitIdByPostId = new Map(
+    threadUnits.flatMap((unit) => unit.postIds.map((postId) => [postId, unit.id] as const))
+  );
+  const profiles = new Map(
+    threadUnits.map((unit) => [unit.id, profileForUnit(unit, postsById)] as const)
+  );
+  for (const unit of threadUnits) {
+    for (const referencedUnitId of quotedUnitIds(unit, postsById, unitIdByPostId)) {
+      if (referencedUnitId === unit.id) continue;
+      const sourceProfile = profiles.get(unit.id);
+      const targetProfile = profiles.get(referencedUnitId);
+      if (!sourceProfile || !targetProfile) continue;
+      const targetAnchors = [...targetProfile.features.values()].filter(
+        (feature) => feature.kind !== 'TOKEN' && feature.kind !== 'REFERENCE'
+      );
+      if (targetAnchors.length === 0) continue;
+      const surface = labelForAnchors(targetAnchors).labelTerms[0];
+      if (!surface) continue;
+      const referenceValue = referencedUnitId;
+      addFeature(sourceProfile.features, 'REFERENCE', referenceValue, surface);
+      addFeature(targetProfile.features, 'REFERENCE', referenceValue, surface);
+    }
+  }
+  const favoriteUnits = threadUnits.filter((unit) => unit.favoritePostIds.length > 0);
+  const followingUnits = threadUnits.filter(
+    (unit) => unit.favoritePostIds.length === 0 && unit.followingPostIds.length > 0
+  );
+  const warnings: string[] = [];
+  const embeddings = new Map<string, number[]>();
+  const semanticUnits = favoriteUnits.slice(0, MAX_SEMANTIC_UNITS);
+  let semanticStatus: 'COMPLETE' | 'PARTIAL' | 'FALLBACK' = 'FALLBACK';
+  if (options.embeddingProvider && favoriteUnits.length >= 2) {
+    try {
+      const texts = semanticUnits.map((unit) => profiles.get(unit.id)?.text ?? '');
+      const values = await options.embeddingProvider.embed(texts);
+      if (values.length !== semanticUnits.length) {
+        throw new Error('embedding count did not match Favorite thread units');
+      }
+      for (let index = 0; index < semanticUnits.length; index++) {
+        embeddings.set(semanticUnits[index].id, values[index]);
+      }
+      semanticStatus = semanticUnits.length === favoriteUnits.length ? 'COMPLETE' : 'PARTIAL';
+      if (semanticStatus === 'PARTIAL') {
+        warnings.push(
+          `Semantic expansion covered the first ${semanticUnits.length}/${favoriteUnits.length} Favorite thread units in source order; explicit evidence still covered every unit.`
+        );
+      }
+    } catch (error) {
+      warnings.push(
+        `Semantic similarity was unavailable; explicit phrases, links, and relationships were used (${error instanceof Error ? error.message : String(error)}).`
+      );
+    }
+  } else if (favoriteUnits.length >= 2) {
+    warnings.push('Semantic similarity was unavailable; explicit phrases and links were used.');
+  }
+
+  const featureSupport = new Map<
+    string,
+    { feature: Feature; unitIds: Set<string>; authorKeys: Set<string> }
+  >();
+  for (const unit of favoriteUnits) {
+    const authorKeys = authorKeysForUnit(unit, postsById);
+    for (const feature of profiles.get(unit.id)?.features.values() ?? []) {
+      if (feature.kind === 'TOKEN' && feature.value.length < 5) continue;
+      const support = featureSupport.get(feature.key) ?? {
+        feature,
+        unitIds: new Set<string>(),
+        authorKeys: new Set<string>(),
+      };
+      support.unitIds.add(unit.id);
+      authorKeys.forEach((authorKey) => support.authorKeys.add(authorKey));
+      featureSupport.set(feature.key, support);
+    }
+  }
+
+  const qualifyingFeatureSupport = [...featureSupport.values()]
+    .filter(({ feature, authorKeys, unitIds }) => {
+      if (unitIds.size < 2) return false;
+      if (authorKeys.size < 2) return false;
+      if (feature.kind === 'TOKEN') return authorKeys.size >= 3;
+      if (feature.kind === 'MARKER') return authorKeys.size >= 3;
+      return true;
+    })
+    .sort(
+      (left, right) =>
+        right.authorKeys.size - left.authorKeys.size ||
+        right.unitIds.size - left.unitIds.size ||
+        right.feature.weight - left.feature.weight ||
+        left.feature.key.localeCompare(right.feature.key)
+    );
+  if (qualifyingFeatureSupport.length > MAX_TOPIC_CANDIDATES) {
+    warnings.push(
+      `Topic candidate evaluation retained the strongest ${MAX_TOPIC_CANDIDATES}/${qualifyingFeatureSupport.length} corroborated evidence signals.`
+    );
+  }
+  const candidates: TopicCandidate[] = qualifyingFeatureSupport
+    .slice(0, MAX_TOPIC_CANDIDATES)
+    .map(({ feature, unitIds }) => ({
+      anchors: [feature],
+      favoriteUnitIds: new Set(unitIds),
+      supportingUnitIds: new Set<string>(),
+      semanticEvidence: new Map<string, number>(),
+    }));
+
+  const mergedCandidates: TopicCandidate[] = [];
+  for (const candidate of candidates) {
+    const existing = mergedCandidates.find(
+      (other) =>
+        jaccard(other.favoriteUnitIds, candidate.favoriteUnitIds) >= 0.75 ||
+        [...candidate.favoriteUnitIds].every((unitId) => other.favoriteUnitIds.has(unitId))
+    );
+    if (existing) {
+      existing.anchors.push(...candidate.anchors);
+      candidate.favoriteUnitIds.forEach((unitId) => existing.favoriteUnitIds.add(unitId));
+    } else {
+      mergedCandidates.push(candidate);
+    }
+  }
+
+  for (const candidate of mergedCandidates) {
+    const seeds = [...candidate.favoriteUnitIds].slice(0, MAX_SEMANTIC_SEEDS);
+    for (const unit of semanticUnits) {
+      if (candidate.favoriteUnitIds.has(unit.id)) continue;
+      const profile = profiles.get(unit.id);
+      if (!profile) continue;
+      const lexical = Math.max(
+        0,
+        ...seeds.map((seedId) => featureSimilarity(profile, profiles.get(seedId)!))
+      );
+      const semantic = Math.max(
+        0,
+        ...seeds.map((seedId) => cosine(embeddings.get(unit.id), embeddings.get(seedId)))
+      );
+      if (
+        semantic >= SEMANTIC_STRONG_THRESHOLD ||
+        (semantic >= SEMANTIC_EXPANSION_THRESHOLD && lexical >= 0.08)
+      ) {
+        candidate.favoriteUnitIds.add(unit.id);
+        candidate.semanticEvidence.set(unit.id, semantic);
+      }
+    }
+
+    const explicitSupport = new Set(
+      [...candidate.favoriteUnitIds].flatMap((unitId) =>
+        quotedUnitIds(unitsById.get(unitId)!, postsById, unitIdByPostId)
+      )
+    );
+    for (const unitId of explicitSupport) {
+      const unit = unitsById.get(unitId);
+      if (unit?.favoritePostIds.length) candidate.favoriteUnitIds.add(unitId);
+    }
+    for (const unit of followingUnits) {
+      const profile = profiles.get(unit.id);
+      if (!profile) continue;
+      const hasAnchor = candidate.anchors.some((anchor) => profile.features.has(anchor.key));
+      const lexical = Math.max(
+        0,
+        ...[...candidate.favoriteUnitIds]
+          .slice(0, MAX_SEMANTIC_SEEDS)
+          .map((favoriteUnitId) => featureSimilarity(profile, profiles.get(favoriteUnitId)!))
+      );
+      if (hasAnchor || lexical >= 0.22 || explicitSupport.has(unit.id)) {
+        candidate.supportingUnitIds.add(unit.id);
+      }
+    }
+    for (const unitId of explicitSupport) {
+      if (!candidate.favoriteUnitIds.has(unitId)) candidate.supportingUnitIds.add(unitId);
+    }
+  }
+
+  const rankedCandidates = mergedCandidates
+    .map((candidate) => {
+      const favoriteUnitsForCandidate = [...candidate.favoriteUnitIds]
+        .map((unitId) => unitsById.get(unitId))
+        .filter((unit): unit is DailyThreadUnit => Boolean(unit));
+      const favoriteAuthors = unique(
+        favoriteUnitsForCandidate.flatMap((unit) => unit.favoriteAuthors)
+      );
+      const favoriteAuthorKeys = unique(
+        favoriteUnitsForCandidate.flatMap((unit) => unit.favoriteAuthorKeys)
+      );
+      const favoritePosts = unique(
+        favoriteUnitsForCandidate.flatMap((unit) => unit.favoritePostIds)
+      );
+      const score =
+        favoriteAuthorKeys.length * 100 +
+        favoriteUnitsForCandidate.length * 25 +
+        favoritePosts.length * 5 +
+        Math.min(candidate.supportingUnitIds.size, 10) * 2;
+      return { candidate, favoriteAuthors, favoriteAuthorKeys, favoritePosts, score };
+    })
+    .filter(({ favoriteAuthorKeys }) => favoriteAuthorKeys.length >= 2)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.candidate.anchors[0].key.localeCompare(right.candidate.anchors[0].key)
+    );
+
+  const selected: typeof rankedCandidates = [];
+  for (const ranked of rankedCandidates) {
+    const duplicate = selected.some(({ candidate }) => {
+      const overlap = jaccard(candidate.favoriteUnitIds, ranked.candidate.favoriteUnitIds);
+      return overlap >= 0.75;
+    });
+    if (duplicate) continue;
+    selected.push(ranked);
+    if (selected.length === MAX_TOPICS) break;
+  }
+
+  const topicClusters = selected.map(
+    ({ candidate, favoriteAuthors, favoriteAuthorKeys, favoritePosts, score }) => {
+      const favoriteUnitIds = [...candidate.favoriteUnitIds].sort((left, right) => {
+        const leftUnit = unitsById.get(left)!;
+        const rightUnit = unitsById.get(right)!;
+        return (
+          (leftUnit.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) -
+            (rightUnit.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) || left.localeCompare(right)
+        );
+      });
+      const supportingUnitIds = [...candidate.supportingUnitIds]
+        .filter((unitId) => !candidate.favoriteUnitIds.has(unitId) && unitsById.has(unitId))
+        .sort((left, right) => {
+          const leftUnit = unitsById.get(left)!;
+          const rightUnit = unitsById.get(right)!;
+          return (
+            (leftUnit.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) -
+              (rightUnit.firstSourcePosition ?? Number.MAX_SAFE_INTEGER) ||
+            left.localeCompare(right)
+          );
+        })
+        .slice(0, MAX_SUPPORTING_UNITS);
+      const unitIds = [...favoriteUnitIds, ...supportingUnitIds];
+      const clusterUnits = unitIds.map((unitId) => unitsById.get(unitId)!);
+      const label = labelForAnchors(candidate.anchors);
+      const signals: DailyTopicSignal[] = candidate.anchors.slice(0, 5).map((anchor) => ({
+        type: signalType(anchor),
+        value: anchor.surface,
+        threadUnitIds: favoriteUnitIds.filter((unitId) =>
+          profiles.get(unitId)?.features.has(anchor.key)
+        ),
+      }));
+      if (candidate.semanticEvidence.size > 0) {
+        signals.push({
+          type: 'SEMANTIC_SIMILARITY',
+          value: options.embeddingProvider?.model ?? DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL,
+          threadUnitIds: [...candidate.semanticEvidence.keys()].sort(),
+        });
+      }
+      const supportingAuthors = unique(
+        supportingUnitIds.flatMap((unitId) => unitsById.get(unitId)?.authors ?? [])
+      );
+      const postIds = unique(clusterUnits.flatMap((unit) => unit.postIds));
+      const latest = clusterUnits
+        .map((unit) => Date.parse(unit.latestActivityAt ?? '') || 0)
+        .reduce((maximum, value) => Math.max(maximum, value), 0);
+      const coverageWarnings = unique(clusterUnits.flatMap((unit) => unit.coverageWarnings));
+      const stableKey = [...favoriteUnitIds, ...candidate.anchors.map((anchor) => anchor.key)]
+        .sort()
+        .join('|');
+      return {
+        id: `topic:${DAILY_TOPIC_ALGORITHM_VERSION}:${stableHash(stableKey)}`,
+        label: label.label,
+        labelSource: label.source,
+        labelTerms: label.labelTerms,
+        evidence: `${favoriteUnitIds.length} Favorite conversation${favoriteUnitIds.length === 1 ? '' : 's'} from ${favoriteAuthorKeys.length} authors share explicit evidence${supportingUnitIds.length > 0 ? `, with ${supportingUnitIds.length} supporting context conversation${supportingUnitIds.length === 1 ? '' : 's'}` : ''}.`,
+        evidenceSignals: signals,
+        threadUnitIds: unitIds,
+        favoriteThreadUnitIds: favoriteUnitIds,
+        supportingThreadUnitIds: supportingUnitIds,
+        postIds,
+        favoritePostIds: favoritePosts,
+        contextPostIds: postIds.filter((postId) => !favoritePostIds.has(postId)),
+        favoriteAuthors,
+        supportingAuthors,
+        score,
+        latestActivityAt: latest > 0 ? new Date(latest).toISOString() : null,
+        coverageWarnings,
+      } satisfies DailyTopicCluster;
+    }
+  );
+
+  const clusteredUnitIds = new Set(topicClusters.flatMap((topic) => topic.threadUnitIds));
+  return {
+    algorithm: {
+      version: DAILY_TOPIC_ALGORITHM_VERSION,
+      method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
+      semanticStatus,
+      embeddingModel:
+        semanticStatus === 'COMPLETE' || semanticStatus === 'PARTIAL'
+          ? (options.embeddingProvider?.model ?? null)
+          : null,
+      maxTopics: MAX_TOPICS,
+      minimumFavoriteAuthors: 2,
+      candidateLimit: MAX_TOPIC_CANDIDATES,
+      semanticUnitLimit: MAX_SEMANTIC_UNITS,
+    },
+    threadUnits,
+    topicClusters,
+    favoriteThreadUnitIds: favoriteUnits
+      .filter((unit) => !clusteredUnitIds.has(unit.id))
+      .map((unit) => unit.id),
+    followingThreadUnitIds: followingUnits
+      .filter((unit) => !clusteredUnitIds.has(unit.id))
+      .map((unit) => unit.id),
+    warnings,
+  };
+}

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -1048,7 +1048,7 @@
         "tags": ["Editorial"],
         "operationId": "getPeopleFirstDailyFeed",
         "summary": "Get the frozen people-first Today review feed",
-        "description": "Returns a frozen rolling-24-hour Favorites-list timeline first, evidence-backed reply/quote/shared-link/topic conversation groups, ungrouped Favorite posts, and a deduplicated secondary count-bounded Following stream with immutable source, membership, collection-policy, window, run-context, and context-budget provenance. This review route does not replace the live editorial Today issue.",
+        "description": "Returns a frozen rolling-24-hour Favorites-list timeline collapsed into exact thread units, then a variable zero-to-five set of corroborated topic clusters ranked by distinct Favorite authors and Favorite thread units. Topic labels are extracted from post evidence rather than synthesized headlines; Following supplies bounded supporting conversations and a secondary thread stream. The response discloses the pinned clustering version, semantic fallback state, immutable source, membership, collection-policy, window, run-context, structure, and context-budget provenance. This review route does not replace the live editorial Today issue.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "experimental",

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -316,6 +316,8 @@ function createMockEnv(): Env['Bindings'] {
     ARTICLE_CONTENT: {} as R2Bucket,
     SPOTIFY_CACHE: {} as KVNamespace,
     CREATOR_CONTENT_CACHE: {} as KVNamespace,
+    AI: { run: vi.fn() } as unknown as Ai,
+    EMBEDDING_MODEL: '@cf/qwen/qwen3-embedding-0.6b',
     ENVIRONMENT: 'test',
   } as Env['Bindings'];
 }
@@ -468,8 +470,8 @@ describe('apiV1Routes', () => {
     });
     mockListEditorialExperiments.mockResolvedValue([]);
     mockGetDailyFeed.mockResolvedValue({
-      schemaVersion: 1,
-      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      schemaVersion: 2,
+      variant: { id: 'people-first-v3', mode: 'REVIEW' },
       date: '2026-07-24',
       timezone: 'America/Chicago',
       frozenAt: '2026-07-24T13:00:00.000Z',
@@ -485,11 +487,23 @@ describe('apiV1Routes', () => {
       },
       sources: [],
       conversations: [],
+      topicClusters: [],
+      threadUnits: [],
+      clustering: {
+        version: 'daily-topics-v1',
+        method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
+        semanticStatus: 'COMPLETE',
+        embeddingModel: '@cf/qwen/qwen3-embedding-0.6b',
+        maxTopics: 5,
+        minimumFavoriteAuthors: 2,
+        candidateLimit: 40,
+        semanticUnitLimit: 256,
+      },
       posts: [],
     });
     mockGetDailyAuthorActivity.mockResolvedValue({
       schemaVersion: 1,
-      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      variant: { id: 'people-first-v2', mode: 'REVIEW' },
       date: '2026-07-24',
       range: 'TODAY',
       startDate: '2026-07-24',
@@ -648,11 +662,13 @@ describe('apiV1Routes', () => {
     );
     expect(feed.status).toBe(200);
     expect(await feed.json()).toMatchObject({
-      variant: { id: 'people-first-v1', mode: 'REVIEW' },
+      variant: { id: 'people-first-v3', mode: 'REVIEW' },
       date: '2026-07-24',
     });
     expect(mockGetDailyFeed).toHaveBeenCalledWith(expect.anything(), 'user_123', {
       date: '2026-07-24',
+      ai: env.AI,
+      embeddingModel: '@cf/qwen/qwen3-embedding-0.6b',
     });
 
     const author = await app.fetch(

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -2093,7 +2093,11 @@ apiV1Routes.get('/today/feed', apiAuth('bookmarks:read'), async (c) => {
       400
     );
   }
-  const result = await getDailyFeed(c.env.X_ARCHIVE_DB, c.get('userId')!, parsed.data);
+  const result = await getDailyFeed(c.env.X_ARCHIVE_DB, c.get('userId')!, {
+    ...parsed.data,
+    ai: c.env.AI as unknown as { run(model: string, input: unknown): Promise<unknown> } | undefined,
+    embeddingModel: c.env.EMBEDDING_MODEL,
+  });
   return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
 });
 

--- a/apps/x-archive/src/index.test.ts
+++ b/apps/x-archive/src/index.test.ts
@@ -252,6 +252,57 @@ describe('X archive worker', () => {
     expect(exported.headers.get('content-encoding')).toBe('gzip');
   });
 
+  it('does not let an unknown recapture erase known author metadata', async () => {
+    for (const [runId, author] of [
+      ['run-known-author', post('author-post').author],
+      [
+        'run-unknown-author',
+        {
+          id: 'author-1',
+          username: 'unknown',
+          name: 'unknown',
+          profileUrl: 'https://x.com/unknown',
+        },
+      ],
+    ] as const) {
+      await api('/api/v1/x-timeline/runs', {
+        method: 'POST',
+        body: JSON.stringify({
+          runId,
+          requestedCount: 1,
+          startedAt: '2026-07-11T13:00:00.000Z',
+          collectorVersion: 'test-v1',
+        }),
+      });
+      await api(`/api/v1/x-timeline/runs/${runId}/chunks/0`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          posts: [{ ...post('author-post'), author }],
+          items: [
+            {
+              tweetId: 'author-post',
+              position: 0,
+              observedAt: '2026-07-11T13:00:00.000Z',
+              presentation: 'POST',
+            },
+          ],
+        }),
+      });
+    }
+
+    const author = await testEnv.ARCHIVE_DB.prepare(
+      'SELECT username, name, profile_url FROM x_authors WHERE user_id = ? AND author_key = ?'
+    )
+      .bind(USER_ID, 'id:author-1')
+      .first<{ username: string; name: string; profile_url: string | null }>();
+
+    expect(author).toEqual({
+      username: 'example',
+      name: 'Example',
+      profile_url: 'https://x.com/example',
+    });
+  });
+
   it('stores explicit Favorite/list author snapshots for daily review', async () => {
     await insertCapturedRunForDailySources();
     const put = await api('/api/v1/x-timeline/daily-sources/favorites', {

--- a/apps/x-archive/src/index.ts
+++ b/apps/x-archive/src/index.ts
@@ -628,9 +628,18 @@ app.put('/api/v1/x-timeline/runs/:runId/chunks/:chunkIndex', async (c) => {
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(user_id, author_key) DO UPDATE SET
           x_user_id = COALESCE(excluded.x_user_id, x_authors.x_user_id),
-          username = excluded.username,
-          name = excluded.name,
-          profile_url = COALESCE(excluded.profile_url, x_authors.profile_url),
+          username = CASE
+            WHEN LOWER(excluded.username) = 'unknown' THEN x_authors.username
+            ELSE excluded.username
+          END,
+          name = CASE
+            WHEN LOWER(excluded.name) = 'unknown' THEN x_authors.name
+            ELSE excluded.name
+          END,
+          profile_url = CASE
+            WHEN LOWER(excluded.username) = 'unknown' THEN x_authors.profile_url
+            ELSE COALESCE(excluded.profile_url, x_authors.profile_url)
+          END,
           profile_image_url = COALESCE(excluded.profile_image_url, x_authors.profile_image_url),
           verified = COALESCE(excluded.verified, x_authors.verified),
           last_seen_at = MAX(x_authors.last_seen_at, excluded.last_seen_at)`

--- a/apps/x-collector/src/network-extractor.mjs
+++ b/apps/x-collector/src/network-extractor.mjs
@@ -53,14 +53,17 @@ function unwrapTweet(value) {
 function authorFromTweet(tweet) {
   const user = object(tweet?.core?.user_results?.result);
   const legacy = object(user?.legacy) || {};
-  const username = legacy.screen_name || 'unknown';
+  const core = object(user?.core) || {};
+  const avatar = object(user?.avatar) || {};
+  const verification = object(user?.verification) || {};
+  const username = core.screen_name || legacy.screen_name || 'unknown';
   return {
     id: user?.rest_id || null,
     username,
-    name: legacy.name || username,
+    name: core.name || legacy.name || username,
     profileUrl: `${X_ORIGIN}/${username}`,
-    profileImageUrl: legacy.profile_image_url_https || null,
-    verified: user?.is_blue_verified ?? legacy.verified ?? null,
+    profileImageUrl: avatar.image_url || legacy.profile_image_url_https || null,
+    verified: user?.is_blue_verified ?? verification.verified ?? legacy.verified ?? null,
   };
 }
 

--- a/apps/x-collector/src/network-extractor.test.mjs
+++ b/apps/x-collector/src/network-extractor.test.mjs
@@ -46,6 +46,18 @@ function tweet(id, username, options = {}) {
   };
 }
 
+function modernUserTweet(id, username) {
+  const value = tweet(id, username);
+  value.core.user_results.result = {
+    rest_id: `user-${username}`,
+    is_blue_verified: true,
+    core: { screen_name: username, name: `Modern ${username}` },
+    avatar: { image_url: `https://img.example/modern-${username}.jpg` },
+    verification: { verified: true },
+  };
+  return value;
+}
+
 function item(value) {
   return { item: { itemContent: { tweet_results: { result: value } } } };
 }
@@ -57,6 +69,27 @@ function timelinePayload(entries) {
 }
 
 describe('network response extraction', () => {
+  it('reads the current split X user shape without degrading authors to unknown', () => {
+    const primary = modernUserTweet('modern-1', 'currentshape');
+    const payload = timelinePayload([
+      {
+        entryId: 'tweet-modern-1',
+        content: { itemContent: { tweet_results: { result: primary } } },
+      },
+    ]);
+
+    const batch = extractTimelineGraphQLResponse(payload, { observedAt, sourceType: 'FAVORITES' });
+
+    expect(batch.posts[0].author).toEqual({
+      id: 'user-currentshape',
+      username: 'currentshape',
+      name: 'Modern currentshape',
+      profileUrl: 'https://x.com/currentshape',
+      profileImageUrl: 'https://img.example/modern-currentshape.jpg',
+      verified: true,
+    });
+  });
+
   it('recognizes stable operation names and rejects a mismatched list source', () => {
     const variables = encodeURIComponent(JSON.stringify({ listId: '123' }));
     expect(

--- a/apps/x-collector/src/receiver.test.ts
+++ b/apps/x-collector/src/receiver.test.ts
@@ -24,7 +24,14 @@ describe('local browser receiver', () => {
         source: 'X_WEB_GRAPHQL_LIST' as const,
         observedAt: '2026-07-11T13:00:00.000Z',
       },
-      author: { username: 'reply', name: 'Reply' },
+      author: {
+        id: 'author-1',
+        username: 'reply',
+        name: 'Reply Author',
+        profileUrl: 'https://x.com/reply',
+        profileImageUrl: 'https://img.example/reply.jpg',
+        verified: true,
+      },
       media: [],
       links: [],
       relationships: [
@@ -46,6 +53,14 @@ describe('local browser receiver', () => {
         observedAt: '2026-07-11T14:00:00.000Z',
       },
       relationships: [],
+      author: {
+        id: 'author-1',
+        username: 'unknown',
+        name: 'unknown',
+        profileUrl: 'https://x.com/unknown',
+        profileImageUrl: null,
+        verified: null,
+      },
       capturedAt: '2026-07-11T14:00:00.000Z',
     };
 
@@ -53,6 +68,14 @@ describe('local browser receiver', () => {
       conversationId: '100',
       structure: { status: 'EXACT', source: 'X_WEB_GRAPHQL_LIST' },
       relationships: [{ type: 'REPLY_TO', tweetId: '100' }],
+      author: {
+        id: 'author-1',
+        username: 'reply',
+        name: 'Reply Author',
+        profileUrl: 'https://x.com/reply',
+        profileImageUrl: 'https://img.example/reply.jpg',
+        verified: true,
+      },
     });
   });
 

--- a/apps/x-collector/src/receiver.ts
+++ b/apps/x-collector/src/receiver.ts
@@ -146,6 +146,25 @@ function structurePriority(post: XPost): number {
   return post.structure ? STRUCTURE_PRIORITY[post.structure.source] : -1;
 }
 
+function meaningfulAuthorValue(value: string | null | undefined): boolean {
+  return Boolean(value && value.trim() && value.toLocaleLowerCase() !== 'unknown');
+}
+
+function mergeAuthor(previous: XPost['author'], incoming: XPost['author']): XPost['author'] {
+  const incomingUsernameIsKnown = meaningfulAuthorValue(incoming.username);
+  return {
+    id: incoming.id ?? previous.id ?? null,
+    username: incomingUsernameIsKnown ? incoming.username : previous.username,
+    name: meaningfulAuthorValue(incoming.name) ? incoming.name : previous.name,
+    profileUrl:
+      incomingUsernameIsKnown && meaningfulAuthorValue(incoming.profileUrl)
+        ? incoming.profileUrl
+        : previous.profileUrl,
+    profileImageUrl: incoming.profileImageUrl ?? previous.profileImageUrl ?? null,
+    verified: incoming.verified ?? previous.verified ?? null,
+  };
+}
+
 export function mergePost(previous: XPost | undefined, incoming: XPost): XPost {
   if (!previous) return incoming;
   const richer = structurePriority(incoming) >= structurePriority(previous) ? incoming : previous;
@@ -164,7 +183,7 @@ export function mergePost(previous: XPost | undefined, incoming: XPost): XPost {
     ...richer,
     conversationId: richer.conversationId ?? other.conversationId ?? null,
     structure: richer.structure ?? other.structure,
-    author: { ...other.author, ...richer.author },
+    author: mergeAuthor(other.author, richer.author),
     media: richer.media.length > 0 ? richer.media : other.media,
     links: [...links.values()],
     relationships: [...relationships.values()],


### PR DESCRIPTION
## Summary

- collapse exact reply and conversation chains into ordered thread units while keeping quote and repost references as topic evidence
- build deterministic, evidence-first Favorite topic clusters with distinct-author corroboration, bounded pinned semantic expansion, convergence-based ranking, and a variable zero-to-five topic count
- render topic clusters and expandable complete threads in the native Daily View while preserving source, freshness, structure, and partial-coverage provenance
- preserve real author metadata across current X web response shapes and lower-information recaptures
- retain the existing review-only Today boundary and backward-compatible conversation/post projections

Release scope includes the core Worker, X archive Worker behavior, X collector behavior, and native iOS app. No D1 migration is required. This PR does not deploy or install anything.

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:web` — 75 passed
- `bun run test:worker:ci` — 1,699 passed
- `bun run --cwd apps/x-archive test:run` — 8 passed
- `bun run --cwd apps/x-collector test` — 26 passed
- native Daily Feed contract replay — decoded `people-first-v3`, 2 posts, 2 threads, 1 topic
- `ZineNative` iOS Simulator test run — 50 passed, 0 failed