### PR TITLE
fix(today): register people daily migration

### DIFF
--- a/apps/worker/src/db/migrations/meta/_journal.json
+++ b/apps/worker/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1785090607000,
       "tag": "0027_add_subscription_auto_bookmark",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1785116600000,
+      "tag": "0028_add_people_daily_editions",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- register the merged `0028_add_people_daily_editions` SQL file in Drizzle's migration journal
- allow the existing Deploy Worker workflow to apply the People Daily tables before the first production edition is published

## Validation
- `jq empty apps/worker/src/db/migrations/meta/_journal.json`
- applied `0028_add_people_daily_editions.sql` to a fresh SQLite database and confirmed all three `people_daily_*` tables
- `bun run format:check`
- pre-push typecheck, web tests (75), and Worker CI subset (1,715) passed
- production readback before this fix confirmed the deployed Worker SHA but no `people_daily_*` tables; no edition was published
