### PR TITLE
feat(ios): add content filters to list views

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -184,6 +184,7 @@ struct APIClient {
     }
 
     func listOpenedBookmarks(
+        contentType: ContentType? = nil,
         cursor: String? = nil,
         limit: Int = 30
     ) async throws -> PaginatedBookmarksResponse {
@@ -192,6 +193,9 @@ struct APIClient {
             resolvingAgainstBaseURL: false
         )!
         var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let contentType {
+            items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
+        }
         if let cursor {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }
@@ -200,6 +204,7 @@ struct APIClient {
     }
 
     func listQuickWinBookmarks(
+        contentType: ContentType? = nil,
         cursor: String? = nil,
         limit: Int = 30
     ) async throws -> PaginatedBookmarksResponse {
@@ -208,6 +213,9 @@ struct APIClient {
             resolvingAgainstBaseURL: false
         )!
         var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let contentType {
+            items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
+        }
         if let cursor {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }
@@ -217,6 +225,7 @@ struct APIClient {
 
     func listCollectionItems(
         id: String,
+        contentType: ContentType? = nil,
         cursor: String? = nil,
         limit: Int = 30
     ) async throws -> PaginatedBookmarksResponse {
@@ -225,6 +234,9 @@ struct APIClient {
             resolvingAgainstBaseURL: false
         )!
         var items = [URLQueryItem(name: "limit", value: String(limit))]
+        if let contentType {
+            items.append(URLQueryItem(name: "contentType", value: contentType.rawValue))
+        }
         if let cursor {
             items.append(URLQueryItem(name: "cursor", value: cursor))
         }

--- a/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
+++ b/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct ContentTypeFilterHeader: View {
+    let title: String
+    @Binding var selection: ContentType?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.largeTitle.weight(.bold))
+                .padding(.horizontal, 18)
+                .padding(.top, 8)
+                .padding(.bottom, 2)
+
+            ContentTypeFilterBar(selection: $selection)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(uiColor: .systemBackground))
+    }
+}
+
+struct ContentTypeFilterBar: View {
+    @Binding var selection: ContentType?
+
+    private let options: [ContentType?] = [nil, .article, .podcast, .video, .post]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            chips
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(uiColor: .systemBackground))
+        .sensoryFeedback(.selection, trigger: selection)
+        .accessibilityLabel("Content format filters")
+    }
+
+    private var chips: some View {
+        LazyHStack(spacing: 8) {
+            ForEach(options, id: \.self) { contentType in
+                ContentTypeFilterChip(
+                    title: contentType.map { "\($0.title)s" } ?? "All",
+                    systemImage: contentType?.systemImage,
+                    isSelected: selection == contentType
+                ) {
+                    selection = Self.toggledSelection(
+                        current: selection,
+                        option: contentType
+                    )
+                }
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 8)
+    }
+
+    static func toggledSelection(
+        current: ContentType?,
+        option: ContentType?
+    ) -> ContentType? {
+        current == option ? nil : option
+    }
+}
+
+private struct ContentTypeFilterChip: View {
+    let title: String
+    let systemImage: String?
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        chipButton
+            .background(Color(uiColor: .systemBackground), in: Capsule())
+            .overlay {
+                Capsule()
+                    .strokeBorder(
+                        isSelected
+                            ? Color.accentColor.opacity(0.5)
+                            : Color.secondary.opacity(0.18),
+                        lineWidth: 1
+                    )
+            }
+            .accessibilityLabel("\(title) filter")
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var chipButton: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.caption.weight(.semibold))
+                }
+
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+extension View {
+    func solidContentTypeFilterChrome() -> some View {
+        toolbarBackground(Color(uiColor: .systemBackground), for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListStore.swift
@@ -12,6 +12,7 @@ final class HomeSectionListStore {
 
     private let route: HomeSectionRoute
     private let client: APIClient
+    private var activeContentType: ContentType?
     private var removedIndices: [String: Int] = [:]
     private var pendingInboxItemIDs: Set<String> = []
 
@@ -20,14 +21,27 @@ final class HomeSectionListStore {
         self.client = client
     }
 
-    func reload() async {
+    func reload(contentType: ContentType? = nil) async {
+        let filterChanged = activeContentType != contentType
+        activeContentType = contentType
         errorMessage = nil
+
+        if filterChanged {
+            items = []
+            nextCursor = nil
+            isLoadingMore = false
+        }
+
         isLoading = items.isEmpty
-        defer { isLoading = false }
+        defer {
+            if activeContentType == contentType {
+                isLoading = false
+            }
+        }
 
         do {
-            let response = try await request()
-            guard !Task.isCancelled else { return }
+            let response = try await request(contentType: contentType)
+            guard !Task.isCancelled, activeContentType == contentType else { return }
             items = response.items
             nextCursor = response.nextCursor
             prefetchImages(in: response.items)
@@ -46,11 +60,19 @@ final class HomeSectionListStore {
         else { return }
 
         isLoadingMore = true
-        defer { isLoadingMore = false }
+        let requestedContentType = activeContentType
+        defer {
+            if activeContentType == requestedContentType {
+                isLoadingMore = false
+            }
+        }
 
         do {
-            let response = try await request(cursor: nextCursor)
-            guard !Task.isCancelled else { return }
+            let response = try await request(
+                contentType: requestedContentType,
+                cursor: nextCursor
+            )
+            guard !Task.isCancelled, activeContentType == requestedContentType else { return }
             let existingIDs = Set(items.map(\.id))
             items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
             self.nextCursor = response.nextCursor
@@ -72,7 +94,8 @@ final class HomeSectionListStore {
     }
 
     func setBookmarked(_ bookmark: Bookmark, isBookmarked: Bool) {
-        let shouldRemain = route == .inbox ? !isBookmarked : isBookmarked
+        let matchesFilter = activeContentType == nil || bookmark.contentType == activeContentType
+        let shouldRemain = (route == .inbox ? !isBookmarked : isBookmarked) && matchesFilter
         if shouldRemain {
             guard !items.contains(where: { $0.id == bookmark.id }) else { return }
             let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
@@ -136,37 +159,45 @@ final class HomeSectionListStore {
         items.insert(bookmark, at: min(index, items.endIndex))
     }
 
-    private func request(cursor: String? = nil) async throws -> PaginatedBookmarksResponse {
+    private func request(
+        contentType: ContentType?,
+        cursor: String? = nil
+    ) async throws -> PaginatedBookmarksResponse {
         switch route {
         case .jumpBackIn:
-            return try await client.listOpenedBookmarks(cursor: cursor)
+            return try await client.listOpenedBookmarks(
+                contentType: contentType,
+                cursor: cursor
+            )
         case .inbox:
-            return try await client.listInbox(query: InboxQuery(), cursor: cursor)
+            return try await client.listInbox(
+                query: InboxQuery(contentType: contentType),
+                cursor: cursor
+            )
         case .quickWins:
-            return try await client.listQuickWinBookmarks(cursor: cursor)
-        case .recentlySaved:
-            return try await client.listBookmarks(query: LibraryQuery(), cursor: cursor)
-        case .podcasts:
-            return try await client.listBookmarks(
-                query: LibraryQuery(contentType: .podcast),
+            return try await client.listQuickWinBookmarks(
+                contentType: contentType,
                 cursor: cursor
             )
-        case .articles:
+        case .recentlySaved, .podcasts, .articles, .videos:
             return try await client.listBookmarks(
-                query: LibraryQuery(contentType: .article),
-                cursor: cursor
-            )
-        case .videos:
-            return try await client.listBookmarks(
-                query: LibraryQuery(contentType: .video),
+                query: LibraryQuery(contentType: contentType),
                 cursor: cursor
             )
         case .collection(let id, _):
-            return try await client.listCollectionItems(id: id, cursor: cursor)
+            return try await client.listCollectionItems(
+                id: id,
+                contentType: contentType,
+                cursor: cursor
+            )
         }
     }
 
     private func shouldKeep(_ bookmark: Bookmark) -> Bool {
+        guard activeContentType == nil || bookmark.contentType == activeContentType else {
+            return false
+        }
+
         switch route {
         case .collection:
             return bookmark.state == "BOOKMARKED"

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -7,6 +7,7 @@ struct HomeSectionListView: View {
     let onExternalOpen: (Bookmark) -> Void
 
     @State private var store: HomeSectionListStore
+    @State private var contentType: ContentType?
     @Namespace private var bookmarkTransition
 
     init(
@@ -20,12 +21,14 @@ struct HomeSectionListView: View {
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         _store = State(initialValue: HomeSectionListStore(route: route, client: client))
+        _contentType = State(initialValue: route.initialContentTypeFilter)
     }
 
     var body: some View {
         content
-            .navigationTitle(route.title)
-            .navigationBarTitleDisplayMode(.large)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .solidContentTypeFilterChrome()
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -45,8 +48,8 @@ struct HomeSectionListView: View {
                     .zoom(sourceID: bookmark.id, in: bookmarkTransition)
                 )
             }
-            .task {
-                await store.reload()
+            .task(id: contentType) {
+                await store.reload(contentType: contentType)
             }
             .alert("Couldn’t update inbox", isPresented: actionErrorBinding) {
                 Button("OK", role: .cancel) {
@@ -59,8 +62,32 @@ struct HomeSectionListView: View {
 
     @ViewBuilder
     private var content: some View {
+        VStack(spacing: 0) {
+            ContentTypeFilterHeader(title: route.title, selection: $contentType)
+
+            List {
+                resultRows
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload(contentType: contentType)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    @ViewBuilder
+    private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
             ProgressView("Loading \(route.title.lowercased())…")
+                .frame(maxWidth: .infinity, minHeight: 260)
+                .listRowSeparator(.hidden)
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("Section unavailable", systemImage: "exclamationmark.triangle")
@@ -68,17 +95,25 @@ struct HomeSectionListView: View {
                 Text(error)
             } actions: {
                 Button("Try again") {
-                    Task { await store.reload() }
+                    Task { await store.reload(contentType: contentType) }
                 }
             }
+            .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
             ContentUnavailableView(
-                "Nothing here yet",
-                systemImage: "rectangle.stack",
-                description: Text("Items for this section will appear here.")
+                contentType.map { "No \($0.title.lowercased())s" } ?? "Nothing here yet",
+                systemImage: contentType?.systemImage ?? "rectangle.stack",
+                description: Text(
+                    contentType == nil
+                        ? "Items for this section will appear here."
+                        : "Try another format or return to All."
+                )
             )
+            .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowSeparator(.hidden)
         } else {
-            List(store.items) { bookmark in
+            ForEach(store.items) { bookmark in
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
@@ -109,16 +144,6 @@ struct HomeSectionListView: View {
                 }
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)
-                }
-            }
-            .listStyle(.plain)
-            .refreshable {
-                await store.reload()
-            }
-            .overlay(alignment: .bottom) {
-                if store.isLoadingMore {
-                    ProgressView()
-                        .padding()
                 }
             }
         }

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -46,6 +46,15 @@ enum HomeSectionRoute: Hashable {
         case .collection(_, let title): title
         }
     }
+
+    var initialContentTypeFilter: ContentType? {
+        switch self {
+        case .podcasts: .podcast
+        case .articles: .article
+        case .videos: .video
+        default: nil
+        }
+    }
 }
 
 struct HomeNavigationLink<Label: View>: View {

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListStore.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListStore.swift
@@ -11,20 +11,34 @@ final class JumpBackInListStore {
     private(set) var nextCursor: String?
 
     private let client: APIClient
+    private var activeContentType: ContentType?
     private var removedIndices: [String: Int] = [:]
 
     init(client: APIClient) {
         self.client = client
     }
 
-    func reload() async {
+    func reload(contentType: ContentType? = nil) async {
+        let filterChanged = activeContentType != contentType
+        activeContentType = contentType
         errorMessage = nil
+
+        if filterChanged {
+            items = []
+            nextCursor = nil
+            isLoadingMore = false
+        }
+
         isLoading = items.isEmpty
-        defer { isLoading = false }
+        defer {
+            if activeContentType == contentType {
+                isLoading = false
+            }
+        }
 
         do {
-            let response = try await client.listOpenedBookmarks()
-            guard !Task.isCancelled else { return }
+            let response = try await client.listOpenedBookmarks(contentType: contentType)
+            guard !Task.isCancelled, activeContentType == contentType else { return }
             items = response.items
             nextCursor = response.nextCursor
             prefetchImages(in: response.items)
@@ -43,11 +57,19 @@ final class JumpBackInListStore {
         else { return }
 
         isLoadingMore = true
-        defer { isLoadingMore = false }
+        let requestedContentType = activeContentType
+        defer {
+            if activeContentType == requestedContentType {
+                isLoadingMore = false
+            }
+        }
 
         do {
-            let response = try await client.listOpenedBookmarks(cursor: nextCursor)
-            guard !Task.isCancelled else { return }
+            let response = try await client.listOpenedBookmarks(
+                contentType: requestedContentType,
+                cursor: nextCursor
+            )
+            guard !Task.isCancelled, activeContentType == requestedContentType else { return }
             let existingIDs = Set(items.map(\.id))
             items.append(contentsOf: response.items.filter { !existingIDs.contains($0.id) })
             self.nextCursor = response.nextCursor
@@ -61,7 +83,10 @@ final class JumpBackInListStore {
 
     func update(_ bookmark: Bookmark) {
         guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return }
-        if bookmark.isFinished || bookmark.state != "BOOKMARKED" {
+        if bookmark.isFinished
+            || bookmark.state != "BOOKMARKED"
+            || (activeContentType != nil && bookmark.contentType != activeContentType)
+        {
             items.remove(at: index)
         } else {
             items[index] = bookmark
@@ -70,13 +95,17 @@ final class JumpBackInListStore {
 
     func setBookmarked(_ bookmark: Bookmark, isBookmarked: Bool, phase: BookmarkChangePhase) {
         if isBookmarked {
-            guard !items.contains(where: { $0.id == bookmark.id }) else { return }
+            guard (activeContentType == nil || bookmark.contentType == activeContentType),
+                  !items.contains(where: { $0.id == bookmark.id })
+            else { return }
             let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
             items.insert(bookmark, at: index)
         } else if let index = items.firstIndex(where: { $0.id == bookmark.id }) {
             removedIndices[bookmark.id] = index
             items.remove(at: index)
-        } else if phase == .rollback {
+        } else if phase == .rollback,
+                  activeContentType == nil || bookmark.contentType == activeContentType
+        {
             let index = min(removedIndices.removeValue(forKey: bookmark.id) ?? 0, items.endIndex)
             items.insert(bookmark, at: index)
         }

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -6,6 +6,7 @@ struct JumpBackInListView: View {
     let onExternalOpen: (Bookmark) -> Void
 
     @State private var store: JumpBackInListStore
+    @State private var contentType: ContentType?
     @Namespace private var bookmarkTransition
 
     init(
@@ -21,8 +22,9 @@ struct JumpBackInListView: View {
 
     var body: some View {
         content
-            .navigationTitle("Jump Back In")
-            .navigationBarTitleDisplayMode(.large)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .solidContentTypeFilterChrome()
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -45,15 +47,39 @@ struct JumpBackInListView: View {
                     .zoom(sourceID: bookmark.id, in: bookmarkTransition)
                 )
             }
-            .task {
-                await store.reload()
+            .task(id: contentType) {
+                await store.reload(contentType: contentType)
             }
     }
 
     @ViewBuilder
     private var content: some View {
+        VStack(spacing: 0) {
+            ContentTypeFilterHeader(title: "Jump Back In", selection: $contentType)
+
+            List {
+                resultRows
+            }
+            .listStyle(.plain)
+            .refreshable {
+                await store.reload(contentType: contentType)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+
+    @ViewBuilder
+    private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
             ProgressView("Loading history…")
+                .frame(maxWidth: .infinity, minHeight: 260)
+                .listRowSeparator(.hidden)
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("History unavailable", systemImage: "exclamationmark.triangle")
@@ -61,17 +87,25 @@ struct JumpBackInListView: View {
                 Text(error)
             } actions: {
                 Button("Try again") {
-                    Task { await store.reload() }
+                    Task { await store.reload(contentType: contentType) }
                 }
             }
+            .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
             ContentUnavailableView(
-                "No opened bookmarks",
-                systemImage: "clock.arrow.circlepath",
-                description: Text("Bookmarks you open will appear here.")
+                contentType.map { "No opened \($0.title.lowercased())s" } ?? "No opened bookmarks",
+                systemImage: contentType?.systemImage ?? "clock.arrow.circlepath",
+                description: Text(
+                    contentType == nil
+                        ? "Bookmarks you open will appear here."
+                        : "Try another format or return to All."
+                )
             )
+            .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowSeparator(.hidden)
         } else {
-            List(store.items) { bookmark in
+            ForEach(store.items) { bookmark in
                 NavigationLink(value: bookmark) {
                     BookmarkRow(bookmark: bookmark)
                 }
@@ -80,16 +114,6 @@ struct JumpBackInListView: View {
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .task {
                     await store.loadMoreIfNeeded(current: bookmark)
-                }
-            }
-            .listStyle(.plain)
-            .refreshable {
-                await store.reload()
-            }
-            .overlay(alignment: .bottom) {
-                if store.isLoadingMore {
-                    ProgressView()
-                        .padding()
                 }
             }
         }

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -30,11 +30,7 @@ struct ScreenshotHomeView: View {
                     )
             }
             .navigationDestination(for: HomeSectionRoute.self) { route in
-                List(ScreenshotHomeFixtures.openedBookmarks) { bookmark in
-                    BookmarkRow(bookmark: bookmark)
-                }
-                .listStyle(.plain)
-                .navigationTitle(route.title)
+                ScreenshotHomeSectionListView(route: route)
             }
             .navigationDestination(for: PeopleDailyRoute.self) { _ in
                 Text("Today topic")
@@ -53,6 +49,39 @@ struct ScreenshotHomeView: View {
             Text(bookmark.title)
                 .navigationTitle(bookmark.title)
         }
+    }
+}
+
+private struct ScreenshotHomeSectionListView: View {
+    let route: HomeSectionRoute
+
+    @State private var contentType: ContentType?
+
+    init(route: HomeSectionRoute) {
+        self.route = route
+        _contentType = State(initialValue: route.initialContentTypeFilter)
+    }
+
+    private var bookmarks: [Bookmark] {
+        guard let contentType else { return ScreenshotHomeFixtures.openedBookmarks }
+        return ScreenshotHomeFixtures.openedBookmarks.filter { $0.contentType == contentType }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ContentTypeFilterHeader(title: route.title, selection: $contentType)
+
+            List {
+                ForEach(bookmarks) { bookmark in
+                    BookmarkRow(bookmark: bookmark)
+                }
+            }
+            .listStyle(.plain)
+        }
+        .background(Color(uiColor: .systemBackground))
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .solidContentTypeFilterChrome()
     }
 }
 

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -52,10 +52,15 @@ struct LibraryView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle(isSearchMode ? "Search" : "Library")
+                .navigationTitle(isSearchMode ? "Search" : "")
+                .navigationBarTitleDisplayMode(.inline)
+                .solidContentTypeFilterChrome()
+                .toolbar(isSearchMode ? .visible : .hidden, for: .navigationBar)
                 .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
-                        filterMenu
+                    if isSearchMode {
+                        ToolbarItem(placement: .topBarLeading) {
+                            filterMenu
+                        }
                     }
                 }
                 .navigationDestination(for: Bookmark.self) { bookmark in
@@ -92,8 +97,40 @@ struct LibraryView: View {
 
     @ViewBuilder
     private var content: some View {
+        if isSearchMode {
+            resultsList
+        } else {
+            VStack(spacing: 0) {
+                ContentTypeFilterHeader(title: "Library", selection: $contentType)
+
+                resultsList
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+
+    private var resultsList: some View {
+        List {
+            resultRows
+        }
+        .listStyle(.plain)
+        .refreshable {
+            await store.reload(query: query)
+        }
+        .overlay(alignment: .bottom) {
+            if store.isLoadingMore {
+                ProgressView()
+                    .padding()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
             ProgressView("Loading library…")
+                .frame(maxWidth: .infinity, minHeight: 260)
+                .listRowSeparator(.hidden)
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("Library unavailable", systemImage: "exclamationmark.triangle")
@@ -104,63 +141,72 @@ struct LibraryView: View {
                     Task { await store.reload(query: query) }
                 }
             }
+            .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
-            if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                ContentUnavailableView(
-                    "Search your library",
-                    systemImage: "magnifyingglass",
-                    description: Text("Find saved items by title or creator.")
-                )
-            } else if isSearchMode {
-                ContentUnavailableView.search(text: search)
-            } else {
-                ContentUnavailableView(
-                    "No bookmarks",
-                    systemImage: "bookmark",
-                    description: Text("Items you bookmark from Inbox will appear here.")
-                )
-            }
-        } else {
-            List(store.items) { bookmark in
-                NavigationLink(value: bookmark) {
-                    BookmarkRow(bookmark: bookmark)
-                }
-                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+            emptyState
+                .frame(maxWidth: .infinity, minHeight: 320)
                 .listRowSeparator(.hidden)
-                .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                    if !bookmark.isFinished {
-                        Button {
-                            Task { await store.complete(bookmark) }
-                        } label: {
-                            Label("Complete", systemImage: "checkmark.circle.fill")
-                        }
-                        .tint(.green)
-                        .accessibilityLabel("Complete bookmark")
-                    }
-                }
-                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    Button(role: .destructive) {
-                        Task { await store.archive(bookmark) }
-                    } label: {
-                        Label("Archive", systemImage: "archivebox.fill")
-                    }
-                    .tint(.red)
-                    .accessibilityLabel("Archive bookmark")
-                }
-                .task {
-                    await store.loadMoreIfNeeded(current: bookmark)
-                }
+        } else {
+            ForEach(store.items) { bookmark in
+                bookmarkRow(bookmark)
             }
-            .listStyle(.plain)
-            .refreshable {
-                await store.reload(query: query)
-            }
-            .overlay(alignment: .bottom) {
-                if store.isLoadingMore {
-                    ProgressView()
-                        .padding()
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            ContentUnavailableView(
+                "Search your library",
+                systemImage: "magnifyingglass",
+                description: Text("Find saved items by title or creator.")
+            )
+        } else if isSearchMode {
+            ContentUnavailableView.search(text: search)
+        } else if let contentType {
+            ContentUnavailableView(
+                "No \(contentType.title.lowercased())s",
+                systemImage: contentType.systemImage,
+                description: Text("Try another format or return to All.")
+            )
+        } else {
+            ContentUnavailableView(
+                "No bookmarks",
+                systemImage: "bookmark",
+                description: Text("Items you bookmark from Inbox will appear here.")
+            )
+        }
+    }
+
+    private func bookmarkRow(_ bookmark: Bookmark) -> some View {
+        NavigationLink(value: bookmark) {
+            BookmarkRow(bookmark: bookmark)
+        }
+        .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+        .listRowSeparator(.hidden)
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            if !bookmark.isFinished {
+                Button {
+                    Task { await store.complete(bookmark) }
+                } label: {
+                    Label("Complete", systemImage: "checkmark.circle.fill")
                 }
+                .tint(.green)
+                .accessibilityLabel("Complete bookmark")
             }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                Task { await store.archive(bookmark) }
+            } label: {
+                Label("Archive", systemImage: "archivebox.fill")
+            }
+            .tint(.red)
+            .accessibilityLabel("Archive bookmark")
+        }
+        .task {
+            await store.loadMoreIfNeeded(current: bookmark)
         }
     }
 

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -6,26 +6,33 @@ struct ScreenshotLibraryView: View {
         baseURL: URL(string: "https://example.invalid")!,
         tokenProvider: { "screenshot-fixture" }
     )
+    @State private var contentType: ContentType?
+
+    private var bookmarks: [Bookmark] {
+        guard let contentType else { return ScreenshotFixtures.bookmarks }
+        return ScreenshotFixtures.bookmarks.filter { $0.contentType == contentType }
+    }
 
     var body: some View {
         NavigationStack {
-            List(ScreenshotFixtures.bookmarks) { bookmark in
-                NavigationLink(value: bookmark) {
-                    BookmarkRow(bookmark: bookmark)
-                }
-                .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
-                .listRowSeparator(.hidden)
-            }
-            .listStyle(.plain)
-            .navigationTitle("Library")
-            .searchable(text: .constant(""), prompt: "Search your library")
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {} label: {
-                        Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+            VStack(spacing: 0) {
+                ContentTypeFilterHeader(title: "Library", selection: $contentType)
+
+                List {
+                    ForEach(bookmarks) { bookmark in
+                        NavigationLink(value: bookmark) {
+                            BookmarkRow(bookmark: bookmark)
+                        }
+                        .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                        .listRowSeparator(.hidden)
                     }
                 }
+                .listStyle(.plain)
             }
+            .background(Color(uiColor: .systemBackground))
+            .navigationTitle("")
+            .solidContentTypeFilterChrome()
+            .toolbar(.hidden, for: .navigationBar)
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(bookmark: bookmark, client: client) { _ in }
             }

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -237,6 +237,28 @@ final class HomeTests: XCTestCase {
         )
     }
 
+    func testContentSpecificHomeListsStartWithTheirMatchingFormatSelected() {
+        XCTAssertEqual(HomeSectionRoute.podcasts.initialContentTypeFilter, .podcast)
+        XCTAssertEqual(HomeSectionRoute.articles.initialContentTypeFilter, .article)
+        XCTAssertEqual(HomeSectionRoute.videos.initialContentTypeFilter, .video)
+        XCTAssertNil(HomeSectionRoute.jumpBackIn.initialContentTypeFilter)
+        XCTAssertNil(HomeSectionRoute.quickWins.initialContentTypeFilter)
+        XCTAssertNil(HomeSectionRoute.collection(id: "collection-1", title: "Ideas").initialContentTypeFilter)
+    }
+
+    func testContentTypeChipSelectionCanChangeOrReturnToAll() {
+        XCTAssertEqual(
+            ContentTypeFilterBar.toggledSelection(current: .article, option: .podcast),
+            .podcast
+        )
+        XCTAssertNil(
+            ContentTypeFilterBar.toggledSelection(current: .article, option: .article)
+        )
+        XCTAssertNil(
+            ContentTypeFilterBar.toggledSelection(current: nil, option: nil)
+        )
+    }
+
     func testHomeItemProvidesImmediateBookmarkDetailContent() {
         let item = makeHomeItem(id: "instant", minutes: 12)
         let content = BookmarkDetailContent(item: item)

--- a/apps/worker/src/routes/api-v1.openapi.json
+++ b/apps/worker/src/routes/api-v1.openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Zine REST API",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "description": "REST API for reading and managing the Zine home dashboard, inbox items, bookmarks, creators, tags, article content, progress, subscriptions across supported sources, and sync jobs. Requests may authenticate with a Clerk session token or a scoped Zine personal access token."
   },
   "servers": [
@@ -452,13 +452,14 @@
         "tags": ["Bookmarks"],
         "operationId": "listOpenedBookmarks",
         "summary": "List opened bookmarks",
-        "description": "Returns unfinished bookmarked items the user has opened, sorted by most recently opened first.",
+        "description": "Returns unfinished bookmarked items the user has opened, optionally filtered by content type and sorted by most recently opened first.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "current",
         "parameters": [
           { "$ref": "#/components/parameters/Limit" },
-          { "$ref": "#/components/parameters/Cursor" }
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/ContentType" }
         ],
         "responses": {
           "200": {
@@ -479,13 +480,14 @@
         "tags": ["Bookmarks"],
         "operationId": "listQuickWinBookmarks",
         "summary": "List quick-win bookmarks",
-        "description": "Returns unfinished bookmarks that take ten minutes or less, sorted by most recently saved first.",
+        "description": "Returns unfinished bookmarks that take ten minutes or less, optionally filtered by content type and sorted by most recently saved first.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "current",
         "parameters": [
           { "$ref": "#/components/parameters/Limit" },
-          { "$ref": "#/components/parameters/Cursor" }
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/ContentType" }
         ],
         "responses": {
           "200": {
@@ -506,7 +508,7 @@
         "tags": ["Bookmarks"],
         "operationId": "listCollectionItems",
         "summary": "List collection items",
-        "description": "Returns all bookmarks in a custom collection using the collection's configured sort order.",
+        "description": "Returns bookmarks in a custom collection, optionally filtered by content type, using the collection's configured sort order.",
         "security": [{ "bearerAuth": [] }],
         "x-required-scopes": ["bookmarks:read"],
         "x-api-status": "current",
@@ -518,7 +520,8 @@
             "schema": { "type": "string" }
           },
           { "$ref": "#/components/parameters/Limit" },
-          { "$ref": "#/components/parameters/Cursor" }
+          { "$ref": "#/components/parameters/Cursor" },
+          { "$ref": "#/components/parameters/ContentType" }
         ],
         "responses": {
           "200": {

--- a/apps/worker/src/routes/api-v1.test.ts
+++ b/apps/worker/src/routes/api-v1.test.ts
@@ -2237,9 +2237,12 @@ describe('apiV1Routes', () => {
     const app = createTestApp();
 
     const res = await app.fetch(
-      new Request('http://localhost/api/v1/bookmarks/opened?limit=20&cursor=opened-cursor', {
-        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
-      }),
+      new Request(
+        'http://localhost/api/v1/bookmarks/opened?limit=20&cursor=opened-cursor&contentType=ARTICLE',
+        {
+          headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+        }
+      ),
       createMockEnv()
     );
 
@@ -2247,6 +2250,7 @@ describe('apiV1Routes', () => {
     expect(mockRecentlyOpened).toHaveBeenCalledWith({
       limit: 20,
       cursor: 'opened-cursor',
+      filter: { contentType: ContentType.ARTICLE },
     });
     expect((await res.json()) as JsonBody).toMatchObject({
       items: [{ title: 'Opened bookmark' }],
@@ -2262,9 +2266,12 @@ describe('apiV1Routes', () => {
     const app = createTestApp();
 
     const res = await app.fetch(
-      new Request('http://localhost/api/v1/bookmarks/quick-wins?limit=20&cursor=quick-cursor', {
-        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
-      }),
+      new Request(
+        'http://localhost/api/v1/bookmarks/quick-wins?limit=20&cursor=quick-cursor&contentType=PODCAST',
+        {
+          headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+        }
+      ),
       createMockEnv()
     );
 
@@ -2272,6 +2279,7 @@ describe('apiV1Routes', () => {
     expect(mockQuickWins).toHaveBeenCalledWith({
       limit: 20,
       cursor: 'quick-cursor',
+      filter: { contentType: ContentType.PODCAST },
     });
     expect((await res.json()) as JsonBody).toMatchObject({
       items: [{ title: 'Quick bookmark' }],
@@ -2288,7 +2296,7 @@ describe('apiV1Routes', () => {
 
     const res = await app.fetch(
       new Request(
-        'http://localhost/api/v1/collections/collection_1/items?limit=20&cursor=collection-cursor',
+        'http://localhost/api/v1/collections/collection_1/items?limit=20&cursor=collection-cursor&contentType=VIDEO',
         {
           headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
         }
@@ -2301,6 +2309,7 @@ describe('apiV1Routes', () => {
       id: 'collection_1',
       limit: 20,
       cursor: 'collection-cursor',
+      filter: { contentType: ContentType.VIDEO },
     });
     expect((await res.json()) as JsonBody).toMatchObject({
       items: [{ title: 'Collected bookmark' }],
@@ -2323,6 +2332,23 @@ describe('apiV1Routes', () => {
       code: 'INVALID_QUERY_PARAMETERS',
     });
     expect(mockLibrary).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid content-type filters on specialized bookmark lists', async () => {
+    const app = createTestApp();
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/v1/bookmarks/opened?contentType=BOOK', {
+        headers: { Authorization: `Bearer ${READ_WRITE_TOKEN}` },
+      }),
+      createMockEnv()
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as JsonBody).toMatchObject({
+      code: 'INVALID_QUERY_PARAMETERS',
+    });
+    expect(mockRecentlyOpened).not.toHaveBeenCalled();
   });
 
   it('moves an inbox item to bookmarks', async () => {

--- a/apps/worker/src/routes/api-v1.ts
+++ b/apps/worker/src/routes/api-v1.ts
@@ -1729,11 +1729,29 @@ apiV1Routes.get('/bookmarks', apiAuth('bookmarks:read'), async (c) => {
 });
 
 apiV1Routes.get('/bookmarks/opened', apiAuth('bookmarks:read'), async (c) => {
+  const parsedQuery = BookmarkQuerySchema.safeParse({
+    contentType: c.req.query('contentType'),
+  });
+
+  if (!parsedQuery.success) {
+    return c.json(
+      {
+        error: 'Invalid query parameters',
+        code: 'INVALID_QUERY_PARAMETERS',
+        issues: parsedQuery.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
   const caller = appRouter.createCaller(await createContext(c));
   const cursor = c.req.query('cursor');
   const result = await caller.items.recentlyOpened({
     limit: parseLimit(c.req.query('limit')),
     cursor: cursor && cursor.length > 0 ? cursor : undefined,
+    filter: { contentType: parsedQuery.data.contentType },
   });
 
   return c.json({
@@ -1745,11 +1763,29 @@ apiV1Routes.get('/bookmarks/opened', apiAuth('bookmarks:read'), async (c) => {
 });
 
 apiV1Routes.get('/bookmarks/quick-wins', apiAuth('bookmarks:read'), async (c) => {
+  const parsedQuery = BookmarkQuerySchema.safeParse({
+    contentType: c.req.query('contentType'),
+  });
+
+  if (!parsedQuery.success) {
+    return c.json(
+      {
+        error: 'Invalid query parameters',
+        code: 'INVALID_QUERY_PARAMETERS',
+        issues: parsedQuery.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
   const caller = appRouter.createCaller(await createContext(c));
   const cursor = c.req.query('cursor');
   const result = await caller.items.quickWins({
     limit: parseLimit(c.req.query('limit')),
     cursor: cursor && cursor.length > 0 ? cursor : undefined,
+    filter: { contentType: parsedQuery.data.contentType },
   });
 
   return c.json({
@@ -1761,12 +1797,30 @@ apiV1Routes.get('/bookmarks/quick-wins', apiAuth('bookmarks:read'), async (c) =>
 });
 
 apiV1Routes.get('/collections/:id/items', apiAuth('bookmarks:read'), async (c) => {
+  const parsedQuery = BookmarkQuerySchema.safeParse({
+    contentType: c.req.query('contentType'),
+  });
+
+  if (!parsedQuery.success) {
+    return c.json(
+      {
+        error: 'Invalid query parameters',
+        code: 'INVALID_QUERY_PARAMETERS',
+        issues: parsedQuery.error.issues,
+        requestId: c.get('requestId'),
+        traceId: c.get('traceId'),
+      },
+      400
+    );
+  }
+
   const caller = appRouter.createCaller(await createContext(c));
   const cursor = c.req.query('cursor');
   const result = await caller.collections.items({
     id: c.req.param('id'),
     limit: parseLimit(c.req.query('limit')),
     cursor: cursor && cursor.length > 0 ? cursor : undefined,
+    filter: { contentType: parsedQuery.data.contentType },
   });
 
   return c.json({

--- a/apps/worker/src/trpc/routers/collections.ts
+++ b/apps/worker/src/trpc/routers/collections.ts
@@ -9,6 +9,7 @@ import {
   CollectionRulesSchema,
   CollectionSort,
   CollectionSortSchema,
+  ContentTypeSchema,
   HomeCollectionLayout,
   HomeCollectionLayoutSchema,
   UserItemState,
@@ -518,6 +519,11 @@ export const collectionsRouter = router({
         id: z.string().min(1),
         cursor: z.string().optional(),
         limit: z.number().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+        filter: z
+          .object({
+            contentType: ContentTypeSchema.nullish(),
+          })
+          .optional(),
       })
     )
     .query(async ({ input, ctx }) => {
@@ -548,6 +554,9 @@ export const collectionsRouter = router({
         eq(userItems.state, UserItemState.BOOKMARKED),
         membershipCondition,
       ];
+      if (input.filter?.contentType) {
+        conditions.push(eq(items.contentType, input.filter.contentType));
+      }
       if (cursorCondition) {
         conditions.push(cursorCondition);
       }

--- a/apps/worker/src/trpc/routers/items.ts
+++ b/apps/worker/src/trpc/routers/items.ts
@@ -657,6 +657,14 @@ const PaginationSchema = z.object({
   limit: z.number().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
 });
 
+const ContentTypePaginationSchema = PaginationSchema.pick({ cursor: true, limit: true }).extend({
+  filter: z
+    .object({
+      contentType: ContentTypeSchema.nullish(),
+    })
+    .optional(),
+});
+
 const HomeInputSchema = z
   .object({
     filter: z
@@ -849,7 +857,7 @@ export const itemsRouter = router({
    * Uses cursor-based pagination sorted by lastOpenedAt DESC.
    */
   recentlyOpened: protectedProcedure
-    .input(PaginationSchema.pick({ cursor: true, limit: true }).optional())
+    .input(ContentTypePaginationSchema.optional())
     .query(async ({ input, ctx }) => {
       const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
       const cursor = input?.cursor ? decodeCursor(input.cursor) : null;
@@ -859,6 +867,10 @@ export const itemsRouter = router({
         eq(userItems.isFinished, false),
         isNotNull(userItems.lastOpenedAt),
       ];
+
+      if (input?.filter?.contentType) {
+        conditions.push(eq(items.contentType, input.filter.contentType));
+      }
 
       if (cursor) {
         conditions.push(
@@ -901,7 +913,7 @@ export const itemsRouter = router({
    * Get unfinished bookmarks that take ten minutes or less, newest save first.
    */
   quickWins: protectedProcedure
-    .input(PaginationSchema.pick({ cursor: true, limit: true }).optional())
+    .input(ContentTypePaginationSchema.optional())
     .query(async ({ input, ctx }) => {
       const limit = input?.limit ?? DEFAULT_PAGE_SIZE;
       const cursor = input?.cursor ? decodeCursor(input.cursor) : null;
@@ -915,6 +927,10 @@ export const itemsRouter = router({
           and(gt(items.duration, 0), lte(items.duration, 10 * 60))
         )!,
       ];
+
+      if (input?.filter?.contentType) {
+        conditions.push(eq(items.contentType, input.filter.contentType));
+      }
 
       if (cursor) {
         conditions.push(


### PR DESCRIPTION
## Summary

- add a shared solid adaptive content-type header to Library and every Home-driven list destination while preserving the large title
- reload and paginate native list stores by content type, including matching defaults for article, podcast, and video sections
- extend specialized REST and collection endpoints with validated content-type filters and update OpenAPI coverage
- keep the Library toolbar filter limited to Search mode

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E886C70-B90D-42EB-B38F-588E2DFAB16A" test`
- visually verified Library and Home list fixtures in light and dark appearances
- signed Release build installed on the physical iPhone; foreground launch was not verified because the phone was locked