### PR TITLE
feat(ios): add reader end actions

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -350,6 +350,22 @@ struct APIClient {
         return response.bookmark
     }
 
+    func listTags() async throws -> [BookmarkTag] {
+        let response: BookmarkTagsResponse = try await request(
+            url: baseURL.appending(path: "/api/v1/tags")
+        )
+        return response.tags
+    }
+
+    func setTags(id: String, tags: [String]) async throws -> [BookmarkTag] {
+        var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/tags"))
+        request.httpMethod = "PUT"
+        request.httpBody = try JSONEncoder().encode(["tags": tags])
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let response: BookmarkTagsResponse = try await send(request)
+        return response.tags
+    }
+
     func archiveBookmark(id: String) async throws {
         var request = URLRequest(url: baseURL.appending(path: "/api/v1/bookmarks/\(id)"))
         request.httpMethod = "DELETE"

--- a/apps/ios/ZineNative/Core/API/APIResponses.swift
+++ b/apps/ios/ZineNative/Core/API/APIResponses.swift
@@ -33,3 +33,7 @@ struct FinishedStateResponse: Decodable {
 
     let bookmark: FinishedBookmark
 }
+
+struct BookmarkTagsResponse: Decodable {
+    let tags: [BookmarkTag]
+}

--- a/apps/ios/ZineNative/Core/Models/ArticleBody.swift
+++ b/apps/ios/ZineNative/Core/Models/ArticleBody.swift
@@ -70,6 +70,7 @@ struct ArticleReaderMetadata: Equatable {
     let readingTimeMinutes: Int?
     let initialProgress: BookmarkProgress?
     let isFinished: Bool
+    let tags: [BookmarkTag]
 }
 
 struct ArticleReaderDocument: Equatable {

--- a/apps/ios/ZineNative/Core/Models/Bookmark.swift
+++ b/apps/ios/ZineNative/Core/Models/Bookmark.swift
@@ -88,7 +88,7 @@ struct Bookmark: Codable, Hashable, Identifiable {
     var progress: BookmarkProgress?
     var isFinished: Bool
     var finishedAt: String?
-    let tags: [BookmarkTag]
+    var tags: [BookmarkTag]
 
     var consumptionLabel: String? {
         if let readingTimeMinutes {

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -303,12 +303,14 @@ struct BookmarkDetailView: View {
                             canonicalURL: content.canonicalUrl,
                             readingTimeMinutes: content.readingTimeMinutes,
                             initialProgress: content.progress,
-                            isFinished: content.isFinished
+                            isFinished: content.isFinished,
+                            tags: content.tags
                         ),
                         client: client,
                         onRead: { onExternalOpen(bookmark) },
                         onProgressSaved: updateReadingProgress,
-                        onFinishedChanged: updateFinishedState
+                        onFinishedChanged: updateFinishedState,
+                        onTagsChanged: updateTags
                     )
                 } label: {
                     Image(systemName: "book.pages")
@@ -718,6 +720,13 @@ struct BookmarkDetailView: View {
         guard var bookmark else { return }
         bookmark.isFinished = isFinished
         bookmark.finishedAt = isFinished ? Date().formatted(.iso8601) : nil
+        self.bookmark = bookmark
+        onUpdate(bookmark)
+    }
+
+    private func updateTags(_ tags: [BookmarkTag]) {
+        guard var bookmark else { return }
+        bookmark.tags = tags
         self.bookmark = bookmark
         onUpdate(bookmark)
     }

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -1,5 +1,19 @@
 import SwiftUI
 
+enum ArticleReaderEndActions {
+    static let revealThreshold = 0.985
+
+    static func shouldReveal(for progress: Double) -> Bool {
+        progress >= revealThreshold
+    }
+}
+
+private enum ArticleReaderSheet: String, Identifiable {
+    case tags
+
+    var id: String { rawValue }
+}
+
 struct ArticleReaderView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
@@ -14,10 +28,16 @@ struct ArticleReaderView: View {
     @State private var hasRecordedOpen = false
     @State private var isUpdatingFinished = false
     @State private var readerChromeOffset: CGFloat = 0
+    @State private var showsEndActions: Bool
+    @State private var presentedSheet: ArticleReaderSheet?
+    @State private var readerTags: [BookmarkTag]
+    @State private var actionErrorMessage: String?
 
     private let onRead: () -> Void
     private let onProgressSaved: (BookmarkProgress) -> Void
     private let onFinishedChanged: (Bool) -> Void
+    private let onTagsChanged: ([BookmarkTag]) -> Void
+    private let client: APIClient
     private let loadsOnAppear: Bool
 
     init(
@@ -27,7 +47,8 @@ struct ArticleReaderView: View {
         loadsOnAppear: Bool = true,
         onRead: @escaping () -> Void = {},
         onProgressSaved: @escaping (BookmarkProgress) -> Void = { _ in },
-        onFinishedChanged: @escaping (Bool) -> Void = { _ in }
+        onFinishedChanged: @escaping (Bool) -> Void = { _ in },
+        onTagsChanged: @escaping ([BookmarkTag]) -> Void = { _ in }
     ) {
         let initialProgress = metadata.initialProgress?.fraction ?? 0
         _store = State(
@@ -39,9 +60,15 @@ struct ArticleReaderView: View {
         )
         _scrollProgress = State(initialValue: initialProgress)
         _lastPersistedProgress = State(initialValue: initialProgress)
+        _showsEndActions = State(
+            initialValue: ArticleReaderEndActions.shouldReveal(for: initialProgress)
+        )
+        _readerTags = State(initialValue: metadata.tags)
         self.onRead = onRead
         self.onProgressSaved = onProgressSaved
         self.onFinishedChanged = onFinishedChanged
+        self.onTagsChanged = onTagsChanged
+        self.client = client
         self.loadsOnAppear = loadsOnAppear
     }
 
@@ -53,6 +80,14 @@ struct ArticleReaderView: View {
             phaseContent
 
             readerChromeViewport
+        }
+        .overlay(alignment: .bottom) {
+            if store.readyDocument != nil, showsEndActions {
+                readerEndActions
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
         .toolbarVisibility(.hidden, for: .navigationBar)
         .task(id: store.metadata.bookmarkID) {
@@ -83,6 +118,28 @@ struct ArticleReaderView: View {
         .onDisappear {
             readerChromeOffset = 0
             flushProgress()
+        }
+        .sheet(item: $presentedSheet) { destination in
+            switch destination {
+            case .tags:
+                ArticleTagEditorView(
+                    bookmarkID: store.metadata.bookmarkID,
+                    initialTags: readerTags,
+                    client: client,
+                    onSaved: { tags in
+                        readerTags = tags
+                        onTagsChanged(tags)
+                    }
+                )
+            }
+        }
+        .alert("Couldn’t update article", isPresented: Binding(
+            get: { actionErrorMessage != nil },
+            set: { if !$0 { actionErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(actionErrorMessage ?? "Please try again.")
         }
     }
 
@@ -123,7 +180,7 @@ struct ArticleReaderView: View {
             document: document,
             initialProgress: store.initialProgressFraction,
             fontScale: readerFontSize.scale,
-            onProgressChanged: { scrollProgress = $0 },
+            onProgressChanged: updateScrollProgress,
             onScrollSettled: persistSettledProgress,
             onChromeOffsetChanged: { readerChromeOffset = $0 },
             onOpenURL: { openURL($0) }
@@ -220,6 +277,71 @@ struct ArticleReaderView: View {
         .clipped()
     }
 
+    private var readerEndActions: some View {
+        VStack(spacing: 12) {
+            Capsule()
+                .fill(ZineTheme.border)
+                .frame(width: 36, height: 4)
+
+            HStack {
+                Text(store.isFinished ? "Reading complete" : "Finished reading?")
+                    .font(.headline)
+                    .foregroundStyle(ZineTheme.primaryText)
+
+                Spacer()
+
+                if isUpdatingFinished {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Updating completion")
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    Task { await toggleFinished() }
+                } label: {
+                    Label(
+                        store.isFinished ? "Mark unfinished" : "Mark complete",
+                        systemImage: store.isFinished
+                            ? "arrow.uturn.backward.circle"
+                            : "checkmark.circle.fill"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(ZineTheme.brandAccent)
+                .foregroundStyle(ZineTheme.onAccent)
+                .disabled(isUpdatingFinished)
+                .accessibilityIdentifier("article-reader-toggle-complete")
+
+                Button {
+                    presentedSheet = .tags
+                } label: {
+                    Label(
+                        readerTags.isEmpty ? "Add tags" : "Edit tags",
+                        systemImage: "tag"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .tint(ZineTheme.primaryText)
+                .accessibilityIdentifier("article-reader-edit-tags")
+            }
+            .font(.subheadline.weight(.semibold))
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 9)
+        .padding(.bottom, 14)
+        .background(ZineTheme.surface.opacity(0.98), in: .rect(cornerRadius: 22))
+        .overlay {
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(ZineTheme.border, lineWidth: 1)
+        }
+        .shadow(color: ZineTheme.primaryText.opacity(0.12), radius: 18, y: 8)
+        .accessibilityIdentifier("article-reader-end-actions")
+    }
+
     private var progressWriteKey: Int {
         Int((scrollProgress * 100).rounded(.down))
     }
@@ -240,7 +362,7 @@ struct ArticleReaderView: View {
     }
 
     private func persistSettledProgress(_ progress: Double) {
-        scrollProgress = progress
+        updateScrollProgress(progress)
         guard store.readyDocument != nil,
               abs(progress - lastPersistedProgress) >= 0.0001
         else { return }
@@ -265,7 +387,253 @@ struct ArticleReaderView: View {
         guard !isUpdatingFinished else { return }
         isUpdatingFinished = true
         defer { isUpdatingFinished = false }
-        guard let value = await store.toggleFinished() else { return }
+        guard let value = await store.toggleFinished() else {
+            actionErrorMessage = "Zine couldn’t change the completion state. Check your connection and try again."
+            return
+        }
         onFinishedChanged(value)
+    }
+
+    private func updateScrollProgress(_ progress: Double) {
+        scrollProgress = progress
+        guard !showsEndActions,
+              ArticleReaderEndActions.shouldReveal(for: progress)
+        else { return }
+        withAnimation(.snappy) {
+            showsEndActions = true
+        }
+    }
+}
+
+private struct ArticleTagEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var availableTags: [BookmarkTag]
+    @State private var selectedTagNames: [String]
+    @State private var query = ""
+    @State private var isLoading = true
+    @State private var isSaving = false
+    @State private var loadErrorMessage: String?
+    @State private var saveErrorMessage: String?
+
+    private let bookmarkID: String
+    private let client: APIClient
+    private let onSaved: ([BookmarkTag]) -> Void
+
+    init(
+        bookmarkID: String,
+        initialTags: [BookmarkTag],
+        client: APIClient,
+        onSaved: @escaping ([BookmarkTag]) -> Void
+    ) {
+        self.bookmarkID = bookmarkID
+        self.client = client
+        self.onSaved = onSaved
+        _availableTags = State(initialValue: initialTags)
+        _selectedTagNames = State(initialValue: initialTags.map(\.name))
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 16) {
+                TextField("Add or search tags", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.done)
+                    .onSubmit(addQuery)
+                    .accessibilityLabel("Tag input")
+
+                if normalizedQuery.count > BookmarkShareStore.maximumTagLength {
+                    Text("Tags can be up to \(BookmarkShareStore.maximumTagLength) characters.")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                } else if canCreateQuery {
+                    Button {
+                        addQuery()
+                    } label: {
+                        Label("Create \"\(normalizedQuery)\"", systemImage: "plus")
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.capsule)
+                    .disabled(selectedTagNames.count >= BookmarkShareStore.maximumTagCount)
+                }
+
+                if isLoading, availableTags.isEmpty {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Loading tags…")
+                            .foregroundStyle(ZineTheme.secondaryText)
+                    }
+                } else if let loadErrorMessage {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(loadErrorMessage)
+                            .font(.caption)
+                            .foregroundStyle(ZineTheme.secondaryText)
+                        Spacer()
+                        Button("Retry") {
+                            Task { await loadTags() }
+                        }
+                        .font(.caption.weight(.semibold))
+                    }
+                }
+
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(filteredTags) { tag in
+                            tagRow(tag)
+                        }
+                    }
+                }
+
+                if selectedTagNames.count >= BookmarkShareStore.maximumTagCount {
+                    Text("You can add up to \(BookmarkShareStore.maximumTagCount) tags.")
+                        .font(.caption)
+                        .foregroundStyle(ZineTheme.secondaryText)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .background(ZineTheme.canvas)
+            .navigationTitle("Article tags")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving…" : "Save") {
+                        Task { await save() }
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(isSaving)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .interactiveDismissDisabled(isSaving)
+        .task { await loadTags() }
+        .alert("Couldn’t save tags", isPresented: Binding(
+            get: { saveErrorMessage != nil },
+            set: { if !$0 { saveErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(saveErrorMessage ?? "Please try again.")
+        }
+    }
+
+    private var normalizedQuery: String {
+        BookmarkShareStore.normalizedTagName(query)
+    }
+
+    private var filteredTags: [BookmarkTag] {
+        let key = tagKey(query)
+        guard !key.isEmpty else { return availableTags }
+        return availableTags.filter { tagKey($0.name).contains(key) }
+    }
+
+    private var canCreateQuery: Bool {
+        guard !normalizedQuery.isEmpty,
+              normalizedQuery.count <= BookmarkShareStore.maximumTagLength
+        else { return false }
+        let key = tagKey(normalizedQuery)
+        return !availableTags.contains { tagKey($0.name) == key }
+    }
+
+    private func tagRow(_ tag: BookmarkTag) -> some View {
+        let isSelected = containsTag(named: tag.name)
+        let isDisabled = !isSelected
+            && selectedTagNames.count >= BookmarkShareStore.maximumTagCount
+
+        return Button {
+            toggleTag(named: tag.name)
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? ZineTheme.brandAccent : ZineTheme.secondaryText)
+                Text(tag.name)
+                    .foregroundStyle(ZineTheme.primaryText)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .frame(minHeight: 48)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(ZineTheme.border, lineWidth: 1)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .accessibilityLabel("\(tag.name) tag")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+
+    private func addQuery() {
+        guard canCreateQuery,
+              selectedTagNames.count < BookmarkShareStore.maximumTagCount
+        else { return }
+        let name = normalizedQuery
+        availableTags.insert(BookmarkTag(id: "local-\(UUID().uuidString)", name: name), at: 0)
+        selectedTagNames.append(name)
+        query = ""
+    }
+
+    private func toggleTag(named name: String) {
+        let key = tagKey(name)
+        if containsTag(named: name) {
+            selectedTagNames.removeAll { tagKey($0) == key }
+        } else if selectedTagNames.count < BookmarkShareStore.maximumTagCount {
+            selectedTagNames.append(name)
+        }
+    }
+
+    private func containsTag(named name: String) -> Bool {
+        let key = tagKey(name)
+        return selectedTagNames.contains { tagKey($0) == key }
+    }
+
+    private func tagKey(_ value: String) -> String {
+        BookmarkShareStore.normalizedTagName(value).lowercased()
+    }
+
+    private func loadTags() async {
+        isLoading = true
+        loadErrorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            availableTags = uniqueTags(availableTags + (try await client.listTags()))
+        } catch is CancellationError {
+            return
+        } catch {
+            loadErrorMessage = "Couldn’t load your tags. You can still add one manually."
+        }
+    }
+
+    private func save() async {
+        guard !isSaving else { return }
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            let tags = try await client.setTags(id: bookmarkID, tags: selectedTagNames)
+            onSaved(tags)
+            dismiss()
+        } catch is CancellationError {
+            return
+        } catch {
+            saveErrorMessage = "Zine couldn’t save these tags. Check your connection and try again."
+        }
+    }
+
+    private func uniqueTags(_ tags: [BookmarkTag]) -> [BookmarkTag] {
+        var seen = Set<String>()
+        return tags.filter { seen.insert(tagKey($0.name)).inserted }
     }
 }

--- a/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ScreenshotArticleReaderView.swift
@@ -17,7 +17,8 @@ struct ScreenshotArticleReaderView: View {
         canonicalURL: URL(string: "https://example.com/calm-software")!,
         readingTimeMinutes: 7,
         initialProgress: BookmarkProgress(position: 0.18, duration: 1, percent: 18),
-        isFinished: false
+        isFinished: false,
+        tags: [BookmarkTag(id: "fixture-tag", name: "Design")]
     )
 
     private let client = APIClient(

--- a/apps/ios/ZineNativeTests/ArticleReaderTests.swift
+++ b/apps/ios/ZineNativeTests/ArticleReaderTests.swift
@@ -162,6 +162,12 @@ final class ArticleReaderTests: XCTestCase {
         XCTAssertEqual(tracker.update(scrollOffset: 66), 42)
     }
 
+    func testEndActionsRevealOnlyAtTheArticleBottom() {
+        XCTAssertFalse(ArticleReaderEndActions.shouldReveal(for: 0.98))
+        XCTAssertTrue(ArticleReaderEndActions.shouldReveal(for: 0.985))
+        XCTAssertTrue(ArticleReaderEndActions.shouldReveal(for: 1))
+    }
+
     func testCachePersistsOnlyReadableDocumentsPerUser() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: "article-cache-\(UUID().uuidString)", directoryHint: .isDirectory)
@@ -229,6 +235,66 @@ final class ArticleReaderTests: XCTestCase {
         XCTAssertEqual(ArticleReaderURLProtocol.requests.map(\.httpMethod), ["GET", "POST"])
     }
 
+    @MainActor
+    func testStoreTogglesCompletionThroughTheBookmarkEndpoint() async throws {
+        let client = Self.client { request in
+            XCTAssertEqual(request.httpMethod, "PATCH")
+            XCTAssertEqual(request.url?.path, "/api/v1/bookmarks/bookmark-1")
+            let body = try XCTUnwrap(Self.bodyData(from: request))
+            let payload = try JSONDecoder().decode([String: Bool].self, from: body)
+            XCTAssertEqual(payload, ["isFinished": true])
+            return (200, """
+                {
+                  "bookmark":{
+                    "id":"bookmark-1","itemId":"item-1","isFinished":true,
+                    "finishedAt":"2026-08-07T12:00:00Z"
+                  }
+                }
+                """)
+        }
+        let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
+
+        let result = await store.toggleFinished()
+
+        XCTAssertEqual(result, true)
+        XCTAssertTrue(store.isFinished)
+    }
+
+    func testTagEndpointsListAndReplaceArticleTags() async throws {
+        let client = Self.client { request in
+            switch request.httpMethod {
+            case "GET":
+                XCTAssertEqual(request.url?.path, "/api/v1/tags")
+                return (200, #"{"tags":[{"id":"tag-1","name":"Design"}]}"#)
+            case "PUT":
+                XCTAssertEqual(request.url?.path, "/api/v1/bookmarks/bookmark-1/tags")
+                let body = try XCTUnwrap(Self.bodyData(from: request))
+                let payload = try JSONDecoder().decode([String: [String]].self, from: body)
+                XCTAssertEqual(payload, ["tags": ["Design", "Reading"]])
+                return (200, """
+                    {
+                      "success":true,
+                      "tags":[
+                        {"id":"tag-1","name":"Design"},
+                        {"id":"tag-2","name":"Reading"}
+                      ]
+                    }
+                    """)
+            default:
+                return (405, "{}")
+            }
+        }
+
+        let available = try await client.listTags()
+        let saved = try await client.setTags(
+            id: "bookmark-1",
+            tags: ["Design", "Reading"]
+        )
+
+        XCTAssertEqual(available.map(\.name), ["Design"])
+        XCTAssertEqual(saved.map(\.name), ["Design", "Reading"])
+    }
+
     private static func metadata(
         title: String = "A dependable reader",
         creatorImageURL: URL? = nil,
@@ -246,7 +312,8 @@ final class ArticleReaderTests: XCTestCase {
             canonicalURL: URL(string: "https://example.com/article")!,
             readingTimeMinutes: 4,
             initialProgress: initialProgress,
-            isFinished: false
+            isFinished: false,
+            tags: []
         )
     }
 
@@ -262,6 +329,25 @@ final class ArticleReaderTests: XCTestCase {
             tokenProvider: { "test-token" },
             session: URLSession(configuration: configuration)
         )
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count > 0 else { break }
+            data.append(buffer, count: count)
+        }
+        return data
     }
 
     private static let availableJSON = """


### PR DESCRIPTION
## Summary

- reveal a compact completion and tagging action panel when the native article reader reaches the end
- persist completed state and tag changes through the existing `/api/v1` REST boundary, with loading and failure handling
- propagate updated bookmark state back to the detail view and add endpoint/threshold coverage

## Validation

- native iOS test suite: 70 tests passed
- `bun run test` (mobile: 1,125; worker: 1,739; web: 75)
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- `bun run design-system:check`
- simulator visual verification in light and dark mode, including the end panel and tag sheet
- signed Release build installed on the physical iPhone; bundle readback confirmed `app.zine.native` version 0.1 (build 1). Foreground launch could not be observed because the phone was locked.