### PR TITLE
fix(ios): restore condensed home experience

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -37,10 +37,10 @@ private struct AuthenticatedAppView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     private let client: APIClient
-    private let peopleDailyCache: PeopleDailyCache
-    private let homeCache: HomeCache
     private let libraryCache: LibraryCache
 
+    @State private var homeStore: HomeStore
+    @State private var peopleDailyStore: PeopleDailyStore
     @State private var search = ""
     @State private var homeRevision = 0
     @State private var libraryRevision = 0
@@ -48,7 +48,7 @@ private struct AuthenticatedAppView: View {
     @State private var externalOpenError: String?
 
     init(configuration: AppConfiguration, userID: String) {
-        client = APIClient(
+        let client = APIClient(
             baseURL: configuration.apiBaseURL,
             tokenProvider: {
                 guard let token = try await Clerk.shared.auth.getToken() else {
@@ -58,30 +58,25 @@ private struct AuthenticatedAppView: View {
             },
             articleBodyCache: ArticleBodyCache(userID: userID)
         )
-        peopleDailyCache = PeopleDailyCache(userID: userID)
-        homeCache = HomeCache(userID: userID)
+        let peopleDailyCache = PeopleDailyCache(userID: userID)
+        let homeCache = HomeCache(userID: userID)
+        self.client = client
         libraryCache = LibraryCache(userID: userID)
+        _homeStore = State(initialValue: HomeStore(client: client, cache: homeCache))
+        _peopleDailyStore = State(initialValue: PeopleDailyStore(
+            client: client,
+            cache: peopleDailyCache
+        ))
     }
 
     var body: some View {
         TabView {
-            Tab("Today", systemImage: "newspaper") {
-                TodayView(
-                    client: client,
-                    cache: peopleDailyCache,
-                    refreshRevision: homeRevision,
-                    onContentChanged: markBookmarkContentChanged,
-                    onExternalOpen: handleExternalOpen
-                )
-                .tint(Color.accentColor)
-            }
-
             Tab("Home", systemImage: "house") {
                 HomeView(
                     client: client,
-                    cache: homeCache,
-                    refreshRevision: homeRevision,
-                    externalOpenEvent: externalOpenEvent,
+                    store: homeStore,
+                    peopleDailyStore: peopleDailyStore,
+                    density: .compact,
                     onContentChanged: markBookmarkContentChanged,
                     onExternalOpen: handleExternalOpen,
                     onHomeItemExternalOpen: handleHomeItemExternalOpen
@@ -119,6 +114,20 @@ private struct AuthenticatedAppView: View {
             }
         }
         .tint(Color.primary)
+        .task(id: homeRevision) {
+            async let home: Void = homeStore.reload()
+            async let today: Void = peopleDailyStore.load()
+            _ = await (home, today)
+        }
+        .onChange(of: externalOpenEvent, initial: true) { _, event in
+            guard let event else { return }
+            switch event.change {
+            case .promote:
+                homeStore.promoteOpened(event.bookmark, at: event.openedAt)
+            case .rollback:
+                homeStore.rollbackOpened(id: event.bookmark.id, openedAt: event.openedAt)
+            }
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 homeRevision += 1

--- a/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
@@ -1,0 +1,495 @@
+import SwiftUI
+
+struct CondensedHomeDashboardSectionView: View {
+    let section: HomeDashboardSection
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        switch section {
+        case .jumpBackIn(let items):
+            CondensedJumpBackInSection(
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .inbox(let items):
+            CondensedInboxSection(
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .quickWins(let items):
+            CondensedGridSection(
+                title: "Quick Wins",
+                route: .quickWins,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .recentlySaved(let items):
+            CondensedLandscapeRail(
+                title: "Recently Saved",
+                route: .recentlySaved,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .podcasts(let items):
+            CondensedCoverRail(
+                title: "Listen Next",
+                route: .podcasts,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .articles(let items):
+            CondensedLandscapeRail(
+                title: "Saved Reads",
+                route: .articles,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .videos(let items):
+            CondensedLandscapeRail(
+                title: "Watch Later",
+                route: .videos,
+                items: items,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .collection(let collection):
+            CondensedCollectionSection(
+                collection: collection,
+                sectionID: section.id,
+                transitionNamespace: transitionNamespace
+            )
+        case .todayTopic(let topic):
+            CondensedTodayTopicSection(topic: topic)
+        }
+    }
+}
+
+private struct CondensedSectionHeader: View {
+    let title: String
+    let route: HomeSectionRoute
+
+    var body: some View {
+        NavigationLink(value: route) {
+            HStack(spacing: 5) {
+                Text(title)
+                    .font(.headline)
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.tertiary)
+            }
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("View all \(title)")
+    }
+}
+
+private struct CondensedJumpBackInSection: View {
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    @State private var selectedPage = 0
+
+    private var carouselItems: [HomeItem] {
+        Array(items.prefix(3))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: "Jump Back In", route: .jumpBackIn)
+
+            TabView(selection: $selectedPage) {
+                ForEach(Array(carouselItems.enumerated()), id: \.element.id) { index, item in
+                    HomeNavigationLink(
+                        route: .item(item, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        HomeResumeCard(item: item)
+                    }
+                    .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(height: 220)
+
+            HStack(spacing: 7) {
+                ForEach(carouselItems.indices, id: \.self) { index in
+                    Circle()
+                        .fill(index == selectedPage ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .frame(width: 7, height: 7)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Jump Back In carousel")
+            .accessibilityValue("Page \(selectedPage + 1) of \(carouselItems.count)")
+        }
+        .padding(.horizontal, 16)
+        .onChange(of: carouselItems.map(\.id)) { _, _ in
+            selectedPage = min(selectedPage, max(carouselItems.count - 1, 0))
+        }
+    }
+}
+
+private struct CondensedInboxSection: View {
+    let items: [Bookmark]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: "Fresh in Your Inbox", route: .inbox)
+                .padding(.horizontal, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 14) {
+                    ForEach(items) { bookmark in
+                        HomeNavigationLink(
+                            route: .bookmark(bookmark, sectionID: sectionID),
+                            transitionNamespace: transitionNamespace
+                        ) {
+                            HomeCompactHorizontalCard(bookmark: bookmark)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+}
+
+private struct CondensedCollectionSection: View {
+    let collection: HomeCollection
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    private var route: HomeSectionRoute {
+        .collection(id: collection.id, title: collection.title)
+    }
+
+    var body: some View {
+        switch collection.layout {
+        case .stackRail:
+            CondensedLandscapeRail(
+                title: collection.title,
+                route: route,
+                items: collection.items,
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .coverRail:
+            CondensedCoverRail(
+                title: collection.title,
+                route: route,
+                items: collection.items,
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .rowGrid:
+            CondensedGridSection(
+                title: collection.title,
+                route: route,
+                items: Array(collection.items.prefix(4)),
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        case .compactList:
+            CondensedItemListSection(
+                title: collection.title,
+                route: route,
+                items: Array(collection.items.prefix(4)),
+                sectionID: sectionID,
+                transitionNamespace: transitionNamespace
+            )
+        }
+    }
+}
+
+private struct CondensedLandscapeRail: View {
+    let title: String
+    let route: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: title, route: route)
+                .padding(.horizontal, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 10) {
+                    ForEach(items) { item in
+                        HomeNavigationLink(
+                            route: .item(item, sectionID: sectionID),
+                            transitionNamespace: transitionNamespace
+                        ) {
+                            CondensedLandscapeCard(item: item)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+}
+
+private struct CondensedCoverRail: View {
+    let title: String
+    let route: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: title, route: route)
+                .padding(.horizontal, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(alignment: .top, spacing: 10) {
+                    ForEach(items) { item in
+                        HomeNavigationLink(
+                            route: .item(item, sectionID: sectionID),
+                            transitionNamespace: transitionNamespace
+                        ) {
+                            CondensedCoverCard(item: item)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+    }
+}
+
+private struct CondensedGridSection: View {
+    let title: String
+    let route: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: title, route: route)
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 10) {
+                ForEach(items) { item in
+                    HomeNavigationLink(
+                        route: .item(item, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        CondensedGridCard(item: item)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+private struct CondensedItemListSection: View {
+    let title: String
+    let route: HomeSectionRoute
+    let items: [HomeItem]
+    let sectionID: String
+    let transitionNamespace: Namespace.ID
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CondensedSectionHeader(title: title, route: route)
+
+            VStack(spacing: 0) {
+                ForEach(items) { item in
+                    HomeNavigationLink(
+                        route: .item(item, sectionID: sectionID),
+                        transitionNamespace: transitionNamespace
+                    ) {
+                        HomeItemRow(item: item)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 4)
+                            .contentShape(Rectangle())
+                    }
+
+                    if item.id != items.last?.id {
+                        Divider()
+                            .padding(.leading, 82)
+                    }
+                }
+            }
+            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 13))
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+private struct CondensedTodayTopicSection: View {
+    let topic: HomeTodayTopic
+
+    var body: some View {
+        NavigationLink(value: PeopleDailyRoute.section(topic.section.id)) {
+            HStack(alignment: .top, spacing: 10) {
+                DailyParticipantFacepile(authors: topic.authors, size: 20, maximumVisible: 3)
+                    .frame(width: 54, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text("TODAY")
+                            .font(.caption2.weight(.heavy))
+                            .tracking(0.8)
+                            .foregroundStyle(Color.accentColor)
+
+                        if let statusText {
+                            Text(statusText)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Text(topic.section.title)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+
+                    Text(topic.section.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+
+                    Text(conversationSummary)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.tertiary)
+                }
+
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 2)
+            }
+            .padding(12)
+            .background(Color.accentColor.opacity(0.07), in: .rect(cornerRadius: 14))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 16)
+        .accessibilityHint("Opens the conversations in this section")
+    }
+
+    private var statusText: String? {
+        if topic.isShowingCachedEdition { return "Saved edition" }
+        switch topic.freshnessStatus {
+        case .complete: return nil
+        case .partial: return nil
+        case .unavailable: return "Unavailable"
+        }
+    }
+
+    private var conversationSummary: String {
+        let favorites = "\(topic.section.favoriteConversationCount) conversation\(topic.section.favoriteConversationCount == 1 ? "" : "s")"
+        guard topic.section.supportingConversationCount > 0 else { return favorites }
+        return "\(favorites) · \(topic.section.supportingConversationCount) nearby"
+    }
+}
+
+private struct CondensedLandscapeCard: View {
+    let item: HomeItem
+
+    private let width: CGFloat = 178
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: width, height: 96)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 22)
+            }
+            .frame(width: width, height: 96)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 10))
+
+            Text(item.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            HomeItemMetadata(item: item)
+        }
+        .frame(width: width, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CondensedCoverCard: View {
+    let item: HomeItem
+
+    private let width: CGFloat = 112
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: width, height: 136)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 24)
+            }
+            .frame(width: width, height: 136)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 10))
+
+            Text(item.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            HomeItemMetadata(item: item)
+        }
+        .frame(width: width, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CondensedGridCard: View {
+    let item: HomeItem
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            CachedRemoteImage(
+                url: item.thumbnailUrl,
+                targetSize: CGSize(width: 180, height: 72)
+            ) {
+                HomeImagePlaceholder(contentType: item.contentType, iconSize: 19)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 72)
+            .clipped()
+            .clipShape(.rect(cornerRadius: 9))
+
+            Text(item.title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            HomeItemMetadata(item: item)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -48,7 +48,7 @@ enum HomeSectionRoute: Hashable {
     }
 }
 
-private struct HomeNavigationLink<Label: View>: View {
+struct HomeNavigationLink<Label: View>: View {
     let route: HomeNavigationRoute
     let transitionNamespace: Namespace.ID
     @ViewBuilder let label: () -> Label
@@ -62,9 +62,22 @@ private struct HomeNavigationLink<Label: View>: View {
 
 struct HomeDashboardSectionView: View {
     let section: HomeDashboardSection
+    var density: HomeLayoutDensity = .standard
     let transitionNamespace: Namespace.ID
 
     var body: some View {
+        if density == .compact {
+            CondensedHomeDashboardSectionView(
+                section: section,
+                transitionNamespace: transitionNamespace
+            )
+        } else {
+            standardContent
+        }
+    }
+
+    @ViewBuilder
+    private var standardContent: some View {
         switch section {
         case .jumpBackIn(let items):
             HomeJumpBackInSection(
@@ -126,7 +139,73 @@ struct HomeDashboardSectionView: View {
                 sectionID: section.id,
                 transitionNamespace: transitionNamespace
             )
+        case .todayTopic(let topic):
+            HomeTodayTopicSection(topic: topic)
         }
+    }
+}
+
+private struct HomeTodayTopicSection: View {
+    let topic: HomeTodayTopic
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 8) {
+                Text("Today")
+                    .font(.caption.weight(.heavy))
+                    .tracking(1.1)
+                    .foregroundStyle(Color.accentColor)
+
+                Text(formattedDate)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                if topic.isShowingCachedEdition {
+                    statusLabel("Saved edition", color: .secondary)
+                } else {
+                    switch topic.freshnessStatus {
+                    case .complete:
+                        EmptyView()
+                    case .partial:
+                        statusLabel("Partial", color: .orange)
+                    case .unavailable:
+                        statusLabel("Unavailable", color: .secondary)
+                    }
+                }
+            }
+
+            NavigationLink(value: PeopleDailyRoute.section(topic.section.id)) {
+                DailyOverviewSectionRow(
+                    section: topic.section,
+                    authors: topic.authors
+                )
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 20)
+    }
+
+    private func statusLabel(_ text: String, color: Color) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 5, height: 5)
+            Text(text)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var formattedDate: String {
+        let components = topic.date.split(separator: "-").compactMap { Int($0) }
+        guard components.count == 3 else { return topic.date }
+        var value = DateComponents()
+        value.calendar = Calendar(identifier: .gregorian)
+        value.timeZone = TimeZone(identifier: topic.timezone)
+        value.year = components[0]
+        value.month = components[1]
+        value.day = components[2]
+        return value.date?.formatted(.dateTime.month(.abbreviated).day()) ?? topic.date
     }
 }
 
@@ -192,7 +271,7 @@ private struct HomeJumpBackInSection: View {
                                 route: .item(item, sectionID: sectionID),
                                 transitionNamespace: transitionNamespace
                             ) {
-                                HomeJumpBackInCompactCard(item: item)
+                                HomeCompactHorizontalCard(item: item)
                             }
                         }
                     }
@@ -203,8 +282,10 @@ private struct HomeJumpBackInSection: View {
     }
 }
 
-private struct HomeJumpBackInCompactCard: View {
-    let item: HomeItem
+struct HomeCompactHorizontalCard: View {
+    private let thumbnailUrl: URL?
+    private let contentType: ContentType
+    private let title: String
 
     private enum Metrics {
         static let cardWidth: CGFloat = 220
@@ -213,19 +294,31 @@ private struct HomeJumpBackInCompactCard: View {
         static let imageHeight: CGFloat = 54
     }
 
+    init(item: HomeItem) {
+        thumbnailUrl = item.thumbnailUrl
+        contentType = item.contentType
+        title = item.title
+    }
+
+    init(bookmark: Bookmark) {
+        thumbnailUrl = bookmark.thumbnailUrl
+        contentType = bookmark.contentType
+        title = bookmark.title
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             CachedRemoteImage(
-                url: item.thumbnailUrl,
+                url: thumbnailUrl,
                 targetSize: CGSize(width: Metrics.imageWidth, height: Metrics.imageHeight)
             ) {
-                HomeImagePlaceholder(contentType: item.contentType, iconSize: 20)
+                HomeImagePlaceholder(contentType: contentType, iconSize: 20)
             }
             .frame(width: Metrics.imageWidth, height: Metrics.imageHeight)
             .clipped()
             .clipShape(.rect(cornerRadius: 9))
 
-            Text(item.title)
+            Text(title)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.primary)
                 .lineLimit(3)
@@ -446,7 +539,7 @@ private struct HomeCompactListSection: View {
     }
 }
 
-private struct HomeResumeCard: View {
+struct HomeResumeCard: View {
     let item: HomeItem
 
     var body: some View {
@@ -579,7 +672,7 @@ private struct HomeGridCard: View {
     }
 }
 
-private struct HomeItemRow: View {
+struct HomeItemRow: View {
     let item: HomeItem
 
     var body: some View {
@@ -607,7 +700,7 @@ private struct HomeItemRow: View {
     }
 }
 
-private struct HomeItemMetadata: View {
+struct HomeItemMetadata: View {
     let item: HomeItem
 
     var body: some View {
@@ -625,7 +718,7 @@ private struct HomeItemMetadata: View {
     }
 }
 
-private struct HomeImagePlaceholder: View {
+struct HomeImagePlaceholder: View {
     let contentType: ContentType
     let iconSize: CGFloat
 

--- a/apps/ios/ZineNative/Features/Home/HomeStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeStore.swift
@@ -1,6 +1,17 @@
 import Foundation
 import Observation
 
+struct HomeTodayTopic: Hashable, Identifiable {
+    let section: DailyOverviewSection
+    let authors: [DailyAuthor]
+    let date: String
+    let timezone: String
+    let freshnessStatus: DailyCoverageStatus
+    let isShowingCachedEdition: Bool
+
+    var id: String { section.id }
+}
+
 enum HomeDashboardSection: Identifiable {
     case jumpBackIn([HomeItem])
     case inbox([Bookmark])
@@ -10,6 +21,7 @@ enum HomeDashboardSection: Identifiable {
     case articles([HomeItem])
     case videos([HomeItem])
     case collection(HomeCollection)
+    case todayTopic(HomeTodayTopic)
 
     var id: String {
         switch self {
@@ -21,6 +33,7 @@ enum HomeDashboardSection: Identifiable {
         case .articles: "articles"
         case .videos: "videos"
         case .collection(let collection): "collection-\(collection.id)"
+        case .todayTopic(let topic): "today-topic-\(topic.id)"
         }
     }
 }
@@ -206,6 +219,77 @@ final class HomeStore {
             result.insert(.quickWins(quickWins), at: insertionIndex)
         }
 
+        return result
+    }
+
+    static func strongestTodayTopics(
+        sections: [DailyOverviewSection],
+        authors: [DailyAuthor],
+        date: String,
+        timezone: String,
+        freshnessStatus: DailyCoverageStatus,
+        isShowingCachedEdition: Bool
+    ) -> [HomeTodayTopic] {
+        let authorsByKey = Dictionary(uniqueKeysWithValues: authors.map { ($0.key, $0) })
+        return sections.prefix(2).map { section in
+            HomeTodayTopic(
+                section: section,
+                authors: section.authorKeys.compactMap { authorsByKey[$0] },
+                date: date,
+                timezone: timezone,
+                freshnessStatus: freshnessStatus,
+                isShowingCachedEdition: isShowingCachedEdition
+            )
+        }
+    }
+
+    static func interleaveTodayTopics(
+        _ topics: [HomeTodayTopic],
+        into sections: [HomeDashboardSection]
+    ) -> [HomeDashboardSection] {
+        guard let firstTopic = topics.first else { return sections }
+
+        var result = sections
+        let firstInsertionIndex: Int
+        if let jumpBackInIndex = result.firstIndex(where: { section in
+            if case .jumpBackIn = section { return true }
+            return false
+        }) {
+            firstInsertionIndex = result.index(after: jumpBackInIndex)
+        } else {
+            firstInsertionIndex = min(1, result.endIndex)
+        }
+        result.insert(.todayTopic(firstTopic), at: firstInsertionIndex)
+
+        guard topics.count > 1 else { return result }
+        let secondTopic = topics[1]
+        let searchStart = result.index(after: firstInsertionIndex)
+
+        if let collectionIndex = result[searchStart...].firstIndex(where: { section in
+            if case .collection = section { return true }
+            return false
+        }) {
+            result.insert(.todayTopic(secondTopic), at: result.index(after: collectionIndex))
+            return result
+        }
+
+        if let quickWinsIndex = result[searchStart...].firstIndex(where: { section in
+            if case .quickWins = section { return true }
+            return false
+        }) {
+            result.insert(.todayTopic(secondTopic), at: result.index(after: quickWinsIndex))
+            return result
+        }
+
+        if let inboxIndex = result[searchStart...].firstIndex(where: { section in
+            if case .inbox = section { return true }
+            return false
+        }) {
+            result.insert(.todayTopic(secondTopic), at: result.index(after: inboxIndex))
+            return result
+        }
+
+        result.append(.todayTopic(secondTopic))
         return result
     }
 

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -1,40 +1,83 @@
 import SwiftUI
 
+enum HomeLayoutDensity: Equatable {
+    case standard
+    case compact
+
+    private static let hiddenCompactCollectionTitles: Set<String> = [
+        "car ride",
+        "care ride",
+        "career ride",
+        "faves",
+    ]
+
+    var sectionSpacing: CGFloat {
+        switch self {
+        case .standard: 30
+        case .compact: 18
+        }
+    }
+
+    func visibleSections(from sections: [HomeDashboardSection]) -> [HomeDashboardSection] {
+        guard self == .compact else { return sections }
+
+        return sections.filter { section in
+            switch section {
+            case .quickWins:
+                false
+            case .collection(let collection):
+                !Self.hiddenCompactCollectionTitles.contains(
+                    collection.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                )
+            default:
+                true
+            }
+        }
+    }
+}
+
 struct HomeView: View {
     let client: APIClient
-    let refreshRevision: Int
-    let externalOpenEvent: ExternalBookmarkOpenEvent?
+    let store: HomeStore
+    let peopleDailyStore: PeopleDailyStore
+    var density: HomeLayoutDensity = .standard
+    var title = "Home"
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
     let onHomeItemExternalOpen: (HomeItem) -> Void
 
-    @State private var store: HomeStore
     @Namespace private var bookmarkTransition
 
     init(
         client: APIClient,
-        cache: HomeCache,
-        refreshRevision: Int,
-        externalOpenEvent: ExternalBookmarkOpenEvent?,
+        store: HomeStore,
+        peopleDailyStore: PeopleDailyStore,
+        density: HomeLayoutDensity = .standard,
+        title: String = "Home",
         onContentChanged: @escaping () -> Void,
         onExternalOpen: @escaping (Bookmark) -> Void,
         onHomeItemExternalOpen: @escaping (HomeItem) -> Void
     ) {
         self.client = client
-        self.refreshRevision = refreshRevision
-        self.externalOpenEvent = externalOpenEvent
+        self.store = store
+        self.peopleDailyStore = peopleDailyStore
+        self.density = density
+        self.title = title
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         self.onHomeItemExternalOpen = onHomeItemExternalOpen
-        _store = State(initialValue: HomeStore(client: client, cache: cache))
     }
 
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle("Home")
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
                 .navigationDestination(for: HomeNavigationRoute.self) { route in
                     destination(for: route)
+                        .navigationTransition(
+                            .zoom(sourceID: route.sourceID, in: bookmarkTransition)
+                        )
                 }
                 .navigationDestination(for: HomeSectionRoute.self) { route in
                     switch route {
@@ -53,28 +96,22 @@ struct HomeView: View {
                         )
                     }
                 }
-        }
-        .task(id: refreshRevision) {
-            await store.reload()
-        }
-        .onChange(of: externalOpenEvent, initial: true) { _, event in
-            guard let event else { return }
-            switch event.change {
-            case .promote:
-                store.promoteOpened(event.bookmark, at: event.openedAt)
-            case .rollback:
-                store.rollbackOpened(id: event.bookmark.id, openedAt: event.openedAt)
-            }
+                .navigationDestination(for: PeopleDailyRoute.self) { route in
+                    switch route {
+                    case let .section(id):
+                        PeopleDailySectionView(client: client, sectionID: id)
+                    }
+                }
         }
     }
 
     @ViewBuilder
     private var content: some View {
-        if store.isLoading && store.sections.isEmpty {
-            ProgressView("Loading Home…")
-        } else if let error = store.errorMessage, store.sections.isEmpty {
+        if store.isLoading && dashboardSections.isEmpty {
+            ProgressView("Loading \(title)…")
+        } else if let error = store.errorMessage, dashboardSections.isEmpty {
             ContentUnavailableView {
-                Label("Home unavailable", systemImage: "exclamationmark.triangle")
+                Label("\(title) unavailable", systemImage: "exclamationmark.triangle")
             } description: {
                 Text(error)
             } actions: {
@@ -82,7 +119,7 @@ struct HomeView: View {
                     Task { await store.reload() }
                 }
             }
-        } else if store.sections.isEmpty {
+        } else if dashboardSections.isEmpty {
             ContentUnavailableView(
                 "Nothing to pick up yet",
                 systemImage: "sparkles.rectangle.stack",
@@ -90,21 +127,41 @@ struct HomeView: View {
             )
         } else {
             ScrollView {
-                LazyVStack(spacing: 30) {
-                    ForEach(store.sections) { section in
+                LazyVStack(spacing: density.sectionSpacing) {
+                    ForEach(dashboardSections) { section in
                         HomeDashboardSectionView(
                             section: section,
+                            density: density,
                             transitionNamespace: bookmarkTransition
                         )
                     }
                 }
-                .padding(.vertical, 10)
-                .padding(.bottom, 24)
+                .padding(.vertical, density == .compact ? 6 : 10)
+                .padding(.bottom, density == .compact ? 16 : 24)
             }
             .refreshable {
-                await store.reload()
+                async let home: Void = store.reload()
+                async let today: Void = peopleDailyStore.load()
+                _ = await (home, today)
             }
         }
+    }
+
+    private var dashboardSections: [HomeDashboardSection] {
+        guard let response = peopleDailyStore.response else {
+            return density.visibleSections(from: store.sections)
+        }
+        let topics = HomeStore.strongestTodayTopics(
+            sections: response.overviewSections,
+            authors: response.authors,
+            date: response.date,
+            timezone: response.timezone,
+            freshnessStatus: response.freshness.status,
+            isShowingCachedEdition: peopleDailyStore.isShowingCachedEdition
+        )
+        return density.visibleSections(
+            from: HomeStore.interleaveTodayTopics(topics, into: store.sections)
+        )
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -2,23 +2,27 @@
 import SwiftUI
 
 struct ScreenshotHomeView: View {
+    var density: HomeLayoutDensity = .standard
+
     @Namespace private var bookmarkTransition
 
     var body: some View {
         NavigationStack {
             ScrollView {
-                LazyVStack(spacing: 30) {
-                    ForEach(ScreenshotHomeFixtures.sections) { section in
+                LazyVStack(spacing: density.sectionSpacing) {
+                    ForEach(density.visibleSections(from: ScreenshotHomeFixtures.sections)) { section in
                         HomeDashboardSectionView(
                             section: section,
+                            density: density,
                             transitionNamespace: bookmarkTransition
                         )
                     }
                 }
-                .padding(.vertical, 10)
-                .padding(.bottom, 24)
+                .padding(.vertical, density == .compact ? 6 : 10)
+                .padding(.bottom, density == .compact ? 16 : 24)
             }
             .navigationTitle("Home")
+            .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
             .navigationDestination(for: HomeNavigationRoute.self) { route in
                 fixtureDestination(for: route)
                     .navigationTransition(
@@ -31,6 +35,10 @@ struct ScreenshotHomeView: View {
                 }
                 .listStyle(.plain)
                 .navigationTitle(route.title)
+            }
+            .navigationDestination(for: PeopleDailyRoute.self) { _ in
+                Text("Today topic")
+                    .navigationTitle("Conversations")
             }
         }
     }
@@ -102,6 +110,14 @@ private enum ScreenshotHomeFixtures {
                 progress: BookmarkProgress(position: 6, duration: 15, percent: 40)
             ),
         ]),
+        .todayTopic(todayTopic(
+            id: "agents",
+            title: "How people are reaching agents remotely",
+            summary: "Private networks and small custom apps are making agents available away from the desk.",
+            authors: ["Dan", "Ken", "Joel"],
+            favoriteCount: 4,
+            nearbyCount: 1
+        )),
         .inbox([
             bookmark(id: "inbox-1", title: "What comes after the app?", creator: "Stratechery"),
             bookmark(id: "inbox-2", title: "Designing tools for thought", creator: "Maggie Appleton"),
@@ -113,6 +129,14 @@ private enum ScreenshotHomeFixtures {
             homeItem(id: "quick-3", title: "A field guide to curiosity", creator: "Works in Progress"),
             homeItem(id: "quick-4", title: "Notes on taste", creator: "Every"),
         ]),
+        .todayTopic(todayTopic(
+            id: "open-weights",
+            title: "Open weights and access",
+            summary: "People compare who benefits when powerful models become easier to use.",
+            authors: ["Alice", "Bob", "Carol"],
+            favoriteCount: 3,
+            nearbyCount: 2
+        )),
         .recentlySaved([
             homeItem(id: "saved-1", title: "The future of personal software", creator: "Ink & Switch"),
             homeItem(id: "saved-2", title: "How great products compound", creator: "A Smart Bear"),
@@ -198,6 +222,47 @@ private enum ScreenshotHomeFixtures {
             isFinished: false,
             finishedAt: nil,
             tags: []
+        )
+    }
+
+    private static func todayTopic(
+        id: String,
+        title: String,
+        summary: String,
+        authors: [String],
+        favoriteCount: Int,
+        nearbyCount: Int
+    ) -> HomeTodayTopic {
+        let dailyAuthors = authors.map { name in
+            DailyAuthor(
+                key: name.lowercased(),
+                username: name.lowercased(),
+                name: name,
+                profileUrl: nil,
+                profileImageUrl: nil,
+                verified: nil
+            )
+        }
+        return HomeTodayTopic(
+            section: DailyOverviewSection(
+                id: id,
+                title: title,
+                summary: summary,
+                source: "GENERATED",
+                representativePostIds: [],
+                favoriteThreadUnitIds: (0..<favoriteCount).map { "favorite-\(id)-\($0)" },
+                supportingThreadUnitIds: (0..<nearbyCount).map { "nearby-\(id)-\($0)" },
+                authorKeys: dailyAuthors.map(\.key),
+                favoriteConversationCount: favoriteCount,
+                supportingConversationCount: nearbyCount,
+                latestActivityAt: "2026-07-28T12:00:00Z",
+                coverageWarnings: []
+            ),
+            authors: dailyAuthors,
+            date: "2026-07-28",
+            timezone: "America/Chicago",
+            freshnessStatus: .complete,
+            isShowingCachedEdition: false
         )
     }
 }

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -1,20 +1,12 @@
 import SwiftUI
 
-private enum PeopleDailyRoute: Hashable {
+enum PeopleDailyRoute: Hashable {
     case section(String)
 }
 
 struct PeopleDailyTodayView: View {
     let client: APIClient
-    let refreshRevision: Int
-
-    @State private var store: PeopleDailyStore
-
-    init(client: APIClient, cache: PeopleDailyCache, refreshRevision: Int) {
-        self.client = client
-        self.refreshRevision = refreshRevision
-        _store = State(initialValue: PeopleDailyStore(client: client, cache: cache))
-    }
+    let store: PeopleDailyStore
 
     var body: some View {
         NavigationStack {
@@ -43,7 +35,6 @@ struct PeopleDailyTodayView: View {
                     }
                 }
         }
-        .task(id: refreshRevision) { await store.load() }
     }
 
     @ViewBuilder
@@ -225,7 +216,7 @@ private struct PeopleDailyCoverageNotice: View {
     }
 }
 
-private struct PeopleDailySectionView: View {
+struct PeopleDailySectionView: View {
     let client: APIClient
     let sectionID: String
 
@@ -503,7 +494,7 @@ private struct DailyOverviewView: View {
     }
 }
 
-private struct DailyOverviewSectionRow: View {
+struct DailyOverviewSectionRow: View {
     let section: DailyOverviewSection
     let authors: [DailyAuthor]
 
@@ -917,7 +908,7 @@ private struct DailyThreadUnitCard: View {
     }
 }
 
-private struct DailyParticipantFacepile: View {
+struct DailyParticipantFacepile: View {
     let authors: [DailyAuthor]
     var size: CGFloat = 30
     var maximumVisible = 3

--- a/apps/ios/ZineNative/Features/Today/DailyFeedStore.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedStore.swift
@@ -14,6 +14,7 @@ final class PeopleDailyStore {
 
     private let client: APIClient
     private let cache: PeopleDailyCache
+    private var loadTask: Task<Void, Never>?
 
     init(client: APIClient, cache: PeopleDailyCache) {
         self.client = client
@@ -21,6 +22,21 @@ final class PeopleDailyStore {
     }
 
     func load() async {
+        if let loadTask {
+            await loadTask.value
+            return
+        }
+
+        let task = Task<Void, Never> { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performLoad()
+        }
+        loadTask = task
+        await task.value
+        loadTask = nil
+    }
+
+    private func performLoad() async {
         errorMessage = nil
         refreshErrorMessage = nil
 

--- a/apps/ios/ZineNative/Features/Today/TodayView.swift
+++ b/apps/ios/ZineNative/Features/Today/TodayView.swift
@@ -2,26 +2,22 @@ import SwiftUI
 
 struct TodayView: View {
     let client: APIClient
-    let cache: PeopleDailyCache
-    let refreshRevision: Int
-
-    init(
-        client: APIClient,
-        cache: PeopleDailyCache,
-        refreshRevision: Int,
-        onContentChanged _: @escaping () -> Void,
-        onExternalOpen _: @escaping (Bookmark) -> Void
-    ) {
-        self.client = client
-        self.cache = cache
-        self.refreshRevision = refreshRevision
-    }
+    let homeStore: HomeStore
+    let peopleDailyStore: PeopleDailyStore
+    let onContentChanged: () -> Void
+    let onExternalOpen: (Bookmark) -> Void
+    let onHomeItemExternalOpen: (HomeItem) -> Void
 
     var body: some View {
-        PeopleDailyTodayView(
+        HomeView(
             client: client,
-            cache: cache,
-            refreshRevision: refreshRevision
+            store: homeStore,
+            peopleDailyStore: peopleDailyStore,
+            density: .compact,
+            title: "Today",
+            onContentChanged: onContentChanged,
+            onExternalOpen: onExternalOpen,
+            onHomeItemExternalOpen: onHomeItemExternalOpen
         )
     }
 }

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -3,6 +3,45 @@ import XCTest
 @testable import ZineNative
 
 final class HomeTests: XCTestCase {
+    func testCompactHomeHidesQuickWinsCareRideAndFavesWithoutChangingStandardHome() {
+        let sections: [HomeDashboardSection] = [
+            .quickWins([makeHomeItem(id: "quick", minutes: 5)]),
+            .collection(HomeCollection(
+                collectionId: "care-ride",
+                title: "Care Ride",
+                layout: .stackRail,
+                position: 0,
+                count: 1,
+                items: [makeHomeItem(id: "care", minutes: 12)]
+            )),
+            .collection(HomeCollection(
+                collectionId: "faves",
+                title: "Faves",
+                layout: .coverRail,
+                position: 1,
+                count: 1,
+                items: [makeHomeItem(id: "favorite", minutes: 12)]
+            )),
+            .collection(HomeCollection(
+                collectionId: "ideas",
+                title: "Ideas",
+                layout: .stackRail,
+                position: 2,
+                count: 1,
+                items: [makeHomeItem(id: "idea", minutes: 12)]
+            )),
+        ]
+
+        XCTAssertEqual(
+            HomeLayoutDensity.compact.visibleSections(from: sections).map(\.id),
+            ["collection-ideas"]
+        )
+        XCTAssertEqual(
+            HomeLayoutDensity.standard.visibleSections(from: sections).map(\.id),
+            sections.map(\.id)
+        )
+    }
+
     @MainActor
     func testBuildsOrderedDashboardAndInsertsQuickWinsAfterInbox() {
         let resume = makeHomeItem(id: "resume", minutes: 30, lastOpenedAt: "2026-07-18T10:00:00Z")
@@ -211,6 +250,103 @@ final class HomeTests: XCTestCase {
         XCTAssertTrue(content.tags.isEmpty)
     }
 
+    @MainActor
+    func testSelectsOnlyTheTwoStrongestTodayTopicsInPublishedOrder() {
+        let authors = [
+            makeDailyAuthor(key: "alice"),
+            makeDailyAuthor(key: "bob"),
+            makeDailyAuthor(key: "carol"),
+        ]
+        let sections = [
+            makeDailySection(id: "strongest", authorKeys: ["alice", "bob"]),
+            makeDailySection(id: "second", authorKeys: ["carol"]),
+            makeDailySection(id: "third", authorKeys: ["alice"]),
+        ]
+
+        let topics = HomeStore.strongestTodayTopics(
+            sections: sections,
+            authors: authors,
+            date: "2026-07-28",
+            timezone: "America/Chicago",
+            freshnessStatus: .partial,
+            isShowingCachedEdition: true
+        )
+
+        XCTAssertEqual(topics.map(\.id), ["strongest", "second"])
+        XCTAssertEqual(topics[0].authors.map(\.key), ["alice", "bob"])
+        XCTAssertEqual(topics[1].authors.map(\.key), ["carol"])
+        XCTAssertEqual(topics[0].freshnessStatus, .partial)
+        XCTAssertTrue(topics[0].isShowingCachedEdition)
+    }
+
+    @MainActor
+    func testInterleavesTodayTopicsAfterJumpBackInAndFirstCollection() {
+        let topics = [makeTodayTopic(id: "one"), makeTodayTopic(id: "two")]
+        let sections: [HomeDashboardSection] = [
+            .jumpBackIn([makeHomeItem(id: "resume", minutes: 20)]),
+            .inbox([makeBookmark(index: 0)]),
+            .collection(HomeCollection(
+                collectionId: "ideas",
+                title: "Ideas",
+                layout: .stackRail,
+                position: 0,
+                count: 1,
+                items: [makeHomeItem(id: "idea", minutes: 12)]
+            )),
+            .recentlySaved([makeHomeItem(id: "recent", minutes: 10)]),
+        ]
+
+        let result = HomeStore.interleaveTodayTopics(topics, into: sections)
+
+        XCTAssertEqual(
+            result.map(\.id),
+            [
+                "jump-back-in",
+                "today-topic-one",
+                "inbox",
+                "collection-ideas",
+                "today-topic-two",
+                "recently-saved",
+            ]
+        )
+    }
+
+    @MainActor
+    func testInterleavesSecondTodayTopicAfterQuickWinsWithoutACollection() {
+        let topics = [makeTodayTopic(id: "one"), makeTodayTopic(id: "two")]
+        let sections: [HomeDashboardSection] = [
+            .jumpBackIn([makeHomeItem(id: "resume", minutes: 20)]),
+            .inbox([makeBookmark(index: 0)]),
+            .quickWins([makeHomeItem(id: "quick", minutes: 5)]),
+            .recentlySaved([makeHomeItem(id: "recent", minutes: 10)]),
+        ]
+
+        let result = HomeStore.interleaveTodayTopics(topics, into: sections)
+
+        XCTAssertEqual(
+            result.map(\.id),
+            [
+                "jump-back-in",
+                "today-topic-one",
+                "inbox",
+                "quick-wins",
+                "today-topic-two",
+                "recently-saved",
+            ]
+        )
+    }
+
+    @MainActor
+    func testLeavesHomeUnchangedWithoutTodayTopics() {
+        let sections: [HomeDashboardSection] = [
+            .inbox([makeBookmark(index: 0)]),
+        ]
+
+        let result = HomeStore.interleaveTodayTopics([], into: sections)
+
+        XCTAssertEqual(result.map(\.id), ["inbox"])
+    }
+
     func testHomeCacheKeepsOnlyFourInboxItems() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString, directoryHint: .isDirectory)
@@ -277,6 +413,45 @@ final class HomeTests: XCTestCase {
             isFinished: false,
             finishedAt: nil,
             tags: []
+        )
+    }
+
+    private func makeTodayTopic(id: String) -> HomeTodayTopic {
+        HomeTodayTopic(
+            section: makeDailySection(id: id, authorKeys: ["author-\(id)"]),
+            authors: [makeDailyAuthor(key: "author-\(id)")],
+            date: "2026-07-28",
+            timezone: "America/Chicago",
+            freshnessStatus: .complete,
+            isShowingCachedEdition: false
+        )
+    }
+
+    private func makeDailySection(id: String, authorKeys: [String]) -> DailyOverviewSection {
+        DailyOverviewSection(
+            id: id,
+            title: "Topic \(id)",
+            summary: "Summary for \(id).",
+            source: "GENERATED",
+            representativePostIds: [],
+            favoriteThreadUnitIds: ["conversation-\(id)"],
+            supportingThreadUnitIds: [],
+            authorKeys: authorKeys,
+            favoriteConversationCount: 1,
+            supportingConversationCount: 0,
+            latestActivityAt: "2026-07-28T12:00:00Z",
+            coverageWarnings: []
+        )
+    }
+
+    private func makeDailyAuthor(key: String) -> DailyAuthor {
+        DailyAuthor(
+            key: key,
+            username: key,
+            name: key.capitalized,
+            profileUrl: nil,
+            profileImageUrl: nil,
+            verified: nil
         )
     }
 }


### PR DESCRIPTION
## Summary

- restore the approved compact Home as the canonical native tab and remove the duplicate Today tab
- interleave the strongest Today topics into Home while preserving newer completion reconciliation behavior
- add the native matched card zoom transition for Home detail navigation

## Validation

- `xcodebuild test -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS\ Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908 -derivedDataPath /tmp/zine-restored-home-tests -only-testing:ZineNativeTests/HomeTests` (14 tests passed)
- `xcodebuild build -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -configuration Release -destination platform=iOS,id=00008140-001A686E0EDB001C -derivedDataPath /tmp/zine-restored-home-device -allowProvisioningUpdates`
- installed and launched `app.zine.native` on the paired iPhone
- `bun run lint`
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`