### PR TITLE
fix(today): prevent repeated posts across categories

### DIFF
--- a/apps/worker/src/lib/daily-feed.test.ts
+++ b/apps/worker/src/lib/daily-feed.test.ts
@@ -363,7 +363,7 @@ describe('people-first daily feed', () => {
       schemaVersion: 3,
       variant: { id: 'people-first-v4-editorial-overview', mode: 'REVIEW' },
       clustering: {
-        version: 'daily-topics-v1',
+        version: 'daily-topics-v2',
         method: 'THREAD_FIRST_EVIDENCE_CLUSTERING',
         maxTopics: 5,
         minimumFavoriteAuthors: 2,

--- a/apps/worker/src/lib/daily-feed.ts
+++ b/apps/worker/src/lib/daily-feed.ts
@@ -1,6 +1,7 @@
 import {
   buildDailyTopicClustering,
   createWorkersAIDailyTopicEmbeddingProvider,
+  DAILY_TOPIC_ALGORITHM_VERSION,
   DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL,
 } from './daily-topic-clustering';
 import { buildDailyOverview, DAILY_OVERVIEW_VERSION } from './daily-overview';
@@ -612,7 +613,7 @@ export async function getDailyFeed(
       },
       overviewSections: [],
       clustering: {
-        version: 'daily-topics-v1',
+        version: DAILY_TOPIC_ALGORITHM_VERSION,
         method: 'THREAD_FIRST_EVIDENCE_CLUSTERING' as const,
         semanticStatus: 'FALLBACK' as const,
         embeddingModel: null,

--- a/apps/worker/src/lib/daily-topic-clustering.test.ts
+++ b/apps/worker/src/lib/daily-topic-clustering.test.ts
@@ -282,6 +282,65 @@ describe('daily topic clustering', () => {
     expect(result.topicClusters[0].score).toBeGreaterThan(result.topicClusters[1].score);
   });
 
+  it('assigns each conversation to only one topic even when it matches multiple categories', async () => {
+    const posts = [
+      post({
+        id: 'atlas-1',
+        username: 'alice',
+        text: 'Atlas launch notes',
+        position: 0,
+        link: 'https://atlas.example/launch',
+      }),
+      post({
+        id: 'atlas-2',
+        username: 'bob',
+        text: 'Atlas benchmark notes',
+        position: 1,
+        link: 'https://atlas.example/launch',
+      }),
+      post({
+        id: 'bridge',
+        username: 'carol',
+        text: 'Comparing Atlas and Beacon',
+        position: 2,
+        link: 'https://atlas.example/launch',
+      }),
+      post({
+        id: 'beacon-1',
+        username: 'dave',
+        text: 'Beacon pricing notes',
+        position: 3,
+        link: 'https://beacon.example/pricing',
+      }),
+      post({
+        id: 'beacon-2',
+        username: 'erin',
+        text: 'Beacon rollout notes',
+        position: 4,
+        link: 'https://beacon.example/pricing',
+      }),
+    ];
+    posts[2].links.push({
+      url: 'https://beacon.example/pricing',
+      normalizedUrl: 'https://beacon.example/pricing',
+    });
+
+    const result = await buildDailyTopicClustering(
+      posts,
+      new Set(posts.map((value) => value.id)),
+      new Set()
+    );
+    const assignedThreadIds = result.topicClusters.flatMap((topic) => topic.threadUnitIds);
+    const assignedPostIds = result.topicClusters.flatMap((topic) => topic.postIds);
+
+    expect(result.topicClusters).toHaveLength(2);
+    expect(new Set(assignedThreadIds).size).toBe(assignedThreadIds.length);
+    expect(new Set(assignedPostIds).size).toBe(assignedPostIds.length);
+    expect(result.topicClusters.filter((topic) => topic.postIds.includes('bridge'))).toHaveLength(
+      1
+    );
+  });
+
   it('uses pinned embeddings only for expansion and records their provenance', async () => {
     const posts = [
       post({ id: 'seed-1', username: 'one', text: 'Robotics safety research', position: 0 }),

--- a/apps/worker/src/lib/daily-topic-clustering.ts
+++ b/apps/worker/src/lib/daily-topic-clustering.ts
@@ -1,4 +1,4 @@
-export const DAILY_TOPIC_ALGORITHM_VERSION = 'daily-topics-v1';
+export const DAILY_TOPIC_ALGORITHM_VERSION = 'daily-topics-v2';
 export const DEFAULT_DAILY_TOPIC_EMBEDDING_MODEL = '@cf/qwen/qwen3-embedding-0.6b';
 
 const MAX_TOPICS = 5;
@@ -884,13 +884,59 @@ export async function buildDailyTopicClustering(
     );
 
   const selected: typeof rankedCandidates = [];
+  const selectedSourceCandidates: TopicCandidate[] = [];
+  const assignedUnitIds = new Set<string>();
   for (const ranked of rankedCandidates) {
-    const duplicate = selected.some(({ candidate }) => {
+    const duplicate = selectedSourceCandidates.some((candidate) => {
       const overlap = jaccard(candidate.favoriteUnitIds, ranked.candidate.favoriteUnitIds);
       return overlap >= 0.75;
     });
     if (duplicate) continue;
-    selected.push(ranked);
+
+    const favoriteUnitIds = new Set(
+      [...ranked.candidate.favoriteUnitIds].filter((unitId) => !assignedUnitIds.has(unitId))
+    );
+    const favoriteUnitsForCandidate = [...favoriteUnitIds]
+      .map((unitId) => unitsById.get(unitId))
+      .filter((unit): unit is DailyThreadUnit => Boolean(unit));
+    const favoriteAuthorKeys = unique(
+      favoriteUnitsForCandidate.flatMap((unit) => unit.favoriteAuthorKeys)
+    );
+    if (favoriteAuthorKeys.length < 2) continue;
+
+    const supportingUnitIds = new Set(
+      [...ranked.candidate.supportingUnitIds].filter(
+        (unitId) => !assignedUnitIds.has(unitId) && !favoriteUnitIds.has(unitId)
+      )
+    );
+    const candidate: TopicCandidate = {
+      anchors: ranked.candidate.anchors,
+      favoriteUnitIds,
+      supportingUnitIds,
+      semanticEvidence: new Map(
+        [...ranked.candidate.semanticEvidence].filter(([unitId]) => favoriteUnitIds.has(unitId))
+      ),
+    };
+    const favoriteAuthors = unique(
+      favoriteUnitsForCandidate.flatMap((unit) => unit.favoriteAuthors)
+    );
+    const favoritePosts = unique(favoriteUnitsForCandidate.flatMap((unit) => unit.favoritePostIds));
+    const score =
+      favoriteAuthorKeys.length * 100 +
+      favoriteUnitsForCandidate.length * 25 +
+      favoritePosts.length * 5 +
+      Math.min(supportingUnitIds.size, 10) * 2;
+
+    selected.push({
+      candidate,
+      favoriteAuthors,
+      favoriteAuthorKeys,
+      favoritePosts,
+      score,
+    });
+    selectedSourceCandidates.push(ranked.candidate);
+    favoriteUnitIds.forEach((unitId) => assignedUnitIds.add(unitId));
+    supportingUnitIds.forEach((unitId) => assignedUnitIds.add(unitId));
     if (selected.length === MAX_TOPICS) break;
   }
 

--- a/apps/worker/src/lib/people-daily-editions.test.ts
+++ b/apps/worker/src/lib/people-daily-editions.test.ts
@@ -402,6 +402,30 @@ describe('People Daily editions', () => {
     expect(active.size).toBe(0);
   });
 
+  it('rejects an edition that repeats a conversation across categories', async () => {
+    const { db, bucket, editions, active } = fakeResources();
+    const repeated = feed();
+    repeated.overviewSections.push({
+      ...repeated.overviewSections[0],
+      id: 'topic:2',
+      title: 'A repeated conversation',
+    });
+    mockGetDailyFeed.mockResolvedValueOnce(repeated);
+
+    await startPeopleDailyBuild(db, 'user-1', {
+      id: 'build-repeated',
+      editionDate: '2026-07-26',
+    });
+    await expect(
+      publishPeopleDailyBuild(db, {} as D1Database, bucket, 'user-1', 'build-repeated', {
+        favoritesRunId: 'favorites-1',
+        followingRunId: 'following-1',
+      })
+    ).rejects.toThrow('Thread unit conversation:1 is repeated in sections topic:1 and topic:2');
+    expect(editions.size).toBe(0);
+    expect(active.size).toBe(0);
+  });
+
   it('lists immutable history and reactivates a validated prior artifact', async () => {
     const { db, bucket, active } = fakeResources();
     await startPeopleDailyBuild(db, 'user-1', {

--- a/apps/worker/src/lib/people-daily-editions.ts
+++ b/apps/worker/src/lib/people-daily-editions.ts
@@ -314,6 +314,10 @@ function validateArtifact(
       supportingThreadUnitIds: string[];
       representativePostIds: string[];
     }>;
+    sections?: {
+      favoriteThreadUnitIds?: string[];
+      followingThreadUnitIds?: string[];
+    };
     inputs?: {
       favorites?: { runId: string } | null;
       following?: { runId: string } | null;
@@ -337,19 +341,49 @@ function validateArtifact(
       throw new PeopleDailyValidationError(`Thread unit ${unit.id} references a missing post`);
     }
   }
-  for (const section of feed.overviewSections ?? []) {
-    const referencedUnits = [...section.favoriteThreadUnitIds, ...section.supportingThreadUnitIds];
-    if (referencedUnits.some((unitId) => !units.has(unitId))) {
+  const assignedUnits = new Map<string, string>();
+  const assignedPosts = new Map<string, string>();
+  const claimUnit = (sectionId: string, unitId: string) => {
+    const unit = units.get(unitId);
+    if (!unit) {
       throw new PeopleDailyValidationError(
-        `Overview section ${section.id} references a missing thread`
+        `Overview section ${sectionId} references a missing thread`
       );
     }
+    const previousUnitSection = assignedUnits.get(unitId);
+    if (previousUnitSection && previousUnitSection !== sectionId) {
+      throw new PeopleDailyValidationError(
+        `Thread unit ${unitId} is repeated in sections ${previousUnitSection} and ${sectionId}`
+      );
+    }
+    assignedUnits.set(unitId, sectionId);
+    for (const postId of unit.postIds) {
+      const previousPostSection = assignedPosts.get(postId);
+      if (previousPostSection && previousPostSection !== sectionId) {
+        throw new PeopleDailyValidationError(
+          `Post ${postId} is repeated in sections ${previousPostSection} and ${sectionId}`
+        );
+      }
+      assignedPosts.set(postId, sectionId);
+    }
+  };
+  for (const section of feed.overviewSections ?? []) {
+    const referencedUnits = new Set([
+      ...section.favoriteThreadUnitIds,
+      ...section.supportingThreadUnitIds,
+    ]);
+    referencedUnits.forEach((unitId) => claimUnit(section.id, unitId));
     if (section.representativePostIds.some((postId) => !postIds.has(postId))) {
       throw new PeopleDailyValidationError(
         `Overview section ${section.id} references a missing post`
       );
     }
   }
+  const moreUnitIds = new Set([
+    ...(feed.sections?.favoriteThreadUnitIds ?? []),
+    ...(feed.sections?.followingThreadUnitIds ?? []),
+  ]);
+  moreUnitIds.forEach((unitId) => claimUnit('more', unitId));
 }
 
 export async function publishPeopleDailyBuild(

--- a/docs/people-daily.md
+++ b/docs/people-daily.md
@@ -21,6 +21,7 @@ Retries use the same build ID. Reusing it with changed inputs is rejected. Publi
 - For You is never accepted.
 - Exact conversation IDs, reply parents, quotes, reposts, links, authors, media metadata, source positions, membership, collection policy, and partial-coverage warnings come from the frozen archive runs.
 - Deterministic topic membership is fixed before copy generation. Workers AI may write a short section title and description from the supplied posts; it cannot add, remove, or move a conversation.
+- Topic membership is exclusive across the edition. The strongest eligible section claims a conversation once; lower-ranked sections can use only unassigned conversations, and publication rejects any repeated thread or post.
 - X posts show what people are discussing. Generated copy must not present post claims as verified facts.
 
 ## Storage


### PR DESCRIPTION
## Summary

- assign each X conversation to only the strongest eligible Today category
- drop lower-ranked categories that no longer have enough independent Favorite authors after deduplication
- reject People Daily artifacts that repeat a thread or post across categories, including More
- bump the topic clustering algorithm to daily-topics-v2 and document exclusive membership

## Validation

- bun run format:check
- bun run --cwd apps/worker lint
- bun run --cwd apps/worker typecheck
- bun run --cwd apps/worker test:run src/lib/daily-topic-clustering.test.ts src/lib/daily-overview.test.ts src/lib/daily-feed.test.ts src/lib/people-daily-editions.test.ts (34 passed)
- bun run test:worker:ci (1,717 passed)
- pre-push gate: design-system check, monorepo typecheck, web tests, and Worker CI suite passed