### PR TITLE
feat(dev): add browser-native simulator workflow

### DIFF
--- a/.codex/skills/zine-local-development/SKILL.md
+++ b/.codex/skills/zine-local-development/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: zine-local-development
+description: Run and visually verify Zine in a local worktree with the repo-owned dev stack, canonical native iOS app, serve-sim, and Codex Browser computer use. Use for every Zine request to implement, run, test, verify, debug, inspect, or visually review local runtime behavior, including prompts phrased only as "test it", "verify it", "run locally", or "check the UI".
+---
+
+# Zine Local Development
+
+Use the worktree-safe stack and treat interactive browser-visible proof as part
+of local verification, not as an optional follow-up.
+
+## Required workflow
+
+1. Work from the repository root and install dependencies with `bun install`
+   when `node_modules` is missing or stale.
+2. Start local development with `bun run dev:worktree`. This command owns the
+   worker, web, proxy, native build/install/launch, and `serve-sim` lifecycle.
+   Do not start a second simulator preview in parallel.
+3. Read the exact `serve-sim` preview URL from terminal output. It normally
+   starts at `http://localhost:3200`, but another port may be selected when that
+   port is occupied.
+4. Invoke the available `browser:control-in-app-browser` skill before browser
+   calls. Open or reload the exact preview URL in the Codex in-app Browser.
+5. Confirm all of these before interacting:
+   - The page reports `iPhone 17 — Zine` or the explicitly selected simulator.
+   - The stream is live and renders a real device frame.
+   - The foreground app is `Zine Native` with bundle `app.zine.native`.
+6. Exercise the relevant user journey through Browser computer use. Use the
+   Browser `cua` or `dom_cua` surface for taps, swipes, typing, and navigation
+   inside the streamed simulator. Use DOM/Playwright inspection for the
+   surrounding `serve-sim` controls when it is more reliable.
+7. Inspect fresh visible state after each material interaction. Capture a
+   screenshot for the final relevant state and for each appearance or screen
+   variant required by the task.
+8. Run focused automated tests and repository gates appropriate to the change.
+   Automated tests complement the interactive pass; they do not replace it.
+
+## Verification contract
+
+Do not call local native behavior verified from build output, unit tests,
+`simctl`, logs, installation, launch, a loaded preview page, or a static
+simulator screenshot alone. Verification requires an actual streamed frame and
+Browser computer-use interaction with the relevant behavior.
+
+Report these states separately:
+
+- automated tests and checks
+- native build
+- simulator install
+- app launch
+- live `serve-sim` frame
+- computer-use interaction performed
+- final UI state visibly observed
+
+For worker or shared-code changes that can affect the native client, include a
+native smoke path through this workflow. For strictly web-only behavior, use
+the local web URL in the Codex Browser for the relevant flow; the default
+`dev:worktree` simulator startup may remain a smoke check but is not proof of
+web behavior.
+
+## Lifecycle and exceptions
+
+- Keep `dev:worktree` and the preview tab alive when the user wants an ongoing
+  development session. Otherwise stop the command and confirm that the scoped
+  helper and preview port exited.
+- Use `ZINE_SKIP_IOS_BUILD=1 bun run dev:worktree` only when an already
+  installed native build is intentionally sufficient.
+- Use `ZINE_SERVE_SIM=0 bun run dev:worktree` only when the user explicitly
+  opts out or the host cannot run Apple Simulator. State the missing UI proof
+  plainly in that case.
+- Use `ZINE_SIMULATOR_NAME` or `ZINE_SIMULATOR_UDID` for an explicit alternate
+  simulator. Never use an unscoped `serve-sim --kill`.
+- Use the physical-device deployment workflow instead when the user asks for
+  proof on their iPhone; simulator proof is not device proof.

