### PR TITLE
feat(subscriptions): manage auto-bookmarking from bookmarks

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -252,6 +252,42 @@ struct APIClient {
         return response.item
     }
 
+    func getBookmarkSubscriptionSettings(id: String) async throws -> BookmarkSubscriptionSettings? {
+        let response: BookmarkSubscriptionSettingsResponse = try await request(
+            url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/subscription-settings")
+        )
+        return response.subscription
+    }
+
+    func setBookmarkSubscriptionAutoBookmark(
+        _ settings: BookmarkSubscriptionSettings,
+        enabled: Bool
+    ) async throws {
+        switch settings.provider {
+        case .youtube, .spotify:
+            guard let source = SubscriptionSource(rawValue: settings.provider.rawValue) else {
+                throw APIError.invalidResponse
+            }
+            try await setProviderSubscriptionAutoBookmark(
+                id: settings.sourceId,
+                provider: source,
+                enabled: enabled
+            )
+        case .gmail:
+            try await updateNewsletter(
+                id: settings.sourceId,
+                action: enabled ? "auto_bookmark_on" : "auto_bookmark_off"
+            )
+        case .rss:
+            try await updateRssFeed(
+                id: settings.sourceId,
+                action: enabled ? "auto_bookmark_on" : "auto_bookmark_off"
+            )
+        case .substack, .web, .x:
+            throw APIError.invalidResponse
+        }
+    }
+
     func getCreator(id: String) async throws -> CreatorResponse {
         try await request(url: baseURL.appending(path: "/api/v1/creators/\(id)"))
     }

--- a/apps/ios/ZineNative/Core/API/APIResponses.swift
+++ b/apps/ios/ZineNative/Core/API/APIResponses.swift
@@ -9,6 +9,10 @@ struct BookmarkResponse: Decodable {
     let item: Bookmark
 }
 
