### PR TITLE
feat(ios): adopt cool editorial color palette

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,11 @@
 ## Design System Workflow
 
 - New mobile UI belongs in `apps/ios` and should follow the existing native SwiftUI component, navigation, typography, color, accessibility, and state-management patterns there.
+- Before changing native iOS UI, read `apps/ios/DESIGN_SYSTEM.md`. Treat its palette and `apps/ios/ZineNative/Core/ZineTheme.swift` as the native color contract.
+- In supported native views, use `ZineTheme` semantic roles instead of raw hex/RGB values or direct `Color.primary`/`Color.secondary` styling. Add a semantic role, both light and dark values, and focused resolution tests when an established role cannot express the design.
+- Keep Zine orange (`#EF661F`) restrained to selection, primary actions, progress, links, and small brand moments. Keep cards and long-form reading surfaces neutral, and preserve the Zine logo exactly.
+- Verify material native color changes in both light and dark mode across the affected screen states. Changes to saved-content or reading UI must include Library, bookmark detail, and article-reader verification where applicable.
+- Content artwork, provider branding, contrast-driven media overlays, semantic status feedback, and third-party account UI may retain their established colors; keep these exceptions local and do not use them as alternate app palette logic.
 - The Expo-specific guidance below applies only to explicitly requested legacy `apps/mobile` work.
 
 - When editing deprecated Expo shared mobile UI, read:

--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -1,0 +1,71 @@
+# Zine Native Design System
+
+This document defines the visual foundation for the canonical native iOS app in
+`apps/ios`. The supported implementation is the semantic theme in
+`ZineNative/Core/ZineTheme.swift`; update that implementation and its focused
+tests whenever this contract changes.
+
+## Color palette
+
+Zine uses a cool, editorial palette with one restrained orange brand accent.
+Views consume semantic roles rather than choosing colors directly so that the
+same hierarchy works in light and dark appearances.
+
+| Role           | Light     | Dark      | Intended use                                                  |
+| -------------- | --------- | --------- | ------------------------------------------------------------- |
+| Canvas         | `#F5F7F8` | `#000000` | Screen backgrounds and navigation chrome                      |
+| Surface        | `#FFFFFF` | `#14171A` | Cards, sheets, reader surfaces, and tab chrome                |
+| Raised         | `#E9EDF0` | `#20252A` | Placeholders, subdued controls, and elevated regions          |
+| Primary text   | `#151719` | `#F5F7F8` | Titles, body copy, and primary icons                          |
+| Secondary text | `#5D646C` | `#B2BAC2` | Metadata, supporting copy, and inactive controls              |
+| Border         | `#CFD4DA` | `#343A40` | Dividers, outlines, and control boundaries                    |
+| Brand accent   | `#EF661F` | `#EF661F` | Selection, primary actions, progress, and small brand moments |
+| On accent      | `#000000` | `#000000` | Text and icons placed directly on the brand accent            |
+| Inline link    | `#B64012` | `#FFAD7C` | Links in reading and content surfaces                         |
+
+The Zine logo is a fixed brand asset and must not be recolored or redrawn when
+the surrounding theme changes.
+
+## Implementation rules
+
+- Use `ZineTheme.canvas`, `surface`, `raised`, `primaryText`, `secondaryText`,
+  `border`, `brandAccent`, `onAccent`, and `inlineLink` in SwiftUI views. Use
+  `ZineTheme.tertiaryText` for de-emphasized metadata.
+- Use `zineAppTheme()` at an app-level container and `zineScreenChrome()` for
+  list-style screens when those modifiers fit the view structure.
+- Do not scatter raw hex, RGB, `Color.primary`, or `Color.secondary` values
+  through supported native views. If the product needs a new reusable role,
+  add it to `ZineTheme.Role`, define both appearances, and update
+  `ZineThemeTests`.
+- Keep orange restrained. It is for selection, actions, progress, links, and
+  small brand moments—not card backgrounds, large decorative regions, or
+  long-form reading surfaces.
+- Keep the reading hierarchy neutral: body content uses surface and text roles,
+  while links and narrow annotations may use the accent roles.
+- Check both light and dark appearances. Preserve Dynamic Type, system control
+  behavior, sufficient contrast, and non-color indicators for meaningful
+  state.
+
+## Intentional exceptions
+
+Colors outside `ZineTheme` are acceptable when their meaning belongs to the
+content or another established system rather than Zine's interface. Examples
+include remote artwork, provider logos and provider-specific buttons, media
+overlays that require black or white for contrast, and semantic success,
+warning, or destructive feedback. Keep these exceptions local and do not use
+them to create parallel app chrome or palette logic.
+
+Third-party account UI may inherit its SDK or system appearance. Zine-owned
+containers around it should still use the semantic palette where possible.
+
+## Verification
+
+When changing a semantic role or applying the palette to a new screen:
+
+1. Update or extend `ZineNativeTests/ZineThemeTests.swift` when token resolution
+   changes.
+2. Build and run the `ZineNative` scheme.
+3. Inspect representative content, loading, empty, error, and selected states in
+   both light and dark mode.
+4. For changes that affect reading or saved content, verify Library, bookmark
+   detail, and the article reader rather than checking navigation chrome alone.

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -26,6 +26,13 @@ iOS 18 or newer simulator or device.
 
 All new iOS product work, verification, and deployment belongs in this project.
 
+## Design system
+
+The native color palette, semantic roles, usage rules, exceptions, and
+verification expectations are documented in [`DESIGN_SYSTEM.md`](DESIGN_SYSTEM.md).
+Use `ZineNative/Core/ZineTheme.swift` rather than introducing view-local palette
+values.
+
 ## Share extension
 
 The `ZineShareExtension` target appears as Zine in the iOS share sheet for web

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -81,7 +81,7 @@ private struct AuthenticatedAppView: View {
                     onExternalOpen: handleExternalOpen,
                     onHomeItemExternalOpen: handleHomeItemExternalOpen
                 )
-                .tint(Color.accentColor)
+                .tint(ZineTheme.brandAccent)
             }
 
             Tab("Library", systemImage: "books.vertical") {
@@ -92,12 +92,12 @@ private struct AuthenticatedAppView: View {
                     onContentChanged: markHomeChanged,
                     onExternalOpen: handleExternalOpen
                 )
-                .tint(Color.accentColor)
+                .tint(ZineTheme.brandAccent)
             }
 
             Tab("Settings", systemImage: "gearshape") {
                 AppSettingsView(client: client)
-                    .tint(Color.accentColor)
+                    .tint(ZineTheme.brandAccent)
             }
 
             Tab(role: .search) {
@@ -110,10 +110,11 @@ private struct AuthenticatedAppView: View {
                     onExternalOpen: handleExternalOpen
                 )
                 .searchable(text: $search, prompt: "Search your library")
-                .tint(Color.accentColor)
+                .tint(ZineTheme.brandAccent)
             }
         }
-        .tint(Color.primary)
+        .tint(ZineTheme.brandAccent)
+        .background(ZineTheme.canvas)
         .task(id: homeRevision) {
             async let home: Void = homeStore.reload()
             async let today: Void = peopleDailyStore.load()

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -41,6 +41,7 @@ struct ZineNativeApp: App {
     @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
 
     init() {
+        ZineTheme.configureUIKitAppearance()
         if configuration.isClerkConfigured {
             Clerk.configure(publishableKey: configuration.clerkPublishableKey)
         }
@@ -50,11 +51,20 @@ struct ZineNativeApp: App {
         WindowGroup {
             rootView
                 .preferredColorScheme(appearance.colorScheme)
+                .zineAppTheme()
         }
     }
 
     private var appearance: AppAppearance {
-        AppAppearance(rawValue: storedAppearance) ?? .system
+#if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-light-mode") {
+            return .light
+        }
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-dark-mode") {
+            return .dark
+        }
+#endif
+        return AppAppearance(rawValue: storedAppearance) ?? .system
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
+++ b/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
@@ -15,7 +15,7 @@ struct ContentTypeFilterHeader: View {
             ContentTypeFilterBar(selection: $selection)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(uiColor: .systemBackground))
+        .background(ZineTheme.canvas)
     }
 }
 
@@ -30,7 +30,7 @@ struct ContentTypeFilterBar: View {
         }
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(uiColor: .systemBackground))
+        .background(ZineTheme.canvas)
         .sensoryFeedback(.selection, trigger: selection)
         .accessibilityLabel("Content format filters")
     }