--- a/.codex/skills/zine-local-development/agents/openai.yaml
+++ b/.codex/skills/zine-local-development/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: 'Zine Local Development'
+  short_description: 'Run and visually verify Zine locally'
+  default_prompt: 'Use $zine-local-development to run Zine locally and verify the relevant native behavior through the serve-sim browser preview.'
+
+policy:
+  allow_implicit_invocation: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Install dependencies: `bun install`
 - Start all dev tasks: `bun run dev`
 - Start the web app only: `bun run dev:web`
-- Worktree-safe dev startup: `bun run dev:worktree`
+- Worktree-safe dev startup with native `serve-sim` preview: `bun run dev:worktree`
 - Reset worktree state before re-seeding: `bun run dev:reset`
 - Run repository tests (deprecated Expo compatibility + worker + web unit/component): `bun run test`
 - Run web unit/component tests: `bun run test:web`
@@ -68,10 +68,24 @@
   - Falls back to `localhost` when Tailscale is unavailable
   - Starts a small local HTTP proxy for non-localhost phone access because local `workerd` is not directly reachable on the Tailscale interface
   - Generates `apps/mobile/.env.local` with `EXPO_PUBLIC_API_URL=http://<reachable-host>:<public-api-port>`
+  - Builds, installs, and launches `apps/ios/ZineNative.xcodeproj` in the dedicated Zine Simulator
+  - Starts a scoped `serve-sim` browser preview and stops it with the rest of the dev stack
 - The Metro, Expo Go, and `apps/mobile/.env.local` behavior above is legacy support for the deprecated client. Do not use it as the default path for new mobile development or verification.
 - Override worker port with `ZINE_WORKER_PORT=<port> bun run dev:worktree`.
 - Override the mobile/API host with `ZINE_DEV_HOST=<host> bun run dev:worktree`.
 - Override the public API port with `ZINE_API_PORT=<port> bun run dev:worktree`.
+- Override the simulator with `ZINE_SIMULATOR_NAME=<name>` or `ZINE_SIMULATOR_UDID=<udid>`.
+- Skip an intentional repeat native build with `ZINE_SKIP_IOS_BUILD=1 bun run dev:worktree`.
+- Disable the native preview only when explicitly required with `ZINE_SERVE_SIM=0 bun run dev:worktree`.
+
+### Required Local Development and Verification Workflow
+
+- Use `.codex/skills/zine-local-development/SKILL.md` for every request to implement, run, test, verify, debug, inspect, or visually review local Zine runtime behavior.
+- `bun run dev:worktree` is the default local entrypoint. It starts the canonical native app and `serve-sim`; do not launch a parallel preview unless the task explicitly requires an isolated alternate simulator.
+- For native local testing and verification, open the exact `serve-sim` URL printed by the command in the Codex in-app Browser and use the Browser plugin's computer-use surface to exercise the relevant user journey.
+- A successful native build, test run, install, launch, loaded preview page, or shell-only `simctl` interaction is not UI verification. Require a real streamed frame, computer-use interaction, and visible final state.
+- Report automated checks, build, install, launch, live stream, computer-use interaction, and UI observation as separate evidence states.
+- If the host cannot provide the simulator or Browser computer-use surface, run every remaining safe check but report native UI verification as skipped or blocked; never silently substitute legacy Expo, a static screenshot, or logs.
 
 ### Production-Shaped Local Data
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -26,6 +26,40 @@ iOS 18 or newer simulator or device.
 
 All new iOS product work, verification, and deployment belongs in this project.
 
