### PR TITLE
feat(today): add editorial conversation overview

### DIFF
--- a/apps/ios/ContractReplay/main.swift
+++ b/apps/ios/ContractReplay/main.swift
@@ -7,17 +7,19 @@ guard CommandLine.arguments.count == 2 else {
 let data = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
 let response = try JSONDecoder().decode(DailyFeedResponse.self, from: data)
 
-guard response.schemaVersion == 2,
-      response.variant.id == "people-first-v3",
+guard response.schemaVersion == 3,
+      response.variant.id == "people-first-v4-editorial-overview",
       response.inputs?.favorites != nil,
       response.sections != nil,
+      response.overview?.version == "daily-overview-v1",
+      response.overviewSections?.isEmpty == false,
       response.clustering?.method == "THREAD_FIRST_EVIDENCE_CLUSTERING",
       response.threadUnits?.isEmpty == false,
       response.topicClusters?.isEmpty == false
 else {
-    fatalError("fixture did not contain the people-first-v3 thread-first contract")
+    fatalError("fixture did not contain the people-first-v4 editorial overview contract")
 }
 
 print(
-    "native-decode=ok variant=\(response.variant.id) posts=\(response.posts.count) threads=\(response.threadUnits?.count ?? 0) topics=\(response.topicClusters?.count ?? 0)"
+    "native-decode=ok variant=\(response.variant.id) posts=\(response.posts.count) threads=\(response.threadUnits?.count ?? 0) topics=\(response.topicClusters?.count ?? 0) overview=\(response.overviewSections?.count ?? 0)"
 )

--- a/apps/ios/Fixtures/daily-feed-v2.json
+++ b/apps/ios/Fixtures/daily-feed-v2.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 2,
-  "variant": { "id": "people-first-v3", "mode": "REVIEW" },
+  "schemaVersion": 3,
+  "variant": { "id": "people-first-v4-editorial-overview", "mode": "REVIEW" },
   "date": "2026-07-25",
   "timezone": "America/Chicago",
   "frozenAt": "2026-07-25T10:15:00.000Z",
@@ -132,6 +132,30 @@
     "candidateLimit": 40,
     "semanticUnitLimit": 256
   },
+  "overview": {
+    "version": "daily-overview-v1",
+    "status": "COMPLETE",
+    "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    "frozen": true,
+    "inputFingerprint": "fixture-fingerprint",
+    "warnings": []
+  },
+  "overviewSections": [
+    {
+      "id": "topic:daily-topics-v1:swiftdata",
+      "title": "SwiftData migrations in practice",
+      "summary": "Two developers are comparing the practical costs and performance of SwiftData migrations.",
+      "source": "GENERATED",
+      "representativePostIds": ["1", "2"],
+      "favoriteThreadUnitIds": ["post:1", "post:2"],
+      "supportingThreadUnitIds": [],
+      "authorKeys": ["id:alice", "id:bob"],
+      "favoriteConversationCount": 2,
+      "supportingConversationCount": 0,
+      "latestActivityAt": "2026-07-25T10:00:00.000Z",
+      "coverageWarnings": []
+    }
+  ],
   "posts": [
     {
       "id": "1",

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -70,6 +70,10 @@ struct ZineNativeApp: App {
             ScreenshotTodayStoryView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-today-fixtures") {
             ScreenshotTodayView()
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-daily-overview-fixture") {
+            ScreenshotDailyOverviewView()
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-daily-thread-fixture") {
+            ScreenshotDailyThreadView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-home-fixtures") {
             ScreenshotHomeView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-fixtures") {

--- a/apps/ios/ZineNative/Core/Models/DailyFeed.swift
+++ b/apps/ios/ZineNative/Core/Models/DailyFeed.swift
@@ -12,12 +12,38 @@ struct DailyFeedResponse: Decodable, Hashable {
     let conversations: [DailyConversation]
     let topicClusters: [DailyTopicCluster]?
     let threadUnits: [DailyThreadUnit]?
+    let overview: DailyOverviewMetadata?
+    let overviewSections: [DailyOverviewSection]?
     let clustering: DailyTopicClustering?
     let posts: [DailyPost]
     let sections: DailyFeedSections?
     let inputs: DailyFeedInputs?
     let requestId: String
     let traceId: String
+}
+
+struct DailyOverviewMetadata: Decodable, Hashable {
+    let version: String
+    let status: String
+    let model: String?
+    let frozen: Bool
+    let inputFingerprint: String
+    let warnings: [String]
+}
+
+struct DailyOverviewSection: Decodable, Hashable, Identifiable {
+    let id: String
+    let title: String
+    let summary: String
+    let source: String
+    let representativePostIds: [String]
+    let favoriteThreadUnitIds: [String]
+    let supportingThreadUnitIds: [String]
+    let authorKeys: [String]
+    let favoriteConversationCount: Int
+    let supportingConversationCount: Int
+    let latestActivityAt: String?
+    let coverageWarnings: [String]
 }
 
 struct DailyFeedVariant: Decodable, Hashable {

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -5,6 +5,34 @@ private struct DailyAuthorRoute: Hashable {
     let date: String
 }
 
+private enum DailySectionRoute: Hashable {
+    case topic(String)
+    case more
+}
+
+private func resolvedOverviewSections(
+    response: DailyFeedResponse,
+    threadUnitsByID: [String: DailyThreadUnit]
+) -> [DailyOverviewSection] {
+    if let sections = response.overviewSections { return sections }
+    return (response.topicClusters ?? []).map { topic in
+        DailyOverviewSection(
+            id: topic.id,
+            title: topic.label,
+            summary: "Related conversations from \(topic.favoriteAuthors.count) people you chose.",
+            source: "LEGACY_FALLBACK",
+            representativePostIds: Array(topic.favoritePostIds.prefix(4)),
+            favoriteThreadUnitIds: topic.favoriteThreadUnitIds,
+            supportingThreadUnitIds: topic.supportingThreadUnitIds,
+            authorKeys: topic.threadUnitIds.flatMap { threadUnitsByID[$0]?.authorKeys ?? [] },
+            favoriteConversationCount: topic.favoriteThreadUnitIds.count,
+            supportingConversationCount: topic.supportingThreadUnitIds.count,
+            latestActivityAt: topic.latestActivityAt,
+            coverageWarnings: topic.coverageWarnings
+        )
+    }
+}
+
 struct DailyFeedReviewView: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -24,10 +52,10 @@ struct DailyFeedReviewView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
-                        Text("REVIEW")
+                        Text("ZINE")
                             .font(.caption2.weight(.heavy))
                             .tracking(1.2)
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(.secondary)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Done") { dismiss() }
@@ -39,6 +67,13 @@ struct DailyFeedReviewView: View {
                         author: route.author,
                         date: route.date
                     )
+                }
+                .navigationDestination(for: DailySectionRoute.self) { route in
+                    if let response = store.response {
+                        DailySectionDetailView(response: response, route: route)
+                    } else {
+                        ContentUnavailableView("Conversation unavailable", systemImage: "bubble.left.and.exclamationmark.bubble.right")
+                    }
                 }
         }
         .task { await store.load() }
@@ -58,14 +93,174 @@ struct DailyFeedReviewView: View {
                 Button("Try again") { Task { await store.load() } }
             }
         } else if let response = store.response {
-            DailyFeedContent(response: response)
-            .refreshable { await store.load() }
+            DailyOverviewView(response: response)
+                .refreshable { await store.load() }
         }
     }
 }
 
