### PR TITLE
fix(worker): harden article understanding canary

### DIFF
--- a/apps/worker/src/enrichment/article-understanding.test.ts
+++ b/apps/worker/src/enrichment/article-understanding.test.ts
@@ -61,6 +61,28 @@ describe('article understanding', () => {
     expect(parsed.actionableTakeaways).toHaveLength(1);
   });
 
+  it('treats empty optional perspective and audience objects as unsupported', () => {
+    const parsed = ArticleChunkAnalysisSchema.parse({
+      summary: { text: 'Summary', evidenceBlockIds: ['article-body'] },
+      claims: [{ statement: 'Supported claim', evidenceBlockIds: ['article-body'] }],
+      concepts: [
+        {
+          name: 'Specific concept',
+          description: 'Supported concept',
+          evidenceBlockIds: ['article-body'],
+        },
+      ],
+      perspective: { description: '', evidenceBlockIds: [] },
+      audience: { description: '', evidenceBlockIds: [] },
+      actionableTakeaways: [
+        { description: 'Supported takeaway', evidenceBlockIds: ['article-body'] },
+      ],
+    });
+
+    expect(parsed.perspective).toBeNull();
+    expect(parsed.audience).toBeNull();
+  });
+
   it('rejects summary-only analysis', () => {
     expect(() =>
       ArticleChunkAnalysisSchema.parse({

--- a/apps/worker/src/enrichment/article-understanding.ts
+++ b/apps/worker/src/enrichment/article-understanding.ts
@@ -20,6 +20,17 @@ const EvidenceSchema = z.object({ evidenceBlockIds: EvidenceIdsSchema });
 const DescriptionEvidenceSchema = EvidenceSchema.extend({
   description: z.string().min(1).max(500),
 });
+const OptionalDescriptionEvidenceSchema = z.preprocess((value) => {
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  const description = typeof record.description === 'string' ? record.description.trim() : '';
+  const evidenceBlockIds = Array.isArray(record.evidenceBlockIds)
+    ? record.evidenceBlockIds.filter(
+        (entry) => typeof entry === 'string' && entry.trim().length > 0
+      )
+    : [];
+  return description.length > 0 && evidenceBlockIds.length > 0 ? value : null;
+}, DescriptionEvidenceSchema.nullable().default(null));
 
 type ArticleChunkAnalysis = Omit<
   ArticleUnderstandingChunk,
@@ -76,8 +87,8 @@ export const ArticleChunkAnalysisSchema: z.ZodType<ArticleChunkAnalysis, z.ZodTy
       )
       .default([])
       .transform((values) => values.slice(0, 15)),
-    perspective: DescriptionEvidenceSchema.nullable().default(null),
-    audience: DescriptionEvidenceSchema.nullable().default(null),
+    perspective: OptionalDescriptionEvidenceSchema,
+    audience: OptionalDescriptionEvidenceSchema,
     prerequisites: z
       .array(DescriptionEvidenceSchema)
       .default([])
@@ -262,6 +273,7 @@ function chunkMessages(chunk: PreparedArticleChunk) {
           'Actionable takeaways state what a reader could do, test, notice, or decide because of the article. Do not invent advice unsupported by the text.',
           'For substantive article text, return at least 3 claims, 2 concepts, and 2 actionable takeaways. Empty semantic arrays are invalid.',
           'Include disagreements, limitations, open problems, or failed approaches when the text supplies them.',
+          'Use null for perspective or audience when the text does not support them. Never return empty descriptions or empty evidenceBlockIds.',
           'Return concise notes suitable for deciding whether this article belongs in a narrowly themed collection.',
           'Return at most 10 topics, 10 claims, 8 questions answered, 10 concepts, 15 entities, 8 prerequisites, and 8 actionable takeaways.',
         ],
@@ -302,9 +314,10 @@ async function analyzeChunk(
     schema: schemaForChunk(chunk),
     maxTokens: 4000,
     repairPrompt:
-      'Retry with exactly the requested JSON fields and no prose outside the JSON object. Copy evidence block IDs exactly from the [block:...] markers; altered or invented IDs will be rejected. A summary alone is invalid: include at least 3 supported claims, 2 article-specific concepts, and 2 supported actionableTakeaways. Return at most 10 topics, 10 claims, 8 questionsAnswered, 10 concepts, 15 entities, 8 prerequisites, and 8 actionableTakeaways.',
+      'Retry with exactly the requested JSON fields and no prose outside the JSON object. Copy evidence block IDs exactly from the [block:...] markers; altered or invented IDs will be rejected. A summary alone is invalid: include at least 3 supported claims, 2 article-specific concepts, and 2 supported actionableTakeaways. Use null, never empty objects, for unsupported perspective or audience. Return at most 10 topics, 10 claims, 8 questionsAnswered, 10 concepts, 15 entities, 8 prerequisites, and 8 actionableTakeaways.',
     operation: `Article chunk ${chunk.ordinal} analysis`,
     model: env.ARTICLE_UNDERSTANDING_MODEL,
+    repairAttempts: 2,
   });
   return normalizeChunkAnalysis(chunk, analysis);
 }

--- a/apps/worker/src/enrichment/consumer.test.ts
+++ b/apps/worker/src/enrichment/consumer.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { enrichmentConsumerInternals } from './consumer';
 
 describe('enrichment consumer helpers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('normalizes, dedupes, caps, and matches suggested tags', () => {
     const suggestions = enrichmentConsumerInternals.normalizeSuggestedTags(
       [
@@ -54,5 +58,46 @@ describe('enrichment consumer helpers', () => {
       { name: 'Vectorize', kind: 'entity', confidence: 0.8 },
       { name: 'reference', kind: 'intent', confidence: 0.65 },
     ]);
+  });
+
+  it('marks canonical and per-user enrichment failed when retries reach the DLQ', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-09T17:30:00.000Z'));
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn().mockReturnValue({ where });
+    const update = vi.fn().mockReturnValue({ set });
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+    const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+    const insert = vi.fn().mockReturnValue({ values });
+    const error = new Error('Enrichment message exhausted retries');
+
+    await enrichmentConsumerInternals.markDlqFailed(
+      { update, insert } as never,
+      {
+        itemId: 'item-1',
+        userItemId: 'user-item-1',
+        userId: 'user-1',
+        trigger: 'backfill',
+        schemaVersion: 3,
+        contentHash: `sha256:${'a'.repeat(64)}`,
+        enqueuedAt: Date.now(),
+      },
+      error
+    );
+
+    expect(set).toHaveBeenCalledWith({
+      status: 'FAILED',
+      errorMessage: error.message,
+      updatedAt: Date.now(),
+    });
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        userItemId: 'user-item-1',
+        itemId: 'item-1',
+        status: 'FAILED',
+        errorMessage: error.message,
+      })
+    );
   });
 });