+## Browser simulator preview
+
+Run the native app in Zine's dedicated Simulator and mirror it into a browser:
+
+```sh
+bun run ios:preview
+```
+
+The normal worktree development command starts this preview alongside the
+worker, web app, and other development services by default:
+
+```sh
+bun run dev:worktree
+```
+
+The command boots `iPhone 17 — Zine`, builds and installs the current
+`ZineNative` checkout, launches `app.zine.native`, and starts the `serve-sim`
+preview. Its default URL is `http://localhost:3200`. Keep the command running
+while using the preview; Control-C stops only the helper attached to Zine's
+simulator.
+
+Set `ZINE_SIMULATOR_NAME` or `ZINE_SIMULATOR_UDID` to use another Simulator.
+Set `ZINE_SKIP_IOS_BUILD=1` to relaunch an already installed build without
+rebuilding it. Set `ZINE_SERVE_SIM=0` when running `dev:worktree` to disable the
+native preview. Additional `serve-sim` options can follow `--` when using the
+standalone command, for example:
+
+```sh
+bun run ios:preview -- --theme dark --panes tools
+```
+
+This workflow requires Apple Silicon, Xcode command-line tools, and the Node 22
+version pinned by the repository.
+
 ## Design system
 
 The native color palette, semantic roles, usage rules, exceptions, and

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.4.2",
+        "serve-sim": "0.1.45",
         "turbo": "^2.3.3",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.49.0",
@@ -2201,6 +2202,8 @@
 
     "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
 
