### PR TITLE
feat(ios): add collapsing list headers

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -34,6 +34,13 @@ struct AppRootView: View {
 }
 
 private struct AuthenticatedAppView: View {
+    private enum AppTab: Hashable {
+        case home
+        case library
+        case settings
+        case search
+    }
+
     @Environment(\.scenePhase) private var scenePhase
 
     private let client: APIClient
@@ -42,6 +49,9 @@ private struct AuthenticatedAppView: View {
     @State private var homeStore: HomeStore
     @State private var peopleDailyStore: PeopleDailyStore
     @State private var search = ""
+    @State private var selectedTab = AppTab.home
+    @State private var homeTabReselection = 0
+    @State private var libraryTabReselection = 0
     @State private var homeRevision = 0
     @State private var libraryRevision = 0
     @State private var externalOpenEvent: ExternalBookmarkOpenEvent?
@@ -70,8 +80,8 @@ private struct AuthenticatedAppView: View {
     }
 
     var body: some View {
-        TabView {
-            Tab("Home", systemImage: "house") {
+        TabView(selection: tabSelection) {
+            Tab("Home", systemImage: "house", value: AppTab.home) {
                 HomeView(
                     client: client,
                     store: homeStore,
@@ -79,28 +89,30 @@ private struct AuthenticatedAppView: View {
                     density: .compact,
                     onContentChanged: markBookmarkContentChanged,
                     onExternalOpen: handleExternalOpen,
-                    onHomeItemExternalOpen: handleHomeItemExternalOpen
+                    onHomeItemExternalOpen: handleHomeItemExternalOpen,
+                    tabReselection: homeTabReselection
                 )
                 .tint(ZineTheme.brandAccent)
             }
 
-            Tab("Library", systemImage: "books.vertical") {
+            Tab("Library", systemImage: "books.vertical", value: AppTab.library) {
                 LibraryView(
                     client: client,
                     cache: libraryCache,
                     refreshRevision: libraryRevision,
                     onContentChanged: markHomeChanged,
-                    onExternalOpen: handleExternalOpen
+                    onExternalOpen: handleExternalOpen,
+                    tabReselection: libraryTabReselection
                 )
                 .tint(ZineTheme.brandAccent)
             }
 
-            Tab("Settings", systemImage: "gearshape") {
+            Tab("Settings", systemImage: "gearshape", value: AppTab.settings) {
                 AppSettingsView(client: client)
                     .tint(ZineTheme.brandAccent)
             }
 
-            Tab(role: .search) {
+            Tab(value: AppTab.search, role: .search) {
                 LibraryView(
                     client: client,
                     cache: libraryCache,
@@ -141,6 +153,30 @@ private struct AuthenticatedAppView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(externalOpenError ?? "Please try again.")
+        }
+    }
+
+    private var tabSelection: Binding<AppTab> {
+        Binding(
+            get: { selectedTab },
+            set: { newTab in
+                if newTab == selectedTab {
+                    handleTabReselection(newTab)
+                } else {
+                    selectedTab = newTab
+                }
+            }
+        )
+    }
+
+    private func handleTabReselection(_ tab: AppTab) {
+        switch tab {
+        case .home:
+            homeTabReselection += 1
+        case .library:
+            libraryTabReselection += 1
+        case .settings, .search:
+            break
         }
     }
 

--- a/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
+++ b/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
@@ -1,21 +1,40 @@
 import SwiftUI
 
-struct ContentTypeFilterHeader: View {
+struct CollapsingListTitle: View {
     let title: String
-    @Binding var selection: ContentType?
+    let progress: CGFloat
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .font(.largeTitle.weight(.bold))
-                .padding(.horizontal, 18)
-                .padding(.top, 8)
-                .padding(.bottom, 2)
+        Text(title)
+            .font(.largeTitle.weight(.bold))
+            .foregroundStyle(ZineTheme.primaryText)
+            .scaleEffect(1 - (progress * 0.12), anchor: .leading)
+            .opacity(1 - progress)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+            .listRowInsets(EdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 18))
+            .listRowBackground(ZineTheme.canvas)
+            .listRowSeparator(.hidden)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityHidden(progress >= 0.5)
+    }
 
-            ContentTypeFilterBar(selection: $selection)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZineTheme.canvas)
+    static func collapseProgress(scrollOffset: CGFloat) -> CGFloat {
+        min(max(scrollOffset / 44, 0), 1)
+    }
+}
+
+struct CollapsedListTitle: View {
+    let title: String
+    let progress: CGFloat
+
+    var body: some View {
+        Text(title)
+            .font(.headline.weight(.semibold))
+            .foregroundStyle(ZineTheme.primaryText)
+            .opacity(progress)
+            .accessibilityHidden(progress < 0.5)
     }
 }
 

--- a/apps/ios/ZineNative/Core/FilteredListTabAction.swift
+++ b/apps/ios/ZineNative/Core/FilteredListTabAction.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+enum FilteredListTabAction: Equatable {
+    case none
+    case scrollToTop
+    case resetFilter
+
+    static func resolve(isVisible: Bool, isAtTop: Bool, hasActiveFilter: Bool) -> Self {
+        guard isVisible, hasActiveFilter else { return .none }
+        return isAtTop ? .resetFilter : .scrollToTop
+    }
+
+    @MainActor
+    static func perform<ID: Hashable>(
+        isVisible: Bool,
+        collapseProgress: CGFloat,
+        hasActiveFilter: Bool,
+        proxy: ScrollViewProxy,
+        topID: ID,
+        resetFilter: () -> Void
+    ) {
+        switch resolve(
+            isVisible: isVisible,
+            isAtTop: collapseProgress <= 0.01,
+            hasActiveFilter: hasActiveFilter
+        ) {
+        case .scrollToTop:
+            withAnimation(.snappy) {
+                proxy.scrollTo(topID, anchor: .top)
+            }
+        case .resetFilter:
+            resetFilter()
+        case .none:
+            break
+        }
+    }
+}

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -8,6 +8,7 @@ struct HomeSectionListView: View {
 
     @State private var store: HomeSectionListStore
     @State private var contentType: ContentType?
+    @State private var titleCollapseProgress: CGFloat = 0
     @Namespace private var bookmarkTransition
 
     init(
@@ -29,6 +30,15 @@ struct HomeSectionListView: View {
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .solidContentTypeFilterChrome()
+            .toolbar(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    CollapsedListTitle(
+                        title: route.title,
+                        progress: titleCollapseProgress
+                    )
+                }
+            }
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -60,28 +70,39 @@ struct HomeSectionListView: View {
             }
     }
 
-    @ViewBuilder
     private var content: some View {
-        VStack(spacing: 0) {
-            ContentTypeFilterHeader(title: route.title, selection: $contentType)
+        List {
+            CollapsingListTitle(
+                title: route.title,
+                progress: titleCollapseProgress
+            )
 
-            List {
+            Section {
                 resultRows
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
-            .refreshable {
-                await store.reload(contentType: contentType)
-            }
-            .overlay(alignment: .bottom) {
-                if store.isLoadingMore {
-                    ProgressView()
-                        .padding()
-                }
+            } header: {
+                ContentTypeFilterBar(selection: $contentType)
+                    .textCase(nil)
+                    .listRowInsets(EdgeInsets())
             }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .background(ZineTheme.canvas)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+        } action: { _, progress in
+            titleCollapseProgress = progress
+        }
+        .refreshable {
+            await store.reload(contentType: contentType)
+        }
+        .overlay(alignment: .bottom) {
+            if store.isLoadingMore {
+                ProgressView()
+                    .padding()
+            }
+        }
         .foregroundStyle(ZineTheme.primaryText)
     }
 

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -5,22 +5,26 @@ struct HomeSectionListView: View {
     let client: APIClient
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
+    let tabReselection: Int
 
     @State private var store: HomeSectionListStore
     @State private var contentType: ContentType?
     @State private var titleCollapseProgress: CGFloat = 0
+    @State private var isVisible = false
     @Namespace private var bookmarkTransition
 
     init(
         route: HomeSectionRoute,
         client: APIClient,
         onContentChanged: @escaping () -> Void = {},
-        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
+        tabReselection: Int = 0
     ) {
         self.route = route
         self.client = client
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
+        self.tabReselection = tabReselection
         _store = State(initialValue: HomeSectionListStore(route: route, client: client))
         _contentType = State(initialValue: route.initialContentTypeFilter)
     }
@@ -71,39 +75,62 @@ struct HomeSectionListView: View {
     }
 
     private var content: some View {
-        List {
-            CollapsingListTitle(
-                title: route.title,
-                progress: titleCollapseProgress
-            )
+        ScrollViewReader { proxy in
+            List {
+                CollapsingListTitle(
+                    title: route.title,
+                    progress: titleCollapseProgress
+                )
+                .id(ScrollAnchor.top)
 
-            Section {
-                resultRows
-            } header: {
-                ContentTypeFilterBar(selection: $contentType)
-                    .textCase(nil)
-                    .listRowInsets(EdgeInsets())
+                Section {
+                    resultRows
+                } header: {
+                    ContentTypeFilterBar(selection: $contentType)
+                        .textCase(nil)
+                        .listRowInsets(EdgeInsets())
+                }
             }
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
-        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-        } action: { _, progress in
-            titleCollapseProgress = progress
-        }
-        .refreshable {
-            await store.reload(contentType: contentType)
-        }
-        .overlay(alignment: .bottom) {
-            if store.isLoadingMore {
-                ProgressView()
-                    .padding()
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
             }
+            .onChange(of: tabReselection) {
+                handleTabReselection(using: proxy)
+            }
+            .onAppear { isVisible = true }
+            .onDisappear { isVisible = false }
+            .refreshable {
+                await store.reload(contentType: contentType)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+            .foregroundStyle(ZineTheme.primaryText)
         }
-        .foregroundStyle(ZineTheme.primaryText)
+    }
+
+    private enum ScrollAnchor {
+        static let top = "home-section-list-top"
+    }
+
+    private func handleTabReselection(using proxy: ScrollViewProxy) {
+        FilteredListTabAction.perform(
+            isVisible: isVisible,
+            collapseProgress: titleCollapseProgress,
+            hasActiveFilter: contentType != nil,
+            proxy: proxy,
+            topID: ScrollAnchor.top,
+            resetFilter: { contentType = nil }
+        )
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -45,6 +45,7 @@ struct HomeView: View {
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
     let onHomeItemExternalOpen: (HomeItem) -> Void
+    let tabReselection: Int
 
     @Namespace private var bookmarkTransition
 
@@ -56,7 +57,8 @@ struct HomeView: View {
         title: String = "Home",
         onContentChanged: @escaping () -> Void,
         onExternalOpen: @escaping (Bookmark) -> Void,
-        onHomeItemExternalOpen: @escaping (HomeItem) -> Void
+        onHomeItemExternalOpen: @escaping (HomeItem) -> Void,
+        tabReselection: Int = 0
     ) {
         self.client = client
         self.store = store
@@ -66,6 +68,7 @@ struct HomeView: View {
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         self.onHomeItemExternalOpen = onHomeItemExternalOpen
+        self.tabReselection = tabReselection
     }
 
     var body: some View {
@@ -85,14 +88,16 @@ struct HomeView: View {
                         JumpBackInListView(
                             client: client,
                             onContentChanged: onContentChanged,
-                            onExternalOpen: onExternalOpen
+                            onExternalOpen: onExternalOpen,
+                            tabReselection: tabReselection
                         )
                     default:
                         HomeSectionListView(
                             route: route,
                             client: client,
                             onContentChanged: onContentChanged,
-                            onExternalOpen: onExternalOpen
+                            onExternalOpen: onExternalOpen,
+                            tabReselection: tabReselection
                         )
                     }
                 }

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -4,20 +4,24 @@ struct JumpBackInListView: View {
     let client: APIClient
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
+    let tabReselection: Int
 
     @State private var store: JumpBackInListStore
     @State private var contentType: ContentType?
     @State private var titleCollapseProgress: CGFloat = 0
+    @State private var isVisible = false
     @Namespace private var bookmarkTransition
 
     init(
         client: APIClient,
         onContentChanged: @escaping () -> Void = {},
-        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
+        tabReselection: Int = 0
     ) {
         self.client = client
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
+        self.tabReselection = tabReselection
         _store = State(initialValue: JumpBackInListStore(client: client))
     }
 
@@ -63,39 +67,62 @@ struct JumpBackInListView: View {
     }
 
     private var content: some View {
-        List {
-            CollapsingListTitle(
-                title: "Jump Back In",
-                progress: titleCollapseProgress
-            )
+        ScrollViewReader { proxy in
+            List {
+                CollapsingListTitle(
+                    title: "Jump Back In",
+                    progress: titleCollapseProgress
+                )
+                .id(ScrollAnchor.top)
 
-            Section {
-                resultRows
-            } header: {
-                ContentTypeFilterBar(selection: $contentType)
-                    .textCase(nil)
-                    .listRowInsets(EdgeInsets())
+                Section {
+                    resultRows
+                } header: {
+                    ContentTypeFilterBar(selection: $contentType)
+                        .textCase(nil)
+                        .listRowInsets(EdgeInsets())
+                }
             }
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
-        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-        } action: { _, progress in
-            titleCollapseProgress = progress
-        }
-        .refreshable {
-            await store.reload(contentType: contentType)
-        }
-        .overlay(alignment: .bottom) {
-            if store.isLoadingMore {
-                ProgressView()
-                    .padding()
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
             }
+            .onChange(of: tabReselection) {
+                handleTabReselection(using: proxy)
+            }
+            .onAppear { isVisible = true }
+            .onDisappear { isVisible = false }
+            .refreshable {
+                await store.reload(contentType: contentType)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
+                }
+            }
+            .foregroundStyle(ZineTheme.primaryText)
         }
-        .foregroundStyle(ZineTheme.primaryText)
+    }
+
+    private enum ScrollAnchor {
+        static let top = "jump-back-in-list-top"
+    }
+
+    private func handleTabReselection(using proxy: ScrollViewProxy) {
+        FilteredListTabAction.perform(
+            isVisible: isVisible,
+            collapseProgress: titleCollapseProgress,
+            hasActiveFilter: contentType != nil,
+            proxy: proxy,
+            topID: ScrollAnchor.top,
+            resetFilter: { contentType = nil }
+        )
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -7,6 +7,7 @@ struct JumpBackInListView: View {
 
     @State private var store: JumpBackInListStore
     @State private var contentType: ContentType?
+    @State private var titleCollapseProgress: CGFloat = 0
     @Namespace private var bookmarkTransition
 
     init(
@@ -25,6 +26,15 @@ struct JumpBackInListView: View {
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .solidContentTypeFilterChrome()
+            .toolbar(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    CollapsedListTitle(
+                        title: "Jump Back In",
+                        progress: titleCollapseProgress
+                    )
+                }
+            }
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -52,28 +62,39 @@ struct JumpBackInListView: View {
             }
     }
 
-    @ViewBuilder
     private var content: some View {
-        VStack(spacing: 0) {
-            ContentTypeFilterHeader(title: "Jump Back In", selection: $contentType)
+        List {
+            CollapsingListTitle(
+                title: "Jump Back In",
+                progress: titleCollapseProgress
+            )
 
-            List {
+            Section {
                 resultRows
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
-            .refreshable {
-                await store.reload(contentType: contentType)
-            }
-            .overlay(alignment: .bottom) {
-                if store.isLoadingMore {
-                    ProgressView()
-                        .padding()
-                }
+            } header: {
+                ContentTypeFilterBar(selection: $contentType)
+                    .textCase(nil)
+                    .listRowInsets(EdgeInsets())
             }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .background(ZineTheme.canvas)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+        } action: { _, progress in
+            titleCollapseProgress = progress
+        }
+        .refreshable {
+            await store.reload(contentType: contentType)
+        }
+        .overlay(alignment: .bottom) {
+            if store.isLoadingMore {
+                ProgressView()
+                    .padding()
+            }
+        }
         .foregroundStyle(ZineTheme.primaryText)
     }
 

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -57,6 +57,7 @@ private struct ScreenshotHomeSectionListView: View {
     let route: HomeSectionRoute
 
     @State private var contentType: ContentType?
+    @State private var titleCollapseProgress: CGFloat = 0
 
     init(route: HomeSectionRoute) {
         self.route = route
@@ -69,22 +70,43 @@ private struct ScreenshotHomeSectionListView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            ContentTypeFilterHeader(title: route.title, selection: $contentType)
+        List {
+            CollapsingListTitle(
+                title: route.title,
+                progress: titleCollapseProgress
+            )
 
-            List {
+            Section {
                 ForEach(bookmarks) { bookmark in
                     BookmarkRow(bookmark: bookmark)
                 }
+            } header: {
+                ContentTypeFilterBar(selection: $contentType)
+                    .textCase(nil)
+                    .listRowInsets(EdgeInsets())
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .background(ZineTheme.canvas)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+        } action: { _, progress in
+            titleCollapseProgress = progress
+        }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .solidContentTypeFilterChrome()
+        .toolbar(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                CollapsedListTitle(
+                    title: route.title,
+                    progress: titleCollapseProgress
+                )
+            }
+        }
     }
 }
 

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -11,6 +11,7 @@ struct LibraryView: View {
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
+    @State private var titleCollapseProgress: CGFloat = 0
 
     init(
         client: APIClient,
@@ -52,14 +53,21 @@ struct LibraryView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle(isSearchMode ? "Search" : "")
+                .navigationTitle(isSearchMode ? "Search" : "Library")
                 .navigationBarTitleDisplayMode(.inline)
                 .solidContentTypeFilterChrome()
-                .toolbar(isSearchMode ? .visible : .hidden, for: .navigationBar)
+                .toolbar(.visible, for: .navigationBar)
                 .toolbar {
                     if isSearchMode {
                         ToolbarItem(placement: .topBarLeading) {
                             filterMenu
+                        }
+                    } else {
+                        ToolbarItem(placement: .principal) {
+                            CollapsedListTitle(
+                                title: "Library",
+                                progress: titleCollapseProgress
+                            )
                         }
                     }
                 }
@@ -98,25 +106,37 @@ struct LibraryView: View {
 
     @ViewBuilder
     private var content: some View {
-        if isSearchMode {
-            resultsList
-        } else {
-            VStack(spacing: 0) {
-                ContentTypeFilterHeader(title: "Library", selection: $contentType)
-
-                resultsList
-            }
-            .background(ZineTheme.canvas)
-        }
+        resultsList
     }
 
     private var resultsList: some View {
         List {
-            resultRows
+            if isSearchMode {
+                resultRows
+            } else {
+                CollapsingListTitle(
+                    title: "Library",
+                    progress: titleCollapseProgress
+                )
+
+                Section {
+                    resultRows
+                } header: {
+                    ContentTypeFilterBar(selection: $contentType)
+                        .textCase(nil)
+                        .listRowInsets(EdgeInsets())
+                }
+            }
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(ZineTheme.canvas)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+        } action: { _, progress in
+            titleCollapseProgress = progress
+        }
         .refreshable {
             await store.reload(query: query)
         }

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -6,12 +6,14 @@ struct LibraryView: View {
     let refreshRevision: Int
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
+    let tabReselection: Int
 
     @State private var store: LibraryStore
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
     @State private var titleCollapseProgress: CGFloat = 0
+    @State private var isVisible = false
 
     init(
         client: APIClient,
@@ -19,13 +21,15 @@ struct LibraryView: View {
         searchText: Binding<String>? = nil,
         refreshRevision: Int = 0,
         onContentChanged: @escaping () -> Void = {},
-        onExternalOpen: @escaping (Bookmark) -> Void = { _ in }
+        onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
+        tabReselection: Int = 0
     ) {
         self.client = client
         self.searchText = searchText
         self.refreshRevision = refreshRevision
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
+        self.tabReselection = tabReselection
         _store = State(initialValue: LibraryStore(
             client: client,
             cache: cache,
@@ -110,42 +114,65 @@ struct LibraryView: View {
     }
 
     private var resultsList: some View {
-        List {
-            if isSearchMode {
-                resultRows
-            } else {
-                CollapsingListTitle(
-                    title: "Library",
-                    progress: titleCollapseProgress
-                )
-
-                Section {
+        ScrollViewReader { proxy in
+            List {
+                if isSearchMode {
                     resultRows
-                } header: {
-                    ContentTypeFilterBar(selection: $contentType)
-                        .textCase(nil)
-                        .listRowInsets(EdgeInsets())
+                } else {
+                    CollapsingListTitle(
+                        title: "Library",
+                        progress: titleCollapseProgress
+                    )
+                    .id(ScrollAnchor.top)
+
+                    Section {
+                        resultRows
+                    } header: {
+                        ContentTypeFilterBar(selection: $contentType)
+                            .textCase(nil)
+                            .listRowInsets(EdgeInsets())
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
+            }
+            .onChange(of: tabReselection) {
+                handleTabReselection(using: proxy)
+            }
+            .onAppear { isVisible = true }
+            .onDisappear { isVisible = false }
+            .refreshable {
+                await store.reload(query: query)
+            }
+            .overlay(alignment: .bottom) {
+                if store.isLoadingMore {
+                    ProgressView()
+                        .padding()
                 }
             }
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
-        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-        } action: { _, progress in
-            titleCollapseProgress = progress
-        }
-        .refreshable {
-            await store.reload(query: query)
-        }
-        .overlay(alignment: .bottom) {
-            if store.isLoadingMore {
-                ProgressView()
-                    .padding()
-            }
-        }
+    }
+
+    private enum ScrollAnchor {
+        static let top = "library-list-top"
+    }
+
+    private func handleTabReselection(using proxy: ScrollViewProxy) {
+        FilteredListTabAction.perform(
+            isVisible: isVisible && !isSearchMode,
+            collapseProgress: titleCollapseProgress,
+            hasActiveFilter: contentType != nil,
+            proxy: proxy,
+            topID: ScrollAnchor.top,
+            resetFilter: { contentType = nil }
+        )
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -7,6 +7,7 @@ struct ScreenshotLibraryView: View {
         tokenProvider: { "screenshot-fixture" }
     )
     @State private var contentType: ContentType?
+    @State private var titleCollapseProgress: CGFloat = 0
 
     private var bookmarks: [Bookmark] {
         guard let contentType else { return ScreenshotFixtures.bookmarks }
@@ -15,11 +16,15 @@ struct ScreenshotLibraryView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                ContentTypeFilterHeader(title: "Library", selection: $contentType)
+            List {
+                CollapsingListTitle(
+                    title: "Library",
+                    progress: titleCollapseProgress
+                )
 
-                List {
-                    ForEach(bookmarks) { bookmark in
+                Section {
+                    ForEach(0..<(bookmarks.count * 3), id: \.self) { index in
+                        let bookmark = bookmarks[index % bookmarks.count]
                         NavigationLink(value: bookmark) {
                             BookmarkRow(bookmark: bookmark)
                         }
@@ -27,15 +32,33 @@ struct ScreenshotLibraryView: View {
                         .listRowBackground(ZineTheme.canvas)
                         .listRowSeparator(.hidden)
                     }
+                } header: {
+                    ContentTypeFilterBar(selection: $contentType)
+                        .textCase(nil)
+                        .listRowInsets(EdgeInsets())
                 }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .background(ZineTheme.canvas)
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
             .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
+            }
             .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
             .solidContentTypeFilterChrome()
-            .toolbar(.hidden, for: .navigationBar)
+            .toolbar(.visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    CollapsedListTitle(
+                        title: "Library",
+                        progress: titleCollapseProgress
+                    )
+                }
+            }
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(bookmark: bookmark, client: client) { _ in }
             }

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -259,6 +259,12 @@ final class HomeTests: XCTestCase {
         )
     }
 
+    func testContentTypeTitleCollapseProgressClampsScrollOffset() {
+        XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: -20), 0)
+        XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: 22), 0.5)
+        XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: 80), 1)
+    }
+
     func testHomeItemProvidesImmediateBookmarkDetailContent() {
         let item = makeHomeItem(id: "instant", minutes: 12)
         let content = BookmarkDetailContent(item: item)

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -265,6 +265,44 @@ final class HomeTests: XCTestCase {
         XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: 80), 1)
     }
 
+    func testFilteredListTabReselectionScrollsBeforeResettingFilter() {
+        XCTAssertEqual(
+            FilteredListTabAction.resolve(
+                isVisible: true,
+                isAtTop: false,
+                hasActiveFilter: true
+            ),
+            .scrollToTop
+        )
+        XCTAssertEqual(
+            FilteredListTabAction.resolve(
+                isVisible: true,
+                isAtTop: true,
+                hasActiveFilter: true
+            ),
+            .resetFilter
+        )
+    }
+
+    func testFilteredListTabReselectionIgnoresUnfilteredOrHiddenLists() {
+        XCTAssertEqual(
+            FilteredListTabAction.resolve(
+                isVisible: true,
+                isAtTop: false,
+                hasActiveFilter: false
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            FilteredListTabAction.resolve(
+                isVisible: false,
+                isAtTop: true,
+                hasActiveFilter: true
+            ),
+            .none
+        )
+    }
+
     func testHomeItemProvidesImmediateBookmarkDetailContent() {
         let item = makeHomeItem(id: "instant", minutes: 12)
         let content = BookmarkDetailContent(item: item)


### PR DESCRIPTION
## Summary

- animate native list titles into the centered toolbar title as content scrolls
- pin content-type filter chips beneath the collapsed title while rows continue underneath
- apply the shared behavior to Library, Home section lists, Jump Back In, and deterministic screenshot fixtures
- keep Search inline and expose one accessible title throughout the transition

## Validation

- XcodeBuildMCP iOS Simulator tests: 65 passed, 0 failed, 0 skipped
- bun run format:check
- bun run design-system:check
- pre-push: format, design-system, typecheck, 75 web tests, and 1,718 worker tests
- signed Release build for app.zine.native; codesign verification passed
- installed and launched on Erik’s physical iPhone
- expanded and pinned states visually verified in light and dark mode on iOS Simulator