--- a/apps/worker/src/enrichment/consumer.ts
+++ b/apps/worker/src/enrichment/consumer.ts
@@ -375,6 +375,29 @@ async function writeUserFailed(db: Database, message: EnrichmentQueueMessage, er
     });
 }
 
+async function markDlqFailed(
+  db: Database,
+  message: EnrichmentQueueMessage,
+  error: Error
+): Promise<void> {
+  const now = Date.now();
+  await db
+    .update(itemEnrichments)
+    .set({
+      status: 'FAILED',
+      errorMessage: error.message,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(itemEnrichments.itemId, message.itemId),
+        eq(itemEnrichments.schemaVersion, message.schemaVersion),
+        eq(itemEnrichments.status, 'PENDING')
+      )
+    );
+  await writeUserFailed(db, message, error);
+}
+
 async function processMessage(message: EnrichmentMessage, db: Database, env: Bindings) {
   const parsed = EnrichmentQueueMessageSchema.safeParse(message.body);
   if (!parsed.success) {
@@ -571,7 +594,7 @@ export async function handleEnrichmentQueue(
 
 export async function handleEnrichmentDLQ(
   batch: MessageBatch<EnrichmentQueueMessage>,
-  _env: Bindings
+  env: Bindings
 ): Promise<void> {
   enrichmentLogger.error('Enrichment messages reached DLQ', {
     messageCount: batch.messages.length,
@@ -579,7 +602,23 @@ export async function handleEnrichmentDLQ(
     messageIds: batch.messages.map((message) => message.id),
   });
 
+  const db = createDb(env.DB);
   for (const message of batch.messages) {
+    const parsed = EnrichmentQueueMessageSchema.safeParse(message.body);
+    if (!parsed.success) {
+      enrichmentLogger.error('Invalid enrichment DLQ message body', {
+        messageId: message.id,
+        error: parsed.error.message,
+      });
+      message.ack();
+      continue;
+    }
+
+    await markDlqFailed(
+      db,
+      parsed.data,
+      new Error(`Enrichment message exhausted retries and reached ${batch.queue}`)
+    );
     message.ack();
   }
 }
@@ -587,4 +626,5 @@ export async function handleEnrichmentDLQ(
 export const enrichmentConsumerInternals = {
   normalizeSuggestedTags,
   buildTagsFromCanonical,
+  markDlqFailed,
 };

--- a/apps/worker/src/enrichment/embeddings.test.ts
+++ b/apps/worker/src/enrichment/embeddings.test.ts
@@ -46,9 +46,21 @@ describe('embedding privacy helpers', () => {
       ordinal: 2,
     });
 
-    expect(first).toContain(':content:');
-    expect(first).toContain(':chunk:2');
+    expect(first).toMatch(/^chunk:[a-f0-9]{58}$/);
+    expect(first.length).toBe(64);
     expect(first).not.toBe(changed);
+  });
+
+  it('keeps long production identifiers within the Vectorize ID limit', () => {
+    const vectorId = buildChunkVectorId({
+      itemId: '01KFCQJ597092ADP0M2NZ4HNF7',
+      userId: 'user_31ejjz59G6mTX1SIyErOi0fwu4A',
+      provider: 'WEB',
+      sourceContentHash: `sha256:${'a'.repeat(64)}`,
+      ordinal: 12,
+    });
+
+    expect(Buffer.byteLength(vectorId, 'utf8')).toBeLessThanOrEqual(64);
   });
 
   it('extracts a vector for every batched chunk', () => {

--- a/apps/worker/src/enrichment/embeddings.ts
+++ b/apps/worker/src/enrichment/embeddings.ts
@@ -1,6 +1,7 @@
 import { ulid } from 'ulid';
 import { eq, inArray } from 'drizzle-orm';
 import { Provider } from '@zine/shared';
+import { createHash } from 'node:crypto';
 
 import type { Bindings } from '../types';
 import type { Database } from '../db';
@@ -100,8 +101,10 @@ export function buildChunkVectorId(
   }
 ) {
   const base = buildVectorId(input);
-  const hash = input.sourceContentHash.replace(/^sha256:/, '').slice(0, 32);
-  return `${base}:content:${hash}:chunk:${input.ordinal}`;
+  const digest = createHash('sha256')
+    .update(`${base}\n${input.sourceContentHash}\n${input.ordinal}`)
+    .digest('hex');
+  return `chunk:${digest.slice(0, 58)}`;
 }
 
 async function upsertEmbeddingRef(
@@ -264,14 +267,16 @@ export async function upsertItemChunkEmbeddings(
   }
 
   const currentIds = new Set(vectorRows.map((vector) => vector.id));
-  const chunkVectorPrefix = `${buildVectorId(input)}:content:`;
+  const legacyChunkVectorPrefix = `${buildVectorId(input)}:content:`;
   const existingRefs = await db
     .select({ id: itemEmbeddingRefs.id, vectorId: itemEmbeddingRefs.vectorId })
     .from(itemEmbeddingRefs)
     .where(eq(itemEmbeddingRefs.itemId, input.itemId));
   const stale = existingRefs.filter(
     (reference) =>
-      reference.vectorId.startsWith(chunkVectorPrefix) && !currentIds.has(reference.vectorId)
+      (reference.vectorId.startsWith('chunk:') ||
+        reference.vectorId.startsWith(legacyChunkVectorPrefix)) &&
+      !currentIds.has(reference.vectorId)
   );
   if (stale.length > 0) {
     if (index.deleteByIds) await index.deleteByIds(stale.map((reference) => reference.vectorId));

--- a/apps/worker/src/enrichment/llm.test.ts
+++ b/apps/worker/src/enrichment/llm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
-import { EnrichmentModelValidationError, enrichWithQwen } from './llm';
+import { EnrichmentModelValidationError, enrichWithQwen, runStructuredJson } from './llm';
 import type { EnrichmentPromptInput } from './types';
 
 function createPromptInput(): EnrichmentPromptInput {
@@ -179,6 +180,44 @@ describe('enrichWithQwen', () => {
     const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
 
     expect(result.entities[0]?.relationship).toBe('MENTIONED');
+  });
+
+  it('bounds verbose free-form classification fields without discarding the output', async () => {
+    const output = createValidModelOutput();
+    output.classification.intent = 'x'.repeat(100);
+    const run = vi.fn().mockResolvedValue({ response: JSON.stringify(output) });
+
+    const result = await enrichWithQwen({ AI: { run } } as never, createPromptInput());
+
+    expect(result.classification.intent).toBe('x'.repeat(64));
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('can make a second evidence-preserving repair attempt with validation feedback', async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ response: '{}' })
+      .mockResolvedValueOnce({ response: '{bad-json' })
+      .mockResolvedValueOnce({ response: JSON.stringify({ value: 'supported' }) });
+
+    const result = await runStructuredJson({ AI: { run } } as never, {
+      messages: [{ role: 'user', content: 'Return a value.' }],
+      schema: z.object({ value: z.string().min(1) }),
+      maxTokens: 100,
+      repairPrompt: 'Repair the object.',
+      operation: 'Test repair',
+      repairAttempts: 2,
+    });
+
+    expect(result.value).toBe('supported');
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run.mock.calls[1]?.[1]).toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          content: expect.stringContaining('Previous validation failure'),
+        }),
+      ]),
+    });
   });
 
   it('throws validation error when both model attempts are invalid', async () => {

--- a/apps/worker/src/enrichment/llm.ts
+++ b/apps/worker/src/enrichment/llm.ts
@@ -144,6 +144,7 @@ export async function runStructuredJson<T>(
     repairPrompt: string;
     operation: string;
     model?: string;
+    repairAttempts?: number;
   }
 ): Promise<T> {
   const request = {
@@ -154,31 +155,38 @@ export async function runStructuredJson<T>(
     max_tokens: input.maxTokens,
   };
 
-  try {
-    return parseModelResponse(await runQwen(env, request, input.model), input.schema);
-  } catch (error) {
-    llmLogger.warn(`${input.operation} response invalid; retrying with repair prompt`, {
-      error,
-    });
+  const repairAttempts = Math.max(0, input.repairAttempts ?? 1);
+  let lastError: unknown;
 
-    return parseModelResponse(
-      await runQwen(
-        env,
-        {
-          ...request,
-          messages: [
+  for (let attempt = 0; attempt <= repairAttempts; attempt++) {
+    const messages =
+      attempt === 0
+        ? input.messages
+        : [
             ...input.messages,
             {
               role: 'user',
-              content: input.repairPrompt,
+              content: `${input.repairPrompt}\n\nPrevious validation failure:\n${lastError instanceof Error ? lastError.message.slice(0, 2_000) : String(lastError).slice(0, 2_000)}`,
             },
-          ],
-        },
-        input.model
-      ),
-      input.schema
-    );
+          ];
+
+    try {
+      return parseModelResponse(
+        await runQwen(env, { ...request, messages }, input.model),
+        input.schema
+      );
+    } catch (error) {
+      lastError = error;
+      if (attempt >= repairAttempts) throw error;
+      llmLogger.warn(`${input.operation} response invalid; retrying with repair prompt`, {
+        attempt: attempt + 1,
+        repairAttempts,
+        error,
+      });
+    }
   }
+
+  throw lastError;
 }
 
 export async function enrichWithQwen(

--- a/apps/worker/src/enrichment/schema.ts
+++ b/apps/worker/src/enrichment/schema.ts
@@ -22,6 +22,13 @@ const BaseEntityRelationshipSchema = z.enum([
 ]);
 const BaseSuggestedTagKindSchema = z.enum(['topic', 'entity', 'intent', 'format']);
 
+function boundedModelString(maxLength: number) {
+  return z.preprocess(
+    (value) => (typeof value === 'string' ? value.trim().slice(0, maxLength) : value),
+    z.string().min(1).max(maxLength)
+  );
+}
+
 function normalizeEnumishString(value: string): string {
   return value
     .trim()
@@ -100,12 +107,12 @@ export const EnrichmentModelOutputSchema: z.ZodType<EnrichmentModelOutput, z.Zod
       detail: z.string().min(1).max(2000),
     }),
     classification: z.object({
-      primaryCategory: z.string().min(1).max(64),
+      primaryCategory: boundedModelString(64),
       secondaryCategories: z.array(z.string().min(1).max(64)).max(5),
-      intent: z.string().min(1).max(64),
-      difficulty: z.string().min(1).max(64),
+      intent: boundedModelString(64),
+      difficulty: boundedModelString(64),
       evergreenScore: ConfidenceSchema,
-      timeSensitivity: z.string().min(1).max(64),
+      timeSensitivity: boundedModelString(64),
     }),
     topics: z
       .array(


### PR DESCRIPTION
## Summary
- bound article chunk vector IDs to the Vectorize 64-byte limit while retaining legacy stale-vector cleanup
- make enrichment DLQ handling transition canonical and per-user records to a truthful terminal failure
- improve Qwen schema-repair feedback and normalize unsupported optional semantic objects and verbose classification strings without relaxing evidence requirements

## Validation
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build
- bun run test:worker:ci (92 files, 1,746 tests)
- focused article-understanding, embeddings, LLM, and consumer tests (29 tests)
- pre-push design-system checks and web tests (75 tests)