### PR TITLE
fix(worker): compact article understanding tails

### DIFF
--- a/apps/worker/src/enrichment/article-understanding.test.ts
+++ b/apps/worker/src/enrichment/article-understanding.test.ts
@@ -131,6 +131,48 @@ describe('article understanding', () => {
     expect(chunks.at(-1)?.text).toContain('tail-marker');
   });
 
+  it('folds an undersized trailing fragment into the preceding chunk', () => {
+    const chunks = prepareArticleChunks(
+      [
+        { id: 'main', kind: 'paragraph', text: 'a'.repeat(140) },
+        { id: 'footer', kind: 'paragraph', text: 'footer' },
+      ],
+      200
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.blockIds).toEqual(['main', 'footer']);
+    expect(chunks[0]?.characterCount).toBeGreaterThan(200);
+    expect(chunks[0]?.characterCount).toBeLessThanOrEqual(220);
+    expect(chunks[0]?.text).toContain('footer');
+  });
+
+  it('keeps a substantive trailing chunk separate', () => {
+    const chunks = prepareArticleChunks(
+      [
+        { id: 'main', kind: 'paragraph', text: 'a'.repeat(140) },
+        { id: 'ending', kind: 'paragraph', text: 'b'.repeat(60) },
+      ],
+      200
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.map((chunk) => chunk.blockIds)).toEqual([['main'], ['ending']]);
+  });
+
+  it('does not compact a small tail when the bounded overflow would be exceeded', () => {
+    const chunks = prepareArticleChunks(
+      [
+        { id: 'main', kind: 'paragraph', text: 'a'.repeat(165) },
+        { id: 'footer', kind: 'paragraph', text: 'footer' },
+      ],
+      200
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks.map((chunk) => chunk.blockIds)).toEqual([['main'], ['footer']]);
+  });
+
   it('splits an oversized block without dropping its ending', () => {
     const chunks = prepareArticleChunks(
       [{ id: 'large', kind: 'paragraph', text: `${'word '.repeat(300)}ending-marker` }],

--- a/apps/worker/src/enrichment/article-understanding.ts
+++ b/apps/worker/src/enrichment/article-understanding.ts
@@ -13,6 +13,9 @@ import type {
 } from './types';
 
 const DEFAULT_CHUNK_CHARACTER_LIMIT = 12_000;
+const MAX_TRAILING_CHUNK_CHARACTER_COUNT = 2_000;
+const TRAILING_CHUNK_FRACTION = 0.2;
+const TRAILING_MERGE_OVERFLOW_FRACTION = 0.1;
 const ANALYSIS_CONCURRENCY = 3;
 
 const EvidenceIdsSchema = z.array(z.string().min(1)).min(1).max(24);
@@ -109,6 +112,38 @@ export interface PreparedArticleChunk {
   text: string;
 }
 
+function compactTrailingChunk(
+  chunks: PreparedArticleChunk[],
+  characterLimit: number
+): PreparedArticleChunk[] {
+  if (chunks.length < 2) return chunks;
+
+  const previous = chunks.at(-2);
+  const trailing = chunks.at(-1);
+  if (!previous || !trailing) return chunks;
+
+  const trailingThreshold = Math.max(
+    1,
+    Math.min(
+      MAX_TRAILING_CHUNK_CHARACTER_COUNT,
+      Math.floor(characterLimit * TRAILING_CHUNK_FRACTION)
+    )
+  );
+  const mergedText = `${previous.text}\n\n${trailing.text}`;
+  const mergedLimit = Math.ceil(characterLimit * (1 + TRAILING_MERGE_OVERFLOW_FRACTION));
+  if (trailing.characterCount >= trailingThreshold || mergedText.length > mergedLimit) {
+    return chunks;
+  }
+
+  chunks.splice(-2, 2, {
+    ordinal: previous.ordinal,
+    blockIds: [...new Set([...previous.blockIds, ...trailing.blockIds])],
+    characterCount: mergedText.length,
+    text: mergedText,
+  });
+  return chunks;
+}
+
 function formatBlock(block: EnrichmentContentBlock): string {
   return `[block:${block.id} kind:${block.kind}]\n${block.text.trim()}`;
 }
@@ -170,7 +205,7 @@ export function prepareArticleChunks(
     }
   }
   flush();
-  return chunks;
+  return compactTrailingChunk(chunks, characterLimit);
 }
 
 function validEvidenceIds(ids: string[], allowed: Set<string>): string[] {
@@ -389,6 +424,7 @@ export async function enrichArticleWithQwen(
 export const articleUnderstandingInternals = {
   buildSemanticDocument,
   chunkMessages,
+  compactTrailingChunk,
   schemaForChunk,
   splitOversizedBlock,
 };


### PR DESCRIPTION
## Summary
- fold undersized trailing article fragments into the preceding semantic chunk
- cap the merged input at 110% of the normal character limit
- keep substantive endings separate and preserve strict evidence-backed output requirements

## Validation
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build
- bun run test:worker:ci (92 files, 1,749 tests)
- exact production-artifact chunk regression: Stevey 3 to 2, management 2 to 1, standup 2 to 1
- local native build, simulator install, app launch, live serve-sim frame, Home action, and Zine Native relaunch verified