### PR TITLE
fix(ios): restore native app chrome

### DIFF
--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -13,8 +13,8 @@ same hierarchy works in light and dark appearances.
 
 | Role           | Light     | Dark      | Intended use                                                  |
 | -------------- | --------- | --------- | ------------------------------------------------------------- |
-| Canvas         | `#F5F7F8` | `#000000` | Screen backgrounds and navigation chrome                      |
-| Surface        | `#FFFFFF` | `#14171A` | Cards, sheets, reader surfaces, and tab chrome                |
+| Canvas         | `#F5F7F8` | `#000000` | Screen backgrounds beneath system navigation chrome           |
+| Surface        | `#FFFFFF` | `#14171A` | Cards, sheets, reader surfaces, and elevated regions          |
 | Raised         | `#E9EDF0` | `#20252A` | Placeholders, subdued controls, and elevated regions          |
 | Primary text   | `#151719` | `#F5F7F8` | Titles, body copy, and primary icons                          |
 | Secondary text | `#5D646C` | `#B2BAC2` | Metadata, supporting copy, and inactive controls              |
@@ -33,6 +33,14 @@ the surrounding theme changes.
   `ZineTheme.tertiaryText` for de-emphasized metadata.
 - Use `zineAppTheme()` at an app-level container and `zineScreenChrome()` for
   list-style screens when those modifiers fit the view structure.
+- Keep navigation bars and tab bars system-managed. Semantic colors may tint
+  controls and provide the content beneath them, but must not globally replace
+  native materials, scroll-edge behavior, or shadows with opaque palette
+  backgrounds. Apply solid toolbar chrome only to a screen that explicitly
+  requires it, such as a collapsing filtered-list header.
+- Keep the root tab bar and ordinary screen navigation bars explicitly visible.
+  Visibility and semantic item tint are separate from the system-managed bar
+  material; hiding either bar must remain scoped to an immersive destination.
 - Do not scatter raw hex, RGB, `Color.primary`, or `Color.secondary` values
   through supported native views. If the product needs a new reusable role,
   add it to `ZineTheme.Role`, define both appearances, and update

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -125,8 +125,7 @@ private struct AuthenticatedAppView: View {
                 .tint(ZineTheme.brandAccent)
             }
         }