+    "inspect-webkit": ["inspect-webkit@0.0.5", "", { "peerDependencies": { "typescript": "^5" }, "bin": { "inspect-webkit": "dist/cli.js" } }, "sha512-584wP/2nJO1LX74nqHP2j0tQzlK9ZTi+D0Z9qeLQjtUR/LCMXQHGX8M0vrsqBwTeGakF7q5GMFpg81nxUYlCvw=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
@@ -2915,6 +2918,8 @@
 
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
+    "serve-sim": ["serve-sim@0.1.45", "", { "dependencies": { "inspect-webkit": "^0.0.5", "sonner": "^2.0.7", "ws": "^8.21.0" }, "bin": { "serve-sim": "dist/serve-sim.js" } }, "sha512-I9YBJRz7DETanzh6hRD1yaVcUPO+xe4egjGNArk22mO7SIWZVCunHVTwpAbriP7H0aZMIKfQyVpuqvYonuKxBw=="],
+
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
@@ -2970,6 +2975,8 @@
     "slugify": ["slugify@1.6.6", "", {}, "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw=="],
 
     "smob": ["smob@1.6.1", "", {}, "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g=="],
+
+    "sonner": ["sonner@2.0.8", "", { "peerDependencies": { "@types/react": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -3355,7 +3362,7 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -3455,6 +3462,8 @@
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "@expo/cli/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "@expo/devcert/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "@expo/fingerprint/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
@@ -3544,6 +3553,8 @@
     "@storybook/addon-docs/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.2.11", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.11" } }, "sha512-29kqYYLvASuxFdagwMUX0xmPgDKbRYdm4uzYGEFWiKVZvJHarbTThzSaCDNhvoQk4qPp783duO29uHkztEHc8Q=="],
+
+    "@storybook/react-native/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@storybook/react-vite/@storybook/react": ["@storybook/react@10.3.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.3.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw=="],
 
@@ -3799,6 +3810,8 @@
 
     "miniflare/workerd": ["workerd@1.20241230.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20241230.0", "@cloudflare/workerd-darwin-arm64": "1.20241230.0", "@cloudflare/workerd-linux-64": "1.20241230.0", "@cloudflare/workerd-linux-arm64": "1.20241230.0", "@cloudflare/workerd-windows-64": "1.20241230.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg=="],
 
+    "miniflare/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -3875,6 +3888,8 @@
 
     "rpc-websockets/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
+    "rpc-websockets/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
@@ -3894,6 +3909,8 @@
     "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "storybook/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -4330,6 +4347,8 @@
     "jest-environment-jsdom/jsdom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "jest-environment-jsdom/jsdom/whatwg-url": ["whatwg-url@11.0.0", "", { "dependencies": { "tr46": "^3.0.0", "webidl-conversions": "^7.0.0" } }, "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ=="],
+
+    "jest-environment-jsdom/jsdom/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "jest-environment-jsdom/jsdom/xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:ios": "bun run --cwd apps/mobile build:ios",
+    "ios:preview": "bash ./scripts/ios-simulator-preview.sh",
     "deploy:ios:production": "bun run --cwd apps/mobile deploy:ios:production",
     "deploy:ios:testflight:local": "bun run --cwd apps/mobile deploy:ios:testflight:local",
     "dev": "turbo run dev",
@@ -86,6 +87,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.4.2",
+    "serve-sim": "0.1.45",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.49.0"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -15,13 +15,15 @@ set -e
 #   3. Symlinks worker secrets (.dev.vars) from main
 #   4. Generates mobile .env.local with a reachable API URL
 #   5. Starts a public dev proxy when non-localhost access is needed
-#   6. Starts all services via turbo
+#   6. Builds, launches, and serves the native iOS app in the browser
+#   7. Starts all services via turbo
 #
 # USAGE:
 #   bun run dev:worktree                                # Normal usage
 #   ZINE_WORKER_PORT=8888 bun run dev:worktree          # Override port
 #   ZINE_DEV_HOST=100.92.242.50 bun run dev:worktree    # Override mobile/API host
 #   ZINE_API_PORT=8890 bun run dev:worktree             # Override public API port
+#   ZINE_SERVE_SIM=0 bun run dev:worktree               # Disable native preview
 #   bun run dev:reset && bun run dev:worktree          # Fresh re-seed
 #
 # =============================================================================
@@ -311,8 +313,13 @@ export EXPO_HOSTNAME="$DEV_HOST"
 export REACT_NATIVE_PACKAGER_HOSTNAME="$DEV_HOST"
 
 PROXY_PID=""
+IOS_PREVIEW_PID=""
 
 cleanup() {
+  if [ -n "$IOS_PREVIEW_PID" ] && kill -0 "$IOS_PREVIEW_PID" 2>/dev/null; then
+    kill "$IOS_PREVIEW_PID" 2>/dev/null || true
+    wait "$IOS_PREVIEW_PID" 2>/dev/null || true
+  fi
   if [ -n "$PROXY_PID" ] && kill -0 "$PROXY_PID" 2>/dev/null; then
     kill "$PROXY_PID" 2>/dev/null || true
     wait "$PROXY_PID" 2>/dev/null || true
@@ -329,6 +336,14 @@ if [ "$PUBLIC_API_PORT" != "$WORKER_PORT" ]; then
     ZINE_PROXY_TARGET_PORT="$WORKER_PORT" \
     node ./scripts/dev-worker-proxy.mjs &
   PROXY_PID=$!
+fi
+
+if [ "${ZINE_SERVE_SIM:-1}" != "0" ]; then
+  echo "   📱 Starting native iOS preview with serve-sim..."
+  bash ./scripts/ios-simulator-preview.sh &
+  IOS_PREVIEW_PID=$!
+else
+  echo "   ℹ️  Native iOS preview disabled (ZINE_SERVE_SIM=0)"
 fi
 
 echo ""

--- a/scripts/ios-simulator-preview.sh
+++ b/scripts/ios-simulator-preview.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+project_path="$repo_root/apps/ios/ZineNative.xcodeproj"
+derived_data_path="$repo_root/.local-data/ios-simulator-preview-derived-data"
+serve_sim_path="$repo_root/node_modules/.bin/serve-sim"
+simulator_name="${ZINE_SIMULATOR_NAME:-iPhone 17 — Zine}"
+simulator_udid="${ZINE_SIMULATOR_UDID:-}"
+bundle_id="app.zine.native"
+build_pid=""
+serve_sim_pid=""
+
+cleanup_serve_sim() {
+  trap - EXIT INT TERM HUP
+  if [[ -n "$build_pid" ]] && kill -0 "$build_pid" 2>/dev/null; then
+    kill "$build_pid" 2>/dev/null || true
+    wait "$build_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$serve_sim_pid" ]] && kill -0 "$serve_sim_pid" 2>/dev/null; then
+    kill "$serve_sim_pid" 2>/dev/null || true
+    wait "$serve_sim_pid" 2>/dev/null || true
+  fi
+  if [[ -n "$simulator_udid" ]]; then
+    "$serve_sim_path" --kill "$simulator_udid" >/dev/null 2>&1 || true
+  fi
+}
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+  echo "serve-sim requires an Apple Silicon Mac." >&2
+  exit 1
+fi
+
+for command_name in node xcodebuild xcrun; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -x "$serve_sim_path" ]]; then
+  echo "serve-sim is not installed. Run 'bun install' from the repository root." >&2
+  exit 1
+fi
+
+if [[ -z "$simulator_udid" ]]; then
+  simulator_udid="$(node -e '
+    const { execFileSync } = require("node:child_process");
+    const requestedName = process.argv[1];
+    const output = execFileSync(
+      "xcrun",
+      ["simctl", "list", "devices", "available", "--json"],
+      { encoding: "utf8" },
+    );
+    const matches = Object.values(JSON.parse(output).devices)
+      .flat()
+      .filter((device) => device.name === requestedName);
+    const selected = matches.find((device) => device.state === "Booted") ?? matches[0];
+    if (selected) process.stdout.write(selected.udid);
+  ' "$simulator_name")"
+fi
+
+if [[ -z "$simulator_udid" ]]; then
+  echo "No available simulator named '$simulator_name'." >&2
+  echo "Set ZINE_SIMULATOR_NAME or ZINE_SIMULATOR_UDID to an available iPhone Simulator." >&2
+  exit 1
+fi
+
+if ! xcrun simctl list devices available | grep -Fq "$simulator_udid"; then
+  echo "Simulator '$simulator_udid' is not available." >&2
+  exit 1
+fi
+
+"$serve_sim_path" --kill "$simulator_udid" >/dev/null 2>&1 || true
+trap cleanup_serve_sim EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
+
+if ! xcrun simctl list devices booted | grep -Fq "$simulator_udid"; then
+  xcrun simctl boot "$simulator_udid"
+fi
+xcrun simctl bootstatus "$simulator_udid" -b
+
+if [[ "${ZINE_SKIP_IOS_BUILD:-0}" != "1" ]]; then
+  xcodebuild \
+    -project "$project_path" \
+    -scheme ZineNative \
+    -configuration Debug \
+    -destination "platform=iOS Simulator,id=$simulator_udid" \
+    -derivedDataPath "$derived_data_path" \
+    -quiet \
+    build &
+  build_pid=$!
+  wait "$build_pid"
+  build_pid=""
+
+  app_path="$derived_data_path/Build/Products/Debug-iphonesimulator/Zine Native.app"
+  if [[ ! -d "$app_path" ]]; then
+    echo "Expected simulator app was not built at '$app_path'." >&2
+    exit 1
+  fi
+  xcrun simctl install "$simulator_udid" "$app_path"
+fi
+
+xcrun simctl launch --terminate-running-process "$simulator_udid" "$bundle_id"
+
+echo "Starting the Zine simulator preview for $simulator_name ($simulator_udid)."
+echo "Press Control-C to stop the preview and its Zine-scoped helper."
+"$serve_sim_path" "$simulator_udid" --fit "$@" &
+serve_sim_pid=$!
+wait "$serve_sim_pid"


### PR DESCRIPTION
## Summary

- make `bun run dev:worktree` build, install, launch, and stream the canonical native iOS app through `serve-sim` by default
- add a scoped simulator preview script with worktree lifecycle cleanup and explicit overrides
- add repo-owned Codex guidance requiring Browser computer-use verification for local Zine development

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run design-system:check`
- `bun run --cwd apps/mobile test -- --runInBand` (1,125 tests)
- `bun run test:worker` (1,762 tests)
- `bun run test:web` (75 tests)
- `bun run build`
- `bash -n scripts/dev.sh scripts/ios-simulator-preview.sh`
- local skill validator
- `bun run dev:worktree`: native build/install/launch plus live `serve-sim` stream
- Codex Browser computer use: pressed Home, relaunched Zine Native from the streamed simulator, and observed the Clerk sign-in screen
- verified scoped shutdown closed preview and development ports