### PR TITLE
fix(ios): remove completed jump back in items

### DIFF
--- a/apps/ios/ZineNative/Features/Home/HomeStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeStore.swift
@@ -113,10 +113,20 @@ final class HomeStore {
 
     private func reconcileOptimisticOpenedItems() {
         guard let home else { return }
-        let serverItems = Dictionary(uniqueKeysWithValues: home.jumpBackIn.map { ($0.id, $0) })
+        optimisticOpenedItems = Self.reconciledOptimisticOpenedItems(
+            optimisticOpenedItems,
+            serverItems: home.jumpBackIn
+        )
+    }
 
-        optimisticOpenedItems = optimisticOpenedItems.filter { id, optimistic in
-            guard let server = serverItems[id] else { return true }
+    static func reconciledOptimisticOpenedItems(
+        _ optimisticItems: [String: HomeItem],
+        serverItems: [HomeItem]
+    ) -> [String: HomeItem] {
+        let serverItemsByID = Dictionary(uniqueKeysWithValues: serverItems.map { ($0.id, $0) })
+
+        return optimisticItems.filter { id, optimistic in
+            guard let server = serverItemsByID[id] else { return false }
             return (server.lastOpenedAt ?? "") < (optimistic.lastOpenedAt ?? "")
         }
     }

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -148,6 +148,43 @@ final class HomeTests: XCTestCase {
         XCTAssertEqual(items.map(\.id), [bookmark.id, previouslyOpened.id])
     }
 
+    @MainActor
+    func testSuccessfulHomeRefreshDropsOptimisticItemMissingAfterCompletion() {
+        let optimistic = makeHomeItem(
+            id: "completed",
+            minutes: 20,
+            lastOpenedAt: "2026-07-18T11:00:00Z"
+        )
+
+        let reconciled = HomeStore.reconciledOptimisticOpenedItems(
+            [optimistic.id: optimistic],
+            serverItems: []
+        )
+
+        XCTAssertTrue(reconciled.isEmpty)
+    }
+
+    @MainActor
+    func testSuccessfulHomeRefreshKeepsNewerOptimisticOpenUntilServerCatchesUp() {
+        let server = makeHomeItem(
+            id: "opened",
+            minutes: 20,
+            lastOpenedAt: "2026-07-18T10:00:00Z"
+        )
+        let optimistic = makeHomeItem(
+            id: "opened",
+            minutes: 20,
+            lastOpenedAt: "2026-07-18T11:00:00Z"
+        )
+
+        let reconciled = HomeStore.reconciledOptimisticOpenedItems(
+            [optimistic.id: optimistic],
+            serverItems: [server]
+        )
+
+        XCTAssertEqual(reconciled[optimistic.id], optimistic)
+    }
+
     func testHomeTransitionSourceIDsAreStableAndSectionScoped() {
         let item = makeHomeItem(id: "shared", minutes: 12)
 


### PR DESCRIPTION
## Summary

- treat a successful Home refresh as authoritative when an optimistic Jump Back In item is absent
- retain genuinely newer optimistic opens until the server timestamp catches up
- add regression coverage for completion removal and newer-open retention

## Validation

- `git diff --check`
- `xcodebuild test -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination 'platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908' -only-testing:ZineNativeTests/HomeTests CODE_SIGNING_ALLOWED=NO` (9 tests passed)