@@ -70,13 +70,13 @@ private struct ContentTypeFilterChip: View {
 
     var body: some View {
         chipButton
-            .background(Color(uiColor: .systemBackground), in: Capsule())
+            .background(isSelected ? ZineTheme.brandAccent : ZineTheme.surface, in: Capsule())
             .overlay {
                 Capsule()
                     .strokeBorder(
                         isSelected
-                            ? Color.accentColor.opacity(0.5)
-                            : Color.secondary.opacity(0.18),
+                            ? ZineTheme.brandAccent
+                            : ZineTheme.border,
                         lineWidth: 1
                     )
             }
@@ -95,7 +95,7 @@ private struct ContentTypeFilterChip: View {
                 Text(title)
                     .font(.subheadline.weight(.semibold))
             }
-            .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+            .foregroundStyle(isSelected ? ZineTheme.onAccent : ZineTheme.secondaryText)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .contentShape(Capsule())
@@ -106,7 +106,7 @@ private struct ContentTypeFilterChip: View {
 
 extension View {
     func solidContentTypeFilterChrome() -> some View {
-        toolbarBackground(Color(uiColor: .systemBackground), for: .navigationBar)
+        toolbarBackground(ZineTheme.canvas, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
     }
 }

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import UIKit
+
+enum ZineTheme {
+    enum Role: CaseIterable, Hashable {
+        case canvas
+        case surface
+        case raised
+        case primaryText
+        case secondaryText
+        case border
+        case brandAccent
+        case onAccent
+        case inlineLink
+
+        var lightHex: String {
+            switch self {
+            case .canvas: "F5F7F8"
+            case .surface: "FFFFFF"
+            case .raised: "E9EDF0"
+            case .primaryText: "151719"
+            case .secondaryText: "5D646C"
+            case .border: "CFD4DA"
+            case .brandAccent: "EF661F"
+            case .onAccent: "000000"
+            case .inlineLink: "B64012"
+            }
+        }
+
+        var darkHex: String {
+            switch self {
+            case .canvas: "000000"
+            case .surface: "14171A"
+            case .raised: "20252A"
+            case .primaryText: "F5F7F8"
+            case .secondaryText: "B2BAC2"
+            case .border: "343A40"
+            case .brandAccent: "EF661F"
+            case .onAccent: "000000"
+            case .inlineLink: "FFAD7C"
+            }
+        }
+    }
+
+    static let canvas = color(.canvas)
+    static let surface = color(.surface)
+    static let raised = color(.raised)
+    static let primaryText = color(.primaryText)
+    static let secondaryText = color(.secondaryText)
+    static let border = color(.border)
+    static let brandAccent = color(.brandAccent)
+    static let onAccent = color(.onAccent)
+    static let inlineLink = color(.inlineLink)
+    static let tertiaryText = secondaryText.opacity(0.72)
+
+    static func color(_ role: Role) -> Color {
+        Color(uiColor: uiColor(role))
+    }
+
+    static func uiColor(_ role: Role) -> UIColor {
+        UIColor { traits in
+            resolvedUIColor(role, interfaceStyle: traits.userInterfaceStyle)
+        }
+    }
+
+    static func resolvedUIColor(
+        _ role: Role,
+        interfaceStyle: UIUserInterfaceStyle
+    ) -> UIColor {
+        UIColor(zineHex: interfaceStyle == .dark ? role.darkHex : role.lightHex)
+    }
+
+    @MainActor
+    static func configureUIKitAppearance() {
+        let navigationAppearance = UINavigationBarAppearance()
+        navigationAppearance.configureWithOpaqueBackground()
+        navigationAppearance.backgroundColor = uiColor(.canvas)
+        navigationAppearance.shadowColor = uiColor(.border)
+        navigationAppearance.titleTextAttributes = [.foregroundColor: uiColor(.primaryText)]
+        navigationAppearance.largeTitleTextAttributes = [.foregroundColor: uiColor(.primaryText)]
+        UINavigationBar.appearance().standardAppearance = navigationAppearance
+        UINavigationBar.appearance().scrollEdgeAppearance = navigationAppearance
+        UINavigationBar.appearance().compactAppearance = navigationAppearance
+        UINavigationBar.appearance().tintColor = uiColor(.brandAccent)
+
+        let tabAppearance = UITabBarAppearance()
+        tabAppearance.configureWithOpaqueBackground()
+        tabAppearance.backgroundColor = uiColor(.surface)
+        tabAppearance.shadowColor = uiColor(.border)
+        configure(
+            tabAppearance.stackedLayoutAppearance,
+            normal: uiColor(.secondaryText),
+            selected: uiColor(.brandAccent)
+        )
+        configure(
+            tabAppearance.inlineLayoutAppearance,
+            normal: uiColor(.secondaryText),
+            selected: uiColor(.brandAccent)
+        )
+        configure(
+            tabAppearance.compactInlineLayoutAppearance,
+            normal: uiColor(.secondaryText),
+            selected: uiColor(.brandAccent)
+        )
+        UITabBar.appearance().standardAppearance = tabAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+
+        UIRefreshControl.appearance().tintColor = uiColor(.brandAccent)
+        UIPageControl.appearance().currentPageIndicatorTintColor = uiColor(.brandAccent)
+        UIPageControl.appearance().pageIndicatorTintColor = uiColor(.secondaryText).withAlphaComponent(0.3)
+    }
+
+    @MainActor
+    private static func configure(
+        _ appearance: UITabBarItemAppearance,
+        normal: UIColor,
+        selected: UIColor
+    ) {
+        appearance.normal.iconColor = normal
+        appearance.normal.titleTextAttributes = [.foregroundColor: normal]
+        appearance.selected.iconColor = selected
+        appearance.selected.titleTextAttributes = [.foregroundColor: selected]
+    }
+}
+
+private extension UIColor {
+    convenience init(zineHex hex: String) {
+        let value = UInt64(hex, radix: 16) ?? 0
+        self.init(
+            red: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}
+
+extension View {
+    func zineAppTheme() -> some View {
+        foregroundStyle(ZineTheme.primaryText)
+            .tint(ZineTheme.brandAccent)
+            .background(ZineTheme.canvas.ignoresSafeArea())
+    }
+
+    func zineScreenChrome() -> some View {
+        scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .foregroundStyle(ZineTheme.primaryText)
+            .tint(ZineTheme.brandAccent)
+            .toolbarBackground(ZineTheme.canvas, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+    }
+}

--- a/apps/ios/ZineNative/Features/Creators/CreatorView.swift
+++ b/apps/ios/ZineNative/Features/Creators/CreatorView.swift
@@ -74,14 +74,14 @@ struct CreatorView: View {
                 if let handle = store.profile?.handle, !handle.isEmpty {
                     Text(handle)
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
             }
 
             if let description = store.profile?.description, !description.isEmpty {
                 Text(description)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .multilineTextAlignment(.center)
                     .lineLimit(5)
             }
@@ -104,7 +104,7 @@ struct CreatorView: View {
             if let error = store.profileErrorMessage {
                 Text("Some profile details couldn’t be loaded. \(error)")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .multilineTextAlignment(.center)
             }
         }
@@ -213,7 +213,7 @@ struct CreatorView: View {
                     .font(.headline)
                 Text("\(bookmarks.count)")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
 
             if isLoading && bookmarks.isEmpty {
@@ -223,7 +223,7 @@ struct CreatorView: View {
             } else if bookmarks.isEmpty {
                 Text(emptyMessage)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .padding(.vertical, 8)
             } else {
                 bookmarkRows(bookmarks, isCompleted: isCompleted)
@@ -319,11 +319,11 @@ struct CreatorView: View {
             Text(title).font(.subheadline.weight(.semibold))
             Text(message)
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 12))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 12))
     }
 
     private func creatorContentRow(
@@ -339,9 +339,9 @@ struct CreatorView: View {
                 targetSize: CGSize(width: 94, height: 60)
             ) {
                 ZStack {
-                    Color.secondary.opacity(0.12)
+                    ZineTheme.raised
                     Image(systemName: placeholderSystemImage)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
             }
             .frame(width: 94, height: 60)
@@ -350,18 +350,18 @@ struct CreatorView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
                     .lineLimit(2)
                 Text(metadataLabel)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(1)
             }
 
             Spacer(minLength: 0)
             Image(systemName: accessorySystemImage)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ZineTheme.tertiaryText)
         }
         .contentShape(Rectangle())
     }

--- a/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
@@ -81,9 +81,9 @@ private struct CondensedSectionHeader: View {
                     .font(.headline)
                 Image(systemName: "chevron.right")
                     .font(.caption2.weight(.bold))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
-            .foregroundStyle(.primary)
+            .foregroundStyle(ZineTheme.primaryText)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(.plain)
@@ -123,7 +123,7 @@ private struct CondensedJumpBackInSection: View {
             HStack(spacing: 7) {
                 ForEach(carouselItems.indices, id: \.self) { index in
                     Circle()
-                        .fill(index == selectedPage ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .fill(index == selectedPage ? ZineTheme.brandAccent : ZineTheme.secondaryText.opacity(0.3))
                         .frame(width: 7, height: 7)
                 }
             }
@@ -331,7 +331,7 @@ private struct CondensedItemListSection: View {
                     }
                 }
             }
-            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 13))
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 13))
         }
         .padding(.horizontal, 16)
     }
@@ -351,40 +351,40 @@ private struct CondensedTodayTopicSection: View {
                         Text("TODAY")
                             .font(.caption2.weight(.heavy))
                             .tracking(0.8)
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(ZineTheme.brandAccent)
 
                         if let statusText {
                             Text(statusText)
                                 .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                         }
                     }
 
                     Text(topic.section.title)
                         .font(.headline)
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(ZineTheme.primaryText)
                         .multilineTextAlignment(.leading)
                         .lineLimit(2)
 
                     Text(topic.section.summary)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .multilineTextAlignment(.leading)
                         .lineLimit(2)
 
                     Text(conversationSummary)
                         .font(.caption2.weight(.medium))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
 
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.right")
                     .font(.caption2.weight(.bold))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
                     .padding(.top, 2)
             }
             .padding(12)