+struct BookmarkSubscriptionSettingsResponse: Decodable {
+    let subscription: BookmarkSubscriptionSettings?
+}
+
 struct CreatorResponse: Decodable {
     let creator: CreatorProfile
 }

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -114,6 +114,8 @@ struct BookmarkDetailView: View {
     @State private var isSaving = false
     @State private var isHydrating = false
     @State private var hydrationFailed = false
+    @State private var subscriptionSettings: BookmarkSubscriptionSettings?
+    @State private var isSavingSubscriptionSettings = false
     @State private var errorMessage: String?
 
     private let initialContent: BookmarkDetailContent
@@ -222,7 +224,10 @@ struct BookmarkDetailView: View {
         .task(id: content.id) {
             await hydrateBookmark()
         }
-        .alert("Couldn’t update bookmark", isPresented: Binding(
+        .task(id: content.id) {
+            await hydrateSubscriptionSettings()
+        }
+        .alert("Couldn’t update", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
         )) {
@@ -435,6 +440,21 @@ struct BookmarkDetailView: View {
             } label: {
                 Label("Copy Link", systemImage: "doc.on.doc")
             }
+
+            if let subscriptionSettings {
+                Divider()
+                Button {
+                    Task { await toggleSubscriptionAutoBookmark() }
+                } label: {
+                    Label(
+                        subscriptionSettings.actionTitle,
+                        systemImage: subscriptionSettings.autoBookmark
+                            ? "bookmark.slash"
+                            : "bookmark"
+                    )
+                }
+                .disabled(isSavingSubscriptionSettings)
+            }
         } label: {
             actionIcon(systemName: "ellipsis")
         }
@@ -606,6 +626,38 @@ struct BookmarkDetailView: View {
             guard needsInitialBookmark else { return }
             isHydrating = false
             hydrationFailed = true
+        }
+    }
+
+    private func hydrateSubscriptionSettings() async {
+        do {
+            let settings = try await client.getBookmarkSubscriptionSettings(id: content.id)
+            guard !Task.isCancelled else { return }
+            subscriptionSettings = settings
+        } catch is CancellationError {
+            return
+        } catch {
+            subscriptionSettings = nil
+        }
+    }
+
+    private func toggleSubscriptionAutoBookmark() async {
+        guard var settings = subscriptionSettings, !isSavingSubscriptionSettings else { return }
+
+        let previousSettings = settings
+        settings.autoBookmark.toggle()
+        subscriptionSettings = settings
+        isSavingSubscriptionSettings = true
+        defer { isSavingSubscriptionSettings = false }
+
+        do {
+            try await client.setBookmarkSubscriptionAutoBookmark(
+                settings,
+                enabled: settings.autoBookmark
+            )
+        } catch {
+            subscriptionSettings = previousSettings
+            errorMessage = error.localizedDescription
         }
     }
 

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
@@ -129,6 +129,17 @@ struct SubscriptionSyncResponse: Decodable, Equatable {
     let itemsFound: Int
 }
 
+struct BookmarkSubscriptionSettings: Decodable, Equatable {
+    let sourceId: String
+    let provider: Provider
+    var autoBookmark: Bool
+
+    var actionTitle: String {
+        if autoBookmark { return "Stop Auto-bookmarking" }
+        return provider == .gmail ? "Auto-bookmark New Issues" : "Auto-bookmark New Items"
+    }
+}
+
 enum NewsletterStatus: String, Decodable {
     case active = "ACTIVE"
     case hidden = "HIDDEN"

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -24,6 +24,28 @@ final class BookmarkTests: XCTestCase {
         XCTAssertEqual(bookmark.consumptionLabel, "1 hr 32 min")
     }
 
+    func testDecodesBookmarkSubscriptionSettingsAndFormatsActions() throws {
+        let enabled = try JSONDecoder().decode(
+            BookmarkSubscriptionSettingsResponse.self,
+            from: Data(
+                """
+                {"subscription":{"sourceId":"feed_1","provider":"GMAIL","autoBookmark":true}}
+                """.utf8
+            )
+        ).subscription
+        let disabled = try JSONDecoder().decode(
+            BookmarkSubscriptionSettingsResponse.self,
+            from: Data(
+                """
+                {"subscription":{"sourceId":"sub_1","provider":"YOUTUBE","autoBookmark":false}}
+                """.utf8
+            )
+        ).subscription
+
+        XCTAssertEqual(enabled?.actionTitle, "Stop Auto-bookmarking")
+        XCTAssertEqual(disabled?.actionTitle, "Auto-bookmark New Items")
+    }
+
     func testLibraryQueryIdentityIncludesEveryFilter() {
         let first = LibraryQuery(search: "swift", isFinished: false, provider: .rss, contentType: .article)
         let second = LibraryQuery(search: "swift", isFinished: true, provider: .rss, contentType: .article)

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "description": "REST API for reading and managing the Zine home dashboard, inbox items, bookmarks, creators, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
@@ -740,6 +740,33 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           }
+        }
+      }
+    },
+    "/api/v1/bookmarks/{id}/subscription-settings": {
+      "get": {
+        "tags": ["Bookmarks", "Subscriptions"],
+        "operationId": "getBookmarkSubscriptionSettings",
+        "summary": "Get the subscription settings for a bookmark",
+        "description": "Returns the auto-bookmark setting for the subscription or feed that produced this item, or null when the item is not linked to a managed source.",
+        "security": [{ "bearerAuth": [] }],
+        "x-required-scopes": ["bookmarks:read"],
+        "x-api-status": "current",
+        "parameters": [{ "$ref": "#/components/parameters/UserItemId" }],
+        "responses": {
+          "200": {
+            "description": "Subscription settings resolved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookmarkSubscriptionSettingsResponse"
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
         }
       }
     },
@@ -3746,6 +3773,35 @@
             "properties": {
               "item": {
                 "$ref": "#/components/schemas/Item"
+              }
+            }
+          }
+        ]
+      },
+      "BookmarkSubscriptionSettings": {
+        "type": "object",
+        "required": ["sourceId", "provider", "autoBookmark"],
+        "properties": {
+          "sourceId": { "type": "string" },
+          "provider": {
+            "type": "string",
+            "enum": ["YOUTUBE", "SPOTIFY", "GMAIL", "RSS"]
+          },
+          "autoBookmark": { "type": "boolean" }
+        }
+      },
+      "BookmarkSubscriptionSettingsResponse": {
+        "allOf": [
+          { "$ref": "#/components/schemas/RequestMetadata" },
+          {
+            "type": "object",
+            "required": ["subscription"],
+            "properties": {
+              "subscription": {
+                "oneOf": [
+                  { "type": "null" },
+                  { "$ref": "#/components/schemas/BookmarkSubscriptionSettings" }
+                ]
               }
             }
           }

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -19,6 +19,7 @@ const {
   mockQuickWins,
   mockCollectionItems,
   mockGetItem,
+  mockGetItemSubscriptionSettings,
   mockBookmarkInboxItem,
   mockArchiveInboxItem,
   mockGetCreator,
@@ -99,6 +100,7 @@ const {
   mockQuickWins: vi.fn(),
   mockCollectionItems: vi.fn(),
   mockGetItem: vi.fn(),
+  mockGetItemSubscriptionSettings: vi.fn(),
   mockBookmarkInboxItem: vi.fn(),
   mockArchiveInboxItem: vi.fn(),
   mockGetCreator: vi.fn(),
@@ -529,6 +531,7 @@ describe('apiV1Routes', () => {
         recentlyOpened: mockRecentlyOpened,
         quickWins: mockQuickWins,
         get: mockGetItem,
+        subscriptionSettings: mockGetItemSubscriptionSettings,
         bookmark: mockBookmarkInboxItem,
         archive: mockArchiveInboxItem,
         unbookmark: mockUnbookmark,
@@ -607,6 +610,7 @@ describe('apiV1Routes', () => {
     expect(body.paths).toHaveProperty('/api/v1/bookmarks');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/preview');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}');
+    expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/subscription-settings');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/tags');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/opened');
     expect(body.paths).toHaveProperty('/api/v1/bookmarks/{id}/progress');
@@ -2330,6 +2334,36 @@ describe('apiV1Routes', () => {
         id: 'ui_1',
         itemId: 'item_1',
         title: 'Detailed bookmark',
+      },
+      requestId: 'test-request-id',
+      traceId: 'test-trace-id',
+    });
+  });
+
+  it('gets auto-bookmark settings for the subscription that produced a bookmark', async () => {
+    mockGetItemSubscriptionSettings.mockResolvedValue({
+      subscription: {
+        sourceId: 'subscription_1',
+        provider: Provider.YOUTUBE,
+        autoBookmark: false,
+      },
+    });
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/ui_1/subscription-settings', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetItemSubscriptionSettings).toHaveBeenCalledWith({ id: 'ui_1' });
+    expect((await res.json()) as JsonBody).toMatchObject({
+      subscription: {
+        sourceId: 'subscription_1',
+        provider: 'YOUTUBE',
+        autoBookmark: false,
       },
       requestId: 'test-request-id',
       traceId: 'test-trace-id',

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1834,6 +1834,21 @@ apiV1Routes.get('/bookmarks/:id', apiAuth('bookmarks:read'), async (c) => {
   }
 });
 
+apiV1Routes.get('/bookmarks/:id/subscription-settings', apiAuth('bookmarks:read'), async (c) => {
+  const caller = appRouter.createCaller(await createContext(c));
+
+  try {
+    const result = await caller.items.subscriptionSettings({ id: c.req.param('id') });
+    return c.json({
+      ...result,
+      requestId: c.get('requestId'),
+      traceId: c.get('traceId'),
+    });
+  } catch (error) {
+    return trpcErrorResponse(c, error);
+  }
+});
+
 apiV1Routes.patch('/bookmarks/:id', apiAuth('bookmarks:write'), async (c) => {
   const body = await c.req.json().catch(() => null);
   const parsedBody = FinishBookmarkBodySchema.safeParse(body);

--- a/apps/worker/src/trpc/routers/items-subscription-settings.test.ts
+++ b/apps/worker/src/trpc/routers/items-subscription-settings.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Provider } from '@zine/shared';
+import { getItemSubscriptionSettings } from './items';
+
+function queryReturning(rows: unknown[]) {
+  const query = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  query.from.mockReturnValue(query);
+  query.innerJoin.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  return query;
+}
+
+function contextWithResults(...results: unknown[][]) {
+  const queries = results.map(queryReturning);
+  return {
+    context: {
+      userId: 'user_1',
+      db: {
+        select: vi.fn().mockImplementation(() => queries.shift()),
+      },
+    },
+  };
+}
+
+describe('getItemSubscriptionSettings', () => {
+  it('resolves provider subscriptions from their item mapping', async () => {
+    const { context } = contextWithResults(
+      [{ itemId: 'item_1', provider: Provider.YOUTUBE }],
+      [{ sourceId: 'sub_1', provider: Provider.YOUTUBE, autoBookmark: true }]
+    );
+
+    await expect(getItemSubscriptionSettings(context as never, 'bookmark_1')).resolves.toEqual({
+      sourceId: 'sub_1',
+      provider: Provider.YOUTUBE,
+      autoBookmark: true,
+    });
+  });
+
+  it('resolves newsletter and RSS feed settings', async () => {
+    const newsletter = contextWithResults(
+      [{ itemId: 'item_2', provider: Provider.GMAIL }],
+      [{ sourceId: 'newsletter_1', autoBookmark: false }]
+    );
+    const rss = contextWithResults(
+      [{ itemId: 'item_3', provider: Provider.RSS }],
+      [{ sourceId: 'rss_1', autoBookmark: true }]
+    );
+
+    await expect(
+      getItemSubscriptionSettings(newsletter.context as never, 'bookmark_2')
+    ).resolves.toEqual({
+      sourceId: 'newsletter_1',
+      provider: Provider.GMAIL,
+      autoBookmark: false,
+    });
+    await expect(getItemSubscriptionSettings(rss.context as never, 'bookmark_3')).resolves.toEqual({
+      sourceId: 'rss_1',
+      provider: Provider.RSS,
+      autoBookmark: true,
+    });
+  });
+
+  it('returns no setting for an item without a managed subscription source', async () => {
+    const { context } = contextWithResults([{ itemId: 'item_4', provider: Provider.X }]);
+
+    await expect(getItemSubscriptionSettings(context as never, 'bookmark_4')).resolves.toBeNull();
+  });
+});

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -41,6 +41,12 @@ import {
   userItems,
   items,
   creators,
+  newsletterFeedMessages,
+  newsletterFeeds,
+  rssFeedItems,
+  rssFeeds,
+  subscriptionItems,
+  subscriptions,
   itemEnrichments,
   collectionItemOverrides,
   collections,
@@ -70,6 +76,12 @@ import { replaceTagsForUserItem } from '../tagging';
 export type ItemTag = {
   id: string;
   name: string;
+};
+
+export type ItemSubscriptionSettings = {
+  sourceId: string;
+  provider: Provider;
+  autoBookmark: boolean;
 };
 
 /**
@@ -370,6 +382,98 @@ async function getTagsForUserItems(
   }
 
   return map;
+}
+
+async function getItemSubscriptionSettings(
+  ctx: { db: Database; userId: string },
+  userItemId: string
+): Promise<ItemSubscriptionSettings | null> {
+  const ownedItems = await ctx.db
+    .select({ itemId: userItems.itemId, provider: items.provider })
+    .from(userItems)
+    .innerJoin(items, eq(userItems.itemId, items.id))
+    .where(and(eq(userItems.id, userItemId), eq(userItems.userId, ctx.userId)))
+    .limit(1);
+
+  if (ownedItems.length === 0) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: `Item ${userItemId} not found` });
+  }
+
+  const ownedItem = ownedItems[0];
+
+  if (ownedItem.provider === Provider.YOUTUBE || ownedItem.provider === Provider.SPOTIFY) {
+    const rows = await ctx.db
+      .select({
+        sourceId: subscriptions.id,
+        provider: subscriptions.provider,
+        autoBookmark: subscriptions.autoBookmark,
+      })
+      .from(subscriptionItems)
+      .innerJoin(subscriptions, eq(subscriptionItems.subscriptionId, subscriptions.id))
+      .where(
+        and(eq(subscriptionItems.itemId, ownedItem.itemId), eq(subscriptions.userId, ctx.userId))
+      )
+      .limit(1);
+
+    const row = rows[0];
+    return row
+      ? {
+          sourceId: row.sourceId,
+          provider: row.provider as Provider,
+          autoBookmark: row.autoBookmark,
+        }
+      : null;
+  }
+
+  if (ownedItem.provider === Provider.GMAIL) {
+    const rows = await ctx.db
+      .select({
+        sourceId: newsletterFeeds.id,
+        autoBookmark: newsletterFeeds.autoBookmark,
+      })
+      .from(newsletterFeedMessages)
+      .innerJoin(newsletterFeeds, eq(newsletterFeedMessages.newsletterFeedId, newsletterFeeds.id))
+      .where(
+        and(
+          eq(newsletterFeedMessages.itemId, ownedItem.itemId),
+          eq(newsletterFeedMessages.userId, ctx.userId),
+          eq(newsletterFeeds.userId, ctx.userId)
+        )
+      )
+      .limit(1);
+
+    const row = rows[0];
+    return row
+      ? {
+          sourceId: row.sourceId,
+          provider: Provider.GMAIL,
+          autoBookmark: row.autoBookmark,
+        }
+      : null;
+  }
+
+  if (ownedItem.provider === Provider.RSS) {
+    const rows = await ctx.db
+      .select({
+        sourceId: rssFeeds.id,
+        autoBookmark: rssFeeds.autoBookmark,
+      })
+      .from(rssFeedItems)
+      .innerJoin(rssFeeds, eq(rssFeedItems.rssFeedId, rssFeeds.id))
+      .where(and(eq(rssFeedItems.itemId, ownedItem.itemId), eq(rssFeeds.userId, ctx.userId)))
+      .limit(1);
+
+    const row = rows[0];
+    return row
+      ? {
+          sourceId: row.sourceId,
+          provider: Provider.RSS,
+          autoBookmark: row.autoBookmark,
+        }
+      : null;
+  }
+
+  return null;
 }
 
 export async function toItemViewsWithTags(
@@ -1112,6 +1216,15 @@ export const itemsRouter = router({
     }),
 
   /**
+   * Resolve the subscription or feed that produced a user item, when one exists.
+   */
+  subscriptionSettings: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ input, ctx }) => ({
+      subscription: await getItemSubscriptionSettings(ctx, input.id),
+    })),
+
+  /**
    * Get AI enrichment and advisory tag suggestions for a user item.
    */
   getEnrichment: protectedProcedure
@@ -1636,4 +1749,4 @@ export const itemsRouter = router({
 export type ItemsRouter = typeof itemsRouter;
 
 // Export helpers for testing and reuse
-export { normalizeNullString, toItemView };
+export { getItemSubscriptionSettings, normalizeNullString, toItemView };


### PR DESCRIPTION
## Summary
- expose a bookmark-to-subscription settings lookup through the authenticated v1 API
- add an auto-bookmark toggle to the native bookmark detail ellipsis menu
- support provider subscriptions, newsletters, and RSS feeds with rollback on failed updates

## Validation
- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -derivedDataPath .derived-test test`