### PR TITLE
feat(worker): filter article understanding backfills

### DIFF
--- a/apps/worker/src/admin/enrichment-backfill.test.ts
+++ b/apps/worker/src/admin/enrichment-backfill.test.ts
@@ -68,6 +68,7 @@ describe('backfillBookmarkEnrichment', () => {
 
     expect(result).toMatchObject({
       dryRun: true,
+      eligibleArticlesOnly: false,
       schemaVersion: ENRICHMENT_SCHEMA_VERSION,
       limit: 2,
       cursor: null,
@@ -118,6 +119,25 @@ describe('backfillBookmarkEnrichment', () => {
     });
 
     expect(bind).toHaveBeenCalledWith(ENRICHMENT_SCHEMA_VERSION, 'ui_099', 10);
+  });
+
+  it('can restrict candidates to articles with a current usable body', async () => {
+    const { env, prepare, bind } = createEnv([]);
+
+    const result = await backfillBookmarkEnrichment(env as never, {
+      dryRun: true,
+      limit: 10,
+      eligibleArticlesOnly: true,
+    });
+
+    const query = prepare.mock.calls[0]?.[0] as string;
+    expect(query).toContain("AND i.content_type = 'ARTICLE'");
+    expect(query).toContain(
+      'INNER JOIN article_body_versions abv ON abv.id = abs.current_version_id'
+    );
+    expect(query).toContain("AND abs.status IN ('AVAILABLE', 'DEGRADED')");
+    expect(bind).toHaveBeenCalledWith(ENRICHMENT_SCHEMA_VERSION, 10);
+    expect(result.eligibleArticlesOnly).toBe(true);
   });
 
   it('only excludes complete enrichment rows so failed rows can be retried', async () => {

--- a/apps/worker/src/admin/enrichment-backfill.ts
+++ b/apps/worker/src/admin/enrichment-backfill.ts
@@ -28,6 +28,7 @@ export interface EnrichmentBackfillOptions {
   dryRun?: boolean;
   limit?: number;
   cursor?: string | null;
+  eligibleArticlesOnly?: boolean;
 }
 
 export interface EnrichmentBackfillCandidate {
@@ -39,6 +40,7 @@ export interface EnrichmentBackfillCandidate {
 
 export interface EnrichmentBackfillResult {
   dryRun: boolean;
+  eligibleArticlesOnly: boolean;
   schemaVersion: number;
   limit: number;
   cursor: string | null;
@@ -73,9 +75,20 @@ function mapCandidate(row: BackfillRow): EnrichmentBackfillCandidate {
 
 async function loadCandidates(
   db: D1Database,
-  options: { limit: number; cursor: string | null }
+  options: { limit: number; cursor: string | null; eligibleArticlesOnly: boolean }
 ): Promise<EnrichmentBackfillCandidate[]> {
   const cursorClause = options.cursor ? 'AND ui.id > ?' : '';
+  const eligibilityClause = options.eligibleArticlesOnly
+    ? `
+      AND i.content_type = 'ARTICLE'
+      AND EXISTS (
+        SELECT 1
+        FROM article_body_states abs
+        INNER JOIN article_body_versions abv ON abv.id = abs.current_version_id
+        WHERE abs.item_id = i.id
+          AND abs.status IN ('AVAILABLE', 'DEGRADED')
+      )`
+    : '';
   const statement = db.prepare(`
     SELECT
       ui.id AS user_item_id,
@@ -98,6 +111,7 @@ async function loadCandidates(
      AND uie.status = 'COMPLETE'
     WHERE ui.state = 'BOOKMARKED'
       AND uie.id IS NULL
+      ${eligibilityClause}
       ${cursorClause}
     ORDER BY ui.id
     LIMIT ?
@@ -118,7 +132,8 @@ export async function backfillBookmarkEnrichment(
   const dryRun = options.dryRun ?? true;
   const limit = normalizeLimit(options.limit);
   const cursor = options.cursor ?? null;
-  const candidates = await loadCandidates(env.DB, { limit, cursor });
+  const eligibleArticlesOnly = options.eligibleArticlesOnly ?? false;
+  const candidates = await loadCandidates(env.DB, { limit, cursor, eligibleArticlesOnly });
   const queue = env.ENRICHMENT_QUEUE as EnrichmentQueue | undefined;
 
   if (!dryRun && !queue) {
@@ -146,6 +161,7 @@ export async function backfillBookmarkEnrichment(
 
   backfillLogger.info('Bookmark enrichment backfill page processed', {
     dryRun,
+    eligibleArticlesOnly,
     limit,
     cursor,
     nextCursor,
@@ -155,6 +171,7 @@ export async function backfillBookmarkEnrichment(
 
   return {
     dryRun,
+    eligibleArticlesOnly,
     schemaVersion: ENRICHMENT_SCHEMA_VERSION,
     limit,
     cursor,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -208,6 +208,7 @@ app.post('/admin/enrichment/backfill', async (c) => {
     dryRun: typeof body.dryRun === 'boolean' ? body.dryRun : true,
     limit: typeof body.limit === 'number' ? body.limit : undefined,
     cursor: typeof body.cursor === 'string' && body.cursor.length > 0 ? body.cursor : null,
+    eligibleArticlesOnly: body.eligibleArticlesOnly === true,
   });
 
   return c.json({

--- a/docs/article-understanding.md
+++ b/docs/article-understanding.md
@@ -54,6 +54,21 @@ not a claim of corpus-wide recommendation quality.
 Missing or invalid values fail closed to `off`. Development and staging use `all`; the initial
 production configuration uses `backfill_only` for a bounded, explicit canary.
 
+Use the authenticated enrichment backfill route with `eligibleArticlesOnly: true` to restrict a
+canary to saved articles that have a current `AVAILABLE` or `DEGRADED` article body. Start with a
+dry run and keep the same filter when enqueueing the reviewed page:
+
+```json
+{
+  "dryRun": true,
+  "eligibleArticlesOnly": true,
+  "limit": 10
+}
+```
+
+The option defaults to `false`, so existing general enrichment backfills retain their current
+selection behavior.
+
 Description-only and metadata-only items continue through the existing lightweight enrichment
 path. Their coverage remains explicit so later collection ranking can require deep understanding or
 degrade honestly. While schema-v3 backfill progresses, enrichment reads retain the latest older


### PR DESCRIPTION
## Summary

- add an opt-in `eligibleArticlesOnly` filter to the enrichment backfill endpoint
- restrict filtered pages to saved articles with current AVAILABLE or DEGRADED body versions
- preserve the existing general backfill selection by default
- document the dry-run-first production canary request

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run design-system:check`
- `bun run test:worker:ci` (92 files, 1,741 tests)
- `bun run --cwd apps/worker test:run src/admin/enrichment-backfill.test.ts` (5 tests)