-private struct DailyFeedContent: View {
+private struct DailyOverviewView: View {
     let response: DailyFeedResponse
+
+    private var threadUnitsByID: [String: DailyThreadUnit] {
+        Dictionary(uniqueKeysWithValues: (response.threadUnits ?? []).map { ($0.id, $0) })
+    }
+
+    private var authorsByKey: [String: DailyAuthor] {
+        var result: [String: DailyAuthor] = [:]
+        for post in response.posts {
+            result[post.author.key] = post.author
+            if let repostedBy = post.repostedBy { result[repostedBy.key] = repostedBy }
+        }
+        return result
+    }
+
+    private var sections: [DailyOverviewSection] {
+        resolvedOverviewSections(response: response, threadUnitsByID: threadUnitsByID)
+    }
+
+    private var moreConversationCount: Int {
+        (response.sections?.favoriteThreadUnitIds?.count ?? 0) +
+            (response.sections?.followingThreadUnitIds?.count ?? 0)
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                DailyFeedHeader(response: response)
+                    .padding(.horizontal, 18)
+                    .padding(.top, 18)
+
+                DailyCoverageNotice(response: response)
+                    .padding(.horizontal, 18)
+                    .padding(.top, 12)
+
+                if sections.isEmpty {
+                    ContentUnavailableView(
+                        "No shared conversations yet",
+                        systemImage: "person.2.slash",
+                        description: Text("Today’s frozen slice does not contain enough independent Favorite voices for an overview section.")
+                    )
+                    .padding(.top, 48)
+                } else {
+                    VStack(spacing: 0) {
+                        ForEach(sections) { section in
+                            NavigationLink(value: DailySectionRoute.topic(section.id)) {
+                                DailyOverviewSectionRow(
+                                    section: section,
+                                    authors: section.authorKeys.compactMap { authorsByKey[$0] }
+                                )
+                            }
+                            .buttonStyle(.plain)
+
+                            Divider()
+                                .padding(.leading, 58)
+                        }
+
+                        if moreConversationCount > 0 {
+                            NavigationLink(value: DailySectionRoute.more) {
+                                DailyMoreConversationsRow(count: moreConversationCount)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal, 18)
+                    .padding(.top, 20)
+                    .padding(.bottom, 40)
+                }
+            }
+        }
+    }
+}
+
+private struct DailyOverviewSectionRow: View {
+    let section: DailyOverviewSection
+    let authors: [DailyAuthor]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            DailyParticipantFacepile(authors: uniqueAuthors, size: 24, maximumVisible: 3)
+                .frame(width: 68, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 7) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(section.title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+                    Spacer(minLength: 4)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+
+                Text(section.summary)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(conversationSummary)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 18)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Opens the conversations in this section")
+    }
+
+    private var uniqueAuthors: [DailyAuthor] {
+        var seen = Set<String>()
+        return authors.filter { seen.insert($0.key).inserted }
+    }
+
+    private var conversationSummary: String {
+        let favorites = "\(section.favoriteConversationCount) conversation\(section.favoriteConversationCount == 1 ? "" : "s")"
+        guard section.supportingConversationCount > 0 else { return favorites }
+        return "\(favorites) · \(section.supportingConversationCount) nearby"
+    }
+}
+
+private struct DailyMoreConversationsRow: View {
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "text.bubble")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("More conversations")
+                    .font(.headline)
+                Text("\(count) conversation\(count == 1 ? "" : "s") that stand on their own today")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 4)
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.vertical, 18)
+        .contentShape(Rectangle())
+    }
+}
+
+private enum DailyConversationScope: String, CaseIterable, Identifiable {
+    case favorites = "Favorites"
+    case context = "Nearby"
+
+    var id: String { rawValue }
+}
+
+private struct DailySectionDetailView: View {
+    let response: DailyFeedResponse
+    let route: DailySectionRoute
+
+    @State private var scope: DailyConversationScope = .favorites
 
     private var postsByID: [String: DailyPost] {
         Dictionary(uniqueKeysWithValues: response.posts.map { ($0.id, $0) })
@@ -79,169 +274,108 @@ private struct DailyFeedContent: View {
         Dictionary(uniqueKeysWithValues: (response.threadUnits ?? []).map { ($0.id, $0) })
     }
 
-    private var favoriteThreadUnits: [DailyThreadUnit] {
-        (response.sections?.favoriteThreadUnitIds ?? []).compactMap { threadUnitsByID[$0] }
+    private var section: DailyOverviewSection? {
+        guard case let .topic(id) = route else { return nil }
+        return resolvedOverviewSections(response: response, threadUnitsByID: threadUnitsByID)
+            .first { $0.id == id }
     }
 
-    private var followingThreadUnits: [DailyThreadUnit] {
-        (response.sections?.followingThreadUnitIds ?? []).compactMap { threadUnitsByID[$0] }
+    private var title: String {
+        switch route {
+        case .topic: section?.title ?? "Conversation"
+        case .more: "More conversations"
+        }
     }
 
-    private var legacyFavoritePosts: [DailyPost] {
-        (response.sections?.favoritePostIds ?? []).compactMap { postsByID[$0] }
+    private var summary: String {
+        switch route {
+        case .topic: section?.summary ?? "The underlying conversations from today’s frozen slice."
+        case .more: "Conversations that did not need to be forced into a broader section."
+        }
     }
 
-    private var legacyFollowingPosts: [DailyPost] {
-        (response.sections?.followingPostIds ?? []).compactMap { postsByID[$0] }
+    private var favoriteUnitIDs: [String] {
+        switch route {
+        case .topic: section?.favoriteThreadUnitIds ?? []
+        case .more: response.sections?.favoriteThreadUnitIds ?? []
+        }
     }
 
-    private var usesThreadFirstContract: Bool {
-        response.topicClusters != nil && response.threadUnits != nil
+    private var contextUnitIDs: [String] {
+        switch route {
+        case .topic: section?.supportingThreadUnitIds ?? []
+        case .more: response.sections?.followingThreadUnitIds ?? []
+        }
+    }
+
+    private var visibleUnits: [DailyThreadUnit] {
+        (scope == .favorites ? favoriteUnitIDs : contextUnitIDs).compactMap { threadUnitsByID[$0] }
     }
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                DailyFeedHeader(response: response)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 18)
+                VStack(alignment: .leading, spacing: 9) {
+                    Text(title)
+                        .font(.largeTitle.weight(.bold))
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(summary)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                DailyCoverageNotice(response: response)
-                    .padding(.horizontal, 18)
-                    .padding(.top, 16)
-
-                sectionTitle("FAVORITES", "What Favorites are talking about")
-                    .padding(.horizontal, 18)
-                    .padding(.top, 30)
-
-                if usesThreadFirstContract, let topics = response.topicClusters {
-                    if topics.isEmpty {
-                        Text("No topic has enough independent Favorite voices in this frozen slice.")
-                            .font(.subheadline)
+                    ForEach(section?.coverageWarnings ?? [], id: \.self) { warning in
+                        Label(warning, systemImage: "exclamationmark.circle")
+                            .font(.caption)
                             .foregroundStyle(.secondary)
-                            .padding(.horizontal, 18)
-                            .padding(.top, 10)
-                    } else {
-                        LazyVStack(spacing: 14) {
-                            ForEach(topics) { topic in
-                                DailyTopicClusterCard(
-                                    topic: topic,
-                                    threadUnitsByID: threadUnitsByID,
-                                    postsByID: postsByID,
-                                    sourceNames: sourceNames,
-                                    date: response.date
-                                )
-                            }
-                        }
-                        .padding(.horizontal, 18)
-                        .padding(.top, 14)
                     }
-                } else if response.conversations.isEmpty {
-                    Text("No evidence-backed Favorite topics were found in this frozen slice.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 18)
-                        .padding(.top, 10)
-                } else {
-                    VStack(spacing: 12) {
-                        ForEach(response.conversations) { conversation in
-                            DailyConversationCard(
-                                conversation: conversation,
-                                posts: conversation.postIds.compactMap { id in
-                                    postsByID[id]
-                                },
-                                date: response.date
-                            )
-                        }
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 18)
+
+                if !contextUnitIDs.isEmpty {
+                    Picker("Conversation source", selection: $scope) {
+                        Text("Favorites · \(favoriteUnitIDs.count)")
+                            .tag(DailyConversationScope.favorites)
+                        Text("Nearby · \(contextUnitIDs.count)")
+                            .tag(DailyConversationScope.context)
                     }
+                    .pickerStyle(.segmented)
                     .padding(.horizontal, 18)
-                    .padding(.top, 14)
+                    .padding(.top, 20)
                 }
 
-                sectionTitle("FAVORITES", "More from Favorites")
-                    .padding(.horizontal, 18)
-                    .padding(.top, 34)
-
-                if usesThreadFirstContract, favoriteThreadUnits.isEmpty {
+                if visibleUnits.isEmpty {
                     ContentUnavailableView(
-                        "No additional Favorite conversations",
-                        systemImage: "person.2.slash",
-                        description: Text("Favorite conversations in this slice are either grouped above or unavailable under the disclosed coverage.")
+                        scope == .favorites ? "No Favorite conversations" : "No nearby conversations",
+                        systemImage: "bubble.left.and.bubble.right",
+                        description: Text("Nothing is available under this source in the frozen slice.")
                     )
-                    .padding(.top, 34)
-                } else if usesThreadFirstContract {
-                    LazyVStack(spacing: 14) {
-                        ForEach(favoriteThreadUnits) { threadUnit in
-                            DailyThreadUnitCard(
-                                threadUnit: threadUnit,
-                                postsByID: postsByID,
-                                sourceNames: sourceNames,
-                                date: response.date
-                            )
-                        }
-                    }
-                    .padding(.horizontal, 18)
-                    .padding(.top, 16)
-                    .padding(.bottom, 38)
+                    .padding(.top, 48)
                 } else {
-                    legacyPostList(legacyFavoritePosts)
-                }
-
-                sectionTitle("FOLLOWING", "More from Following")
-                    .padding(.horizontal, 18)
-                    .padding(.top, 34)
-
-                if usesThreadFirstContract, followingThreadUnits.isEmpty {
-                    Text("No additional Following conversations remain after topic support and deduplication.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    ForEach(Array(visibleUnits.enumerated()), id: \.element.id) { index, threadUnit in
+                        DailyThreadUnitCard(
+                            threadUnit: threadUnit,
+                            postsByID: postsByID,
+                            sourceNames: sourceNames,
+                            date: response.date,
+                            isEmbedded: true
+                        )
                         .padding(.horizontal, 18)
-                        .padding(.top, 10)
-                } else if usesThreadFirstContract {
-                    LazyVStack(spacing: 14) {
-                        ForEach(followingThreadUnits) { threadUnit in
-                            DailyThreadUnitCard(
-                                threadUnit: threadUnit,
-                                postsByID: postsByID,
-                                sourceNames: sourceNames,
-                                date: response.date
-                            )
+                        .padding(.top, 22)
+
+                        if index < visibleUnits.count - 1 {
+                            Divider()
+                                .padding(.leading, 76)
+                                .padding(.top, 20)
                         }
                     }
-                    .padding(.horizontal, 18)
-                    .padding(.top, 16)
-                    .padding(.bottom, 38)
-                } else {
-                    legacyPostList(legacyFollowingPosts)
+                    .padding(.bottom, 40)
                 }
             }
         }
-    }
-
-    private func legacyPostList(_ posts: [DailyPost]) -> some View {
-        LazyVStack(spacing: 14) {
-            ForEach(posts) { post in
-                DailyFeedPostCard(
-                    post: post,
-                    sourceNames: sourceNames,
-                    authorDestinationDate: response.date
-                )
-            }
-        }
-        .padding(.horizontal, 18)
-        .padding(.top, 16)
-        .padding(.bottom, 38)
-    }
-
-    private func sectionTitle(_ eyebrow: String, _ title: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(eyebrow)
-                .font(.caption2.weight(.heavy))
-                .tracking(1.2)
-                .foregroundStyle(Color.accentColor)
-            Text(title)
-                .font(.title2.weight(.bold))
-        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
@@ -249,24 +383,13 @@ private struct DailyFeedHeader: View {
     let response: DailyFeedResponse
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack {
-                Label("People-first prototype", systemImage: "person.2.fill")
-                    .font(.subheadline.weight(.semibold))
-                Spacer()
-                Text("FROZEN")
-                    .font(.caption2.weight(.heavy))
-                    .tracking(0.9)
-                    .foregroundStyle(.secondary)
-            }
-
+        VStack(alignment: .leading, spacing: 5) {
             Text(formattedDate)
-                .font(.system(size: 36, weight: .bold, design: .rounded))
-                .tracking(-0.8)
-
-            Text("The posts are the source of truth. Groups above them are navigation backed by explicit archive evidence, not generated headlines.")
-                .font(.subheadline)
+                .font(.subheadline.weight(.medium))
                 .foregroundStyle(.secondary)
+
+            Text("What people are talking about")
+                .font(.largeTitle.weight(.bold))
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -286,40 +409,55 @@ private struct DailyFeedHeader: View {
 
 private struct DailyCoverageNotice: View {
     let response: DailyFeedResponse
+    @State private var showsDetails = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 8) {
-                Image(systemName: statusIcon)
-                    .foregroundStyle(statusColor)
-                Text(statusTitle)
-                    .font(.subheadline.weight(.semibold))
-                Spacer()
-                Text(scopeSummary)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) { showsDetails.toggle() }
+            } label: {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 7, height: 7)
+                    Text(statusTitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Spacer()
+                    Text(scopeSummary)
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Image(systemName: showsDetails ? "chevron.up" : "chevron.down")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
 
-            Text(response.coverage.message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            if let clustering = response.clustering {
-                Label(topicMethod(clustering), systemImage: "point.3.connected.trianglepath.dotted")
+            if showsDetails {
+                Text(response.coverage.message)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-            }
 
-            ForEach(response.freshness.warnings, id: \.self) { warning in
-                Label(warning, systemImage: "exclamationmark.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                ForEach(response.freshness.warnings, id: \.self) { warning in
+                    Label(warning, systemImage: "exclamationmark.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                ForEach(response.overview?.warnings ?? [], id: \.self) { warning in
+                    Label(warning, systemImage: "text.quote")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
         }
-        .padding(12)
-        .background(statusColor.opacity(0.09), in: RoundedRectangle(cornerRadius: 14))
-        .accessibilityElement(children: .combine)
+        .padding(.vertical, 10)
+        .overlay(alignment: .bottom) { Divider() }
+        .accessibilityElement(children: .contain)
     }
 
     private var statusTitle: String {
@@ -330,10 +468,6 @@ private struct DailyCoverageNotice: View {
         }
     }
 
-    private var statusIcon: String {
-        response.coverage.status == .complete ? "checkmark.seal.fill" : "exclamationmark.triangle.fill"
-    }
-
     private var scopeSummary: String {
         if let windowHours = response.coverage.windowHours {
             return "Last \(windowHours)h · \(response.coverage.collectedCount) posts"
@@ -342,139 +476,9 @@ private struct DailyCoverageNotice: View {
     }
 
     private var statusColor: Color {
-        response.coverage.status == .complete ? .green : .orange
+        response.coverage.status == .complete ? .green : .secondary
     }
 
-    private func topicMethod(_ clustering: DailyTopicClustering) -> String {
-        if let model = clustering.embeddingModel {
-            let scope = clustering.semanticStatus == "PARTIAL" ? "bounded" : "complete"
-            return "Topics use extracted evidence plus \(scope) pinned semantic similarity (\(model))."
-        }
-        return "Topics use deterministic extracted phrases, links, and relationships."
-    }
-}
-
-private struct DailyTopicClusterCard: View {
-    let topic: DailyTopicCluster
-    let threadUnitsByID: [String: DailyThreadUnit]
-    let postsByID: [String: DailyPost]
-    let sourceNames: [String: String]
-    let date: String
-
-    @State private var showsAllFavorites = false
-    @State private var showsFollowingSupport = false
-
-    private var favoriteUnits: [DailyThreadUnit] {
-        topic.favoriteThreadUnitIds.compactMap { threadUnitsByID[$0] }
-    }
-
-    private var supportingUnits: [DailyThreadUnit] {
-        topic.supportingThreadUnitIds.compactMap { threadUnitsByID[$0] }
-    }
-
-    private var visibleFavoriteUnits: [DailyThreadUnit] {
-        showsAllFavorites ? favoriteUnits : Array(favoriteUnits.prefix(3))
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Image(systemName: "person.3.sequence.fill")
-                        .foregroundStyle(Color.accentColor)
-                    Text(topic.label)
-                        .font(.title3.weight(.bold))
-                    Spacer(minLength: 0)
-                }
-
-                Text(topic.evidence)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 6) {
-                        ForEach(Array(topic.evidenceSignals.prefix(4))) { signal in
-                            Label(signal.value, systemImage: signalIcon(signal.type))
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 5)
-                                .background(Color.secondary.opacity(0.09), in: Capsule())
-                        }
-                    }
-                }
-
-                ForEach(topic.coverageWarnings, id: \.self) { warning in
-                    Label(warning, systemImage: "exclamationmark.circle")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            Divider()
-
-            ForEach(visibleFavoriteUnits) { threadUnit in
-                DailyThreadUnitCard(
-                    threadUnit: threadUnit,
-                    postsByID: postsByID,
-                    sourceNames: sourceNames,
-                    date: date,
-                    isEmbedded: true
-                )
-            }
-
-            if favoriteUnits.count > visibleFavoriteUnits.count {
-                Button("Show all \(favoriteUnits.count) Favorite conversations") {
-                    withAnimation(.easeInOut(duration: 0.2)) { showsAllFavorites = true }
-                }
-                .font(.caption.weight(.semibold))
-            } else if showsAllFavorites, favoriteUnits.count > 3 {
-                Button("Show fewer Favorite conversations") {
-                    withAnimation(.easeInOut(duration: 0.2)) { showsAllFavorites = false }
-                }
-                .font(.caption.weight(.semibold))
-            }
-
-            if !supportingUnits.isEmpty {
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) { showsFollowingSupport.toggle() }
-                } label: {
-                    Label(
-                        showsFollowingSupport
-                            ? "Hide supporting context"
-                            : "Show \(supportingUnits.count) supporting context conversation\(supportingUnits.count == 1 ? "" : "s")",
-                        systemImage: showsFollowingSupport ? "chevron.up" : "chevron.down"
-                    )
-                }
-                .font(.caption.weight(.semibold))
-
-                if showsFollowingSupport {
-                    ForEach(supportingUnits) { threadUnit in
-                        DailyThreadUnitCard(
-                            threadUnit: threadUnit,
-                            postsByID: postsByID,
-                            sourceNames: sourceNames,
-                            date: date,
-                            isEmbedded: true
-                        )
-                    }
-                }
-            }
-        }
-        .padding(15)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 18))
-        .accessibilityElement(children: .contain)
-    }
-
-    private func signalIcon(_ type: String) -> String {
-        switch type {
-        case "DIRECT_REFERENCE": "quote.bubble"
-        case "SHARED_LINK": "link"
-        case "SHARED_MARKER": "number"
-        case "SEMANTIC_SIMILARITY": "point.3.connected.trianglepath.dotted"
-        default: "text.quote"
-        }
-    }
 }
 
 private struct DailyThreadUnitCard: View {
@@ -491,29 +495,55 @@ private struct DailyThreadUnitCard: View {
     }
 
     private var visiblePosts: [DailyPost] {
-        isExpanded ? posts : Array(posts.prefix(threadUnit.isThread ? 2 : 1))
+        isExpanded ? posts : Array(posts.prefix(threadUnit.isThread ? 3 : 1))
+    }
+
+    private var participants: [DailyAuthor] {
+        var seen = Set<String>()
+        return posts.compactMap { post in
+            guard seen.insert(post.author.key).inserted else { return nil }
+            return post.author
+        }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 0) {
             if threadUnit.isThread {
-                HStack(spacing: 8) {
-                    Label("\(posts.count)-post thread", systemImage: "arrow.triangle.branch")
-                        .font(.caption.weight(.semibold))
-                    Spacer()
-                    Text(threadUnit.structureStatus == "EXACT" ? "EXACT" : "PARTIAL")
-                        .font(.caption2.weight(.heavy))
-                        .tracking(0.6)
-                        .foregroundStyle(threadUnit.structureStatus == "EXACT" ? .green : .orange)
-                }
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("\(posts.count)-post thread", systemImage: "arrow.triangle.branch")
+                            .font(.subheadline.weight(.semibold))
+                        Text(participantSummary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
 
-                Text(threadUnit.authors.prefix(3).map { "@\($0)" }.joined(separator: ", "))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                        if threadUnit.structureStatus != "EXACT" {
+                            Label("Some replies may be missing", systemImage: "exclamationmark.circle")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    DailyParticipantFacepile(authors: participants)
+                }
+                .padding(.bottom, 14)
             }
 
-            ForEach(Array(visiblePosts.enumerated()), id: \.element.id) { index, post in
-                if index > 0 { Divider() }
+            if threadUnit.isThread {
+                VStack(spacing: 0) {
+                    ForEach(Array(visiblePosts.enumerated()), id: \.element.id) { index, post in
+                        DailyThreadPostRow(
+                            post: post,
+                            postsByID: postsByID,
+                            sourceNames: sourceNames,
+                            date: date,
+                            connectsAbove: index > 0,
+                            connectsBelow: index < visiblePosts.count - 1 || posts.count > visiblePosts.count
+                        )
+                    }
+                }
+            } else if let post = posts.first {
                 DailyFeedPostCard(
                     post: post,
                     sourceNames: sourceNames,
@@ -522,29 +552,233 @@ private struct DailyThreadUnitCard: View {
                 )
             }
 
-            if posts.count > visiblePosts.count {
-                Button("Show complete \(posts.count)-post thread") {
-                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded = true }
+            if posts.count > 3 {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        Text(isExpanded ? "Collapse thread" : "Show complete \(posts.count)-post thread")
+                    }
                 }
                 .font(.caption.weight(.semibold))
-            } else if isExpanded, posts.count > 2 {
-                Button("Collapse thread") {
-                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded = false }
-                }
-                .font(.caption.weight(.semibold))
+                .padding(.leading, threadUnit.isThread ? 58 : 0)
+                .padding(.top, 2)
             }
 
             ForEach(threadUnit.coverageWarnings, id: \.self) { warning in
                 Label(warning, systemImage: "exclamationmark.circle")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+                    .padding(.top, 8)
             }
         }
-        .padding(isEmbedded ? 11 : 14)
+        .padding(isEmbedded ? 0 : 14)
         .background(
-            Color.secondary.opacity(isEmbedded ? 0.055 : 0.08),
-            in: RoundedRectangle(cornerRadius: isEmbedded ? 13 : 16)
+            isEmbedded ? Color.clear : Color.secondary.opacity(0.08),
+            in: RoundedRectangle(cornerRadius: 16)
         )
+    }
+
+    private var participantSummary: String {
+        let visible = participants.prefix(3).map { "@\($0.username)" }
+        let remainder = participants.count - visible.count
+        return visible.joined(separator: " · ") + (remainder > 0 ? " · +\(remainder)" : "")
+    }
+}
+
+private struct DailyParticipantFacepile: View {
+    let authors: [DailyAuthor]
+    var size: CGFloat = 30
+    var maximumVisible = 3
+
+    var body: some View {
+        HStack(spacing: -8) {
+            ForEach(Array(authors.prefix(maximumVisible)), id: \.key) { author in
+                DailyAuthorAvatar(author: author, size: size)
+                    .overlay {
+                        Circle()
+                            .stroke(Color(uiColor: .systemBackground), lineWidth: 2)
+                    }
+            }
+
+            if authors.count > maximumVisible {
+                Text("+\(authors.count - maximumVisible)")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: size, height: size)
+                    .background(Color(uiColor: .secondarySystemBackground), in: Circle())
+                    .overlay {
+                        Circle()
+                            .stroke(Color(uiColor: .systemBackground), lineWidth: 2)
+                    }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Participants: \(authors.map(\.name).joined(separator: ", "))")
+    }
+}
+
+private struct DailyThreadPostRow: View {
+    let post: DailyPost
+    let postsByID: [String: DailyPost]
+    let sourceNames: [String: String]
+    let date: String
+    let connectsAbove: Bool
+    let connectsBelow: Bool
+
+    private var nonReplyRelationships: [DailyPostRelationship] {
+        post.relationships.filter { $0.type != "REPLY_TO" }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            DailyThreadRail(
+                author: post.author,
+                connectsAbove: connectsAbove,
+                connectsBelow: connectsBelow
+            )
+
+            VStack(alignment: .leading, spacing: 10) {
+                authorHeader
+
+                if let relationshipLabel {
+                    Label(relationshipLabel.text, systemImage: relationshipLabel.icon)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+
+                if let repostedBy = post.repostedBy {
+                    Label("Reposted by @\(repostedBy.username)", systemImage: "arrow.2.squarepath")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(post.text)
+                    .font(.body)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ForEach(nonReplyRelationships) { relationship in
+                    DailyRelationshipContext(relationship: relationship)
+                }
+
+                if !post.media.isEmpty {
+                    DailyPostMediaStrip(media: post.media)
+                }
+
+                ForEach(Array(post.links.prefix(2))) { link in
+                    DailyPostLinkView(link: link)
+                }
+
+                HStack(spacing: 10) {
+                    if let postURL = post.postURL {
+                        Link(destination: postURL) {
+                            Label("Open on X", systemImage: "arrow.up.right")
+                                .foregroundStyle(.secondary)
+                        }
+                        .tint(.secondary)
+                    }
+                    Spacer(minLength: 8)
+                    DailyPostMetricsView(metrics: post.metrics)
+                }
+                .font(.caption.weight(.semibold))
+
+                if let sourceName {
+                    HStack(spacing: 5) {
+                        if sourceName.localizedCaseInsensitiveContains("favorite") {
+                            Image(systemName: "star.fill")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                        Text(sourceName)
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.caption2.weight(.semibold))
+                }
+            }
+            .padding(.bottom, 22)
+        }
+    }
+
+    private var authorHeader: some View {
+        NavigationLink(value: DailyAuthorRoute(author: post.author, date: date)) {
+            HStack(spacing: 5) {
+                Text(post.author.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                if post.author.verified == true {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text("@\(post.author.username)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer(minLength: 4)
+                if let effectiveDate = post.effectiveDate {
+                    Text(effectiveDate, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sourceName: String? {
+        post.sourceIds.first.map { sourceNames[$0] ?? $0 }
+    }
+
+    private var relationshipLabel: (icon: String, text: String)? {
+        guard let relationship = post.relationships.first(where: {
+            $0.type == "REPLY_TO" || $0.type == "QUOTE_OF" || $0.type == "REPOST_OF"
+        }) else { return nil }
+
+        let targetAuthor = relationship.target?.author ?? postsByID[relationship.tweetId]?.author
+        let handle = targetAuthor.map { " @\($0.username)" } ?? ""
+        switch relationship.type {
+        case "REPLY_TO": return ("arrowshape.turn.up.left", "Reply to\(handle)")
+        case "QUOTE_OF": return ("quote.bubble", "Quoted\(handle)")
+        case "REPOST_OF": return ("arrow.2.squarepath", "Reposted\(handle)")
+        default: return nil
+        }
+    }
+}
+
+private struct DailyThreadRail: View {
+    let author: DailyAuthor
+    let connectsAbove: Bool
+    let connectsBelow: Bool
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            DailyAuthorAvatar(author: author, size: 44)
+                .overlay {
+                    Circle()
+                        .stroke(Color(uiColor: .separator), lineWidth: 1)
+                }
+                .background(Color(uiColor: .systemBackground), in: Circle())
+        }
+        .frame(width: 46)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background {
+            GeometryReader { geometry in
+                Path { path in
+                    if connectsAbove {
+                        path.move(to: CGPoint(x: geometry.size.width / 2, y: 0))
+                        path.addLine(to: CGPoint(x: geometry.size.width / 2, y: 22))
+                    }
+                    if connectsBelow {
+                        path.move(to: CGPoint(x: geometry.size.width / 2, y: 22))
+                        path.addLine(to: CGPoint(x: geometry.size.width / 2, y: geometry.size.height))
+                    }
+                }
+                .stroke(Color.secondary.opacity(0.28), lineWidth: 1.5)
+            }
+        }
+        .accessibilityHidden(true)
     }
 }
 
@@ -916,6 +1150,328 @@ private struct DailyPostMetricsView: View {
         .padding()
     }
 }
+
+#if DEBUG
+struct ScreenshotDailyOverviewView: View {
+    var body: some View {
+        NavigationStack {
+            DailyOverviewView(response: DailyThreadScreenshotFixtures.overviewResponse)
+                .navigationTitle("Daily View")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Text("ZINE")
+                            .font(.caption2.weight(.heavy))
+                            .tracking(1.2)
+                            .foregroundStyle(.secondary)
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") {}
+                    }
+                }
+                .navigationDestination(for: DailySectionRoute.self) { route in
+                    DailySectionDetailView(
+                        response: DailyThreadScreenshotFixtures.overviewResponse,
+                        route: route
+                    )
+                }
+                .navigationDestination(for: DailyAuthorRoute.self) { _ in
+                    Text("Author activity")
+                }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+struct ScreenshotDailyThreadView: View {
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("Favorites")
+                        .font(.caption.weight(.heavy))
+                        .tracking(1.1)
+                        .foregroundStyle(.secondary)
+
+                    Text("Conversations from people you chose")
+                        .font(.title2.weight(.bold))
+
+                    DailyThreadUnitCard(
+                        threadUnit: DailyThreadScreenshotFixtures.thread,
+                        postsByID: DailyThreadScreenshotFixtures.postsByID,
+                        sourceNames: ["favorites": "Favorites"],
+                        date: "2026-07-26"
+                    )
+
+                    Text("Related conversation")
+                        .font(.headline)
+                        .padding(.top, 6)
+
+                    DailyFeedPostCard(
+                        post: DailyThreadScreenshotFixtures.relatedPost,
+                        sourceNames: ["favorites": "Favorites"],
+                        authorDestinationDate: "2026-07-26"
+                    )
+                }
+                .padding(18)
+            }
+            .navigationTitle("Daily View")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {}
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+private enum DailyThreadScreenshotFixtures {
+    static let dan = author("dandigangi", "Dan DiGangi")
+    static let ken = author("kenwheeler", "Ken Wheeler", verified: true)
+    static let joel = author("joelhooks", "joel")
+    static let matt = author("elithrar", "Matt Silverlock")
+
+    static let root = post(
+        id: "2081092447354912941",
+        author: dan,
+        text: "@AdamRackis @kenwheeler pretty sure I saw you guys talking about how you can access your clankers from mobile. how were you guys doing that?",
+        publishedAt: "2026-07-26T10:12:00.000Z",
+        replies: 3,
+        likes: 3
+    )
+
+    static let reply = post(
+        id: "2081093440104800434",
+        author: ken,
+        text: "so you establish a tailnet with tailscale and set up a dual redundancy interface. i like pi with codex and a telegram channel and a custom channel to a custom ios and web app.",
+        publishedAt: "2026-07-26T10:18:00.000Z",
+        relationships: [relationship(type: "REPLY_TO", target: root)],
+        replies: 2,
+        likes: 4
+    )
+
+    static let nestedReply = post(
+        id: "2081159242606850138",
+        author: joel,
+        text: "the way @t3dotcodes works in a tailnet is wild\n\nherdr in termious is pretty good too",
+        publishedAt: "2026-07-26T10:24:00.000Z",
+        relationships: [relationship(type: "REPLY_TO", target: reply)],
+        replies: 1,
+        likes: 1
+    )
+
+    static let relatedPost = post(
+        id: "2081159242606850199",
+        author: matt,
+        text: "given the huge uptake of voice and speaking-to-your-agent tooling, I’d like to think I was ahead of the curve on this one.",
+        publishedAt: "2026-07-26T11:04:00.000Z",
+        replies: 2,
+        likes: 6
+    )
+
+    static let posts = [root, reply, nestedReply]
+    static let postsByID = Dictionary(uniqueKeysWithValues: posts.map { ($0.id, $0) })
+
+    static let thread = DailyThreadUnit(
+        id: "conversation:2081092447354912941",
+        conversationId: "2081092447354912941",
+        rootPostId: root.id,
+        postIds: posts.map(\.id),
+        favoritePostIds: posts.map(\.id),
+        followingPostIds: [],
+        contextPostIds: [],
+        authorKeys: posts.map(\.author.key),
+        favoriteAuthorKeys: posts.map(\.author.key),
+        authors: posts.map(\.author.username),
+        favoriteAuthors: posts.map(\.author.username),
+        relationshipTypes: ["REPLY_TO"],
+        structureStatus: "EXACT",
+        latestActivityAt: nestedReply.publishedAt,
+        firstSourcePosition: 0,
+        coverageWarnings: []
+    )
+
+    static let relatedUnit = DailyThreadUnit(
+        id: "conversation:\(relatedPost.id)",
+        conversationId: relatedPost.id,
+        rootPostId: relatedPost.id,
+        postIds: [relatedPost.id],
+        favoritePostIds: [relatedPost.id],
+        followingPostIds: [],
+        contextPostIds: [],
+        authorKeys: [relatedPost.author.key],
+        favoriteAuthorKeys: [relatedPost.author.key],
+        authors: [relatedPost.author.username],
+        favoriteAuthors: [relatedPost.author.username],
+        relationshipTypes: [],
+        structureStatus: "EXACT",
+        latestActivityAt: relatedPost.publishedAt,
+        firstSourcePosition: 4,
+        coverageWarnings: []
+    )
+
+    static let overviewResponse = DailyFeedResponse(
+        schemaVersion: 3,
+        variant: DailyFeedVariant(id: "people-first-v4-editorial-overview", mode: .review),
+        date: "2026-07-26",
+        timezone: "America/Chicago",
+        frozenAt: "2026-07-26T13:00:00.000Z",
+        freshness: DailyFeedFreshness(isCurrent: true, status: .partial, warnings: []),
+        coverage: DailyFeedCoverage(
+            status: .partial,
+            archiveStatus: .complete,
+            selectionStatus: .complete,
+            runId: "fixture-run",
+            requestedCount: 5_000,
+            collectedCount: 101,
+            message: "This frozen review slice is usable with partial thread-expansion coverage.",
+            collectionMode: "ROLLING_WINDOW",
+            windowHours: 24,
+            safetyLimit: 5_000,
+            terminationReason: "WINDOW_BOUNDARY_REACHED"
+        ),
+        sources: [],
+        conversations: [],
+        topicClusters: nil,
+        threadUnits: [thread, relatedUnit],
+        overview: DailyOverviewMetadata(
+            version: "daily-overview-v1",
+            status: "COMPLETE",
+            model: "fixture-model",
+            frozen: true,
+            inputFingerprint: "fixture",
+            warnings: []
+        ),
+        overviewSections: [
+            DailyOverviewSection(
+                id: "agents",
+                title: "How developers are teaching their agents",
+                summary: "People are comparing durable project memory, session review, and the tools that let agents improve across repeated work.",
+                source: "GENERATED",
+                representativePostIds: posts.map(\.id),
+                favoriteThreadUnitIds: [thread.id],
+                supportingThreadUnitIds: [relatedUnit.id],
+                authorKeys: posts.map(\.author.key),
+                favoriteConversationCount: 8,
+                supportingConversationCount: 1,
+                latestActivityAt: nestedReply.publishedAt,
+                coverageWarnings: []
+            ),
+            DailyOverviewSection(
+                id: "voice",
+                title: "Voice becomes a working interface",
+                summary: "The conversation is moving from speech recognition toward practical ways to direct computers and coding agents by voice.",
+                source: "GENERATED",
+                representativePostIds: [relatedPost.id],
+                favoriteThreadUnitIds: [relatedUnit.id],
+                supportingThreadUnitIds: [],
+                authorKeys: [matt.key, dan.key, ken.key],
+                favoriteConversationCount: 5,
+                supportingConversationCount: 1,
+                latestActivityAt: relatedPost.publishedAt,
+                coverageWarnings: []
+            ),
+            DailyOverviewSection(
+                id: "open-models",
+                title: "The argument over open model access",
+                summary: "Several voices are focusing on who gets to distribute, regulate, and build on open-weight models.",
+                source: "GENERATED",
+                representativePostIds: [root.id, relatedPost.id],
+                favoriteThreadUnitIds: [thread.id],
+                supportingThreadUnitIds: [relatedUnit.id],
+                authorKeys: [dan.key, ken.key, joel.key, matt.key],
+                favoriteConversationCount: 6,
+                supportingConversationCount: 3,
+                latestActivityAt: root.publishedAt,
+                coverageWarnings: []
+            )
+        ],
+        clustering: nil,
+        posts: posts + [relatedPost],
+        sections: DailyFeedSections(
+            favoritePostIds: [],
+            followingPostIds: [],
+            favoriteThreadUnitIds: [],
+            followingThreadUnitIds: []
+        ),
+        inputs: nil,
+        requestId: "fixture-request",
+        traceId: "fixture-trace"
+    )
+
+    private static func author(
+        _ username: String,
+        _ name: String,
+        verified: Bool = false
+    ) -> DailyAuthor {
+        DailyAuthor(
+            key: "username:\(username)",
+            username: username,
+            name: name,
+            profileUrl: "https://x.com/\(username)",
+            profileImageUrl: nil,
+            verified: verified
+        )
+    }
+
+    private static func relationship(type: String, target: DailyPost) -> DailyPostRelationship {
+        DailyPostRelationship(
+            type: type,
+            tweetId: target.id,
+            url: target.url,
+            evidenceSource: "SCREENSHOT_FIXTURE",
+            target: DailyRelatedPost(
+                tweetId: target.id,
+                text: target.text,
+                url: target.url,
+                author: target.author
+            )
+        )
+    }
+
+    private static func post(
+        id: String,
+        author: DailyAuthor,
+        text: String,
+        publishedAt: String,
+        relationships: [DailyPostRelationship] = [],
+        replies: Int,
+        likes: Int
+    ) -> DailyPost {
+        DailyPost(
+            id: id,
+            url: "https://x.com/\(author.username)/status/\(id)",
+            text: text,
+            publishedAt: publishedAt,
+            observedAt: publishedAt,
+            kind: relationships.contains(where: { $0.type == "REPLY_TO" }) ? "REPLY" : "POST",
+            conversationId: "2081092447354912941",
+            structure: DailyPostStructure(
+                status: "EXACT",
+                source: "X_WEB_GRAPHQL_LIST",
+                observedAt: publishedAt
+            ),
+            author: author,
+            media: [],
+            links: [],
+            metrics: DailyPostMetrics(
+                replies: replies,
+                reposts: nil,
+                likes: likes,
+                views: nil,
+                bookmarks: nil
+            ),
+            relationships: relationships,
+            presentation: "POST",
+            repostedBy: nil,
+            sourceIds: ["favorites"],
+            sourcePosition: 0
+        )
+    }
+}
+#endif
 
 private extension DailyAuthor {
     static let preview = DailyAuthor(

--- a/apps/ios/ZineNativeTests/EditorialTests.swift
+++ b/apps/ios/ZineNativeTests/EditorialTests.swift
@@ -3,14 +3,14 @@ import XCTest
 @testable import ZineNative
 
 final class EditorialTests: XCTestCase {
-    func testDecodesPeopleFirstV3ThreadAndTopicContract() throws {
+    func testDecodesPeopleFirstV4OverviewThreadAndTopicContract() throws {
         let response = try JSONDecoder().decode(
             DailyFeedResponse.self,
             from: Data(
                 """
                 {
-                  "schemaVersion":2,
-                  "variant":{"id":"people-first-v3","mode":"REVIEW"},
+                  "schemaVersion":3,
+                  "variant":{"id":"people-first-v4-editorial-overview","mode":"REVIEW"},
                   "date":"2026-07-25",
                   "timezone":"America/Chicago",
                   "frozenAt":"2026-07-25T13:00:00.000Z",
@@ -56,6 +56,25 @@ final class EditorialTests: XCTestCase {
                     "structureStatus":"EXACT","latestActivityAt":"2026-07-25T11:00:00.000Z",
                     "firstSourcePosition":1,"coverageWarnings":[]
                   }],
+                  "overview":{
+                    "version":"daily-overview-v1","status":"COMPLETE",
+                    "model":"overview-model","frozen":true,
+                    "inputFingerprint":"fingerprint-1","warnings":[]
+                  },
+                  "overviewSections":[{
+                    "id":"topic:daily-topics-v1:one",
+                    "title":"Open weights and access",
+                    "summary":"People are comparing how open-weight models should be distributed and kept available.",
+                    "source":"GENERATED",
+                    "representativePostIds":["1","2"],
+                    "favoriteThreadUnitIds":["post:1","post:2"],
+                    "supportingThreadUnitIds":[],
+                    "authorKeys":["id:alice","id:bob"],
+                    "favoriteConversationCount":2,
+                    "supportingConversationCount":0,
+                    "latestActivityAt":"2026-07-25T12:00:00.000Z",
+                    "coverageWarnings":[]
+                  }],
                   "clustering":{
                     "version":"daily-topics-v1","method":"THREAD_FIRST_EVIDENCE_CLUSTERING",
                     "semanticStatus":"COMPLETE","embeddingModel":"@cf/qwen/qwen3-embedding-0.6b",
@@ -73,7 +92,10 @@ final class EditorialTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(response.variant.id, "people-first-v3")
+        XCTAssertEqual(response.variant.id, "people-first-v4-editorial-overview")
+        XCTAssertEqual(response.overview?.version, "daily-overview-v1")
+        XCTAssertEqual(response.overviewSections?.first?.title, "Open weights and access")
+        XCTAssertEqual(response.overviewSections?.first?.representativePostIds, ["1", "2"])
         XCTAssertEqual(response.clustering?.version, "daily-topics-v1")
         XCTAssertEqual(response.threadUnits?.count, 2)
         XCTAssertEqual(response.topicClusters?.first?.favoriteThreadUnitIds, ["post:1", "post:2"])

--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -360,13 +360,17 @@ describe('people-first daily feed', () => {
     const result = await getDailyFeed(fakeArchiveDb(), USER_ID, { now: NOW });
 
     expect(result).toMatchObject({
-      schemaVersion: 2,
-      variant: { id: 'people-first-v3', mode: 'REVIEW' },
+      schemaVersion: 3,
+      variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' },
       clustering: {
         version: 'daily-topics-v1',
         method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
         maxTopics: 5,
         minimumFavoriteAuthors: 2,
+      },
+      overview: {
+        version: 'daily-overview-v1',
+        status: 'FALLBACK',
       },
     });
     expect(result.coverage).toMatchObject({

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -3,6 +3,7 @@ import {
   createWorkersAIDailyTopicEmbeddingProvider,
   DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL,
 } from './daily-topic-clustering';
+import { buildDailyOverview, DAILY_OVERVIEW_VERSION } from './daily-overview';
 
 const DEFAULT_TIMEZONE = 'America/Chicago';
 const MAX_RUN_POSTS = 5_000;
@@ -512,6 +513,7 @@ export async function getDailyFeed(
     now?: Date;
     ai?: { run(model: string, input: unknown): Promise<unknown> } | null;
     embeddingModel?: string;
+    overviewModel?: string;
   } = {}
 ) {
   const timezone = options.timezone ?? DEFAULT_TIMEZONE;
@@ -533,8 +535,8 @@ export async function getDailyFeed(
   const primaryRun = favoritesRun ?? followingRun;
   if (!primaryRun) {
     return {
-      schemaVersion: 2,
-      variant: { id: 'people-first-v3', mode: 'REVIEW' as const },
+      schemaVersion: 3,
+      variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' as const },
       date: options.date ?? expectedDate,
       timezone,
       frozenAt: null,
@@ -552,6 +554,15 @@ export async function getDailyFeed(
       conversations: [],
       topicClusters: [],
       threadUnits: [],
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'FALLBACK' as const,
+        model: null,
+        frozen: true,
+        inputFingerprint: '',
+        warnings: [] as string[],
+      },
+      overviewSections: [],
       clustering: {
         version: 'daily-topics-v1',
         method: 'THREAD_FIRST_EVIDENCE_CLUSTERING' as const,
@@ -743,6 +754,18 @@ export async function getDailyFeed(
   );
   const threadUnitsById = new Map(topicClustering.threadUnits.map((unit) => [unit.id, unit]));
   const postById = new Map(posts.map((post) => [post.id, post]));
+  const dailyOverview = await buildDailyOverview({
+    db,
+    userId,
+    date,
+    favoritesRunId: favoritesRun?.id ?? null,
+    followingRunId: followingRun?.id ?? null,
+    clusters: topicClustering.topicClusters,
+    threadUnits: topicClustering.threadUnits,
+    posts,
+    ai: options.ai,
+    model: options.overviewModel,
+  });
   const conversations = topicClustering.topicClusters.map((topic) => {
     const topicPosts = topic.postIds
       .map((postId) => postById.get(postId))
@@ -822,8 +845,8 @@ export async function getDailyFeed(
       : ('PARTIAL' as const);
 
   return {
-    schemaVersion: 2,
-    variant: { id: 'people-first-v3', mode: 'REVIEW' as const },
+    schemaVersion: 3,
+    variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' as const },
     date,
     timezone,
     frozenAt: frozenAt.toISOString(),
@@ -883,6 +906,8 @@ export async function getDailyFeed(
     conversations,
     topicClusters: topicClustering.topicClusters,
     threadUnits: topicClustering.threadUnits,
+    overview: dailyOverview.overview,
+    overviewSections: dailyOverview.overviewSections,
     clustering: topicClustering.algorithm,
     posts,
     sections: {

--- a/apps/worker/src/lib/daily-overview.test.ts
+++ b/apps/worker/src/lib/daily-overview.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildDailyOverview } from './daily-overview';
+import type { DailyThreadUnit, DailyTopicCluster, DailyTopicPost } from './daily-topic-clustering';
+
+function post(id: string, username: string, text: string): DailyTopicPost {
+  return {
+    id,
+    text,
+    publishedAt: '2026-07-26T12:00:00.000Z',
+    observedAt: '2026-07-26T12:01:00.000Z',
+    kind: 'POST',
+    conversationId: id,
+    structure: { status: 'EXACT', source: 'X_WEB_GRAPHQL_LIST' },
+    author: { key: `id:${username}`, username, name: username.toLocaleUpperCase() },
+    relationships: [],
+    links: [],
+    sourcePosition: 0,
+  };
+}
+
+function unit(postValue: DailyTopicPost): DailyThreadUnit {
+  return {
+    id: `conversation:${postValue.id}`,
+    conversationId: postValue.id,
+    rootPostId: postValue.id,
+    postIds: [postValue.id],
+    favoritePostIds: [postValue.id],
+    followingPostIds: [],
+    contextPostIds: [],
+    authorKeys: [postValue.author.key],
+    favoriteAuthorKeys: [postValue.author.key],
+    authors: [postValue.author.username],
+    favoriteAuthors: [postValue.author.username],
+    relationshipTypes: [],
+    structureStatus: 'EXACT',
+    latestActivityAt: postValue.publishedAt,
+    firstSourcePosition: 0,
+    coverageWarnings: [],
+  };
+}
+
+const posts = [
+  post('one', 'alice', 'Open-weight models should remain widely available.'),
+  post('two', 'bob', 'The new open-weight letter focuses on distribution and research access.'),
+];
+const units = posts.map(unit);
+const cluster: DailyTopicCluster = {
+  id: 'topic:open-weight',
+  label: 'open weight · models',
+  labelSource: 'EXTRACTED_PHRASE',
+  labelTerms: ['open weight', 'models'],
+  evidence: 'Two conversations share explicit evidence.',
+  evidenceSignals: [],
+  threadUnitIds: units.map((value) => value.id),
+  favoriteThreadUnitIds: units.map((value) => value.id),
+  supportingThreadUnitIds: [],
+  postIds: posts.map((value) => value.id),
+  favoritePostIds: posts.map((value) => value.id),
+  contextPostIds: [],
+  favoriteAuthors: ['alice', 'bob'],
+  supportingAuthors: [],
+  score: 250,
+  latestActivityAt: '2026-07-26T12:00:00.000Z',
+  coverageWarnings: [],
+};
+
+function cacheDb() {
+  let stored: { sections_json: string; model: string | null } | null = null;
+  const db = {
+    prepare(sql: string) {
+      let bindings: unknown[] = [];
+      return {
+        bind(...values: unknown[]) {
+          bindings = values;
+          return this;
+        },
+        async first() {
+          return sql.includes('SELECT sections_json') ? stored : null;
+        },
+        async run() {
+          if (sql.includes('INSERT OR IGNORE')) {
+            stored ??= {
+              model: String(bindings[6]),
+              sections_json: String(bindings[7]),
+            };
+          }
+          return { success: true };
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return { db, getStored: () => stored };
+}
+
+describe('daily editorial overview', () => {
+  it('lets generated copy describe a cluster without changing its evidence membership', async () => {
+    const cache = cacheDb();
+    const ai = {
+      run: vi.fn(async (_model: string, _input: unknown) => ({
+        response: JSON.stringify({
+          sections: [
+            {
+              id: cluster.id,
+              title: 'The open-weight access debate',
+              summary:
+                'Two voices focus on how open-weight models should be distributed and kept available for research.',
+            },
+          ],
+        }),
+      })),
+    };
+
+    const result = await buildDailyOverview({
+      db: cache.db,
+      userId: 'user-1',
+      date: '2026-07-26',
+      favoritesRunId: 'favorites-run',
+      followingRunId: 'following-run',
+      clusters: [cluster],
+      threadUnits: units,
+      posts,
+      ai,
+      model: 'overview-model',
+    });
+
+    expect(result.overview).toMatchObject({
+      status: 'COMPLETE',
+      model: 'overview-model',
+      frozen: true,
+    });
+    expect(result.overviewSections).toEqual([
+      expect.objectContaining({
+        id: cluster.id,
+        title: 'The open-weight access debate',
+        source: 'GENERATED',
+        representativePostIds: ['one', 'two'],
+        favoriteThreadUnitIds: units.map((value) => value.id),
+        supportingThreadUnitIds: [],
+      }),
+    ]);
+    expect(cache.getStored()).not.toBeNull();
+    expect(ai.run.mock.calls[0]?.[1]).toMatchObject({
+      response_format: { type: 'json_object' },
+    });
+  });
+
+  it('reads the immutable generated copy for the same input fingerprint', async () => {
+    const cache = cacheDb();
+    const firstAi = {
+      run: vi.fn(async () => ({
+        response: JSON.stringify({
+          sections: [
+            {
+              id: cluster.id,
+              title: 'Open weights and access',
+              summary: 'The conversation centers on distribution and research access.',
+            },
+          ],
+        }),
+      })),
+    };
+    const input = {
+      db: cache.db,
+      userId: 'user-1',
+      date: '2026-07-26',
+      favoritesRunId: 'favorites-run',
+      followingRunId: 'following-run',
+      clusters: [cluster],
+      threadUnits: units,
+      posts,
+    };
+    const first = await buildDailyOverview({ ...input, ai: firstAi, model: 'overview-model' });
+    const secondAi = { run: vi.fn(async () => Promise.reject(new Error('must not run'))) };
+    const second = await buildDailyOverview({ ...input, ai: secondAi, model: 'new-model' });
+
+    expect(secondAi.run).not.toHaveBeenCalled();
+    expect(second.overview.model).toBe('overview-model');
+    expect(second.overviewSections).toEqual(first.overviewSections);
+  });
+
+  it('accepts Workers AI JSON mode object responses', async () => {
+    const cache = cacheDb();
+    const result = await buildDailyOverview({
+      db: cache.db,
+      userId: 'user-1',
+      date: '2026-07-26',
+      favoritesRunId: 'favorites-run',
+      followingRunId: 'following-run',
+      clusters: [cluster],
+      threadUnits: units,
+      posts,
+      ai: {
+        run: vi.fn(async () => ({
+          response: {
+            sections: [
+              {
+                id: cluster.id,
+                title: 'Open weights and access',
+                summary: 'The conversation centers on distribution and research access.',
+              },
+            ],
+          },
+        })),
+      },
+    });
+
+    expect(result.overview.status).toBe('COMPLETE');
+    expect(result.overviewSections[0].source).toBe('GENERATED');
+  });
+
+  it('falls back to conservative evidence-derived copy without losing the section', async () => {
+    const cache = cacheDb();
+    const result = await buildDailyOverview({
+      db: cache.db,
+      userId: 'user-1',
+      date: '2026-07-26',
+      favoritesRunId: 'favorites-run',
+      followingRunId: 'following-run',
+      clusters: [cluster],
+      threadUnits: units,
+      posts,
+      ai: null,
+    });
+
+    expect(result.overview.status).toBe('FALLBACK');
+    expect(result.overviewSections[0]).toMatchObject({
+      title: 'Open Weight · Models',
+      source: 'EXTRACTIVE_FALLBACK',
+      favoriteConversationCount: 2,
+    });
+    expect(result.overviewSections[0].summary).toContain('ALICE and BOB');
+  });
+
+  it('does not claim generated copy is frozen when cache retention is unavailable', async () => {
+    const db = {
+      prepare(sql: string) {
+        return {
+          bind() {
+            return this;
+          },
+          async first() {
+            return null;
+          },
+          async run() {
+            throw new Error(`missing table for ${sql}`);
+          },
+        };
+      },
+    } as unknown as D1Database;
+    const result = await buildDailyOverview({
+      db,
+      userId: 'user-1',
+      date: '2026-07-26',
+      favoritesRunId: 'favorites-run',
+      followingRunId: 'following-run',
+      clusters: [cluster],
+      threadUnits: units,
+      posts,
+      ai: {
+        run: vi.fn(async () => ({
+          response: JSON.stringify({
+            sections: [
+              {
+                id: cluster.id,
+                title: 'Open weights and access',
+                summary: 'The conversation centers on distribution and research access.',
+              },
+            ],
+          }),
+        })),
+      },
+    });
+
+    expect(result.overview).toMatchObject({ status: 'PARTIAL', frozen: false });
+    expect(result.overview.warnings).toEqual([
+      'Editorial overview could not be retained for stable replay.',
+    ]);
+  });
+});

--- a/apps/worker/src/lib/daily-overview.ts
+++ b/apps/worker/src/lib/daily-overview.ts
@@ -1,0 +1,485 @@
+import type { DailyThreadUnit, DailyTopicCluster, DailyTopicPost } from './daily-topic-clustering';
+
+export const DAILY_OVERVIEW_VERSION = 'daily-overview-v1';
+export const DEFAULT_DAILY_OVERVIEW_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+
+const MAX_REPRESENTATIVE_POSTS = 4;
+const MAX_PROMPT_UNITS = 8;
+const MAX_PROMPT_POSTS_PER_UNIT = 3;
+const MAX_PROMPT_POST_LENGTH = 700;
+const MAX_TITLE_LENGTH = 90;
+const MAX_SUMMARY_LENGTH = 320;
+
+type WorkersAIRunner = {
+  run(model: string, input: unknown): Promise<unknown>;
+};
+
+export type DailyOverviewSection = {
+  id: string;
+  title: string;
+  summary: string;
+  source: 'GENERATED' | 'EXTRACTIVE_FALLBACK';
+  representativePostIds: string[];
+  favoriteThreadUnitIds: string[];
+  supportingThreadUnitIds: string[];
+  authorKeys: string[];
+  favoriteConversationCount: number;
+  supportingConversationCount: number;
+  latestActivityAt: string | null;
+  coverageWarnings: string[];
+};
+
+export type DailyOverviewResult = {
+  overview: {
+    version: typeof DAILY_OVERVIEW_VERSION;
+    status: 'COMPLETE' | 'PARTIAL' | 'FALLBACK';
+    model: string | null;
+    frozen: boolean;
+    inputFingerprint: string;
+    warnings: string[];
+  };
+  overviewSections: DailyOverviewSection[];
+};
+
+type GeneratedCopy = {
+  id: string;
+  title: string;
+  summary: string;
+};
+
+type StoredOverviewRow = {
+  sections_json: string;
+  model: string | null;
+};
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function normalizedWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function sentence(value: string): string {
+  const clean = normalizedWhitespace(value);
+  if (!clean) return clean;
+  return /[.!?]$/.test(clean) ? clean : `${clean}.`;
+}
+
+function titleCase(value: string): string {
+  return normalizedWhitespace(value)
+    .split(' ')
+    .map((word) => {
+      if (/^[A-Z0-9][A-Za-z0-9.+-]*$/.test(word)) return word;
+      return word.length > 0 ? `${word[0].toLocaleUpperCase()}${word.slice(1)}` : word;
+    })
+    .join(' ');
+}
+
+function extractResponse(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  if (record.response !== undefined) return record.response;
+  if (record.result && typeof record.result === 'object') {
+    const nested = record.result as Record<string, unknown>;
+    if (nested.response !== undefined) return nested.response;
+  }
+  return value;
+}
+
+function parseGeneratedCopy(value: unknown): GeneratedCopy[] {
+  const extracted = extractResponse(value);
+  let parsed: unknown = extracted;
+  if (typeof extracted === 'string') {
+    const clean = extracted
+      .trim()
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```$/, '');
+    parsed = JSON.parse(clean);
+  }
+  if (!parsed || typeof parsed !== 'object') throw new Error('overview response was empty');
+  const sections = (parsed as Record<string, unknown>).sections;
+  if (!Array.isArray(sections)) throw new Error('overview response omitted sections');
+  return sections.map((section) => {
+    if (!section || typeof section !== 'object') throw new Error('overview section was invalid');
+    const record = section as Record<string, unknown>;
+    if (
+      typeof record.id !== 'string' ||
+      typeof record.title !== 'string' ||
+      typeof record.summary !== 'string'
+    ) {
+      throw new Error('overview section copy was incomplete');
+    }
+    return {
+      id: record.id,
+      title: normalizedWhitespace(record.title),
+      summary: normalizedWhitespace(record.summary),
+    };
+  });
+}
+
+function representativePostIds(
+  cluster: DailyTopicCluster,
+  unitsById: Map<string, DailyThreadUnit>,
+  postsById: Map<string, DailyTopicPost>
+): string[] {
+  const selected: string[] = [];
+  const seenAuthors = new Set<string>();
+  for (const unitId of cluster.favoriteThreadUnitIds) {
+    const unit = unitsById.get(unitId);
+    if (!unit) continue;
+    const post = unit.favoritePostIds
+      .map((postId) => postsById.get(postId))
+      .find((candidate) => candidate && !seenAuthors.has(candidate.author.key));
+    if (!post) continue;
+    selected.push(post.id);
+    seenAuthors.add(post.author.key);
+    if (selected.length === MAX_REPRESENTATIVE_POSTS) return selected;
+  }
+  for (const postId of cluster.favoritePostIds) {
+    if (postsById.has(postId) && !selected.includes(postId)) selected.push(postId);
+    if (selected.length === MAX_REPRESENTATIVE_POSTS) break;
+  }
+  return selected;
+}
+
+function fallbackSummary(
+  cluster: DailyTopicCluster,
+  representativeIds: string[],
+  postsById: Map<string, DailyTopicPost>
+): string {
+  const names = unique(
+    representativeIds
+      .map((postId) => postsById.get(postId)?.author.name)
+      .filter((name): name is string => Boolean(name))
+  );
+  const visibleNames = names.slice(0, 3);
+  const people =
+    visibleNames.length === 0
+      ? 'Several Favorites'
+      : visibleNames.length === 1
+        ? visibleNames[0]
+        : `${visibleNames.slice(0, -1).join(', ')} and ${visibleNames.at(-1)}`;
+  const nearby =
+    cluster.supportingThreadUnitIds.length > 0
+      ? `, with ${cluster.supportingThreadUnitIds.length} nearby conversation${cluster.supportingThreadUnitIds.length === 1 ? '' : 's'} adding context`
+      : '';
+  return sentence(`${people} are comparing perspectives on ${cluster.label}${nearby}`);
+}
+
+function baseSections(
+  clusters: DailyTopicCluster[],
+  threadUnits: DailyThreadUnit[],
+  posts: DailyTopicPost[]
+): DailyOverviewSection[] {
+  const unitsById = new Map(threadUnits.map((unit) => [unit.id, unit]));
+  const postsById = new Map(posts.map((post) => [post.id, post]));
+  return clusters.map((cluster) => {
+    const representativeIds = representativePostIds(cluster, unitsById, postsById);
+    const authorKeys = unique(
+      cluster.threadUnitIds.flatMap((unitId) => unitsById.get(unitId)?.authorKeys ?? [])
+    );
+    return {
+      id: cluster.id,
+      title: titleCase(cluster.label),
+      summary: fallbackSummary(cluster, representativeIds, postsById),
+      source: 'EXTRACTIVE_FALLBACK' as const,
+      representativePostIds: representativeIds,
+      favoriteThreadUnitIds: cluster.favoriteThreadUnitIds,
+      supportingThreadUnitIds: cluster.supportingThreadUnitIds,
+      authorKeys,
+      favoriteConversationCount: cluster.favoriteThreadUnitIds.length,
+      supportingConversationCount: cluster.supportingThreadUnitIds.length,
+      latestActivityAt: cluster.latestActivityAt,
+      coverageWarnings: cluster.coverageWarnings,
+    };
+  });
+}
+
+function generationPrompt(
+  sections: DailyOverviewSection[],
+  unitsById: Map<string, DailyThreadUnit>,
+  postsById: Map<string, DailyTopicPost>
+) {
+  return sections.map((section) => ({
+    id: section.id,
+    evidenceLabel: section.title,
+    conversations: [...section.favoriteThreadUnitIds, ...section.supportingThreadUnitIds]
+      .slice(0, MAX_PROMPT_UNITS)
+      .map((unitId) => {
+        const unit = unitsById.get(unitId);
+        return {
+          id: unitId,
+          source: section.favoriteThreadUnitIds.includes(unitId) ? 'FAVORITES' : 'FOLLOWING',
+          posts: (unit?.postIds ?? [])
+            .slice(0, MAX_PROMPT_POSTS_PER_UNIT)
+            .map((postId) => postsById.get(postId))
+            .filter((post): post is DailyTopicPost => Boolean(post))
+            .map((post) => ({
+              id: post.id,
+              author: post.author.name,
+              username: post.author.username,
+              text: post.text.slice(0, MAX_PROMPT_POST_LENGTH),
+            })),
+        };
+      }),
+  }));
+}
+
+function validateGeneratedCopy(
+  copies: GeneratedCopy[],
+  sections: DailyOverviewSection[]
+): Map<string, GeneratedCopy> {
+  const expectedIds = new Set(sections.map((section) => section.id));
+  const byId = new Map<string, GeneratedCopy>();
+  for (const copy of copies) {
+    if (!expectedIds.has(copy.id) || byId.has(copy.id)) continue;
+    if (
+      copy.title.length < 3 ||
+      copy.title.length > MAX_TITLE_LENGTH ||
+      copy.summary.length < 12 ||
+      copy.summary.length > MAX_SUMMARY_LENGTH
+    ) {
+      continue;
+    }
+    byId.set(copy.id, { ...copy, summary: sentence(copy.summary) });
+  }
+  if (byId.size !== sections.length) {
+    throw new Error(`overview response validated ${byId.size}/${sections.length} sections`);
+  }
+  return byId;
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function readStoredOverview(
+  db: D1Database,
+  userId: string,
+  date: string,
+  inputFingerprint: string
+): Promise<{ sections: DailyOverviewSection[]; model: string | null } | null> {
+  try {
+    const row = await db
+      .prepare(
+        `SELECT sections_json, model FROM x_daily_overviews
+         WHERE user_id = ? AND edition_date = ? AND variant_id = ?
+           AND input_fingerprint = ? AND algorithm_version = ?`
+      )
+      .bind(
+        userId,
+        date,
+        'people-first-v4-editorial-overview',
+        inputFingerprint,
+        DAILY_OVERVIEW_VERSION
+      )
+      .first<StoredOverviewRow>();
+    if (!row) return null;
+    const parsed = JSON.parse(row.sections_json) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    const sections = parsed as DailyOverviewSection[];
+    return { sections, model: row.model };
+  } catch {
+    return null;
+  }
+}
+
+async function storeOverview(
+  db: D1Database,
+  userId: string,
+  date: string,
+  inputFingerprint: string,
+  model: string,
+  sections: DailyOverviewSection[]
+): Promise<void> {
+  const id = await sha256(
+    `${userId}|${date}|people-first-v4-editorial-overview|${inputFingerprint}|${DAILY_OVERVIEW_VERSION}`
+  );
+  try {
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO x_daily_overviews
+          (id, user_id, edition_date, variant_id, input_fingerprint, algorithm_version,
+           model, status, sections_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'COMPLETE', ?, ?)`
+      )
+      .bind(
+        id,
+        userId,
+        date,
+        'people-first-v4-editorial-overview',
+        inputFingerprint,
+        DAILY_OVERVIEW_VERSION,
+        model,
+        JSON.stringify(sections),
+        Date.now()
+      )
+      .run();
+  } catch {
+    // A missing cache migration must not make the evidence feed unavailable.
+  }
+}
+
+function storedSectionsAreValid(
+  stored: DailyOverviewSection[],
+  base: DailyOverviewSection[]
+): boolean {
+  const expected = new Map(base.map((section) => [section.id, section]));
+  return (
+    stored.length === base.length &&
+    stored.every((section) => {
+      const current = expected.get(section.id);
+      return (
+        current !== undefined &&
+        Array.isArray(section.favoriteThreadUnitIds) &&
+        Array.isArray(section.supportingThreadUnitIds) &&
+        Array.isArray(section.representativePostIds) &&
+        JSON.stringify(section.favoriteThreadUnitIds) ===
+          JSON.stringify(current.favoriteThreadUnitIds) &&
+        JSON.stringify(section.supportingThreadUnitIds) ===
+          JSON.stringify(current.supportingThreadUnitIds) &&
+        section.representativePostIds.every((postId) =>
+          current.representativePostIds.includes(postId)
+        )
+      );
+    })
+  );
+}
+
+export async function buildDailyOverview(input: {
+  db: D1Database;
+  userId: string;
+  date: string;
+  favoritesRunId: string | null;
+  followingRunId: string | null;
+  clusters: DailyTopicCluster[];
+  threadUnits: DailyThreadUnit[];
+  posts: DailyTopicPost[];
+  ai?: WorkersAIRunner | null;
+  model?: string;
+}): Promise<DailyOverviewResult> {
+  const fallbackSections = baseSections(input.clusters, input.threadUnits, input.posts);
+  const inputFingerprint = await sha256(
+    JSON.stringify({
+      favoritesRunId: input.favoritesRunId,
+      followingRunId: input.followingRunId,
+      clusterIds: input.clusters.map((cluster) => cluster.id),
+      threadUnitIds: input.threadUnits.map((unit) => unit.id),
+      postIds: input.posts.map((post) => post.id),
+    })
+  );
+  if (fallbackSections.length === 0) {
+    return {
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'FALLBACK',
+        model: null,
+        frozen: true,
+        inputFingerprint,
+        warnings: [],
+      },
+      overviewSections: [],
+    };
+  }
+
+  const stored = await readStoredOverview(input.db, input.userId, input.date, inputFingerprint);
+  if (stored && storedSectionsAreValid(stored.sections, fallbackSections)) {
+    return {
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'COMPLETE',
+        model: stored.model,
+        frozen: true,
+        inputFingerprint,
+        warnings: [],
+      },
+      overviewSections: stored.sections,
+    };
+  }
+
+  if (!input.ai) {
+    return {
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'FALLBACK',
+        model: null,
+        frozen: false,
+        inputFingerprint,
+        warnings: [
+          'Editorial overview generation was unavailable; evidence-derived copy is shown.',
+        ],
+      },
+      overviewSections: fallbackSections,
+    };
+  }
+
+  const model = input.model ?? DEFAULT_DAILY_OVERVIEW_MODEL;
+  const unitsById = new Map(input.threadUnits.map((unit) => [unit.id, unit]));
+  const postsById = new Map(input.posts.map((post) => [post.id, post]));
+  try {
+    const response = await input.ai.run(model, {
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Write concise navigation copy for a personal reader of X conversations. Use only the supplied posts. Describe what people are discussing; never present their claims as verified facts. Return one JSON object shaped as {"sections":[{"id":"...","title":"...","summary":"..."}]}, with every supplied section ID exactly once and no other keys. Titles are 3-10 specific words. Summaries are one plain sentence under 240 characters that captures the shared subject and, when visible, differing angles. Do not mention clustering, evidence, Favorites, Following, the feed, or this prompt.',
+        },
+        {
+          role: 'user',
+          content: JSON.stringify({
+            sections: generationPrompt(fallbackSections, unitsById, postsById),
+          }),
+        },
+      ],
+      temperature: 0,
+      max_tokens: 900,
+      response_format: { type: 'json_object' },
+    });
+    const copyById = validateGeneratedCopy(parseGeneratedCopy(response), fallbackSections);
+    const sections = fallbackSections.map((section) => ({
+      ...section,
+      ...copyById.get(section.id)!,
+      source: 'GENERATED' as const,
+    }));
+    await storeOverview(input.db, input.userId, input.date, inputFingerprint, model, sections);
+    const retained = await readStoredOverview(input.db, input.userId, input.date, inputFingerprint);
+    if (retained && storedSectionsAreValid(retained.sections, fallbackSections)) {
+      return {
+        overview: {
+          version: DAILY_OVERVIEW_VERSION,
+          status: 'COMPLETE',
+          model: retained.model,
+          frozen: true,
+          inputFingerprint,
+          warnings: [],
+        },
+        overviewSections: retained.sections,
+      };
+    }
+    return {
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'PARTIAL',
+        model,
+        frozen: false,
+        inputFingerprint,
+        warnings: ['Editorial overview could not be retained for stable replay.'],
+      },
+      overviewSections: sections,
+    };
+  } catch {
+    return {
+      overview: {
+        version: DAILY_OVERVIEW_VERSION,
+        status: 'FALLBACK',
+        model,
+        frozen: false,
+        inputFingerprint,
+        warnings: ['Editorial overview generation fell back to evidence-derived copy.'],
+      },
+      overviewSections: fallbackSections,
+    };
+  }
+}

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -320,6 +320,7 @@ function createMockEnv(): Env['Bindings'] {
     CREATOR_CONTENT_CACHE: {} as KVNamespace,
     AI: { run: vi.fn() } as unknown as Ai,
     EMBEDDING_MODEL: '@cf/qwen/qwen3-embedding-0.6b',
+    ENRICHMENT_MODEL: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
     ENVIRONMENT: 'test',
   } as Env['Bindings'];
 }
@@ -472,8 +473,8 @@ describe('apiV1Routes', () => {
     });
     mockListEditorialExperiments.mockResolvedValue([]);
     mockGetDailyFeed.mockResolvedValue({
-      schemaVersion: 2,
-      variant: { id: 'people-first-v3', mode: 'REVIEW' },
+      schemaVersion: 3,
+      variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' },
       date: '2026-07-24',
       timezone: 'America/Chicago',
       frozenAt: '2026-07-24T13:00:00.000Z',
@@ -666,13 +667,14 @@ describe('apiV1Routes', () => {
     );
     expect(feed.status).toBe(200);
     expect(await feed.json()).toMatchObject({
-      variant: { id: 'people-first-v3', mode: 'REVIEW' },
+      variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' },
       date: '2026-07-24',
     });
     expect(mockGetDailyFeed).toHaveBeenCalledWith(expect.anything(), 'user_123', {
       date: '2026-07-24',
       ai: env.AI,
       embeddingModel: '@cf/qwen/qwen3-embedding-0.6b',
+      overviewModel: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
     });
 
     const author = await app.fetch(

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -2131,6 +2131,7 @@ apiV1Routes.get('/today/feed', apiAuth('bookmarks:read'), async (c) => {
     ...parsed.data,
     ai: c.env.AI as unknown as { run(model: string, input: unknown): Promise<unknown> } | undefined,
     embeddingModel: c.env.EMBEDDING_MODEL,
+    overviewModel: c.env.ENRICHMENT_MODEL,
   });
   return c.json({ ...result, requestId: c.get('requestId'), traceId: c.get('traceId') });
 });

--- a/apps/worker/src/types.ts
+++ b/apps/worker/src/types.ts
@@ -13,7 +13,7 @@ import type { SyncQueueMessage } from './sync/types';
 export interface Bindings {
   /** D1 database for persistent storage */
   DB: D1Database;
-  /** Read-only access to the canonical X Following archive for people-first Today. */
+  /** Canonical X archive plus frozen people-first Daily View artifacts. */
   X_ARCHIVE_DB: D1Database;
   /** KV namespace for webhook idempotency */
   WEBHOOK_IDEMPOTENCY: KVNamespace;

--- a/apps/x-archive/src/db/migrations/0005_daily_overviews.sql
+++ b/apps/x-archive/src/db/migrations/0005_daily_overviews.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS x_daily_overviews (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL,
+  edition_date TEXT NOT NULL,
+  variant_id TEXT NOT NULL,
+  input_fingerprint TEXT NOT NULL,
+  algorithm_version TEXT NOT NULL,
+  model TEXT,
+  status TEXT NOT NULL,
+  sections_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS x_daily_overviews_input_idx
+  ON x_daily_overviews(user_id, edition_date, variant_id, input_fingerprint, algorithm_version);


### PR DESCRIPTION
## Summary

- replace the crowded review-only Daily View root with a compact editorial overview of what Favorites are discussing
- open each section into full-width exact thread units, defaulting to Favorites with related Following conversations available under Nearby
- add the v3 `/api/v1/today/feed` overview contract, Workers AI copy generation constrained to deterministic topic membership, and immutable D1-backed frozen overview storage
- retain provenance, freshness, partial-coverage states, existing author activity, and isolation from live Today

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- `bun run test:worker:ci` — 1,709 tests passed
- `bun run --cwd apps/x-archive test:run` — 8 tests passed
- `bun run --cwd apps/x-archive typecheck`
- native `ZineNative` simulator tests — 51 tests passed
- Swift v4 contract replay — decoded 2 posts, 2 threads, 1 topic, and 1 overview section
- isolated D1 migration application and table readback
- manual simulator review of overview navigation, exact inline threads, and Favorites/Nearby switching