### PR TITLE
docs(people-daily): define partial context policy

### DIFF
--- a/docs/people-daily.md
+++ b/docs/people-daily.md
@@ -59,7 +59,7 @@ The single 5:00 AM America/Chicago task must:
 7. Decode the exact production overview and section JSON through the shipped Swift models.
 8. Report collection, generation, validation, upload, publication, readback, and decode states separately.
 
-If any collection step fails, the task records the matching failure stage and does not publish. If publication succeeds but readback fails, it records/report the readback failure without misrepresenting the already-published edition.
+Favorites is the edition's agenda and must finish with verified rolling-window boundary evidence. A missing, unverified, or incomplete Favorites run records the matching failure stage and does not publish. Following is secondary context: after all bounded recovery is exhausted, a receiver-verified `PARTIAL` Following run may still publish when its source is verified and its structure coverage is exact. The resulting edition must remain visibly `PARTIAL` and retain the requested/collected counts, termination reason, and failure warning. Authentication failures, source ambiguity, For You contamination, unverified uploads, or partial thread structure still prevent publication. If publication succeeds but readback fails, the task records/reports the readback failure without misrepresenting the already-published edition.
 
 ## Native behavior
 


### PR DESCRIPTION
## Summary

- require Favorites to complete with verified rolling-window boundary evidence before publication
- allow receiver-verified, exact-structure Following context to publish as visibly partial after bounded recovery is exhausted
- keep auth, source ambiguity, For You contamination, unverified uploads, and partial structure as hard publication blockers

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (1125 mobile compatibility, 1736 Worker, 75 web)
- `bun run build`
- pre-push parity: 75 web and 1715 Worker CI-subset tests
- production People Daily revision 1 published and read back with COMPLETE Favorites plus receiver-verified PARTIAL Following, preserving visible partial coverage