-            .background(Color.accentColor.opacity(0.07), in: .rect(cornerRadius: 14))
+            .background(ZineTheme.brandAccent.opacity(0.07), in: .rect(cornerRadius: 14))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -427,7 +427,7 @@ private struct CondensedLandscapeCard: View {
 
             Text(item.title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
 
             HomeItemMetadata(item: item)
@@ -456,7 +456,7 @@ private struct CondensedCoverCard: View {
 
             Text(item.title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
 
             HomeItemMetadata(item: item)
@@ -484,7 +484,7 @@ private struct CondensedGridCard: View {
 
             Text(item.title)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
 
             HomeItemMetadata(item: item)

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -69,6 +69,8 @@ struct HomeSectionListView: View {
                 resultRows
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
             .refreshable {
                 await store.reload(contentType: contentType)
             }
@@ -79,7 +81,8 @@ struct HomeSectionListView: View {
                 }
             }
         }
-        .background(Color(uiColor: .systemBackground))
+        .background(ZineTheme.canvas)
+        .foregroundStyle(ZineTheme.primaryText)
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -163,14 +163,14 @@ private struct HomeTodayTopicSection: View {
                 Text("Today")
                     .font(.caption.weight(.heavy))
                     .tracking(1.1)
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(ZineTheme.brandAccent)
 
                 Text(formattedDate)
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
 
                 if topic.isShowingCachedEdition {
-                    statusLabel("Saved edition", color: .secondary)
+                    statusLabel("Saved edition", color: ZineTheme.secondaryText)
                 } else {
                     switch topic.freshnessStatus {
                     case .complete:
@@ -178,7 +178,7 @@ private struct HomeTodayTopicSection: View {
                     case .partial:
                         statusLabel("Partial", color: .orange)
                     case .unavailable:
-                        statusLabel("Unavailable", color: .secondary)
+                        statusLabel("Unavailable", color: ZineTheme.secondaryText)
                     }
                 }
             }
@@ -201,7 +201,7 @@ private struct HomeTodayTopicSection: View {
                 .frame(width: 5, height: 5)
             Text(text)
                 .font(.caption2.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
         }
     }
 
@@ -231,9 +231,9 @@ private struct HomeSectionHeader: View {
                         .font(.title3.bold())
                     Image(systemName: "chevron.right")
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("View all \(title)")
@@ -241,7 +241,7 @@ private struct HomeSectionHeader: View {
             if let subtitle {
                 Text(subtitle)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -329,14 +329,14 @@ struct HomeCompactHorizontalCard: View {
 
             Text(title)
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(3)
                 .frame(maxHeight: .infinity, alignment: .leading)
                 .padding(.trailing, 10)
         }
         .padding(.leading, 9)
         .frame(width: Metrics.cardWidth, height: Metrics.cardHeight, alignment: .leading)
-        .background(.secondary.opacity(0.08))
+        .background(ZineTheme.surface)
         .clipShape(.rect(cornerRadius: 14))
         .accessibilityElement(children: .combine)
     }
@@ -373,7 +373,7 @@ private struct HomeInboxSection: View {
                     }
                 }
             }
-            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
         }
         .padding(.horizontal, 20)
     }
@@ -542,7 +542,7 @@ private struct HomeCompactListSection: View {
                     }
                 }
             }
-            .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
         }
         .padding(.horizontal, 20)
     }
@@ -590,7 +590,7 @@ struct HomeResumeCard: View {
 
                 if let progress = item.progress, progress.percent > 0 {
                     ProgressView(value: min(max(progress.percent / 100, 0), 1))
-                        .tint(Color.accentColor)
+                        .tint(ZineTheme.brandAccent)
                 }
             }
             .padding(16)
@@ -618,7 +618,7 @@ private struct HomeLandscapeCard: View {
 
             Text(item.title)
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
 
             HomeItemMetadata(item: item)
@@ -645,7 +645,7 @@ private struct HomeCoverCard: View {
 
             Text(item.title)
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
             HomeItemMetadata(item: item)
         }
@@ -672,7 +672,7 @@ private struct HomeGridCard: View {
 
             Text(item.title)
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
                 .lineLimit(2)
             HomeItemMetadata(item: item)
         }
@@ -699,7 +699,7 @@ struct HomeItemRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.title)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
                     .lineLimit(1)
                 HomeItemMetadata(item: item)
             }
@@ -723,7 +723,7 @@ struct HomeItemMetadata: View {
             }
         }
         .font(.caption)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(ZineTheme.secondaryText)
     }
 }
 
@@ -733,10 +733,10 @@ struct HomeImagePlaceholder: View {
 
     var body: some View {
         ZStack {
-            Color.secondary.opacity(0.12)
+            ZineTheme.raised
             Image(systemName: contentType.systemImage)
                 .font(.system(size: iconSize))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
         }
     }
 }

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -103,6 +103,7 @@ struct HomeView: View {
                     }
                 }
         }
+        .zineScreenChrome()
     }
 
     @ViewBuilder
@@ -139,6 +140,7 @@ struct HomeView: View {
                 .padding(.vertical, density == .compact ? 6 : 10)
                 .padding(.bottom, density == .compact ? 16 : 24)
             }
+            .background(ZineTheme.canvas)
             .refreshable {
                 async let home: Void = store.reload()
                 async let today: Void = peopleDailyStore.load()

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -61,6 +61,8 @@ struct JumpBackInListView: View {
                 resultRows
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
             .refreshable {
                 await store.reload(contentType: contentType)
             }
@@ -71,7 +73,8 @@ struct JumpBackInListView: View {
                 }
             }
         }
-        .background(Color(uiColor: .systemBackground))
+        .background(ZineTheme.canvas)
+        .foregroundStyle(ZineTheme.primaryText)
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -37,6 +37,7 @@ struct ScreenshotHomeView: View {
                     .navigationTitle("Conversations")
             }
         }
+        .zineScreenChrome()
     }
 
     @ViewBuilder
@@ -77,8 +78,10 @@ private struct ScreenshotHomeSectionListView: View {
                 }
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
         }
-        .background(Color(uiColor: .systemBackground))
+        .background(ZineTheme.canvas)
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .solidContentTypeFilterChrome()

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -61,6 +61,7 @@ struct InboxView: View {
                     )
                 }
         }
+        .zineScreenChrome()
         .task(id: query) {
             await store.reload(query: query)
         }
@@ -99,6 +100,7 @@ struct InboxView: View {
                     BookmarkRow(bookmark: bookmark)
                 }
                 .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowBackground(ZineTheme.canvas)
                 .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -124,6 +126,8 @@ struct InboxView: View {
                 }
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
             .refreshable {
                 await store.reload(query: query)
             }

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -199,7 +199,7 @@ struct BookmarkDetailView: View {
             let heroHeight = heroHeight(in: viewport.size)
 
             ZStack {
-                Color(uiColor: .systemBackground)
+                ZineTheme.canvas
                     .ignoresSafeArea()
 
                 ScrollView {
@@ -210,7 +210,7 @@ struct BookmarkDetailView: View {
                                 minHeight: max(viewport.size.height - heroHeight, 0),
                                 alignment: .top
                             )
-                            .background(Color(uiColor: .systemBackground))
+                            .background(ZineTheme.canvas)
                     }
                 }
                 .coordinateSpace(name: "bookmarkDetailScroll")
@@ -251,7 +251,7 @@ struct BookmarkDetailView: View {
             if let summary = content.summary, !summary.isEmpty {
                 Text(summary)
                     .font(.body)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
 
             if !content.tags.isEmpty {
@@ -262,7 +262,7 @@ struct BookmarkDetailView: View {
                                 .font(.caption)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 6)
-                                .background(.secondary.opacity(0.12), in: .capsule)
+                                .background(ZineTheme.raised, in: .capsule)
                         }
                     }
                 }
@@ -323,8 +323,8 @@ struct BookmarkDetailView: View {
                             width: ProviderOpenButton.controlSize,
                             height: ProviderOpenButton.controlSize
                         )
-                        .background(Color("AccentColor"), in: Circle())
-                        .foregroundStyle(.white)
+                        .background(ZineTheme.brandAccent, in: Circle())
+                        .foregroundStyle(ZineTheme.onAccent)
                         .accessibilityHidden(true)
                 }
                 .buttonStyle(.plain)
@@ -369,7 +369,7 @@ struct BookmarkDetailView: View {
                 .accessibilityLabel("Retry loading bookmark actions")
             }
 
-            actionIcon(systemName: "tag", color: .secondary.opacity(0.45))
+            actionIcon(systemName: "tag", color: ZineTheme.secondaryText.opacity(0.45))
                 .accessibilityHidden(true)
         }
     }
@@ -380,7 +380,7 @@ struct BookmarkDetailView: View {
         } label: {
             actionIcon(
                 systemName: isBookmarked ? "bookmark.fill" : "bookmark",
-                color: isBookmarked ? .primary : .secondary
+                color: isBookmarked ? ZineTheme.primaryText : ZineTheme.secondaryText
             )
             .contentTransition(.symbolEffect(.replace))
         }
@@ -400,7 +400,7 @@ struct BookmarkDetailView: View {
                 systemName: isFinished
                     ? "checkmark.circle.fill"
                     : "checkmark.circle",
-                color: isFinished ? .green : .secondary
+                color: isFinished ? .green : ZineTheme.secondaryText
             )
         }
         .buttonStyle(.plain)
