### PR TITLE
feat(subscriptions): auto-bookmark all feed sources

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -453,6 +453,26 @@ struct APIClient {
         let _: EmptyResponse = try await send(request)
     }
 
+    func setProviderSubscriptionAutoBookmark(
+        id: String,
+        provider: SubscriptionSource,
+        enabled: Bool
+    ) async throws {
+        var request = URLRequest(
+            url: baseURL.appending(
+                path: "/api/v1/subscriptions/\(provider.pathComponent)/\(id)"
+            )
+        )
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(
+            UpdateProviderSubscriptionRequest(
+                action: enabled ? "auto_bookmark_on" : "auto_bookmark_off"
+            )
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let _: EmptyResponse = try await send(request)
+    }
+
     func syncProviderSubscription(
         id: String,
         provider: SubscriptionSource

--- a/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
@@ -78,6 +78,15 @@ private final class NewsletterSubscriptionsStore {
         await perform(feed) { try await client.unsubscribeNewsletter(id: feed.id) }
     }
 
+    func setAutoBookmark(_ feed: NewsletterFeed, enabled: Bool) async {
+        await perform(feed) {
+            try await client.updateNewsletter(
+                id: feed.id,
+                action: enabled ? "auto_bookmark_on" : "auto_bookmark_off"
+            )
+        }
+    }
+
     func dismissMessage() { actionMessage = nil }
 
     private func perform(_ feed: NewsletterFeed, action: () async throws -> Void) async {
@@ -288,6 +297,14 @@ struct NewsletterSubscriptionsView: View {
                         Button { Task { await store.setActive(feed, isActive: true) } } label: {
                             Label("Activate", systemImage: "checkmark.circle")
                         }
+                    }
+                    Button {
+                        Task { await store.setAutoBookmark(feed, enabled: !feed.autoBookmark) }
+                    } label: {
+                        Label(
+                            feed.autoBookmark ? "Stop Auto-bookmarking" : "Auto-bookmark New Issues",
+                            systemImage: feed.autoBookmark ? "bookmark.slash" : "bookmark"
+                        )
                     }
                     Button("Unsubscribe", systemImage: "envelope.badge", role: .destructive) {
                         pendingUnsubscribe = feed

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsClient.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsClient.swift
@@ -5,6 +5,7 @@ struct ProviderSubscriptionsClient {
     var add: (ProviderSubscriptionItem) async throws -> Void
     var remove: (String) async throws -> Void
     var setPaused: (String, Bool) async throws -> Void
+    var setAutoBookmark: (String, Bool) async throws -> Void
     var sync: (String) async throws -> SubscriptionSyncResponse
     var connect: () async throws -> Void
     var disconnect: () async throws -> Void
@@ -25,6 +26,13 @@ struct ProviderSubscriptionsClient {
                     id: $0,
                     provider: provider,
                     isPaused: $1
+                )
+            },
+            setAutoBookmark: {
+                try await apiClient.setProviderSubscriptionAutoBookmark(
+                    id: $0,
+                    provider: provider,
+                    enabled: $1
                 )
             },
             sync: { try await apiClient.syncProviderSubscription(id: $0, provider: provider) },

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsStore.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsStore.swift
@@ -89,6 +89,13 @@ final class ProviderSubscriptionsStore {
         }
     }
 
+    func setAutoBookmark(_ item: ProviderSubscriptionItem, enabled: Bool) async {
+        guard let subscriptionId = item.subscriptionId else { return }
+        await perform(item: item, failureMessage: "The auto-bookmark setting couldn’t be updated.") {
+            try await client.setAutoBookmark(subscriptionId, enabled)
+        }
+    }
+
     func sync(_ item: ProviderSubscriptionItem) async {
         guard let subscriptionId = item.subscriptionId else { return }
         pendingItemIDs.insert(item.channelId)

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
@@ -231,6 +231,15 @@ struct ProviderSubscriptionsView: View {
                 }
             }
 
+            if let autoBookmark = item.autoBookmark {
+                Button { Task { await store.setAutoBookmark(item, enabled: !autoBookmark) } } label: {
+                    Label(
+                        autoBookmark ? "Stop Auto-bookmarking" : "Auto-bookmark New Items",
+                        systemImage: autoBookmark ? "bookmark.slash" : "bookmark"
+                    )
+                }
+            }
+
             Button("Remove", systemImage: "trash", role: .destructive) {
                 pendingRemoval = item
             }

--- a/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
@@ -61,6 +61,15 @@ private final class RssSubscriptionsStore {
         await perform(feed) { try await client.removeRssFeed(id: feed.id) }
     }
 
+    func setAutoBookmark(_ feed: RssFeed, enabled: Bool) async {
+        await perform(feed) {
+            try await client.updateRssFeed(
+                id: feed.id,
+                action: enabled ? "auto_bookmark_on" : "auto_bookmark_off"
+            )
+        }
+    }
+
     func sync(_ feed: RssFeed) async {
         pendingFeedIDs.insert(feed.id)
         defer { pendingFeedIDs.remove(feed.id) }
@@ -238,6 +247,14 @@ struct RssSubscriptionsView: View {
                         Button { Task { await store.setPaused(feed, isPaused: false) } } label: {
                             Label("Resume", systemImage: "play.circle")
                         }
+                    }
+                    Button {
+                        Task { await store.setAutoBookmark(feed, enabled: !feed.autoBookmark) }
+                    } label: {
+                        Label(
+                            feed.autoBookmark ? "Stop Auto-bookmarking" : "Auto-bookmark New Items",
+                            systemImage: feed.autoBookmark ? "bookmark.slash" : "bookmark"
+                        )
                     }
                     Button("Remove", systemImage: "trash", role: .destructive) {
                         pendingRemoval = feed

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
@@ -114,6 +114,7 @@ struct ProviderSubscriptionItem: Decodable, Equatable, Identifiable {
     let status: ProviderSubscriptionStatus?
     let isSubscribed: Bool
     let lastPolledAt: Int?
+    let autoBookmark: Bool?
 
     var id: String { channelId }
 }
@@ -149,6 +150,7 @@ struct NewsletterFeed: Decodable, Equatable, Identifiable {
     let imageUrl: URL?
     let status: NewsletterStatus
     let lastSeenAt: Int?
+    let autoBookmark: Bool
 }
 
 struct NewsletterStats: Decodable, Equatable {
@@ -195,6 +197,7 @@ struct RssFeed: Decodable, Equatable, Identifiable {
     let lastError: String?
     let lastPolledAt: Int?
     let lastSuccessAt: Int?
+    let autoBookmark: Bool
 }
 
 struct RssStats: Decodable, Equatable {

--- a/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
+++ b/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
@@ -116,7 +116,8 @@ struct SubscriptionSourcesTests {
             imageUrl: nil,
             status: nil,
             isSubscribed: false,
-            lastPolledAt: nil
+            lastPolledAt: nil,
+            autoBookmark: nil
         )
         let subscribed = ProviderSubscriptionItem(
             subscriptionId: "sub-1",
@@ -125,7 +126,8 @@ struct SubscriptionSourcesTests {
             imageUrl: nil,
             status: .active,
             isSubscribed: true,
-            lastPolledAt: nil
+            lastPolledAt: nil,
+            autoBookmark: false
         )
         let recorder = SubscriptionClientRecorder(
             responses: [response(items: [item]), response(items: [subscribed])]
@@ -174,6 +176,7 @@ private actor SubscriptionClientRecorder {
             add: { [self] item in await recordAdd(item.channelId) },
             remove: { _ in },
             setPaused: { _, _ in },
+            setAutoBookmark: { _, _ in },
             sync: { _ in SubscriptionSyncResponse(itemsFound: 0) },
             connect: {},
             disconnect: {}

--- a/apps/mobile/hooks/use-subscriptions.ts
+++ b/apps/mobile/hooks/use-subscriptions.ts
@@ -293,6 +293,7 @@ function createTempSubscriptionRow(
     lastPublishedAt: null,
     lastPolledAt: null,
     pollIntervalSeconds: 3600,
+    autoBookmark: false,
     status: 'ACTIVE',
     disconnectedAt: null,
     disconnectedReason: null,

--- a/apps/web/src/mobile-parity-pages.tsx
+++ b/apps/web/src/mobile-parity-pages.tsx
@@ -724,6 +724,17 @@ function getCollectionRuleSummary(rules: CollectionRules) {
   return parts.length === 0 ? 'Manual collection' : `Saved filter: ${parts.join(', ')}`;
 }
 
+type LibrarySourceRow = {
+  id: string;
+  sourceId: string | null;
+  sourceType: 'provider' | 'newsletter' | 'rss' | 'x';
+  title: string;
+  meta: string;
+  status: string;
+  imageUrl: string | null;
+  autoBookmark: boolean | null;
+};
+
 function LibrarySources() {
   const subscriptionsQuery = trpc.subscriptions.list.useQuery({ limit: 100 });
   const newslettersQuery = trpc.subscriptions.newsletters.list.useQuery({ limit: 100 });
@@ -731,43 +742,74 @@ function LibrarySources() {
   const xBookmarksQuery = trpc.subscriptions.xBookmarks.status.useQuery(undefined, {
     staleTime: 60 * 1000,
   });
-  const rows = [
+  const utils = trpc.useUtils();
+  const providerAutoBookmark = trpc.subscriptions.setAutoBookmark.useMutation();
+  const newsletterAutoBookmark = trpc.subscriptions.newsletters.setAutoBookmark.useMutation();
+  const rssAutoBookmark = trpc.subscriptions.rss.setAutoBookmark.useMutation();
+  const rows: LibrarySourceRow[] = [
     ...(subscriptionsQuery.data?.items ?? []).map((source) => ({
       id: `subscription:${source.id}`,
+      sourceId: source.id,
+      sourceType: 'provider' as const,
       title: source.name,
       meta: `${mapProvider(source.provider)} subscription`,
       status: source.status,
       imageUrl: source.imageUrl ?? null,
+      autoBookmark: source.autoBookmark,
     })),
     ...(newslettersQuery.data?.items ?? []).map((source) => ({
       id: `newsletter:${source.id}`,
+      sourceId: source.id,
+      sourceType: 'newsletter' as const,
       title: source.displayName,
       meta: source.fromAddress ?? source.listId ?? 'Newsletter',
       status: source.status,
       imageUrl: source.imageUrl ?? null,
+      autoBookmark: source.autoBookmark,
     })),
     ...(rssQuery.data?.items ?? [])
       .filter((source) => source.status !== 'UNSUBSCRIBED')
       .map((source) => ({
         id: `rss:${source.id}`,
+        sourceId: source.id,
+        sourceType: 'rss' as const,
         title: formatDisplayText(source.title),
         meta: source.siteUrl ?? source.feedUrl,
         status: source.status,
         imageUrl: source.imageUrl ?? null,
+        autoBookmark: source.autoBookmark,
       })),
   ];
 
   if (xBookmarksQuery.data?.connected || xBookmarksQuery.data?.importedCount) {
     rows.push({
       id: 'x-bookmarks',
+      sourceId: null,
+      sourceType: 'x',
       title: 'X Bookmarks',
       meta: `${xBookmarksQuery.data.importedCount} imported`,
       status: xBookmarksQuery.data.connected
         ? 'ACTIVE'
         : (xBookmarksQuery.data.connectionStatus ?? 'DISCONNECTED'),
       imageUrl: null,
+      autoBookmark: null,
     });
   }
+
+  const toggleAutoBookmark = async (source: LibrarySourceRow) => {
+    if (!source.sourceId || source.autoBookmark === null) return;
+    const enabled = !source.autoBookmark;
+    if (source.sourceType === 'provider') {
+      await providerAutoBookmark.mutateAsync({ subscriptionId: source.sourceId, enabled });
+      await utils.subscriptions.list.invalidate();
+    } else if (source.sourceType === 'newsletter') {
+      await newsletterAutoBookmark.mutateAsync({ feedId: source.sourceId, enabled });
+      await utils.subscriptions.newsletters.list.invalidate();
+    } else {
+      await rssAutoBookmark.mutateAsync({ feedId: source.sourceId, enabled });
+      await utils.subscriptions.rss.list.invalidate();
+    }
+  };
 
   const isLoading =
     subscriptionsQuery.isLoading || newslettersQuery.isLoading || rssQuery.isLoading;
@@ -810,7 +852,25 @@ function LibrarySources() {
             <strong>{formatDisplayText(source.title)}</strong>
             <span>{source.meta}</span>
           </div>
-          <Badge>{source.status.toLowerCase()}</Badge>
+          <div className="flex items-center gap-2">
+            <Badge>{source.status.toLowerCase()}</Badge>
+            {source.autoBookmark !== null ? (
+              <Button
+                type="button"
+                variant={source.autoBookmark ? 'default' : 'outline'}
+                className="h-8 px-2 text-xs"
+                aria-pressed={source.autoBookmark}
+                onClick={() => void toggleAutoBookmark(source)}
+                disabled={
+                  providerAutoBookmark.isPending ||
+                  newsletterAutoBookmark.isPending ||
+                  rssAutoBookmark.isPending
+                }
+              >
+                {source.autoBookmark ? 'Auto-bookmarking' : 'Auto-bookmark'}
+              </Button>
+            ) : null}
+          </div>
         </Surface>
       ))}
     </div>

--- a/apps/worker/src/db/migrations/0027_add_subscription_auto_bookmark.sql
+++ b/apps/worker/src/db/migrations/0027_add_subscription_auto_bookmark.sql
@@ -1,0 +1,8 @@
+-- Created: 2026-07-26
+-- Keep future items from any supported feed subscription out of Inbox when enabled.
+
+ALTER TABLE `subscriptions` ADD COLUMN `auto_bookmark` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `rss_feeds` ADD COLUMN `auto_bookmark` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `newsletter_feeds` ADD COLUMN `auto_bookmark` integer NOT NULL DEFAULT 0;

--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1784899320000,
       "tag": "0026_add_article_body_dlq_resolution",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1785090607000,
+      "tag": "0027_add_subscription_auto_bookmark",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -1003,6 +1003,7 @@ export const newsletterFeeds = sqliteTable(
     unsubscribePostHeader: text('unsubscribe_post_header'),
     detectionScore: real('detection_score').notNull(),
     status: text('status').notNull().default('ACTIVE'), // ACTIVE | HIDDEN | UNSUBSCRIBED (ingestion path sets UNSUBSCRIBED by default)
+    autoBookmark: integer('auto_bookmark', { mode: 'boolean' }).notNull().default(false),
     firstSeenAt: integer('first_seen_at').notNull(),
     lastSeenAt: integer('last_seen_at').notNull(),
     createdAt: integer('created_at').notNull(),
@@ -1099,6 +1100,7 @@ export const rssFeeds = sqliteTable(
     errorCount: integer('error_count').notNull().default(0),
     status: text('status').notNull().default('ACTIVE'), // ACTIVE | PAUSED | UNSUBSCRIBED | ERROR
     pollIntervalSeconds: integer('poll_interval_seconds').notNull().default(3600),
+    autoBookmark: integer('auto_bookmark', { mode: 'boolean' }).notNull().default(false),
     createdAt: integer('created_at').notNull(), // Unix ms
     updatedAt: integer('updated_at').notNull(), // Unix ms
   },
@@ -1180,6 +1182,7 @@ export const subscriptions = sqliteTable(
     lastPublishedAt: integer('last_published_at'), // Unix ms
     lastPolledAt: integer('last_polled_at'), // Unix ms
     pollIntervalSeconds: integer('poll_interval_seconds').default(3600), // Polling frequency
+    autoBookmark: integer('auto_bookmark', { mode: 'boolean' }).notNull().default(false),
 
     // Status
     status: text('status').notNull().default('ACTIVE'), // ACTIVE | PAUSED | DISCONNECTED | UNSUBSCRIBED

--- a/apps/worker/src/ingestion/processor/batch.ts
+++ b/apps/worker/src/ingestion/processor/batch.ts
@@ -9,6 +9,7 @@ import { ingestItem } from './ingest';
 import { prepareBatch } from './prepare';
 import type { BatchIngestResult, ConsolidatedBatchIngestResult, PreparedItem } from './types';
 import { buildIngestionStatements, executeBatchStatements } from './write';
+import { isProviderSubscriptionAutoBookmarkEnabled } from '../../subscriptions/auto-bookmark';
 
 // Batch Ingestion
 
@@ -184,6 +185,13 @@ export async function ingestBatchConsolidated<T>(
     return result;
   }
 
+  const autoBookmark = await isProviderSubscriptionAutoBookmarkEnabled(
+    db,
+    userId,
+    subscriptionId,
+    provider
+  );
+
   // Phase 1: Transform, validate, and check idempotency for all items
   const { preparedItems, skippedCount, errors, errorDetails } = await prepareBatch({
     userId,
@@ -205,7 +213,14 @@ export async function ingestBatchConsolidated<T>(
     result.batchCount = chunks.length;
 
     for (const itemChunk of chunks) {
-      const chunkSuccess = await executeChunkBatch(itemChunk, userId, subscriptionId, provider, db);
+      const chunkSuccess = await executeChunkBatch(
+        itemChunk,
+        userId,
+        subscriptionId,
+        provider,
+        db,
+        autoBookmark
+      );
 
       if (chunkSuccess) {
         result.created += itemChunk.length;
@@ -217,7 +232,8 @@ export async function ingestBatchConsolidated<T>(
             userId,
             subscriptionId,
             provider,
-            db
+            db,
+            autoBookmark
           );
 
           if (itemSuccess) {
@@ -272,12 +288,13 @@ async function executeChunkBatch(
   userId: string,
   subscriptionId: string,
   provider: Provider,
-  db: Database
+  db: Database,
+  autoBookmark: boolean
 ): Promise<boolean> {
   try {
     const nowISO = new Date().toISOString();
     const now = Date.now();
-    const context = { db, userId, subscriptionId, provider, nowISO, now };
+    const context = { db, userId, subscriptionId, provider, autoBookmark, nowISO, now };
     const statements = itemChunk.flatMap((prepared) => buildIngestionStatements(prepared, context));
 
     await executeBatchStatements(statements, db);
@@ -301,12 +318,13 @@ async function executeIndividualInsert(
   userId: string,
   subscriptionId: string,
   provider: Provider,
-  db: Database
+  db: Database,
+  autoBookmark: boolean
 ): Promise<boolean> {
   try {
     const nowISO = new Date().toISOString();
     const now = Date.now();
-    const context = { db, userId, subscriptionId, provider, nowISO, now };
+    const context = { db, userId, subscriptionId, provider, autoBookmark, nowISO, now };
     const statements = buildIngestionStatements(prepared, context);
 
     await executeBatchStatements(statements, db);

--- a/apps/worker/src/ingestion/processor/ingest.ts
+++ b/apps/worker/src/ingestion/processor/ingest.ts
@@ -5,6 +5,7 @@ import type { NewItem } from '../transformers';
 import type { IngestResult } from './types';
 import { prepareItem } from './prepare';
 import { buildIngestionStatements, executeBatchStatements } from './write';
+import { isProviderSubscriptionAutoBookmarkEnabled } from '../../subscriptions/auto-bookmark';
 
 // Main Ingestion Function
 
@@ -65,12 +66,19 @@ export async function ingestItem<T>(
 
   const nowISO = new Date().toISOString();
   const now = Date.now();
+  const autoBookmark = await isProviderSubscriptionAutoBookmarkEnabled(
+    db,
+    userId,
+    subscriptionId,
+    provider
+  );
 
   const statements = buildIngestionStatements(prepared.item, {
     db,
     userId,
     subscriptionId,
     provider,
+    autoBookmark,
     nowISO,
     now,
   });

--- a/apps/worker/src/ingestion/processor/types.ts
+++ b/apps/worker/src/ingestion/processor/types.ts
@@ -59,6 +59,7 @@ export interface IngestContext {
  */
 export interface WriteContext extends IngestContext {
   subscriptionId: string;
+  autoBookmark?: boolean;
   nowISO: string;
   now: number;
 }

--- a/apps/worker/src/ingestion/processor/write.test.ts
+++ b/apps/worker/src/ingestion/processor/write.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ContentType, Provider } from '@zine/shared';
+import { ContentType, Provider, UserItemState } from '@zine/shared';
 import { items, providerItemsSeen, subscriptionItems, userItems } from '../../db/schema';
 import { buildIngestionStatements, executeBatchStatements } from './write';
 
@@ -114,6 +114,26 @@ describe('buildIngestionStatements', () => {
 
     expect(statements).toHaveLength(3);
     expect(inserted.find((entry) => entry.table === items)).toBeUndefined();
+  });
+
+  it('writes enabled auto-bookmarked items with the required timestamp', () => {
+    const { db, inserted } = createMockDb();
+
+    buildIngestionStatements(createPreparedItem(), {
+      db: db as never,
+      userId: 'user-1',
+      subscriptionId: 'sub-1',
+      provider: Provider.SPOTIFY,
+      autoBookmark: true,
+      nowISO: '2024-01-15T12:00:00.000Z',
+      now: 1705320000000,
+    });
+
+    const userItemInsert = inserted.find((entry) => entry.table === userItems);
+    expect(userItemInsert?.values).toMatchObject({
+      state: UserItemState.BOOKMARKED,
+      bookmarkedAt: '2024-01-15T12:00:00.000Z',
+    });
   });
 
   it('stores null publishedAt when timestamp is zero', () => {

--- a/apps/worker/src/ingestion/processor/write.ts
+++ b/apps/worker/src/ingestion/processor/write.ts
@@ -1,10 +1,10 @@
 import { ulid } from 'ulid';
-import { UserItemState } from '@zine/shared';
 import type { BatchItem } from 'drizzle-orm/batch';
 
 import type { Database } from '../../db';
 import { items, providerItemsSeen, subscriptionItems, userItems } from '../../db/schema';
 import { unixToIso } from '../../lib/timestamps';
+import { getAutoBookmarkFields } from '../../subscriptions/auto-bookmark';
 import type { PreparedItem, WriteContext } from './types';
 
 // Write Helpers
@@ -16,7 +16,8 @@ export function buildIngestionStatements(
   prepared: PreparedItem,
   context: WriteContext
 ): BatchItem<'sqlite'>[] {
-  const { db, userId, subscriptionId, provider, nowISO, now } = context;
+  const { db, userId, subscriptionId, provider, autoBookmark, nowISO, now } = context;
+  const userItemState = getAutoBookmarkFields(autoBookmark === true, nowISO);
   const statements: BatchItem<'sqlite'>[] = [];
 
   if (!prepared.canonicalItemExists) {
@@ -53,7 +54,7 @@ export function buildIngestionStatements(
         id: prepared.userItemId,
         userId,
         itemId: prepared.canonicalItemId,
-        state: UserItemState.INBOX,
+        ...userItemState,
         ingestedAt: nowISO,
         createdAt: nowISO,
         updatedAt: nowISO,

--- a/apps/worker/src/newsletters/gmail.ts
+++ b/apps/worker/src/newsletters/gmail.ts
@@ -1584,6 +1584,7 @@ async function upsertNewsletterFeed(
     return {
       ...existing,
       status: existing.status as NewsletterFeedStatus,
+      autoBookmark: existing.autoBookmark,
     };
   }
 
@@ -1601,6 +1602,7 @@ async function upsertNewsletterFeed(
     unsubscribePostHeader: parsed.unsubscribePostHeader,
     detectionScore: parsed.detection.score,
     status: 'UNSUBSCRIBED',
+    autoBookmark: false,
     firstSeenAt: parsed.internalDateMs,
     lastSeenAt: parsed.internalDateMs,
     createdAt: now,
@@ -1610,6 +1612,7 @@ async function upsertNewsletterFeed(
   return {
     id: feedId,
     status: 'UNSUBSCRIBED' as NewsletterFeedStatus,
+    autoBookmark: false,
   };
 }
 
@@ -1620,6 +1623,7 @@ async function ingestNewsletterMessage(params: {
   googleSub: string;
   parsed: ParsedMessage;
   feedId: string;
+  autoBookmark: boolean;
   accessToken: string | null;
 }): Promise<boolean> {
   const existingMapping = await params.db.query.newsletterFeedMessages.findFirst({
@@ -1730,9 +1734,9 @@ async function ingestNewsletterMessage(params: {
       id: ulid(),
       userId: params.userId,
       itemId: canonicalItem.id,
-      state: 'INBOX',
+      state: params.autoBookmark ? 'BOOKMARKED' : 'INBOX',
       ingestedAt: nowIso,
-      bookmarkedAt: null,
+      bookmarkedAt: params.autoBookmark ? nowIso : null,
       archivedAt: null,
       lastOpenedAt: null,
       progressPosition: null,
@@ -1872,6 +1876,7 @@ async function backfillNewsletterItemsForFeedInternal(params: {
       canonicalKey: true,
       listId: true,
       fromAddress: true,
+      autoBookmark: true,
     },
   });
 
@@ -1959,6 +1964,7 @@ async function backfillNewsletterItemsForFeedInternal(params: {
       googleSub: mailbox.googleSub,
       parsed,
       feedId: feed.id,
+      autoBookmark: feed.autoBookmark === true,
       accessToken,
     });
 
@@ -2152,6 +2158,7 @@ export async function syncGmailNewslettersForUser(
         googleSub: mailbox.googleSub,
         parsed,
         feedId: feed.id,
+        autoBookmark: feed.autoBookmark === true,
         accessToken,
       });
 

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2305,7 +2305,10 @@
                 "required": ["action"],
                 "additionalProperties": false,
                 "properties": {
-                  "action": { "type": "string", "enum": ["pause", "resume"] }
+                  "action": {
+                    "type": "string",
+                    "enum": ["pause", "resume", "auto_bookmark_on", "auto_bookmark_off"]
+                  }
                 }
               }
             }
@@ -2562,7 +2565,10 @@
               "required": ["action"],
               "additionalProperties": false,
               "properties": {
-                "action": { "type": "string", "enum": ["pause", "resume"] }
+                "action": {
+                  "type": "string",
+                  "enum": ["pause", "resume", "auto_bookmark_on", "auto_bookmark_off"]
+                }
               }
             }
           }
@@ -2577,7 +2583,10 @@
               "required": ["action"],
               "additionalProperties": false,
               "properties": {
-                "action": { "type": "string", "enum": ["activate", "hide"] }
+                "action": {
+                  "type": "string",
+                  "enum": ["activate", "hide", "auto_bookmark_on", "auto_bookmark_off"]
+                }
               }
             }
           }
@@ -4182,7 +4191,8 @@
           "imageUrl",
           "status",
           "isSubscribed",
-          "lastPolledAt"
+          "lastPolledAt",
+          "autoBookmark"
         ],
         "properties": {
           "subscriptionId": { "type": ["string", "null"] },
@@ -4194,7 +4204,8 @@
             "enum": ["ACTIVE", "PAUSED", "DISCONNECTED", null]
           },
           "isSubscribed": { "type": "boolean" },
-          "lastPolledAt": { "type": ["integer", "null"] }
+          "lastPolledAt": { "type": ["integer", "null"] },
+          "autoBookmark": { "type": ["boolean", "null"] }
         }
       },
       "CreateSyncJobRequest": {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -182,7 +182,7 @@ const AddProviderSubscriptionBodySchema = z
 
 const UpdateProviderSubscriptionBodySchema = z
   .object({
-    action: z.enum(['pause', 'resume']),
+    action: z.enum(['pause', 'resume', 'auto_bookmark_on', 'auto_bookmark_off']),
   })
   .strict();
 
@@ -203,7 +203,7 @@ const CompleteOAuthBodySchema = z
 
 const UpdateNewsletterBodySchema = z
   .object({
-    action: z.enum(['activate', 'hide']),
+    action: z.enum(['activate', 'hide', 'auto_bookmark_on', 'auto_bookmark_off']),
   })
   .strict();
 
@@ -216,7 +216,7 @@ const AddRssFeedBodySchema = z
 
 const UpdateRssFeedBodySchema = z
   .object({
-    action: z.enum(['pause', 'resume']),
+    action: z.enum(['pause', 'resume', 'auto_bookmark_on', 'auto_bookmark_off']),
   })
   .strict();
 
@@ -622,6 +622,7 @@ apiV1Routes.get('/subscriptions/youtube', apiAuth('sync:read'), async (c) => {
         name: subscription.name,
         imageUrl: subscription.imageUrl,
         status: subscription.status,
+        autoBookmark: subscription.autoBookmark,
         isSubscribed: true,
         lastPolledAt: subscription.lastPolledAt,
       })),
@@ -795,8 +796,12 @@ apiV1Routes.patch('/subscriptions/youtube/:subscriptionId', apiAuth('sync:write'
   const caller = appRouter.createCaller(await createContext(c));
   const input = { subscriptionId: c.req.param('subscriptionId') };
   try {
-    const result =
-      parsedBody.data.action === 'pause'
+    const result = parsedBody.data.action.startsWith('auto_bookmark')
+      ? await caller.subscriptions.setAutoBookmark({
+          ...input,
+          enabled: parsedBody.data.action === 'auto_bookmark_on',
+        })
+      : parsedBody.data.action === 'pause'
         ? await caller.subscriptions.pause(input)
         : await caller.subscriptions.resume(input);
     return c.json({
@@ -959,6 +964,7 @@ function registerManagedProviderRoutes(slug: string, provider: typeof Provider.S
           name: subscription.name,
           imageUrl: subscription.imageUrl,
           status: subscription.status,
+          autoBookmark: subscription.autoBookmark,
           isSubscribed: true,
           lastPolledAt: subscription.lastPolledAt,
         })),
@@ -1050,8 +1056,12 @@ function registerManagedProviderRoutes(slug: string, provider: typeof Provider.S
     const caller = appRouter.createCaller(await createContext(c));
     const input = { subscriptionId: c.req.param('subscriptionId') };
     try {
-      const result =
-        parsedBody.data.action === 'pause'
+      const result = parsedBody.data.action.startsWith('auto_bookmark')
+        ? await caller.subscriptions.setAutoBookmark({
+            ...input,
+            enabled: parsedBody.data.action === 'auto_bookmark_on',
+          })
+        : parsedBody.data.action === 'pause'
           ? await caller.subscriptions.pause(input)
           : await caller.subscriptions.resume(input);
       return c.json({
@@ -1144,10 +1154,15 @@ apiV1Routes.patch('/subscriptions/gmail/:feedId', apiAuth('sync:write'), async (
 
   const caller = appRouter.createCaller(await createContext(c));
   try {
-    const result = await caller.subscriptions.newsletters.updateStatus({
-      feedId: c.req.param('feedId'),
-      status: parsedBody.data.action === 'activate' ? 'ACTIVE' : 'HIDDEN',
-    });
+    const result = parsedBody.data.action.startsWith('auto_bookmark')
+      ? await caller.subscriptions.newsletters.setAutoBookmark({
+          feedId: c.req.param('feedId'),
+          enabled: parsedBody.data.action === 'auto_bookmark_on',
+        })
+      : await caller.subscriptions.newsletters.updateStatus({
+          feedId: c.req.param('feedId'),
+          status: parsedBody.data.action === 'activate' ? 'ACTIVE' : 'HIDDEN',
+        });
     return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
   } catch (error) {
     return trpcErrorResponse(c, error);
@@ -1238,8 +1253,12 @@ apiV1Routes.patch('/subscriptions/rss/:feedId', apiAuth('sync:write'), async (c)
   const caller = appRouter.createCaller(await createContext(c));
   const input = { feedId: c.req.param('feedId') };
   try {
-    const result =
-      parsedBody.data.action === 'pause'
+    const result = parsedBody.data.action.startsWith('auto_bookmark')
+      ? await caller.subscriptions.rss.setAutoBookmark({
+          ...input,
+          enabled: parsedBody.data.action === 'auto_bookmark_on',
+        })
+      : parsedBody.data.action === 'pause'
         ? await caller.subscriptions.rss.pause(input)
         : await caller.subscriptions.rss.resume(input);
     return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });

--- a/apps/worker/src/rss/service.ts
+++ b/apps/worker/src/rss/service.ts
@@ -225,10 +225,11 @@ async function ingestEntry(params: {
   db: Database;
   userId: string;
   feedId: string;
+  autoBookmark: boolean;
   entry: ParsedRssEntry;
   articleBodyEnv?: SyncOptions['articleBodyEnv'];
 }): Promise<boolean> {
-  const { db, userId, feedId, entry, articleBodyEnv } = params;
+  const { db, userId, feedId, autoBookmark, entry, articleBodyEnv } = params;
   const enrichedEntry = await enrichRssEntryMetadata(entry, feedId);
 
   const prepared = await prepareItem({
@@ -328,8 +329,9 @@ async function ingestEntry(params: {
         id: prepared.item.userItemId,
         userId,
         itemId: prepared.item.canonicalItemId,
-        state: UserItemState.INBOX,
+        state: autoBookmark ? UserItemState.BOOKMARKED : UserItemState.INBOX,
         ingestedAt: nowISO,
+        bookmarkedAt: autoBookmark ? nowISO : null,
         createdAt: nowISO,
         updatedAt: nowISO,
       })
@@ -391,6 +393,7 @@ async function ingestEntries(params: {
   db: Database;
   userId: string;
   feedId: string;
+  autoBookmark: boolean;
   entries: ParsedRssEntry[];
   maxEntries: number;
   articleBodyEnv?: SyncOptions['articleBodyEnv'];
@@ -404,6 +407,7 @@ async function ingestEntries(params: {
         db: params.db,
         userId: params.userId,
         feedId: params.feedId,
+        autoBookmark: params.autoBookmark,
         entry,
         articleBodyEnv: params.articleBodyEnv,
       });
@@ -528,6 +532,7 @@ export async function syncRssFeed(
       db,
       userId: feed.userId,
       feedId: feed.id,
+      autoBookmark: feed.autoBookmark === true,
       entries: parsed.entries,
       maxEntries,
       articleBodyEnv: options.articleBodyEnv,

--- a/apps/worker/src/subscriptions/auto-bookmark.ts
+++ b/apps/worker/src/subscriptions/auto-bookmark.ts
@@ -1,0 +1,48 @@
+import { and, eq } from 'drizzle-orm';
+import { UserItemState } from '@zine/shared';
+import type { Provider } from '@zine/shared';
+
+import type { Database } from '../db';
+import { subscriptions } from '../db/schema';
+
+export type AutoBookmarkFields = {
+  state: UserItemState;
+  bookmarkedAt: string | null;
+};
+
+export function getAutoBookmarkFields(enabled: boolean, nowISO: string): AutoBookmarkFields {
+  return enabled
+    ? { state: UserItemState.BOOKMARKED, bookmarkedAt: nowISO }
+    : { state: UserItemState.INBOX, bookmarkedAt: null };
+}
+
+/** Older isolated ingestion test doubles may not expose relational query helpers. */
+export async function isProviderSubscriptionAutoBookmarkEnabled(
+  db: Database,
+  userId: string,
+  subscriptionId: string,
+  provider: Provider
+): Promise<boolean> {
+  const query = (
+    db as unknown as {
+      query?: {
+        subscriptions?: {
+          findFirst?: (args: unknown) => Promise<{ autoBookmark?: boolean } | undefined>;
+        };
+      };
+    }
+  ).query?.subscriptions;
+
+  if (!query?.findFirst) return false;
+
+  const row = await query.findFirst({
+    where: and(
+      eq(subscriptions.id, subscriptionId),
+      eq(subscriptions.userId, userId),
+      eq(subscriptions.provider, provider)
+    ),
+    columns: { autoBookmark: true },
+  });
+
+  return row?.autoBookmark === true;
+}

--- a/apps/worker/src/trpc/router.ts
+++ b/apps/worker/src/trpc/router.ts
@@ -58,6 +58,7 @@ export const appRouter = router({
     pause: subscriptionsRouter.pause,
     resume: subscriptionsRouter.resume,
     syncNow: subscriptionsRouter.syncNow,
+    setAutoBookmark: subscriptionsRouter.setAutoBookmark,
     syncAllAsync: subscriptionsRouter.syncAllAsync,
     syncStatus: subscriptionsRouter.syncStatus,
     activeSyncJob: subscriptionsRouter.activeSyncJob,

--- a/apps/worker/src/trpc/routers/newsletters.ts
+++ b/apps/worker/src/trpc/routers/newsletters.ts
@@ -39,6 +39,10 @@ const UnsubscribeInputSchema = z.object({
   feedId: z.string().min(1),
 });
 
+const SetAutoBookmarkInputSchema = UnsubscribeInputSchema.extend({
+  enabled: z.boolean(),
+});
+
 type ActiveGmailMailbox = {
   id: string;
   lastSyncAt: number | null;
@@ -230,10 +234,36 @@ export const newslettersRouter = router({
           firstSeenAt: row.firstSeenAt,
           unsubscribeUrl: row.unsubscribeUrl,
           unsubscribeMailto: row.unsubscribeMailto,
+          autoBookmark: row.autoBookmark,
         })),
         nextCursor: hasMore ? (rows[rows.length - 1]?.id ?? null) : null,
         hasMore,
       };
+    }),
+
+  setAutoBookmark: protectedProcedure
+    .input(SetAutoBookmarkInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const activeMailboxes = await getActiveGmailMailboxes(ctx.db, ctx.userId);
+      const mailboxIds = activeMailboxes.map((row) => row.id);
+      const row = await ctx.db.query.newsletterFeeds.findFirst({
+        where: and(
+          eq(newsletterFeeds.id, input.feedId),
+          eq(newsletterFeeds.userId, ctx.userId),
+          inArray(newsletterFeeds.gmailMailboxId, mailboxIds)
+        ),
+      });
+
+      if (!row) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Newsletter feed not found' });
+      }
+
+      await ctx.db
+        .update(newsletterFeeds)
+        .set({ autoBookmark: input.enabled, updatedAt: Date.now() })
+        .where(eq(newsletterFeeds.id, row.id));
+
+      return { success: true as const, autoBookmark: input.enabled };
     }),
 
   updateStatus: protectedProcedure

--- a/apps/worker/src/trpc/routers/rss.ts
+++ b/apps/worker/src/trpc/routers/rss.ts
@@ -28,6 +28,10 @@ const RssFeedActionInputSchema = z.object({
   feedId: z.string().min(1),
 });
 
+const SetAutoBookmarkInputSchema = RssFeedActionInputSchema.extend({
+  enabled: z.boolean(),
+});
+
 const DiscoverRssFeedInputSchema = z.object({
   url: z.string().url('Invalid URL format'),
   refresh: z.boolean().optional(),
@@ -76,6 +80,7 @@ export const rssRouter = router({
           description: row.description,
           siteUrl: row.siteUrl,
           imageUrl: row.imageUrl,
+          autoBookmark: row.autoBookmark,
           status: row.status as z.infer<typeof RssFeedStatusSchema>,
           errorCount: row.errorCount,
           lastError: row.lastError,
@@ -87,6 +92,22 @@ export const rssRouter = router({
         nextCursor: hasMore ? (visibleRows[visibleRows.length - 1]?.id ?? null) : null,
         hasMore,
       };
+    }),
+
+  setAutoBookmark: protectedProcedure
+    .input(SetAutoBookmarkInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const feed = await getOwnedFeed(ctx.db, ctx.userId, input.feedId);
+      if (!feed) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'RSS feed not found' });
+      }
+
+      await ctx.db
+        .update(rssFeeds)
+        .set({ autoBookmark: input.enabled, updatedAt: Date.now() })
+        .where(eq(rssFeeds.id, feed.id));
+
+      return { success: true as const, autoBookmark: input.enabled };
     }),
 
   add: protectedProcedure.input(AddRssFeedInputSchema).mutation(async ({ ctx, input }) => {

--- a/apps/worker/src/trpc/routers/subscriptions.ts
+++ b/apps/worker/src/trpc/routers/subscriptions.ts
@@ -67,6 +67,11 @@ const SyncNowInputSchema = z.object({
   subscriptionId: z.string().min(1),
 });
 
+const SetAutoBookmarkInputSchema = z.object({
+  subscriptionId: z.string().min(1),
+  enabled: z.boolean(),
+});
+
 const DiscoverAvailableInputSchema = z.object({
   provider: SubscriptionProviderSchema,
 });
@@ -138,6 +143,7 @@ export const subscriptionsRouter = router({
         lastPublishedAt: row.subscription.lastPublishedAt,
         lastPolledAt: row.subscription.lastPolledAt,
         pollIntervalSeconds: row.subscription.pollIntervalSeconds,
+        autoBookmark: row.subscription.autoBookmark,
         status: row.subscription.status,
         disconnectedAt: row.subscription.disconnectedAt,
         disconnectedReason: row.subscription.disconnectedReason,
@@ -150,6 +156,23 @@ export const subscriptionsRouter = router({
         nextCursor: hasMore && items.length > 0 ? items[items.length - 1].id : null,
         hasMore,
       };
+    }),
+  setAutoBookmark: protectedProcedure
+    .input(SetAutoBookmarkInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const updated = await ctx.db
+        .update(subscriptions)
+        .set({ autoBookmark: input.enabled, updatedAt: Date.now() })
+        .where(
+          and(eq(subscriptions.id, input.subscriptionId), eq(subscriptions.userId, ctx.userId))
+        )
+        .returning({ id: subscriptions.id, autoBookmark: subscriptions.autoBookmark });
+
+      if (updated.length === 0) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Subscription not found' });
+      }
+
+      return { success: true as const, autoBookmark: updated[0].autoBookmark };
     }),
   add: protectedProcedure.input(AddSubscriptionInputSchema).mutation(async ({ ctx, input }) => {
     const connection = await ctx.db.query.providerConnections.findFirst({


### PR DESCRIPTION
## Summary
- Add per-subscription auto-bookmark settings for provider subscriptions, RSS feeds, and newsletters.
- Apply BOOKMARKED plus bookmarkedAt to newly ingested enabled-source items across single, batch, RSS, and Gmail ingestion while preserving INBOX defaults and existing items.
- Expose controls through worker REST/tRPC APIs, web Library Sources, and the canonical native iOS subscription screens.

## Validation
- `bun run test` — passed: 63 mobile suites/1,125 tests, 87 worker files/1,721 tests, 11 web files/75 tests.
- `bun run build` — passed.
- `bun run format:check` — passed.
- `bun run design-system:check` — passed.
- `bun run typecheck` — passed all 14 tasks.
- `bun run lint` — passed all 15 tasks.
- `git diff --check` — passed.
- Native `xcodebuild` simulator build passed; simulator runtime execution remains unavailable in this environment.

No deployment performed.