-        .tint(ZineTheme.brandAccent)
-        .background(ZineTheme.canvas)
+        .zineTabShellChrome()
         .task(id: homeRevision) {
             async let home: Void = homeStore.reload()
             async let today: Void = peopleDailyStore.load()

--- a/apps/ios/ZineNative/App/ZineNativeApp.swift
+++ b/apps/ios/ZineNative/App/ZineNativeApp.swift
@@ -85,7 +85,7 @@ struct ZineNativeApp: App {
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-daily-thread-fixture") {
             ScreenshotDailyThreadView()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-home-fixtures") {
-            ScreenshotHomeView()
+            ScreenshotHomeTabShell()
         } else if ProcessInfo.processInfo.arguments.contains("-screenshot-fixtures") {
             ScreenshotLibraryView()
         } else {

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -72,54 +72,13 @@ enum ZineTheme {
 
     @MainActor
     static func configureUIKitAppearance() {
-        let navigationAppearance = UINavigationBarAppearance()
-        navigationAppearance.configureWithOpaqueBackground()
-        navigationAppearance.backgroundColor = uiColor(.canvas)
-        navigationAppearance.shadowColor = uiColor(.border)
-        navigationAppearance.titleTextAttributes = [.foregroundColor: uiColor(.primaryText)]
-        navigationAppearance.largeTitleTextAttributes = [.foregroundColor: uiColor(.primaryText)]
-        UINavigationBar.appearance().standardAppearance = navigationAppearance
-        UINavigationBar.appearance().scrollEdgeAppearance = navigationAppearance
-        UINavigationBar.appearance().compactAppearance = navigationAppearance
         UINavigationBar.appearance().tintColor = uiColor(.brandAccent)
-
-        let tabAppearance = UITabBarAppearance()
-        tabAppearance.configureWithOpaqueBackground()
-        tabAppearance.backgroundColor = uiColor(.surface)
-        tabAppearance.shadowColor = uiColor(.border)
-        configure(
-            tabAppearance.stackedLayoutAppearance,
-            normal: uiColor(.secondaryText),
-            selected: uiColor(.brandAccent)
-        )
-        configure(
-            tabAppearance.inlineLayoutAppearance,
-            normal: uiColor(.secondaryText),
-            selected: uiColor(.brandAccent)
-        )
-        configure(
-            tabAppearance.compactInlineLayoutAppearance,
-            normal: uiColor(.secondaryText),
-            selected: uiColor(.brandAccent)
-        )
-        UITabBar.appearance().standardAppearance = tabAppearance
-        UITabBar.appearance().scrollEdgeAppearance = tabAppearance
+        UITabBar.appearance().tintColor = uiColor(.brandAccent)
+        UITabBar.appearance().unselectedItemTintColor = uiColor(.secondaryText)
 
         UIRefreshControl.appearance().tintColor = uiColor(.brandAccent)
         UIPageControl.appearance().currentPageIndicatorTintColor = uiColor(.brandAccent)
         UIPageControl.appearance().pageIndicatorTintColor = uiColor(.secondaryText).withAlphaComponent(0.3)
-    }
-
-    @MainActor
-    private static func configure(
-        _ appearance: UITabBarItemAppearance,
-        normal: UIColor,
-        selected: UIColor
-    ) {
-        appearance.normal.iconColor = normal
-        appearance.normal.titleTextAttributes = [.foregroundColor: normal]
-        appearance.selected.iconColor = selected
-        appearance.selected.titleTextAttributes = [.foregroundColor: selected]
     }
 }
 
@@ -147,7 +106,12 @@ extension View {
             .background(ZineTheme.canvas)
             .foregroundStyle(ZineTheme.primaryText)
             .tint(ZineTheme.brandAccent)
-            .toolbarBackground(ZineTheme.canvas, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar(.visible, for: .navigationBar)
+    }
+
+    func zineTabShellChrome() -> some View {
+        toolbar(.visible, for: .tabBar)
+            .tint(ZineTheme.brandAccent)
+            .background(ZineTheme.canvas)
     }
 }

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -1,6 +1,43 @@
 #if DEBUG
 import SwiftUI
 
+struct ScreenshotHomeTabShell: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            Tab("Home", systemImage: "house", value: 0) {
+                ScreenshotHomeView(density: .compact)
+            }
+
+            Tab("Library", systemImage: "books.vertical", value: 1) {
+                NavigationStack {
+                    Text("Library")
+                        .navigationTitle("Library")
+                }
+                .zineScreenChrome()
+            }
+
+            Tab("Settings", systemImage: "gearshape", value: 2) {
+                NavigationStack {
+                    Text("Settings")
+                        .navigationTitle("Settings")
+                }
+                .zineScreenChrome()
+            }
+
+            Tab("Search", systemImage: "magnifyingglass", value: 3) {
+                NavigationStack {
+                    Text("Search")
+                        .navigationTitle("Search")
+                }
+                .zineScreenChrome()
+            }
+        }
+        .zineTabShellChrome()
+    }
+}
+
 struct ScreenshotHomeView: View {
     var density: HomeLayoutDensity = .standard
 

--- a/apps/ios/ZineNativeTests/ZineThemeTests.swift
+++ b/apps/ios/ZineNativeTests/ZineThemeTests.swift
@@ -45,6 +45,22 @@ final class ZineThemeTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testUIKitBarsKeepSystemManagedMaterialsAndScrollEdges() {
+        ZineTheme.configureUIKitAppearance()
+
+        let navigationBar = UINavigationBar()
+        XCTAssertNil(navigationBar.standardAppearance.backgroundColor)
+        XCTAssertNil(navigationBar.scrollEdgeAppearance)
+
+        let tabBar = UITabBar()
+        XCTAssertNil(tabBar.standardAppearance.backgroundColor)
+        XCTAssertNil(tabBar.scrollEdgeAppearance)
+
+        let darkTraits = UITraitCollection(userInterfaceStyle: .dark)
+        XCTAssertEqual(tabBar.tintColor.resolvedColor(with: darkTraits).hexRGB, "EF661F")
+    }
+
     private func assertPalette(
         style: UIUserInterfaceStyle,
         expected: [ZineTheme.Role: String],


### PR DESCRIPTION
## Summary

- keep navigation and tab bar materials system-managed while preserving the Zine palette
- explicitly restore ordinary navigation and root tab bar visibility
- add a representative four-tab Home fixture and focused regression coverage

## Validation

- `xcodebuild test -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -derivedDataPath /tmp/zine-pr-system-chrome-tests -parallel-testing-enabled NO -only-testing:ZineNativeTests/ZineThemeTests` (4 passed)
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run --cwd apps/web test` (86 Vitest + 4 preview-target tests passed)
- `bun run --cwd apps/worker test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"` (1,753 passed)
- live `serve-sim` verification in light and dark mode, including switching from Home to Library
- signed physical-device build installed and launched as `app.zine.native`