@@ -510,12 +510,12 @@ struct BookmarkDetailView: View {
 
             Text(content.creator)
                 .font(.headline)
-                .foregroundStyle(.primary)
+                .foregroundStyle(ZineTheme.primaryText)
 
             if showsDisclosure {
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
         .accessibilityElement(children: .combine)
@@ -550,7 +550,7 @@ struct BookmarkDetailView: View {
 
     private var heroBase: some View {
         ZStack {
-            Color(uiColor: .systemBackground)
+            ZineTheme.canvas
 
             heroImage
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -572,10 +572,10 @@ struct BookmarkDetailView: View {
             targetSize: CGSize(width: 430, height: 320)
         ) {
             ZStack {
-                Color.secondary.opacity(0.12)
+                ZineTheme.raised
                 Image(systemName: content.contentType.systemImage)
                     .font(.system(size: 48))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
     }
@@ -601,7 +601,7 @@ struct BookmarkDetailView: View {
             }
         }
         .font(.subheadline)
-        .foregroundStyle(Color.primary.opacity(0.72))
+        .foregroundStyle(ZineTheme.primaryText.opacity(0.72))
     }
 
     private func hydrateBookmark() async {

--- a/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkRow.swift
@@ -9,7 +9,7 @@ struct BookmarkRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(bookmark.title)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
@@ -44,7 +44,7 @@ struct BookmarkRow: View {
                     .lineLimit(1)
             }
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(ZineTheme.secondaryText)
         }
     }
 
@@ -54,10 +54,10 @@ struct BookmarkRow: View {
             targetSize: CGSize(width: 64, height: 48)
         ) {
             ZStack {
-                Color.secondary.opacity(0.12)
+                ZineTheme.raised
                 Image(systemName: bookmark.contentType.systemImage)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
         .frame(width: 64, height: 48)

--- a/apps/ios/ZineNative/Features/Library/CreatorAvatar.swift
+++ b/apps/ios/ZineNative/Features/Library/CreatorAvatar.swift
@@ -21,16 +21,16 @@ struct CreatorAvatar: View {
     private var fallback: some View {
         ZStack {
             Circle()
-                .fill(.secondary.opacity(0.12))
+                .fill(ZineTheme.raised)
 
             if let initial {
                 Text(initial)
                     .font(.system(size: size * 0.45, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             } else {
                 Image(systemName: contentType.systemImage)
                     .font(.system(size: size * 0.38, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
     }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -75,6 +75,7 @@ struct LibraryView: View {
                     )
                 }
         }
+        .zineScreenChrome()
         .task(id: LibraryReloadKey(query: query, revision: refreshRevision)) {
             if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 store.reset()
@@ -105,7 +106,7 @@ struct LibraryView: View {
 
                 resultsList
             }
-            .background(Color(uiColor: .systemBackground))
+            .background(ZineTheme.canvas)
         }
     }
 
@@ -114,6 +115,8 @@ struct LibraryView: View {
             resultRows
         }
         .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .refreshable {
             await store.reload(query: query)
         }
@@ -184,6 +187,7 @@ struct LibraryView: View {
             BookmarkRow(bookmark: bookmark)
         }
         .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+        .listRowBackground(ZineTheme.canvas)
         .listRowSeparator(.hidden)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             if !bookmark.isFinished {

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -24,12 +24,15 @@ struct ScreenshotLibraryView: View {
                             BookmarkRow(bookmark: bookmark)
                         }
                         .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                        .listRowBackground(ZineTheme.canvas)
                         .listRowSeparator(.hidden)
                     }
                 }
                 .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(ZineTheme.canvas)
             }
-            .background(Color(uiColor: .systemBackground))
+            .background(ZineTheme.canvas)
             .navigationTitle("")
             .solidContentTypeFilterChrome()
             .toolbar(.hidden, for: .navigationBar)
@@ -37,6 +40,7 @@ struct ScreenshotLibraryView: View {
                 BookmarkDetailView(bookmark: bookmark, client: client) { _ in }
             }
         }
+        .zineScreenChrome()
     }
 }
 

--- a/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleHTMLView.swift
@@ -137,7 +137,7 @@ enum ArticleHTMLDocumentBuilder {
               max-width: 760px;
               padding: \(topPadding)px 22px 96px;
               background: #ffffff;
-              color: #1c1c1e;
+              color: #151719;
               font: -apple-system-body;
               font-size: calc(17px * var(--reader-font-scale));
               line-height: 1.66;
@@ -155,13 +155,13 @@ enum ArticleHTMLDocumentBuilder {
             .title-rule {
               margin: 14px 0 0;
               border: 0;
-              border-top: 1px solid #d1d1d6;
+              border-top: 1px solid #cfd4da;
             }
             .meta {
               display: flex;
               align-items: center;
               gap: 8px;
-              color: #636366;
+              color: #5d646c;
               font: -apple-system-subheadline;
               font-size: calc(15px * var(--reader-font-scale));
               line-height: 1.4;
@@ -178,7 +178,7 @@ enum ArticleHTMLDocumentBuilder {
               border-radius: 50%;
               object-fit: cover;
               flex: 0 0 auto;
-              background: #e5e5ea;
+              background: #e9edf0;
             }
             main > :first-child { margin-top: 0; }
             p, ul, ol, blockquote, pre, figure { margin: 0 0 1.25em; }
@@ -214,7 +214,7 @@ enum ArticleHTMLDocumentBuilder {
             figure { margin-left: 0; margin-right: 0; }
             figcaption {
               margin-top: -0.8em;
-              color: #6e6e73;
+              color: #5d646c;
               font-size: calc(14px * var(--reader-font-scale));
               line-height: 1.45;
               text-align: center;
@@ -222,8 +222,8 @@ enum ArticleHTMLDocumentBuilder {
             blockquote {
               margin-left: 0;
               padding-left: 18px;
-              border-left: 3px solid #c7c7cc;
-              color: #48484a;
+              border-left: 3px solid #ef661f;
+              color: #5d646c;
             }
             pre, code {
               font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -233,18 +233,20 @@ enum ArticleHTMLDocumentBuilder {
               padding: 15px;
               overflow-x: auto;
               white-space: pre-wrap;
-              background: #f2f2f7;
+              background: #e9edf0;
               border-radius: 12px;
             }
-            a { color: #0066cc; text-decoration-thickness: 0.08em; }
-            hr { border: 0; border-top: 1px solid #d1d1d6; margin: 2em 0; }
+            a { color: #b64012; text-decoration-thickness: 0.08em; }
+            hr { border: 0; border-top: 1px solid #cfd4da; margin: 2em 0; }
+            ::selection { background: rgba(239, 102, 31, 0.24); }
             @media (prefers-color-scheme: dark) {
-              body { background: #000000; color: #f2f2f7; }
-              .meta, figcaption { color: #a1a1a6; }
-              blockquote { color: #d1d1d6; border-left-color: #636366; }
-              pre { background: #1c1c1e; }
-              a { color: #64a8ff; }
-              hr { border-top-color: #38383a; }
+              body { background: #14171a; color: #f5f7f8; }
+              .meta, figcaption { color: #b2bac2; }
+              .creator-avatar { background: #20252a; }
+              blockquote { color: #b2bac2; border-left-color: #ef661f; }
+              pre { background: #20252a; }
+              a { color: #ffad7c; }
+              hr, .title-rule { border-top-color: #343a40; }
             }
             @media (max-width: 420px) {
               body { padding-left: 20px; padding-right: 20px; }

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -47,7 +47,7 @@ struct ArticleReaderView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            Color(uiColor: .systemBackground)
+            ZineTheme.canvas
                 .ignoresSafeArea()
 
             phaseContent
@@ -160,7 +160,9 @@ struct ArticleReaderView: View {
                     .frame(width: 44, height: 44)
             }
             .buttonStyle(.plain)
-            .background(.thinMaterial, in: Circle())
+            .foregroundStyle(ZineTheme.primaryText)
+            .background(ZineTheme.surface.opacity(0.96), in: Circle())
+            .overlay { Circle().stroke(ZineTheme.border, lineWidth: 1) }
             .accessibilityLabel("Back")
 
             Spacer(minLength: 8)
@@ -198,7 +200,9 @@ struct ArticleReaderView: View {
                 }
                 .accessibilityLabel("Open original article")
             }
-            .background(.thinMaterial, in: Capsule())
+            .foregroundStyle(ZineTheme.primaryText)
+            .background(ZineTheme.surface.opacity(0.96), in: Capsule())
+            .overlay { Capsule().stroke(ZineTheme.border, lineWidth: 1) }
         }
         .padding(.horizontal, 12)
         .frame(height: ArticleReaderChromeOffsetTracker.maximumOffset)

--- a/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
+++ b/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
@@ -76,6 +76,8 @@ private struct AppearanceSettingsView: View {
                 Text("System follows your iPhone’s appearance setting.")
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .navigationTitle("Appearance")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
@@ -215,6 +215,8 @@ struct NewsletterSubscriptionsView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .refreshable { await store.reload() }
     }
 
@@ -225,7 +227,7 @@ struct NewsletterSubscriptionsView: View {
             }
 
             if store.isUpdatingConnection {
-                HStack { ProgressView(); Text("Updating connection…").foregroundStyle(.secondary) }
+                HStack { ProgressView(); Text("Updating connection…").foregroundStyle(ZineTheme.secondaryText) }
             } else if store.response?.connection?.isActive == true {
                 Button {
                     Task { await store.sync() }
@@ -260,8 +262,8 @@ struct NewsletterSubscriptionsView: View {
 
     private var connectionColor: Color {
         if store.response?.connection?.isActive == true { return .green }
-        if store.response?.connection?.needsAttention == true { return .orange }
-        return .secondary
+        if store.response?.connection?.needsAttention == true { return ZineTheme.brandAccent }
+        return ZineTheme.secondaryText
     }
 
     private func newsletterRow(_ feed: NewsletterFeed) -> some View {
@@ -271,7 +273,7 @@ struct NewsletterSubscriptionsView: View {
                     .resizable()
                     .scaledToFit()
                     .padding(10)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
             .frame(width: 44, height: 44)
             .clipShape(.circle)
@@ -280,7 +282,7 @@ struct NewsletterSubscriptionsView: View {
                 Text(feed.displayName).lineLimit(2)
                 Text(feed.fromAddress ?? feed.status.title)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(1)
             }
 

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
@@ -132,6 +132,8 @@ struct ProviderSubscriptionsView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .refreshable { await store.reload() }
     }
 
@@ -148,7 +150,7 @@ struct ProviderSubscriptionsView: View {
                 HStack {
                     ProgressView()
                     Text(store.connection?.isActive == true ? "Disconnecting…" : "Connecting…")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
             } else if store.connection?.isActive == true {
                 Button("Disconnect \(provider.providerTitle)", role: .destructive) {
@@ -177,8 +179,8 @@ struct ProviderSubscriptionsView: View {
 
     private var connectionColor: Color {
         if store.connection?.isActive == true { return .green }
-        if store.connection?.needsAttention == true { return .orange }
-        return .secondary
+        if store.connection?.needsAttention == true { return ZineTheme.brandAccent }
+        return ZineTheme.secondaryText
     }
 
     private func itemRow(_ item: ProviderSubscriptionItem) -> some View {
@@ -188,7 +190,7 @@ struct ProviderSubscriptionsView: View {
                     .resizable()
                     .scaledToFit()
                     .padding(8)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
             .frame(width: 44, height: 44)
             .clipShape(.circle)
@@ -198,7 +200,9 @@ struct ProviderSubscriptionsView: View {
                 Text(item.status?.title ?? "Available to add")
                     .font(.caption)
                     .foregroundStyle(
-                        item.status == .active || item.status == nil ? Color.secondary : Color.orange
+                        item.status == .active || item.status == nil
+                            ? ZineTheme.secondaryText
+                            : ZineTheme.brandAccent
                     )
             }
 

--- a/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
@@ -209,6 +209,8 @@ struct RssSubscriptionsView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .refreshable { await store.reload() }
     }
 
@@ -219,7 +221,7 @@ struct RssSubscriptionsView: View {
                     .resizable()
                     .scaledToFit()
                     .padding(10)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
             .frame(width: 44, height: 44)
             .clipShape(.circle)
@@ -228,7 +230,9 @@ struct RssSubscriptionsView: View {
                 Text(feed.title).lineLimit(2)
                 Text(feed.status.title)
                     .font(.caption)
-                    .foregroundStyle(feed.status == .active ? Color.secondary : Color.orange)
+                    .foregroundStyle(
+                        feed.status == .active ? ZineTheme.secondaryText : ZineTheme.brandAccent
+                    )
             }
 
             Spacer()

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
@@ -69,6 +69,8 @@ struct SubscriptionsView: View {
                         Text("Connect accounts and choose what Zine should sync from each source.")
                     }
                 }
+                .scrollContentBackground(.hidden)
+                .background(ZineTheme.canvas)
                 .refreshable { await store.reload() }
             }
         }
@@ -78,6 +80,7 @@ struct SubscriptionsView: View {
             destination(for: source)
         }
         .task { await store.reload() }
+        .zineScreenChrome()
     }
 
     private var orderedSources: [SubscriptionSourceSummary] {
@@ -89,14 +92,14 @@ struct SubscriptionsView: View {
         HStack(spacing: 12) {
             Image(systemName: summary.provider.systemImage)
                 .font(.title3)
-                .foregroundStyle(summary.needsAttention ? .orange : .primary)
+                .foregroundStyle(summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.primaryText)
                 .frame(width: 28)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(summary.provider.title)
                 Text(summary.statusText)
                     .font(.caption)
-                    .foregroundStyle(summary.needsAttention ? .orange : .secondary)
+                    .foregroundStyle(summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.secondaryText)
             }
         }
         .padding(.vertical, 3)

--- a/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
@@ -165,7 +165,7 @@ struct XSubscriptionsView: View {
                 }
 
                 if store.isUpdatingConnection {
-                    HStack { ProgressView(); Text("Updating connection…").foregroundStyle(.secondary) }
+                    HStack { ProgressView(); Text("Updating connection…").foregroundStyle(ZineTheme.secondaryText) }
                 } else if store.response?.connection?.isActive == true {
                     Button("Disconnect X", role: .destructive) {
                         showsDisconnectConfirmation = true
@@ -210,7 +210,7 @@ struct XSubscriptionsView: View {
                         }
                     }
                     if let error = store.response?.sync?.lastError, !error.isEmpty {
-                        Text(error).font(.caption).foregroundStyle(.orange)
+                        Text(error).font(.caption).foregroundStyle(ZineTheme.brandAccent)
                     }
                 } header: {
                     Text("Bookmark Sync")
@@ -227,6 +227,8 @@ struct XSubscriptionsView: View {
                 }
             }
         }
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
         .refreshable { await store.reload() }
     }
 
@@ -238,8 +240,8 @@ struct XSubscriptionsView: View {
 
     private var connectionColor: Color {
         if store.response?.connection?.isActive == true { return .green }
-        if store.response?.connection?.needsAttention == true { return .orange }
-        return .secondary
+        if store.response?.connection?.needsAttention == true { return ZineTheme.brandAccent }
+        return ZineTheme.secondaryText
     }
 
     private var messageBinding: Binding<Bool> {

--- a/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
@@ -92,7 +92,7 @@ struct DailyAuthorActivityView: View {
                 image.resizable().scaledToFill()
             } placeholder: {
                 ZStack {
-                    Circle().fill(Color.secondary.opacity(0.15))
+                    Circle().fill(ZineTheme.raised)
                     Text(author.name.prefix(1).uppercased())
                         .font(.title2.weight(.bold))
                 }
@@ -105,10 +105,10 @@ struct DailyAuthorActivityView: View {
                     .font(.title2.weight(.bold))
                 Text("@\(author.username)")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                 Text("All posts available in Zine’s X archive")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
         }
     }
@@ -120,12 +120,12 @@ struct DailyAuthorActivityView: View {
             ForEach(coverage.warnings, id: \.self) { warning in
                 Text(warning)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(11)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.orange.opacity(0.09), in: RoundedRectangle(cornerRadius: 12))
+        .background(ZineTheme.brandAccent.opacity(0.09), in: RoundedRectangle(cornerRadius: 12))
     }
 }

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -82,7 +82,7 @@ private struct PeopleDailyOverviewView: View {
                 VStack(alignment: .leading, spacing: 5) {
                     Text(formattedDate)
                         .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                     Text("What people are talking about")
                         .font(.largeTitle.weight(.bold))
                         .fixedSize(horizontal: false, vertical: true)
@@ -164,18 +164,22 @@ private struct PeopleDailyCoverageNotice: View {
             } label: {
                 HStack(spacing: 8) {
                     Circle()
-                        .fill(response.freshness.status == .complete ? Color.green : Color.orange)
+                        .fill(
+                            response.freshness.status == .complete
+                                ? Color.green
+                                : ZineTheme.brandAccent
+                        )
                         .frame(width: 7, height: 7)
                     Text(isShowingCachedEdition ? "Saved edition" : statusTitle)
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(ZineTheme.primaryText)
                     Spacer()
                     Text("\(response.more.favoriteConversationCount) Favorites")
                         .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                     Image(systemName: showsDetails ? "chevron.up" : "chevron.down")
                         .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
                 .contentShape(Rectangle())
             }
@@ -184,21 +188,21 @@ private struct PeopleDailyCoverageNotice: View {
             if showsDetails {
                 Text(response.coverage.message)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                 if let cachedAt, isShowingCachedEdition {
                     Text("Saved \(cachedAt.formatted(.relative(presentation: .named)))")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
                 if let refreshErrorMessage {
                     Label(refreshErrorMessage, systemImage: "wifi.exclamationmark")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
                 ForEach(response.freshness.warnings, id: \.self) { warning in
                     Label(warning, systemImage: "exclamationmark.circle")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -267,12 +271,12 @@ struct PeopleDailySectionView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(response.section.summary)
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                     ForEach(response.section.coverageWarnings, id: \.self) { warning in
                         Label(warning, systemImage: "exclamationmark.circle")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                 }
                 .padding(.horizontal, 18)
@@ -376,7 +380,7 @@ struct DailyFeedReviewView: View {
                         Text("ZINE")
                             .font(.caption2.weight(.heavy))
                             .tracking(1.2)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Done") { dismiss() }
@@ -507,22 +511,22 @@ struct DailyOverviewSectionRow: View {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(section.title)
                         .font(.title3.weight(.semibold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(ZineTheme.primaryText)
                         .multilineTextAlignment(.leading)
                     Spacer(minLength: 4)
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
 
                 Text(section.summary)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(conversationSummary)
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
         }
         .padding(.vertical, 18)
@@ -550,7 +554,7 @@ private struct DailyMoreConversationsRow: View {
         HStack(spacing: 14) {
             Image(systemName: "text.bubble")
                 .font(.title3)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
                 .frame(width: 44, height: 44)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -558,12 +562,12 @@ private struct DailyMoreConversationsRow: View {
                     .font(.headline)
                 Text("\(count) conversation\(count == 1 ? "" : "s") that stand on their own today")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
             Spacer(minLength: 4)
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ZineTheme.tertiaryText)
         }
         .padding(.vertical, 18)
         .contentShape(Rectangle())
@@ -642,13 +646,13 @@ private struct DailySectionDetailView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(summary)
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
 
                     ForEach(section?.coverageWarnings ?? [], id: \.self) { warning in
                         Label(warning, systemImage: "exclamationmark.circle")
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                 }
                 .padding(.horizontal, 18)
@@ -707,7 +711,7 @@ private struct DailyFeedHeader: View {
         VStack(alignment: .leading, spacing: 5) {
             Text(formattedDate)
                 .font(.subheadline.weight(.medium))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
 
             Text("What people are talking about")
                 .font(.largeTitle.weight(.bold))
@@ -743,14 +747,14 @@ private struct DailyCoverageNotice: View {
                         .frame(width: 7, height: 7)
                     Text(statusTitle)
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(ZineTheme.primaryText)
                     Spacer()
                     Text(scopeSummary)
                         .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                     Image(systemName: showsDetails ? "chevron.up" : "chevron.down")
                         .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
                 .contentShape(Rectangle())
             }
@@ -759,19 +763,19 @@ private struct DailyCoverageNotice: View {
             if showsDetails {
                 Text(response.coverage.message)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
 
                 ForEach(response.freshness.warnings, id: \.self) { warning in
                     Label(warning, systemImage: "exclamationmark.circle")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 ForEach(response.overview?.warnings ?? [], id: \.self) { warning in
                     Label(warning, systemImage: "text.quote")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
@@ -797,7 +801,7 @@ private struct DailyCoverageNotice: View {
     }
 
     private var statusColor: Color {
-        response.coverage.status == .complete ? .green : .secondary
+        response.coverage.status == .complete ? .green : ZineTheme.secondaryText
     }
 
 }
@@ -836,13 +840,13 @@ private struct DailyThreadUnitCard: View {
                             .font(.subheadline.weight(.semibold))
                         Text(participantSummary)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                             .lineLimit(1)
 
                         if threadUnit.structureStatus != "EXACT" {
                             Label("Some replies may be missing", systemImage: "exclamationmark.circle")
                                 .font(.caption2)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                         }
                     }
                     Spacer(minLength: 8)
@@ -890,13 +894,13 @@ private struct DailyThreadUnitCard: View {
             ForEach(threadUnit.coverageWarnings, id: \.self) { warning in
                 Label(warning, systemImage: "exclamationmark.circle")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .padding(.top, 8)
             }
         }
         .padding(isEmbedded ? 0 : 14)
         .background(
-            isEmbedded ? Color.clear : Color.secondary.opacity(0.08),
+            isEmbedded ? Color.clear : ZineTheme.surface,
             in: RoundedRectangle(cornerRadius: 16)
         )
     }
@@ -919,19 +923,19 @@ struct DailyParticipantFacepile: View {
                 DailyAuthorAvatar(author: author, size: size)
                     .overlay {
                         Circle()
-                            .stroke(Color(uiColor: .systemBackground), lineWidth: 2)
+                            .stroke(ZineTheme.canvas, lineWidth: 2)
                     }
             }
 
             if authors.count > maximumVisible {
                 Text("+\(authors.count - maximumVisible)")
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .frame(width: size, height: size)
-                    .background(Color(uiColor: .secondarySystemBackground), in: Circle())
+                    .background(ZineTheme.raised, in: Circle())
                     .overlay {
                         Circle()
-                            .stroke(Color(uiColor: .systemBackground), lineWidth: 2)
+                            .stroke(ZineTheme.canvas, lineWidth: 2)
                     }
             }
         }
@@ -966,13 +970,13 @@ private struct DailyThreadPostRow: View {
                 if let relationshipLabel {
                     Label(relationshipLabel.text, systemImage: relationshipLabel.icon)
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
 
                 if let repostedBy = post.repostedBy {
                     Label("Reposted by @\(repostedBy.username)", systemImage: "arrow.2.squarepath")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
 
                 Text(post.text)
@@ -996,9 +1000,9 @@ private struct DailyThreadPostRow: View {
                     if let postURL = post.postURL {
                         Link(destination: postURL) {
                             Label("Open on X", systemImage: "arrow.up.right")
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                         }
-                        .tint(.secondary)
+                        .tint(ZineTheme.secondaryText)
                     }
                     Spacer(minLength: 8)
                     DailyPostMetricsView(metrics: post.metrics)
@@ -1009,10 +1013,10 @@ private struct DailyThreadPostRow: View {
                     HStack(spacing: 5) {
                         if sourceName.localizedCaseInsensitiveContains("favorite") {
                             Image(systemName: "star.fill")
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(ZineTheme.brandAccent)
                         }
                         Text(sourceName)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                     .font(.caption2.weight(.semibold))
                 }
@@ -1026,21 +1030,21 @@ private struct DailyThreadPostRow: View {
             HStack(spacing: 5) {
                 Text(post.author.name)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
                 if post.author.verified == true {
                     Image(systemName: "checkmark.seal.fill")
                         .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
                 Text("@\(post.author.username)")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(1)
                 Spacer(minLength: 4)
                 if let effectiveDate = post.effectiveDate {
                     Text(effectiveDate, style: .relative)
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
             }
             .contentShape(Rectangle())
@@ -1080,7 +1084,7 @@ private struct DailyThreadRail: View {
                     Circle()
                         .stroke(Color(uiColor: .separator), lineWidth: 1)
                 }
-                .background(Color(uiColor: .systemBackground), in: Circle())
+                .background(ZineTheme.canvas, in: Circle())
         }
         .frame(width: 46)
         .frame(maxHeight: .infinity, alignment: .top)
@@ -1096,7 +1100,7 @@ private struct DailyThreadRail: View {
                         path.addLine(to: CGPoint(x: geometry.size.width / 2, y: geometry.size.height))
                     }
                 }
-                .stroke(Color.secondary.opacity(0.28), lineWidth: 1.5)
+                .stroke(ZineTheme.border, lineWidth: 1.5)
             }
         }
         .accessibilityHidden(true)
@@ -1117,18 +1121,18 @@ private struct DailyConversationCard: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 10) {
                 Image(systemName: evidenceIcon)
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(ZineTheme.brandAccent)
                 VStack(alignment: .leading, spacing: 3) {
                     Text(conversation.label)
                         .font(.headline)
                     Text(conversation.evidence)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
 
                     ForEach(conversation.coverageWarnings ?? [], id: \.self) { warning in
                         Label(warning, systemImage: "exclamationmark.circle")
                             .font(.caption2)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                 }
             }
@@ -1142,15 +1146,17 @@ private struct DailyConversationCard: View {
                         VStack(alignment: .leading, spacing: 3) {
                             Text("\(post.author.name)  @\(post.author.username)")
                                 .font(.caption.weight(.semibold))
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(ZineTheme.primaryText)
                             Text(post.text)
                                 .font(.subheadline)
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(ZineTheme.primaryText)
                                 .lineLimit(3)
                                 .multilineTextAlignment(.leading)
                             Text(isFavorite(post) ? "Favorite source" : "Conversation context")
                                 .font(.caption2.weight(.semibold))
-                                .foregroundStyle(isFavorite(post) ? Color.accentColor : .secondary)
+                                .foregroundStyle(
+                                    isFavorite(post) ? ZineTheme.brandAccent : ZineTheme.secondaryText
+                                )
                         }
                         Spacer(minLength: 0)
                     }
@@ -1166,7 +1172,7 @@ private struct DailyConversationCard: View {
             }
         }
         .padding(14)
-        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+        .background(ZineTheme.surface, in: RoundedRectangle(cornerRadius: 16))
     }
 
     private func isFavorite(_ post: DailyPost) -> Bool {
@@ -1205,7 +1211,7 @@ struct DailyFeedPostCard: View {
             if let repostedBy = post.repostedBy {
                 Label("Reposted by @\(repostedBy.username)", systemImage: "arrow.2.squarepath")
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
 
             authorHeader
@@ -1249,14 +1255,14 @@ struct DailyFeedPostCard: View {
                             .font(.caption2.weight(.semibold))
                             .padding(.horizontal, 7)
                             .padding(.vertical, 4)
-                            .background(Color.accentColor.opacity(0.1), in: Capsule())
+                            .background(ZineTheme.brandAccent.opacity(0.1), in: Capsule())
                     }
                 }
             }
         }
         .padding(isEmbedded ? 0 : 14)
         .background(
-            isEmbedded ? Color.clear : Color.secondary.opacity(0.08),
+            isEmbedded ? Color.clear : ZineTheme.surface,
             in: RoundedRectangle(cornerRadius: 16)
         )
     }
@@ -1283,7 +1289,7 @@ struct DailyFeedPostCard: View {
                     if post.author.verified == true {
                         Image(systemName: "checkmark.seal.fill")
                             .font(.caption2)
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(ZineTheme.brandAccent)
                     }
                 }
                 HStack(spacing: 5) {
@@ -1297,13 +1303,13 @@ struct DailyFeedPostCard: View {
                     }
                 }
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
             }
             Spacer()
             if authorDestinationDate != nil {
                 Image(systemName: "chevron.right")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(ZineTheme.tertiaryText)
             }
         }
         .contentShape(Rectangle())
@@ -1319,10 +1325,10 @@ private struct DailyAuthorAvatar: View {
             image.resizable().scaledToFill()
         } placeholder: {
             ZStack {
-                Circle().fill(Color.secondary.opacity(0.16))
+                Circle().fill(ZineTheme.raised)
                 Text(author.name.prefix(1).uppercased())
                     .font(.caption.weight(.bold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
         .frame(width: size, height: size)
@@ -1338,7 +1344,7 @@ private struct DailyRelationshipContext: View {
         VStack(alignment: .leading, spacing: 6) {
             Label(label, systemImage: icon)
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
 
             if let target = relationship.target {
                 VStack(alignment: .leading, spacing: 3) {
@@ -1346,12 +1352,12 @@ private struct DailyRelationshipContext: View {
                         .font(.caption.weight(.semibold))
                     Text(target.text)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .lineLimit(4)
                 }
                 .padding(10)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+                .background(ZineTheme.surface, in: RoundedRectangle(cornerRadius: 10))
             }
         }
     }
@@ -1386,9 +1392,9 @@ private struct DailyPostMediaStrip: View {
                         image.resizable().scaledToFill()
                     } placeholder: {
                         ZStack {
-                            Color.secondary.opacity(0.12)
+                            ZineTheme.raised
                             Image(systemName: item.type == "VIDEO" ? "play.fill" : "photo")
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                         }
                     }
                     .frame(width: 220, height: 128)
@@ -1411,7 +1417,7 @@ private struct DailyPostLinkView: View {
                         AsyncImage(url: imageURL) { image in
                             image.resizable().scaledToFill()
                         } placeholder: {
-                            Color.secondary.opacity(0.12)
+                            ZineTheme.raised
                         }
                         .frame(width: 54, height: 54)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -1419,19 +1425,19 @@ private struct DailyPostLinkView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(link.card?.domain ?? domain)
                             .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                         Text(link.card?.title ?? link.displayUrl ?? link.normalizedUrl)
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(ZineTheme.primaryText)
                             .lineLimit(2)
                     }
                     Spacer(minLength: 0)
                     Image(systemName: "arrow.up.right")
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
                 .padding(9)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 11))
+                .background(ZineTheme.surface, in: RoundedRectangle(cornerRadius: 11))
             }
             .buttonStyle(.plain)
         }
@@ -1457,7 +1463,7 @@ private struct DailyPostMetricsView: View {
                 Label("\(likes)", systemImage: "heart")
             }
         }
-        .foregroundStyle(.secondary)
+        .foregroundStyle(ZineTheme.secondaryText)
     }
 }
 
@@ -1484,7 +1490,7 @@ struct ScreenshotDailyOverviewView: View {
                         Text("ZINE")
                             .font(.caption2.weight(.heavy))
                             .tracking(1.2)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("Done") {}
@@ -1512,7 +1518,7 @@ struct ScreenshotDailyThreadView: View {
                     Text("Favorites")
                         .font(.caption.weight(.heavy))
                         .tracking(1.1)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
 
                     Text("Conversations from people you chose")
                         .font(.title2.weight(.bold))

--- a/apps/ios/ZineNative/Features/Today/EditorialComponents.swift
+++ b/apps/ios/ZineNative/Features/Today/EditorialComponents.swift
@@ -152,7 +152,7 @@ private struct TodayMasthead: View {
                 Spacer()
                 Text(issueDate)
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
 
             Divider()
@@ -164,12 +164,12 @@ private struct TodayMasthead: View {
 
             Text(issue.dek)
                 .font(.title3)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
 
             Text(coverageWindow)
                 .font(.caption)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ZineTheme.tertiaryText)
         }
     }
 
@@ -217,16 +217,16 @@ private struct TodayCoverStory: View {
                 Text("COVER STORY")
                     .font(.caption2.weight(.heavy))
                     .tracking(1.4)
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(ZineTheme.brandAccent)
 
                 Text(story.title)
                     .font(.system(size: 28, weight: .bold, design: .serif))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(story.lede.text)
                     .font(.body)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(4)
 
                 TodayStorySignalLine(story: story, issue: issue)
@@ -245,10 +245,10 @@ private struct TodayCoverStory: View {
 
     private var coverPlaceholder: some View {
         ZStack {
-            Color.secondary.opacity(0.1)
+            ZineTheme.raised
             Image(systemName: "newspaper")
                 .font(.system(size: 42))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
         }
     }
 }
@@ -264,7 +264,7 @@ private struct TodayBriefing: View {
                 HStack(alignment: .top, spacing: 14) {
                     Text(String(format: "%02d", index + 1))
                         .font(.caption.monospacedDigit().weight(.bold))
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(ZineTheme.brandAccent)
                         .padding(.top, 3)
                     Text(item.text)
                         .font(.body)
@@ -293,16 +293,16 @@ private struct TodayStoryCard: View {
                     Text("\(story.type.rawValue) · \(story.lifecycle.rawValue)")
                         .font(.caption2.weight(.bold))
                         .tracking(0.7)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
 
                     Text(story.title)
                         .font(.title3.weight(.bold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(ZineTheme.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
 
                     Text(story.lede.text)
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .lineLimit(3)
 
                     TodayStorySignalLine(story: story, issue: issue)
@@ -313,7 +313,7 @@ private struct TodayStoryCard: View {
                         url: imageURL,
                         targetSize: CGSize(width: 104, height: 104)
                     ) {
-                        Color.secondary.opacity(0.1)
+                        ZineTheme.raised
                     }
                     .frame(width: 104, height: 104)
                     .clipped()
@@ -347,7 +347,7 @@ private struct TodayStorySignalLine: View {
             Image(systemName: "chevron.right")
         }
         .font(.caption)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(ZineTheme.secondaryText)
     }
 
     private var storySources: [EditorialSource] {
@@ -372,7 +372,7 @@ private struct TodayRecommendationCard: View {
                 HStack(alignment: .top, spacing: 13) {
                     Image(systemName: recommendation.format.systemImage)
                         .font(.title3)
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(ZineTheme.brandAccent)
                         .frame(width: 28)
 
                     VStack(alignment: .leading, spacing: 6) {
@@ -384,23 +384,23 @@ private struct TodayRecommendationCard: View {
                         }
                         .font(.caption2.weight(.bold))
                         .tracking(0.7)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
 
                         Text(recommendation.title)
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(ZineTheme.primaryText)
                             .fixedSize(horizontal: false, vertical: true)
 
                         Text(recommendation.reason)
                             .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
                     Spacer(minLength: 0)
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
             }
             .buttonStyle(.plain)
@@ -414,7 +414,7 @@ private struct TodayRecommendationCard: View {
                         .foregroundStyle(.green)
                 } else if presentation?.isSaved == true {
                     Label("Saved", systemImage: "bookmark.fill")
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(ZineTheme.brandAccent)
                 } else if source != nil {
                     Button(action: onSave) {
                         Label("Save", systemImage: "bookmark")
@@ -455,7 +455,7 @@ private struct TodayRecommendationCard: View {
             .font(.caption.weight(.semibold))
         }
         .padding(16)
-        .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
         .task {
             onFeedback(.impression)
         }
@@ -470,19 +470,19 @@ private struct TodayEmergingSignalCard: View {
             Text(signal.momentum.rawValue)
                 .font(.caption2.weight(.bold))
                 .tracking(0.7)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             Text(signal.title)
                 .font(.headline)
             Text(signal.summary.text)
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
             Text("Why watch: \(signal.whyWatch.text)")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.secondary.opacity(0.08), in: .rect(cornerRadius: 16))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
     }
 }
 
@@ -494,14 +494,14 @@ private struct TodayBigPicture: View {
             Text("THE BIG PICTURE")
                 .font(.caption2.weight(.heavy))
                 .tracking(1.3)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             Text(text)
                 .font(.system(.title3, design: .serif, weight: .medium))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.secondary.opacity(0.1), in: .rect(cornerRadius: 18))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
     }
 }
 
@@ -516,11 +516,11 @@ private struct TodayCoverageFooter: View {
                 }
             }
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(ZineTheme.secondaryText)
             .padding(.top, 10)
         }
         .font(.caption.weight(.semibold))
-        .foregroundStyle(.secondary)
+        .foregroundStyle(ZineTheme.secondaryText)
     }
 }
 
@@ -533,7 +533,7 @@ private struct TodaySectionTitle: View {
             Text(eyebrow)
                 .font(.caption2.weight(.heavy))
                 .tracking(1.4)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             Text(title)
                 .font(.title2.bold())
         }
@@ -597,18 +597,18 @@ private struct TodayIssueNoticeView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 11) {
             Image(systemName: systemImage)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             VStack(alignment: .leading, spacing: 3) {
                 Text(notice.title)
                     .font(.subheadline.weight(.semibold))
                 Text(notice.message)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
             }
         }
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.secondary.opacity(0.09), in: .rect(cornerRadius: 14))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 14))
         .accessibilityElement(children: .combine)
     }
 

--- a/apps/ios/ZineNative/Features/Today/EditorialLabView.swift
+++ b/apps/ios/ZineNative/Features/Today/EditorialLabView.swift
@@ -71,14 +71,14 @@ struct EditorialLabView: View {
                         Text("EXPERIMENT")
                             .font(.caption2.weight(.bold))
                             .tracking(1)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                         Text(experiment.title)
                             .font(.headline)
-                            .foregroundStyle(.primary)
+                            .foregroundStyle(ZineTheme.primaryText)
                     }
                     Spacer()
                     Image(systemName: "chevron.up.chevron.down")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
                 .contentShape(.rect)
             }
@@ -95,7 +95,11 @@ struct EditorialLabView: View {
                 Text(experiment.status.title.uppercased())
                     .font(.caption2.weight(.bold))
                     .tracking(0.7)
-                    .foregroundStyle(experiment.status == .readyForReview ? Color.accentColor : .secondary)
+                    .foregroundStyle(
+                        experiment.status == .readyForReview
+                            ? ZineTheme.brandAccent
+                            : ZineTheme.secondaryText
+                    )
             }
 
             LabBriefItem(title: "Hypothesis", text: experiment.hypothesis)
@@ -122,39 +126,43 @@ struct EditorialLabView: View {
                             .frame(width: 34, height: 34)
                             .background(
                                 store.selectedVariantID == variant.id
-                                    ? Color.accentColor
-                                    : Color.secondary.opacity(0.12),
+                                    ? ZineTheme.brandAccent
+                                    : ZineTheme.raised,
                                 in: Circle()
                             )
-                            .foregroundStyle(store.selectedVariantID == variant.id ? .white : .primary)
+                            .foregroundStyle(
+                                store.selectedVariantID == variant.id
+                                    ? ZineTheme.onAccent
+                                    : ZineTheme.primaryText
+                            )
 
                         VStack(alignment: .leading, spacing: 5) {
                             Text(variant.name)
                                 .font(.headline)
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(ZineTheme.primaryText)
                             Text(variant.description)
                                 .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                             Text(variant.headline)
                                 .font(.subheadline.weight(.medium))
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(ZineTheme.primaryText)
                             Text("Quality \(variant.qualityScore, specifier: "%.1f")")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                         }
                         Spacer(minLength: 0)
                         if store.selectedVariantID == variant.id {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(ZineTheme.brandAccent)
                         }
                     }
                     .padding(16)
-                    .background(Color.secondary.opacity(0.07), in: .rect(cornerRadius: 18))
+                    .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
                     .overlay {
                         RoundedRectangle(cornerRadius: 18)
                             .stroke(
                                 store.selectedVariantID == variant.id
-                                    ? Color.accentColor.opacity(0.7)
+                                    ? ZineTheme.brandAccent.opacity(0.7)
                                     : .clear,
                                 lineWidth: 1.5
                             )
@@ -195,7 +203,7 @@ struct EditorialLabView: View {
                 .font(.title3.bold())
             Text("This saves your judgment. It never publishes a winner automatically.")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
 
             HStack(spacing: 8) {
                 ForEach(EditorialExperimentPreference.allCases) { option in
@@ -203,7 +211,9 @@ struct EditorialLabView: View {
                         store.setPreference(option)
                     }
                     .buttonStyle(.bordered)
-                    .tint(store.preference == option ? Color.accentColor : .secondary)
+                    .tint(
+                        store.preference == option ? ZineTheme.brandAccent : ZineTheme.secondaryText
+                    )
                     .fontWeight(store.preference == option ? .semibold : .regular)
                     .frame(maxWidth: .infinity)
                 }
@@ -217,7 +227,7 @@ struct EditorialLabView: View {
             ))
             .frame(minHeight: 110)
             .padding(10)
-            .background(Color.secondary.opacity(0.07), in: .rect(cornerRadius: 14))
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 14))
             .accessibilityLabel("Experiment decision notes")
 
             Button {
@@ -251,13 +261,13 @@ struct EditorialLabView: View {
             Text("NEXT")
                 .font(.caption2.bold())
                 .tracking(1)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
             Text(experiment.nextAction)
                 .font(.subheadline)
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.secondary.opacity(0.07), in: .rect(cornerRadius: 16))
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
     }
 }
 
@@ -270,7 +280,7 @@ private struct LabBriefItem: View {
             Text(title.uppercased())
                 .font(.caption2.bold())
                 .tracking(1)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
             Text(text)
                 .font(.body)
         }
@@ -286,7 +296,7 @@ private struct LabBulletList: View {
             Text(title.uppercased())
                 .font(.caption2.bold())
                 .tracking(1)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
             ForEach(items, id: \.self) { item in
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text("•")

--- a/apps/ios/ZineNative/Features/Today/EditorialStoryDetailView.swift
+++ b/apps/ios/ZineNative/Features/Today/EditorialStoryDetailView.swift
@@ -52,12 +52,12 @@ struct EditorialStoryDetailView: View {
                                 if let handle = voice.handle {
                                     Text(handle.hasPrefix("@") ? handle : "@\(handle)")
                                         .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(ZineTheme.secondaryText)
                                 }
                             }
                             Text(voice.contribution)
                                 .font(.subheadline)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(ZineTheme.secondaryText)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -79,15 +79,15 @@ struct EditorialStoryDetailView: View {
                     NavigationLink(value: TodayNavigationRoute.source(connection.sourceId)) {
                         HStack(alignment: .top, spacing: 10) {
                             Image(systemName: "bookmark.fill")
-                                .foregroundStyle(Color.accentColor)
+                                .foregroundStyle(ZineTheme.brandAccent)
                             Text(connection.reason)
                                 .font(.subheadline)
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(ZineTheme.primaryText)
                                 .fixedSize(horizontal: false, vertical: true)
                             Spacer(minLength: 0)
                             Image(systemName: "chevron.right")
                                 .font(.caption.weight(.semibold))
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(ZineTheme.tertiaryText)
                         }
                         .contentShape(Rectangle())
                     }
@@ -101,7 +101,7 @@ struct EditorialStoryDetailView: View {
         Text(text)
             .font(.caption2.weight(.heavy))
             .tracking(1.2)
-            .foregroundStyle(Color.accentColor)
+            .foregroundStyle(ZineTheme.brandAccent)
     }
 
     private var header: some View {
@@ -109,7 +109,7 @@ struct EditorialStoryDetailView: View {
             Text("\(story.type.rawValue) · \(story.momentum.rawValue) MOMENTUM")
                 .font(.caption2.weight(.bold))
                 .tracking(1)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
 
             Text(story.title)
                 .font(.system(size: 36, weight: .bold, design: .serif))
@@ -117,7 +117,7 @@ struct EditorialStoryDetailView: View {
 
             Text(story.lede.text)
                 .font(.title3)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZineTheme.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -127,7 +127,7 @@ struct EditorialStoryDetailView: View {
             Text(label)
                 .font(.caption2.weight(.heavy))
                 .tracking(1.2)
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             Text(text)
                 .font(.body)
                 .fixedSize(horizontal: false, vertical: true)
@@ -193,24 +193,26 @@ private struct EditorialSourceRow: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: systemImage)
                 .font(.headline)
-                .foregroundStyle(source.origin == .x ? .primary : Color.accentColor)
+                .foregroundStyle(
+                    source.origin == .x ? ZineTheme.primaryText : ZineTheme.brandAccent
+                )
                 .frame(width: 26)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(presentation?.title ?? source.title ?? source.creator ?? "Source")
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(ZineTheme.primaryText)
 
                 if let detail = presentation?.subtitle ?? source.creator ?? source.publisher {
                     Text(detail)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
 
                 if let excerpt = presentation?.excerpt, !excerpt.isEmpty {
                     Text(excerpt)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                         .lineLimit(3)
                 }
             }
@@ -221,11 +223,11 @@ private struct EditorialSourceRow: View {
                     .foregroundStyle(.green)
             } else if presentation?.isSaved == true {
                 Image(systemName: "bookmark.fill")
-                    .foregroundStyle(Color.accentColor)
+                    .foregroundStyle(ZineTheme.brandAccent)
             }
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(ZineTheme.tertiaryText)
         }
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)

--- a/apps/ios/ZineNative/Features/Today/TodayView.swift
+++ b/apps/ios/ZineNative/Features/Today/TodayView.swift
@@ -82,7 +82,7 @@ private struct LegacyEditorialTodayView: View {
                                 .overlay(alignment: .topTrailing) {
                                     if labStore.readyExperimentCount > 0 {
                                         Circle()
-                                            .fill(Color.accentColor)
+                                            .fill(ZineTheme.brandAccent)
                                             .frame(width: 7, height: 7)
                                             .offset(x: 3, y: -2)
                                     }
@@ -202,14 +202,14 @@ private struct LegacyEditorialTodayView: View {
     ) -> some View {
         HStack(spacing: 12) {
             Image(systemName: "flask.fill")
-                .foregroundStyle(Color.accentColor)
+                .foregroundStyle(ZineTheme.brandAccent)
             VStack(alignment: .leading, spacing: 2) {
                 Text("PREVIEWING VARIANT \(variant.label.rawValue)")
                     .font(.caption2.bold())
                     .tracking(0.8)
                 Text(experiment.title)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(1)
             }
             Spacer()
@@ -221,7 +221,7 @@ private struct LegacyEditorialTodayView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 9)
-        .background(.thinMaterial)
+        .background(ZineTheme.surface.opacity(0.96))
         .accessibilityElement(children: .combine)
     }
 
@@ -366,7 +366,7 @@ private struct EditorialExternalSourceView: View {
                         url: imageURL,
                         targetSize: CGSize(width: 390, height: 220)
                     ) {
-                        Color.secondary.opacity(0.1)
+                        ZineTheme.raised
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 220)
@@ -378,7 +378,7 @@ private struct EditorialExternalSourceView: View {
                     Text(sourceLabel.uppercased())
                         .font(.caption2.weight(.bold))
                         .tracking(1)
-                        .foregroundStyle(Color.accentColor)
+                        .foregroundStyle(ZineTheme.brandAccent)
 
                     Text(presentation?.title ?? source?.title ?? "Source")
                         .font(.system(size: 30, weight: .bold, design: .serif))
@@ -386,14 +386,14 @@ private struct EditorialExternalSourceView: View {
                     if let subtitle = presentation?.subtitle ?? source?.creator {
                         Text(subtitle)
                             .font(.headline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZineTheme.secondaryText)
                     }
                 }
 
                 if let excerpt = presentation?.excerpt, !excerpt.isEmpty {
                     Text(excerpt)
                         .font(.body)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZineTheme.secondaryText)
                 }
 
                 actions
@@ -423,7 +423,7 @@ private struct EditorialExternalSourceView: View {
                 HStack(spacing: 18) {
                     if presentation?.isSaved == true {
                         Label("Saved", systemImage: "bookmark.fill")
-                            .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(ZineTheme.brandAccent)
                     } else {
                         Button {
                             Task {

--- a/apps/ios/ZineNativeTests/ZineThemeTests.swift
+++ b/apps/ios/ZineNativeTests/ZineThemeTests.swift
@@ -1,0 +1,76 @@
+import UIKit
+import XCTest
+@testable import ZineNative
+
+final class ZineThemeTests: XCTestCase {
+    func testSemanticRolesResolveToApprovedLightPalette() {
+        assertPalette(
+            style: .light,
+            expected: [
+                .canvas: "F5F7F8",
+                .surface: "FFFFFF",
+                .raised: "E9EDF0",
+                .primaryText: "151719",
+                .secondaryText: "5D646C",
+                .border: "CFD4DA",
+                .brandAccent: "EF661F",
+                .onAccent: "000000",
+                .inlineLink: "B64012",
+            ]
+        )
+    }
+
+    func testSemanticRolesResolveToApprovedDarkPalette() {
+        assertPalette(
+            style: .dark,
+            expected: [
+                .canvas: "000000",
+                .surface: "14171A",
+                .raised: "20252A",
+                .primaryText: "F5F7F8",
+                .secondaryText: "B2BAC2",
+                .border: "343A40",
+                .brandAccent: "EF661F",
+                .onAccent: "000000",
+                .inlineLink: "FFAD7C",
+            ]
+        )
+    }
+
+    func testEveryRoleHasAValueInBothAppearances() {
+        XCTAssertEqual(ZineTheme.Role.allCases.count, 9)
+        for role in ZineTheme.Role.allCases {
+            XCTAssertEqual(role.lightHex.count, 6)
+            XCTAssertEqual(role.darkHex.count, 6)
+        }
+    }
+
+    private func assertPalette(
+        style: UIUserInterfaceStyle,
+        expected: [ZineTheme.Role: String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(expected.count, ZineTheme.Role.allCases.count, file: file, line: line)
+        for role in ZineTheme.Role.allCases {
+            let color = ZineTheme.resolvedUIColor(role, interfaceStyle: style)
+            XCTAssertEqual(color.hexRGB, expected[role], "Unexpected value for \(role)", file: file, line: line)
+        }
+    }
+}
+
+private extension UIColor {
+    var hexRGB: String? {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return nil }
+        return String(
+            format: "%02X%02X%02X",
+            Int((red * 255).rounded()),
+            Int((green * 255).rounded()),
+            Int((blue * 255).rounded())
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a centralized semantic ZineTheme with the approved cool editorial palette for light and dark appearances
- apply the palette across native navigation, Today/Home, Inbox, Library and bookmark detail, reader surfaces, subscriptions, settings, filters, and state affordances
- document native palette rules and exceptions, and test exact semantic color resolution

## Validation

- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -parallel-testing-enabled NO test` — passed, 64 tests
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -configuration Release -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" build` — succeeded
- `bunx prettier --check AGENTS.md apps/ios/README.md apps/ios/DESIGN_SYSTEM.md` — passed
- `git diff --check` — passed
- manually verified representative Home, Library, and reader screens in light and dark mode; installed and launched the palette build on a physical iPhone