### PR TITLE
Add read-only semantic collection experiment

### DIFF
--- a/apps/worker/src/collections/semantic-experiment.test.ts
+++ b/apps/worker/src/collections/semantic-experiment.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  assertReadOnlySql,
+  buildProductionCorpusQuery,
+  buildSemanticCollectionCorpus,
+  compareCollectionGenerations,
+  renderSemanticCollectionReview,
+  runWorkersAIStructured,
+  validateCollectionProposal,
+  validateCollectionProposalSet,
+  validateDiscoveredThemes,
+  validateProposalNovelty,
+  type CollectionGeneration,
+  type CollectionProposal,
+  type SemanticCollectionCorpus,
+} from './semantic-experiment';
+
+function understanding(itemId: string) {
+  return JSON.stringify({
+    schemaVersion: 1,
+    sourceContentHash: `sha256:source-${itemId}`,
+    coverage: 'FULL_CONTENT',
+    chunks: [
+      {
+        ordinal: 0,
+        blockIds: ['b1', 'b2', 'b3'],
+        characterCount: 500,
+        summary: { text: `Summary for ${itemId}.`, evidenceBlockIds: ['b1'] },
+        topics: [
+          {
+            name: 'Intentional work',
+            description: `Topic for ${itemId}.`,
+            evidenceBlockIds: ['b1'],
+          },
+        ],
+        claims: [
+          { statement: `Claim one for ${itemId}.`, evidenceBlockIds: ['b1'] },
+          { statement: `Claim two for ${itemId}.`, evidenceBlockIds: ['b2'] },
+        ],
+        questionsAnswered: [
+          {
+            question: `Question for ${itemId}?`,
+            answer: `Answer for ${itemId}.`,
+            evidenceBlockIds: ['b2'],
+          },
+        ],
+        concepts: [
+          {
+            name: 'Deliberate impact',
+            description: `Concept for ${itemId}.`,
+            evidenceBlockIds: ['b2'],
+          },
+        ],
+        perspective: { description: `Perspective for ${itemId}.`, evidenceBlockIds: ['b3'] },
+        audience: { description: `Audience for ${itemId}.`, evidenceBlockIds: ['b3'] },
+        actionableTakeaways: [{ description: `Takeaway for ${itemId}.`, evidenceBlockIds: ['b3'] }],
+      },
+    ],
+  });
+}
+
+function row(itemId: string) {
+  return {
+    item_id: itemId,
+    user_item_id: `user-${itemId}`,
+    title: `Article ${itemId}`,
+    canonical_url: `https://example.com/${itemId}`,
+    creator: `Author ${itemId}`,
+    publisher: null,
+    enrichment_content_hash: `sha256:enrichment-${itemId}`,
+    source_content_hash: `sha256:source-${itemId}`,
+    source_coverage: 'FULL_CONTENT',
+    source_kind: 'PUBLIC_WEB',
+    source_word_count: 1_000,
+    source_quality_score: 1,
+    source_quality_warnings_json: '[]',
+    understanding_json: understanding(itemId),
+  };
+}
+
+async function corpus(): Promise<SemanticCollectionCorpus> {
+  return buildSemanticCollectionCorpus(
+    'user-1',
+    [row('item-1'), row('item-2'), row('item-3'), row('item-4')],
+    '2026-08-10T00:00:00.000Z'
+  );
+}
+
+function proposal(
+  input: {
+    proposalId?: string;
+    origin?: 'USER_DIRECTED' | 'AI_DISCOVERED';
+    title?: string;
+    selectedIds?: string[];
+    seed?: number;
+  } = {}
+): CollectionProposal {
+  const selectedIds = input.selectedIds ?? ['item-1', 'item-2', 'item-3'];
+  const signal = (itemId: string) => `${itemId}:c0:claim:0`;
+  return {
+    proposalId: input.proposalId ?? 'user-directed',
+    origin: input.origin ?? 'USER_DIRECTED',
+    lens: 'How deliberate choices turn engineering effort into organizational impact.',
+    discoveryRationale:
+      input.origin === 'AI_DISCOVERED'
+        ? 'Several articles distinguish visible activity from consequential work.'
+        : null,
+    themeSeedItemIds: input.origin === 'AI_DISCOVERED' ? selectedIds : [],
+    model: 'collection-model',
+    promptVersion: 'semantic-collections-v1',
+    seed: input.seed ?? 1001,
+    title: input.title ?? 'Choosing Work That Actually Matters',
+    description: 'A collection about directing technical effort toward consequential outcomes.',
+    collectionRationale:
+      'These articles describe different mechanisms for separating visible activity from durable impact.',
+    candidateScores: ['item-1', 'item-2', 'item-3', 'item-4'].map((itemId, index) => ({
+      itemId,
+      overallScore: 95 - index * 10,
+      verdict: index < 3 ? ('STRONG' as const) : ('WEAK' as const),
+    })),
+    selectedItems: selectedIds.map((itemId, index) => ({
+      itemId,
+      rank: index + 1,
+      reason: `This selection contributes a distinct mechanism to the collection thesis ${index}.`,
+      signalIds: [signal(itemId)],
+    })),
+    nearMisses: selectedIds.includes('item-4')
+      ? []
+      : [
+          {
+            itemId: 'item-4',
+            reason:
+              'This article is adjacent but offers weaker support for the exact collection lens.',
+            signalIds: [signal('item-4')],
+          },
+        ],
+  };
+}
+
+function generation(proposals: CollectionProposal[], corpusHash: string): CollectionGeneration {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-08-10T00:01:00.000Z',
+    corpusHash,
+    model: 'collection-model',
+    promptVersion: 'semantic-collections-v1',
+    proposals,
+  };
+}
+
+describe('semantic collection production query', () => {
+  it('builds one read-only statement selecting only understood bookmarked articles', () => {
+    const query = buildProductionCorpusQuery("user'oops");
+    expect(query).toContain("ui.user_id = 'user''oops'");
+    expect(query).toContain('ie.understanding_json IS NOT NULL');
+    expect(query).toContain("i.content_type = 'ARTICLE'");
+    expect(() => assertReadOnlySql(query)).not.toThrow();
+  });
+
+  it.each([
+    'DELETE FROM items',
+    'WITH rows AS (SELECT 1) UPDATE items SET title = NULL',
+    'SELECT 1; DROP TABLE items',
+    'PRAGMA table_info(items)',
+  ])('rejects production SQL with a write or administrative path: %s', (query) => {
+    expect(() => assertReadOnlySql(query)).toThrow();
+  });
+});
+
+describe('semantic collection model client', () => {
+  it('parses Workers AI chat completions and repairs schema-invalid output', async () => {
+    const requests: Array<{ messages: Array<{ content: string }> }> = [];
+    const responses = [
+      { result: { choices: [{ message: { content: '{"value":"the"}' } }] } },
+      { result: { choices: [{ message: { content: '```json\n{"value":"complete"}\n```' } }] } },
+    ];
+    const fetchImpl = async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(JSON.stringify(responses.shift()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const result = await runWorkersAIStructured({
+      accountId: 'account',
+      apiToken: 'token',
+      model: 'model',
+      seed: 1,
+      maxTokens: 100,
+      operation: 'test generation',
+      repairPrompt: 'Repair the value.',
+      messages: [{ role: 'user', content: 'Return a value. /no_think' }],
+      schema: {
+        safeParse(value: unknown) {
+          if (
+            value &&
+            typeof value === 'object' &&
+            (value as { value?: unknown }).value === 'complete'
+          ) {
+            return { success: true as const, data: value as { value: string } };
+          }
+          return {
+            success: false as const,
+            error: { message: 'value must be complete' },
+          } as never;
+        },
+      } as never,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result).toEqual({ value: 'complete' });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]?.messages.at(-1)?.content).toContain('value must be complete');
+    expect(requests[1]?.messages.at(-1)?.content).toContain('{"value":"the"}');
+    expect(requests[1]?.messages.at(-1)?.content).toContain('/no_think');
+  });
+
+  it('retries transient transport failures without consuming semantic repair attempts', async () => {
+    let calls = 0;
+    const result = await runWorkersAIStructured({
+      accountId: 'account',
+      apiToken: 'token',
+      model: 'model',
+      seed: 1,
+      maxTokens: 100,
+      operation: 'transport test',
+      repairPrompt: 'Repair.',
+      repairAttempts: 0,
+      transportRetries: 1,
+      messages: [{ role: 'user', content: 'Return JSON. /no_think' }],
+      schema: z.object({ ok: z.literal(true) }),
+      fetchImpl: (async () => {
+        calls++;
+        return calls === 1
+          ? new Response(JSON.stringify({ errors: [{ message: 'timeout' }] }), {
+              status: 408,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          : new Response(JSON.stringify({ result: { response: '{"ok":true}' } }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            });
+      }) as typeof fetch,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toBe(2);
+  });
+});
+
+describe('semantic collection corpus', () => {
+  it('creates a stable content-addressed corpus with exact evidence signals', async () => {
+    const first = await corpus();
+    const second = await buildSemanticCollectionCorpus(
+      'user-1',
+      [row('item-4'), row('item-3'), row('item-2'), row('item-1')],
+      '2026-08-11T00:00:00.000Z'
+    );
+
+    expect(first.corpusHash).toBe(second.corpusHash);
+    expect(first.items[0]?.signals.map((signal) => signal.kind)).toContain('CLAIM');
+    expect(first.items[0]?.signals[0]?.evidenceBlockIds).toEqual(['b1']);
+  });
+
+  it('rejects stale source hashes and invented understanding evidence', async () => {
+    const stale = row('stale');
+    stale.source_content_hash = 'sha256:different';
+    await expect(
+      buildSemanticCollectionCorpus('user-1', [stale, row('2'), row('3')])
+    ).rejects.toThrow('source hash is stale');
+
+    const invalid = row('invalid');
+    const parsed = JSON.parse(invalid.understanding_json);
+    parsed.chunks[0].claims[0].evidenceBlockIds = ['invented'];
+    invalid.understanding_json = JSON.stringify(parsed);
+    await expect(
+      buildSemanticCollectionCorpus('user-1', [invalid, row('2'), row('3')])
+    ).rejects.toThrow('invalid block IDs');
+  });
+});
+
+describe('semantic collection validation', () => {
+  it('accepts grounded proposals and rejects missing candidates, invalid signals, and truncation', async () => {
+    const snapshot = await corpus();
+    expect(validateCollectionProposal(proposal(), snapshot)).toEqual([]);
+
+    const invalid = proposal();
+    invalid.candidateScores.pop();
+    invalid.selectedItems[0]!.signalIds = ['invented'];
+    invalid.collectionRationale = 'This explanation ends with the';
+    expect(validateCollectionProposal(invalid, snapshot)).toEqual(
+      expect.arrayContaining([
+        'candidateScores must contain every corpus item exactly once',
+        'candidateScores is missing item-4',
+        expect.stringContaining('invalid signal IDs'),
+        expect.stringContaining('truncated endings'),
+      ])
+    );
+  });
+
+  it('rejects duplicate AI-discovered portfolios above the overlap limit', async () => {
+    const snapshot = await corpus();
+    const proposals = [
+      proposal(),
+      proposal({ proposalId: 'ai-1', origin: 'AI_DISCOVERED', title: 'Impact Beyond Activity' }),
+      proposal({ proposalId: 'ai-2', origin: 'AI_DISCOVERED', title: 'Judgment Over Motion' }),
+      proposal({
+        proposalId: 'ai-3',
+        origin: 'AI_DISCOVERED',
+        title: 'Choosing Consequential Systems',
+        selectedIds: ['item-1', 'item-2', 'item-4'],
+      }),
+    ];
+    const issues = validateCollectionProposalSet(
+      generation(proposals, snapshot.corpusHash),
+      snapshot
+    );
+    expect(issues.some((issue) => issue.includes('overlap too heavily'))).toBe(true);
+  });
+
+  it('requires diverse theme seeds and repairs each new proposal against prior portfolios', async () => {
+    const snapshot = await corpus();
+    const themeIssues = validateDiscoveredThemes(
+      [
+        {
+          lens: 'How intentional work produces durable outcomes across engineering organizations.',
+          rationale: 'Several articles distinguish consequential projects from visible activity.',
+          seedItemIds: ['item-1', 'item-2', 'item-3'],
+        },
+        {
+          lens: 'How human judgment constrains automation in changing software development systems.',
+          rationale: 'Several articles retain review and accountability as automation expands.',
+          seedItemIds: ['item-1', 'item-2', 'item-3'],
+        },
+        {
+          lens: 'How teams replace process theater with context-sensitive coordination practices.',
+          rationale: 'Several articles challenge formal process when it obscures local judgment.',
+          seedItemIds: ['item-2', 'item-3', 'item-4'],
+        },
+      ],
+      snapshot
+    );
+    expect(themeIssues).toEqual(
+      expect.arrayContaining([expect.stringContaining('seed portfolios overlap too heavily')])
+    );
+
+    const prior = proposal({
+      proposalId: 'ai-1',
+      origin: 'AI_DISCOVERED',
+      title: 'Impact Beyond Activity',
+    });
+    const duplicate = proposal({
+      proposalId: 'ai-2',
+      origin: 'AI_DISCOVERED',
+      title: 'Judgment Over Motion',
+    });
+    expect(validateProposalNovelty(duplicate, [prior])).toEqual([
+      expect.stringContaining('choose a more distinct evidence-backed portfolio'),
+    ]);
+  });
+
+  it('requires AI-discovered collections to retain their three-item theme core', async () => {
+    const snapshot = await corpus();
+    const invalid = proposal({
+      proposalId: 'ai-1',
+      origin: 'AI_DISCOVERED',
+      title: 'Impact Beyond Activity',
+      selectedIds: ['item-1', 'item-2', 'item-3'],
+    });
+    invalid.themeSeedItemIds = ['item-1', 'item-2', 'item-4'];
+    expect(validateCollectionProposal(invalid, snapshot)).toEqual([
+      'AI-discovered proposal is missing theme seed item item-4',
+    ]);
+  });
+});
+
+describe('semantic collection stability and review', () => {
+  it('compares fixed lenses across seeds and renders evidence-backed review controls', async () => {
+    const snapshot = await corpus();
+    const primaryProposals = [
+      proposal(),
+      proposal({ proposalId: 'ai-1', origin: 'AI_DISCOVERED', title: 'Impact Beyond Activity' }),
+      proposal({
+        proposalId: 'ai-2',
+        origin: 'AI_DISCOVERED',
+        title: 'Judgment Over Motion',
+        selectedIds: ['item-1', 'item-3', 'item-4'],
+      }),
+      proposal({
+        proposalId: 'ai-3',
+        origin: 'AI_DISCOVERED',
+        title: 'Choosing Consequential Systems',
+        selectedIds: ['item-2', 'item-3', 'item-4'],
+      }),
+    ];
+    const replayProposals = primaryProposals.map((entry) => ({
+      ...entry,
+      seed: 2001,
+      selectedItems: entry.selectedItems.map((item) => ({ ...item })),
+    }));
+    replayProposals[0]!.selectedItems[2] = {
+      itemId: 'item-4',
+      rank: 3,
+      reason:
+        'This replay selection contributes a distinct supported perspective to the collection.',
+      signalIds: ['item-4:c0:claim:0'],
+    };
+
+    const primary = generation(primaryProposals, snapshot.corpusHash);
+    const replay = generation(replayProposals, snapshot.corpusHash);
+    const stability = compareCollectionGenerations(primary, replay);
+
+    expect(stability.passes).toBe(false);
+    expect(stability.proposals[0]?.coreRetention).toBeCloseTo(2 / 3);
+    const review = renderSemanticCollectionReview({
+      corpus: snapshot,
+      primary,
+      replay,
+      stability,
+      validationIssues: [],
+    });
+    expect(review).toContain('# Semantic collection experiment review');
+    expect(review).toContain('CLAIM: Claim one for item-1. [b1]');
+    expect(review).toContain('theme core');
+    expect(review).toContain('- [ ] Productize');
+  });
+});

--- a/apps/worker/src/collections/semantic-experiment.test.ts
+++ b/apps/worker/src/collections/semantic-experiment.test.ts
@@ -220,6 +220,7 @@ describe('semantic collection model client', () => {
 
   it('retries transient transport failures without consuming semantic repair attempts', async () => {
     let calls = 0;
+    const diagnostics: string[] = [];
     const result = await runWorkersAIStructured({
       accountId: 'account',
       apiToken: 'token',
@@ -230,6 +231,7 @@ describe('semantic collection model client', () => {
       repairPrompt: 'Repair.',
       repairAttempts: 0,
       transportRetries: 1,
+      onDiagnostic: (message) => diagnostics.push(message),
       messages: [{ role: 'user', content: 'Return JSON. /no_think' }],
       schema: z.object({ ok: z.literal(true) }),
       fetchImpl: (async () => {
@@ -248,6 +250,7 @@ describe('semantic collection model client', () => {
 
     expect(result).toEqual({ ok: true });
     expect(calls).toBe(2);
+    expect(diagnostics).toEqual(['transport test transport 408; retry 1/1']);
   });
 });
 

--- a/apps/worker/src/collections/semantic-experiment.ts
+++ b/apps/worker/src/collections/semantic-experiment.ts
@@ -1,0 +1,1080 @@
+import { z } from 'zod';
+
+const INCOMPLETE_SEMANTIC_ENDING =
+  /(?:[,;:\-\u2013\u2014]|\b(?:a|an|the|and|or|but|of|to|for|with|in|on|at|by|from|as|that|which|who|when|where|because|while|if))$/i;
+
+const GENERIC_COLLECTION_TITLES = new Set([
+  'ai',
+  'articles',
+  'career development',
+  'engineering',
+  'entrepreneurship',
+  'media studies',
+  'software',
+  'software development',
+  'technology',
+]);
+
+function completeText(label: string, minimum: number, maximum: number) {
+  return z
+    .string()
+    .trim()
+    .min(minimum)
+    .max(maximum)
+    .refine((value) => !INCOMPLETE_SEMANTIC_ENDING.test(value), {
+      message: `${label} must be a complete thought, not truncated prose`,
+    });
+}
+
+const EvidenceBlockIdsSchema = z.array(z.string().trim().min(1)).min(1).max(24);
+const UnderstandingEvidenceSchema = z.object({ evidenceBlockIds: EvidenceBlockIdsSchema });
+const DescriptionEvidenceSchema = UnderstandingEvidenceSchema.extend({
+  description: z.string().trim().min(1).max(1_200),
+});
+const OptionalDescriptionEvidenceSchema = DescriptionEvidenceSchema.nullable().default(null);
+const UnderstandingChunkSchema = z.object({
+  ordinal: z.number().int().min(0),
+  blockIds: z.array(z.string().trim().min(1)).min(1),
+  characterCount: z.number().int().min(1),
+  summary: UnderstandingEvidenceSchema.extend({ text: z.string().trim().min(1).max(2_000) }),
+  topics: z
+    .array(
+      DescriptionEvidenceSchema.extend({
+        name: z.string().trim().min(1).max(160),
+      })
+    )
+    .default([]),
+  claims: z
+    .array(UnderstandingEvidenceSchema.extend({ statement: z.string().trim().min(1).max(1_200) }))
+    .default([]),
+  questionsAnswered: z
+    .array(
+      UnderstandingEvidenceSchema.extend({
+        question: z.string().trim().min(1).max(800),
+        answer: z.string().trim().min(1).max(1_600),
+      })
+    )
+    .default([]),
+  concepts: z
+    .array(
+      DescriptionEvidenceSchema.extend({
+        name: z.string().trim().min(1).max(160),
+      })
+    )
+    .default([]),
+  perspective: OptionalDescriptionEvidenceSchema,
+  audience: OptionalDescriptionEvidenceSchema,
+  actionableTakeaways: z.array(DescriptionEvidenceSchema).default([]),
+});
+
+const ArticleUnderstandingSchema = z.object({
+  schemaVersion: z.literal(1),
+  sourceContentHash: z.string().trim().min(1),
+  coverage: z.enum(['FULL_CONTENT', 'PARTIAL_CONTENT']),
+  chunks: z.array(UnderstandingChunkSchema).min(1),
+});
+
+export const SemanticSignalKindSchema = z.enum([
+  'SUMMARY',
+  'TOPIC',
+  'CLAIM',
+  'QUESTION_ANSWERED',
+  'CONCEPT',
+  'PERSPECTIVE',
+  'AUDIENCE',
+  'ACTIONABLE_TAKEAWAY',
+]);
+
+export const SemanticSignalSchema = z.object({
+  id: z.string().min(1),
+  kind: SemanticSignalKindSchema,
+  chunkOrdinal: z.number().int().min(0),
+  text: z.string().trim().min(1).max(2_400),
+  evidenceBlockIds: EvidenceBlockIdsSchema,
+});
+
+export const SemanticCollectionCorpusItemSchema = z.object({
+  itemId: z.string().min(1),
+  userItemId: z.string().min(1),
+  title: z.string().trim().min(1),
+  canonicalUrl: z.string().url(),
+  creator: z.string().trim().min(1).nullable(),
+  publisher: z.string().trim().min(1).nullable(),
+  enrichmentContentHash: z.string().min(1),
+  sourceContentHash: z.string().min(1),
+  sourceCoverage: z.enum(['FULL_CONTENT', 'PARTIAL_CONTENT']),
+  sourceKind: z.string().trim().min(1),
+  sourceWordCount: z.number().int().min(1),
+  sourceQualityScore: z.number().min(0).max(1),
+  sourceQualityWarnings: z.array(z.string()),
+  signals: z.array(SemanticSignalSchema).min(3),
+});
+
+export const SemanticCollectionCorpusSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime(),
+  userId: z.string().min(1),
+  corpusHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  items: z.array(SemanticCollectionCorpusItemSchema).min(3),
+});
+
+export const DiscoveredThemeSchema = z.object({
+  lens: completeText('Theme lens', 20, 240),
+  rationale: completeText('Theme rationale', 30, 500),
+  seedItemIds: z.array(z.string().trim().min(1)).length(3),
+});
+
+export const ThemeDiscoverySchema = z
+  .object({ themes: z.array(DiscoveredThemeSchema).length(3) })
+  .superRefine((value, context) => {
+    const normalized = value.themes.map((theme) => normalizeKey(theme.lens));
+    if (new Set(normalized).size !== normalized.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['themes'],
+        message: 'Discovered collection lenses must be distinct',
+      });
+    }
+  });
+
+const SignalIdsSchema = z.array(z.string().trim().min(1)).min(1).max(6);
+
+export const CandidateScoreSchema = z.object({
+  itemId: z.string().min(1),
+  overallScore: z.number().min(0).max(100),
+  verdict: z.enum(['STRONG', 'MODERATE', 'WEAK']),
+});
+
+export const SelectedCollectionItemSchema = z.object({
+  itemId: z.string().min(1),
+  rank: z.number().int().min(1).max(6),
+  reason: completeText('Selection reason', 20, 500),
+  signalIds: SignalIdsSchema,
+});
+
+export const NearMissSchema = z.object({
+  itemId: z.string().min(1),
+  reason: completeText('Near-miss reason', 20, 500),
+  signalIds: SignalIdsSchema,
+});
+
+export const CollectionProposalModelOutputSchema = z.object({
+  title: completeText('Collection title', 4, 80),
+  description: completeText('Collection description', 20, 240),
+  collectionRationale: completeText('Collection rationale', 40, 800),
+  candidateScores: z.array(CandidateScoreSchema).min(3).max(80),
+  selectedItems: z.array(SelectedCollectionItemSchema).min(3).max(6),
+  nearMisses: z.array(NearMissSchema).max(2).default([]),
+});
+
+export const CollectionProposalSchema = CollectionProposalModelOutputSchema.extend({
+  proposalId: z.string().min(1),
+  origin: z.enum(['USER_DIRECTED', 'AI_DISCOVERED']),
+  lens: completeText('Collection lens', 20, 240),
+  discoveryRationale: completeText('Discovery rationale', 20, 500).nullable(),
+  themeSeedItemIds: z.array(z.string().min(1)).max(6),
+  model: z.string().min(1),
+  promptVersion: z.string().min(1),
+  seed: z.number().int().positive(),
+});
+
+export const CollectionGenerationSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().datetime(),
+  corpusHash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  model: z.string().min(1),
+  promptVersion: z.string().min(1),
+  proposals: z.array(CollectionProposalSchema).length(4),
+});
+
+export const ProposalStabilitySchema = z.object({
+  proposalId: z.string().min(1),
+  primaryItemIds: z.array(z.string()),
+  replayItemIds: z.array(z.string()),
+  intersectionItemIds: z.array(z.string()),
+  unionItemIds: z.array(z.string()),
+  coreRetention: z.number().min(0).max(1),
+  jaccardSimilarity: z.number().min(0).max(1),
+  passes: z.boolean(),
+});
+
+export const StabilityReportSchema = z.object({
+  minimumCoreRetention: z.number().min(0).max(1),
+  proposals: z.array(ProposalStabilitySchema).length(4),
+  passes: z.boolean(),
+});
+
+export type SemanticSignal = z.infer<typeof SemanticSignalSchema>;
+export type SemanticCollectionCorpusItem = z.infer<typeof SemanticCollectionCorpusItemSchema>;
+export type SemanticCollectionCorpus = z.infer<typeof SemanticCollectionCorpusSchema>;
+export type DiscoveredTheme = z.infer<typeof DiscoveredThemeSchema>;
+export type CollectionProposalModelOutput = z.infer<typeof CollectionProposalModelOutputSchema>;
+export type CollectionProposal = z.infer<typeof CollectionProposalSchema>;
+export type CollectionGeneration = z.infer<typeof CollectionGenerationSchema>;
+export type StabilityReport = z.infer<typeof StabilityReportSchema>;
+
+export interface WorkersAIStructuredOptions<T> {
+  accountId: string;
+  apiToken: string;
+  model: string;
+  seed: number;
+  maxTokens: number;
+  messages: Array<{ role: 'system' | 'user'; content: string }>;
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>;
+  validate?: (value: T) => string[];
+  operation: string;
+  repairPrompt: string;
+  repairAttempts?: number;
+  transportRetries?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface SemanticCollectionCorpusRow {
+  item_id: string;
+  user_item_id: string;
+  title: string;
+  canonical_url: string;
+  creator: string | null;
+  publisher: string | null;
+  enrichment_content_hash: string;
+  source_content_hash: string;
+  source_coverage: string;
+  source_kind: string;
+  source_word_count: number;
+  source_quality_score: number;
+  source_quality_warnings_json: string;
+  understanding_json: string;
+}
+
+function extractJsonCandidates(value: string): string[] {
+  const trimmed = value.trim();
+  const candidates = [trimmed];
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  if (fenced?.[1]) candidates.push(fenced[1].trim());
+  for (const match of trimmed.matchAll(/```(?:json)?\s*([\s\S]*?)\s*```/gi)) {
+    if (match[1]) candidates.push(match[1].trim());
+  }
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    candidates.push(trimmed.slice(firstBrace, lastBrace + 1));
+  }
+  return [...new Set(candidates)];
+}
+
+export function workersAIResponseText(response: unknown): string {
+  const visit = (value: unknown): string | null => {
+    if (typeof value === 'string') return value;
+    if (!value || typeof value !== 'object') return null;
+    const record = value as Record<string, unknown>;
+    for (const key of ['response', 'output_text', 'text', 'content']) {
+      if (typeof record[key] === 'string' && record[key]) return record[key];
+    }
+    if (Array.isArray(record.choices)) {
+      for (const choice of record.choices) {
+        if (!choice || typeof choice !== 'object') continue;
+        const choiceRecord = choice as Record<string, unknown>;
+        const direct = visit(choiceRecord);
+        if (direct) return direct;
+        const message = visit(choiceRecord.message);
+        if (message) return message;
+      }
+    }
+    for (const key of ['result', 'message']) {
+      const nested = visit(record[key]);
+      if (nested) return nested;
+    }
+    return null;
+  };
+
+  const text = visit(response);
+  if (!text) throw new Error('Workers AI response did not contain final response text');
+  return text;
+}
+
+function parseStructuredModelResponse<T>(
+  response: unknown,
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>
+): T {
+  const direct = schema.safeParse(response);
+  if (direct.success) return direct.data;
+
+  const text = workersAIResponseText(response);
+  let parseError: unknown;
+  for (const candidate of extractJsonCandidates(text)) {
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      const validated = schema.safeParse(parsed);
+      if (validated.success) return validated.data;
+      parseError = new Error(validated.error.message);
+    } catch (error) {
+      parseError = error;
+    }
+  }
+  throw new Error(
+    `Workers AI response failed structured validation: ${parseError instanceof Error ? parseError.message : String(parseError)}`
+  );
+}
+
+export async function runWorkersAIStructured<T>(
+  options: WorkersAIStructuredOptions<T>
+): Promise<T> {
+  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${options.accountId}/ai/run/${options.model}`;
+  const repairAttempts = Math.max(0, options.repairAttempts ?? 2);
+  const transportRetries = Math.max(0, options.transportRetries ?? 2);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let lastFailure = '';
+  let lastResponseText = '';
+
+  for (let attempt = 0; attempt <= repairAttempts; attempt++) {
+    const messages =
+      attempt === 0
+        ? options.messages
+        : [
+            ...options.messages,
+            {
+              role: 'user' as const,
+              content: `${options.repairPrompt}\n\nPrevious validation failure:\n${lastFailure.slice(0, 4_000)}${lastResponseText ? `\n\nPrevious invalid JSON response to repair:\n${lastResponseText.slice(0, 10_000)}` : ''}\n/no_think`,
+            },
+          ];
+    const request = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${options.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages,
+        response_format: { type: 'json_object' },
+        max_tokens: options.maxTokens,
+        temperature: 0.4,
+        top_p: 0.8,
+        top_k: 20,
+        seed: options.seed,
+      }),
+      signal: AbortSignal.timeout(180_000),
+    } satisfies RequestInit;
+    let response: Response | null = null;
+    let body: unknown;
+    for (let transportAttempt = 0; transportAttempt <= transportRetries; transportAttempt++) {
+      response = await fetchImpl(endpoint, request);
+      body = (await response.json()) as unknown;
+      const retryable =
+        response.status === 408 || response.status === 429 || response.status >= 500;
+      if (response.ok || !retryable || transportAttempt >= transportRetries) break;
+      console.error(
+        `${options.operation} transport ${response.status}; retry ${transportAttempt + 1}/${transportRetries}`
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500 * (transportAttempt + 1)));
+    }
+    if (!response) throw new Error(`${options.operation} did not receive a Workers AI response`);
+    if (!response.ok) {
+      lastFailure = `HTTP ${response.status}: ${JSON.stringify(body).slice(0, 4_000)}`;
+    } else {
+      try {
+        lastResponseText = workersAIResponseText(body);
+        const value = parseStructuredModelResponse(body, options.schema);
+        const semanticIssues = options.validate?.(value) ?? [];
+        if (semanticIssues.length === 0) return value;
+        lastFailure = semanticIssues.join('\n');
+      } catch (error) {
+        lastFailure = error instanceof Error ? error.message : String(error);
+      }
+    }
+
+    if (attempt < repairAttempts) {
+      console.error(
+        `${options.operation} failed validation; repair ${attempt + 1}/${repairAttempts}: ${lastFailure.slice(0, 800)}`
+      );
+    }
+  }
+
+  throw new Error(`${options.operation} failed after repair attempts: ${lastFailure}`);
+}
+
+const CorpusRowSchema = z.object({
+  item_id: z.string().min(1),
+  user_item_id: z.string().min(1),
+  title: z.string().trim().min(1),
+  canonical_url: z.string().url(),
+  creator: z.string().trim().min(1).nullable(),
+  publisher: z.string().trim().min(1).nullable(),
+  enrichment_content_hash: z.string().min(1),
+  source_content_hash: z.string().min(1),
+  source_coverage: z.enum(['FULL_CONTENT', 'PARTIAL_CONTENT']),
+  source_kind: z.string().trim().min(1),
+  source_word_count: z.number().int().min(1),
+  source_quality_score: z.number().min(0).max(1),
+  source_quality_warnings_json: z.string(),
+  understanding_json: z.string(),
+});
+
+function normalizeKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function signalId(itemId: string, chunkOrdinal: number, kind: string, index: number): string {
+  return `${itemId}:c${chunkOrdinal}:${kind.toLowerCase()}:${index}`;
+}
+
+function addSignal(
+  signals: SemanticSignal[],
+  input: {
+    itemId: string;
+    chunkOrdinal: number;
+    kind: z.infer<typeof SemanticSignalKindSchema>;
+    index: number;
+    text: string;
+    evidenceBlockIds: string[];
+    allowedBlockIds: Set<string>;
+  }
+) {
+  const evidenceBlockIds = [...new Set(input.evidenceBlockIds.map((value) => value.trim()))];
+  const invalid = evidenceBlockIds.filter((id) => !input.allowedBlockIds.has(id));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Understanding signal for ${input.itemId} cites invalid block IDs: ${invalid.join(', ')}`
+    );
+  }
+
+  signals.push(
+    SemanticSignalSchema.parse({
+      id: signalId(input.itemId, input.chunkOrdinal, input.kind, input.index),
+      kind: input.kind,
+      chunkOrdinal: input.chunkOrdinal,
+      text: input.text,
+      evidenceBlockIds,
+    })
+  );
+}
+
+function signalsFromUnderstanding(
+  itemId: string,
+  understanding: z.infer<typeof ArticleUnderstandingSchema>
+): SemanticSignal[] {
+  const signals: SemanticSignal[] = [];
+
+  for (const chunk of understanding.chunks) {
+    const allowedBlockIds = new Set(chunk.blockIds);
+    addSignal(signals, {
+      itemId,
+      chunkOrdinal: chunk.ordinal,
+      kind: 'SUMMARY',
+      index: 0,
+      text: chunk.summary.text,
+      evidenceBlockIds: chunk.summary.evidenceBlockIds,
+      allowedBlockIds,
+    });
+
+    chunk.topics.slice(0, 2).forEach((topic, index) =>
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'TOPIC',
+        index,
+        text: `${topic.name}: ${topic.description}`,
+        evidenceBlockIds: topic.evidenceBlockIds,
+        allowedBlockIds,
+      })
+    );
+    chunk.claims.slice(0, 6).forEach((claim, index) =>
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'CLAIM',
+        index,
+        text: claim.statement,
+        evidenceBlockIds: claim.evidenceBlockIds,
+        allowedBlockIds,
+      })
+    );
+    chunk.questionsAnswered.slice(0, 2).forEach((question, index) =>
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'QUESTION_ANSWERED',
+        index,
+        text: `${question.question} ${question.answer}`,
+        evidenceBlockIds: question.evidenceBlockIds,
+        allowedBlockIds,
+      })
+    );
+    chunk.concepts.slice(0, 4).forEach((concept, index) =>
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'CONCEPT',
+        index,
+        text: `${concept.name}: ${concept.description}`,
+        evidenceBlockIds: concept.evidenceBlockIds,
+        allowedBlockIds,
+      })
+    );
+    if (chunk.perspective) {
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'PERSPECTIVE',
+        index: 0,
+        text: chunk.perspective.description,
+        evidenceBlockIds: chunk.perspective.evidenceBlockIds,
+        allowedBlockIds,
+      });
+    }
+    if (chunk.audience) {
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'AUDIENCE',
+        index: 0,
+        text: chunk.audience.description,
+        evidenceBlockIds: chunk.audience.evidenceBlockIds,
+        allowedBlockIds,
+      });
+    }
+    chunk.actionableTakeaways.slice(0, 4).forEach((takeaway, index) =>
+      addSignal(signals, {
+        itemId,
+        chunkOrdinal: chunk.ordinal,
+        kind: 'ACTIONABLE_TAKEAWAY',
+        index,
+        text: takeaway.description,
+        evidenceBlockIds: takeaway.evidenceBlockIds,
+        allowedBlockIds,
+      })
+    );
+  }
+
+  return signals;
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return `sha256:${Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('')}`;
+}
+
+export async function buildSemanticCollectionCorpus(
+  userId: string,
+  rawRows: unknown[],
+  generatedAt = new Date().toISOString()
+): Promise<SemanticCollectionCorpus> {
+  const rows = rawRows.map((row) => CorpusRowSchema.parse(row));
+  const itemIds = rows.map((row) => row.item_id);
+  if (new Set(itemIds).size !== itemIds.length) {
+    throw new Error('Semantic collection corpus contains duplicate canonical items');
+  }
+
+  const items = rows
+    .map((row) => {
+      const understanding = ArticleUnderstandingSchema.parse(JSON.parse(row.understanding_json));
+      if (understanding.sourceContentHash !== row.source_content_hash) {
+        throw new Error(`Understanding source hash is stale for ${row.item_id}`);
+      }
+      if (understanding.coverage !== row.source_coverage) {
+        throw new Error(`Understanding source coverage disagrees for ${row.item_id}`);
+      }
+
+      return SemanticCollectionCorpusItemSchema.parse({
+        itemId: row.item_id,
+        userItemId: row.user_item_id,
+        title: row.title,
+        canonicalUrl: row.canonical_url,
+        creator: row.creator,
+        publisher: row.publisher,
+        enrichmentContentHash: row.enrichment_content_hash,
+        sourceContentHash: row.source_content_hash,
+        sourceCoverage: row.source_coverage,
+        sourceKind: row.source_kind,
+        sourceWordCount: row.source_word_count,
+        sourceQualityScore: row.source_quality_score,
+        sourceQualityWarnings: z
+          .array(z.string())
+          .parse(JSON.parse(row.source_quality_warnings_json)),
+        signals: signalsFromUnderstanding(row.item_id, understanding),
+      });
+    })
+    .sort((left, right) => left.itemId.localeCompare(right.itemId));
+
+  const corpusHash = await sha256(JSON.stringify({ schemaVersion: 1, userId, items }));
+  return SemanticCollectionCorpusSchema.parse({
+    schemaVersion: 1,
+    generatedAt,
+    userId,
+    corpusHash,
+    items,
+  });
+}
+
+export function buildProductionCorpusQuery(userId: string): string {
+  const escapedUserId = userId.replaceAll("'", "''");
+  const query = `
+WITH latest_understanding AS (
+  SELECT
+    ie.*,
+    ROW_NUMBER() OVER (PARTITION BY ie.item_id ORDER BY ie.updated_at DESC, ie.id DESC) AS row_number
+  FROM item_enrichments ie
+  WHERE ie.schema_version = 3
+    AND ie.status = 'COMPLETE'
+    AND ie.understanding_json IS NOT NULL
+)
+SELECT
+  i.id AS item_id,
+  ui.id AS user_item_id,
+  i.title,
+  i.canonical_url,
+  c.name AS creator,
+  i.publisher,
+  lu.content_hash AS enrichment_content_hash,
+  lu.source_content_hash,
+  lu.source_coverage,
+  lu.source_kind,
+  lu.source_word_count,
+  lu.source_quality_score,
+  lu.source_quality_warnings_json,
+  lu.understanding_json
+FROM user_items ui
+INNER JOIN items i ON i.id = ui.item_id
+INNER JOIN latest_understanding lu ON lu.item_id = i.id AND lu.row_number = 1
+LEFT JOIN creators c ON c.id = i.creator_id
+WHERE ui.user_id = '${escapedUserId}'
+  AND ui.state = 'BOOKMARKED'
+  AND i.content_type = 'ARTICLE'
+ORDER BY i.id
+`.trim();
+  assertReadOnlySql(query);
+  return query;
+}
+
+export function assertReadOnlySql(sql: string): void {
+  const normalized = sql
+    .replace(/--.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .trim()
+    .replace(/;+$/, '')
+    .trim();
+  if (!/^(?:SELECT|WITH)\b/i.test(normalized)) {
+    throw new Error('Production corpus SQL must begin with SELECT or WITH');
+  }
+  if (/;\s*\S/.test(normalized)) {
+    throw new Error('Production corpus SQL must contain exactly one statement');
+  }
+  if (
+    /\b(?:INSERT|UPDATE|DELETE|REPLACE|CREATE|ALTER|DROP|TRUNCATE|VACUUM|ATTACH|DETACH|PRAGMA)\b/i.test(
+      normalized
+    )
+  ) {
+    throw new Error('Production corpus SQL contains a forbidden write or administrative keyword');
+  }
+}
+
+function itemSignalIds(item: SemanticCollectionCorpusItem): Set<string> {
+  return new Set(item.signals.map((signal) => signal.id));
+}
+
+function validateReferencedSignals(
+  item: SemanticCollectionCorpusItem,
+  signalIds: string[],
+  path: string,
+  issues: string[]
+) {
+  const allowed = itemSignalIds(item);
+  const invalid = signalIds.filter((signalId) => !allowed.has(signalId));
+  if (invalid.length > 0) issues.push(`${path} cites invalid signal IDs: ${invalid.join(', ')}`);
+}
+
+function proseValues(proposal: CollectionProposal): string[] {
+  return [
+    proposal.title,
+    proposal.description,
+    proposal.collectionRationale,
+    proposal.lens,
+    proposal.discoveryRationale ?? '',
+    ...proposal.selectedItems.map((selected) => selected.reason),
+    ...proposal.nearMisses.map((nearMiss) => nearMiss.reason),
+  ].filter(Boolean);
+}
+
+export function validateCollectionProposal(
+  proposal: CollectionProposal,
+  corpus: SemanticCollectionCorpus
+): string[] {
+  const issues: string[] = [];
+  const itemById = new Map(corpus.items.map((item) => [item.itemId, item]));
+  const corpusIds = new Set(itemById.keys());
+  const candidateIds = proposal.candidateScores.map((candidate) => candidate.itemId);
+  const candidateIdSet = new Set(candidateIds);
+
+  if (candidateIds.length !== corpus.items.length || candidateIdSet.size !== corpus.items.length) {
+    issues.push('candidateScores must contain every corpus item exactly once');
+  }
+  for (const itemId of corpusIds) {
+    if (!candidateIdSet.has(itemId)) issues.push(`candidateScores is missing ${itemId}`);
+  }
+  for (const itemId of candidateIdSet) {
+    if (!corpusIds.has(itemId)) issues.push(`candidateScores contains unknown item ${itemId}`);
+  }
+
+  const selectedIds = proposal.selectedItems.map((selected) => selected.itemId);
+  if (new Set(selectedIds).size !== selectedIds.length) {
+    issues.push('selectedItems contains duplicate items');
+  }
+  const sortedRanks = proposal.selectedItems.map((selected) => selected.rank).sort((a, b) => a - b);
+  const expectedRanks = Array.from(
+    { length: proposal.selectedItems.length },
+    (_, index) => index + 1
+  );
+  if (JSON.stringify(sortedRanks) !== JSON.stringify(expectedRanks)) {
+    issues.push('selectedItems ranks must be consecutive from 1');
+  }
+  proposal.selectedItems.forEach((selected, index) => {
+    const item = itemById.get(selected.itemId);
+    if (!item) {
+      issues.push(`selectedItems[${index}] contains unknown item ${selected.itemId}`);
+      return;
+    }
+    if (!candidateIdSet.has(selected.itemId)) {
+      issues.push(`selectedItems[${index}] was not scored as a candidate`);
+    }
+    validateReferencedSignals(item, selected.signalIds, `selectedItems[${index}]`, issues);
+  });
+
+  const selectedIdSet = new Set(selectedIds);
+  const nearMissIds = proposal.nearMisses.map((nearMiss) => nearMiss.itemId);
+  if (new Set(nearMissIds).size !== nearMissIds.length) {
+    issues.push('nearMisses contains duplicate items');
+  }
+  proposal.nearMisses.forEach((nearMiss, index) => {
+    const item = itemById.get(nearMiss.itemId);
+    if (!item) {
+      issues.push(`nearMisses[${index}] contains unknown item ${nearMiss.itemId}`);
+      return;
+    }
+    if (selectedIdSet.has(nearMiss.itemId)) {
+      issues.push(`nearMisses[${index}] is also selected`);
+    }
+    validateReferencedSignals(item, nearMiss.signalIds, `nearMisses[${index}]`, issues);
+  });
+
+  if (proposal.origin === 'AI_DISCOVERED') {
+    if (proposal.themeSeedItemIds.length !== 3) {
+      issues.push('AI-discovered proposals must retain exactly three theme seed items');
+    }
+    if (proposal.selectedItems.length > 4) {
+      issues.push('AI-discovered proposals may select at most four items in this experiment');
+    }
+    for (const seedItemId of proposal.themeSeedItemIds) {
+      if (!selectedIdSet.has(seedItemId)) {
+        issues.push(`AI-discovered proposal is missing theme seed item ${seedItemId}`);
+      }
+    }
+  }
+
+  if (GENERIC_COLLECTION_TITLES.has(normalizeKey(proposal.title))) {
+    issues.push(`Collection title is a generic category: ${proposal.title}`);
+  }
+  const malformed = proseValues(proposal).filter((value) => INCOMPLETE_SEMANTIC_ENDING.test(value));
+  if (malformed.length > 0) {
+    issues.push(`Collection prose contains truncated endings: ${malformed.join(' | ')}`);
+  }
+
+  return [...new Set(issues)];
+}
+
+function selectedSet(proposal: CollectionProposal): Set<string> {
+  return new Set(proposal.selectedItems.map((item) => item.itemId));
+}
+
+function setIntersection(left: Set<string>, right: Set<string>): string[] {
+  return [...left].filter((value) => right.has(value)).sort();
+}
+
+function setUnion(left: Set<string>, right: Set<string>): string[] {
+  return [...new Set([...left, ...right])].sort();
+}
+
+export function validateCollectionProposalSet(
+  generation: CollectionGeneration,
+  corpus: SemanticCollectionCorpus,
+  maximumDiscoveredOverlap = 0.6
+): string[] {
+  const issues = generation.proposals.flatMap((proposal) =>
+    validateCollectionProposal(proposal, corpus).map((issue) => `${proposal.proposalId}: ${issue}`)
+  );
+
+  const proposalIds = generation.proposals.map((proposal) => proposal.proposalId);
+  if (new Set(proposalIds).size !== proposalIds.length) {
+    issues.push('Proposal IDs must be distinct');
+  }
+  const normalizedTitles = generation.proposals.map((proposal) => normalizeKey(proposal.title));
+  if (new Set(normalizedTitles).size !== normalizedTitles.length) {
+    issues.push('Collection titles must be distinct');
+  }
+  if (generation.proposals.filter((proposal) => proposal.origin === 'USER_DIRECTED').length !== 1) {
+    issues.push('Generation must contain exactly one user-directed collection');
+  }
+  if (generation.proposals.filter((proposal) => proposal.origin === 'AI_DISCOVERED').length !== 3) {
+    issues.push('Generation must contain exactly three AI-discovered collections');
+  }
+
+  const discovered = generation.proposals.filter((proposal) => proposal.origin === 'AI_DISCOVERED');
+  for (let leftIndex = 0; leftIndex < discovered.length; leftIndex++) {
+    for (let rightIndex = leftIndex + 1; rightIndex < discovered.length; rightIndex++) {
+      const left = discovered[leftIndex];
+      const right = discovered[rightIndex];
+      if (!left || !right) continue;
+      const intersection = setIntersection(selectedSet(left), selectedSet(right));
+      const union = setUnion(selectedSet(left), selectedSet(right));
+      const similarity = union.length === 0 ? 0 : intersection.length / union.length;
+      if (similarity > maximumDiscoveredOverlap) {
+        issues.push(
+          `${left.proposalId} and ${right.proposalId} overlap too heavily (${similarity.toFixed(2)})`
+        );
+      }
+    }
+  }
+
+  return [...new Set(issues)];
+}
+
+export function validateDiscoveredThemes(
+  themes: DiscoveredTheme[],
+  corpus: SemanticCollectionCorpus,
+  maximumSeedOverlap = 0.4,
+  minimumCorpusCoverage = 0.7
+): string[] {
+  const issues: string[] = [];
+  const corpusIds = new Set(corpus.items.map((item) => item.itemId));
+  const covered = new Set<string>();
+
+  themes.forEach((theme, index) => {
+    const seedIds = new Set(theme.seedItemIds);
+    if (seedIds.size !== theme.seedItemIds.length) {
+      issues.push(`themes[${index}] contains duplicate seed items`);
+    }
+    for (const itemId of seedIds) {
+      if (!corpusIds.has(itemId))
+        issues.push(`themes[${index}] contains unknown seed item ${itemId}`);
+      covered.add(itemId);
+    }
+  });
+
+  for (let leftIndex = 0; leftIndex < themes.length; leftIndex++) {
+    for (let rightIndex = leftIndex + 1; rightIndex < themes.length; rightIndex++) {
+      const left = new Set(themes[leftIndex]?.seedItemIds ?? []);
+      const right = new Set(themes[rightIndex]?.seedItemIds ?? []);
+      const intersection = setIntersection(left, right);
+      const union = setUnion(left, right);
+      const overlap = union.length === 0 ? 0 : intersection.length / union.length;
+      if (overlap > maximumSeedOverlap) {
+        issues.push(
+          `themes[${leftIndex}] and themes[${rightIndex}] seed portfolios overlap too heavily (${overlap.toFixed(2)})`
+        );
+      }
+    }
+  }
+
+  const coverage = covered.size / corpus.items.length;
+  if (coverage < minimumCorpusCoverage) {
+    issues.push(
+      `Discovered theme seeds cover only ${(coverage * 100).toFixed(0)}% of the corpus; require ${(minimumCorpusCoverage * 100).toFixed(0)}%`
+    );
+  }
+  return [...new Set(issues)];
+}
+
+export function validateProposalNovelty(
+  proposal: CollectionProposal,
+  priorProposals: CollectionProposal[],
+  maximumOverlap = 0.6
+): string[] {
+  if (proposal.origin !== 'AI_DISCOVERED') return [];
+  const current = selectedSet(proposal);
+  return priorProposals
+    .filter((prior) => prior.origin === 'AI_DISCOVERED')
+    .flatMap((prior) => {
+      const priorSet = selectedSet(prior);
+      const intersection = setIntersection(current, priorSet);
+      const union = setUnion(current, priorSet);
+      const overlap = union.length === 0 ? 0 : intersection.length / union.length;
+      return overlap > maximumOverlap
+        ? [
+            `${proposal.proposalId} overlaps ${prior.proposalId} too heavily (${overlap.toFixed(2)}); choose a more distinct evidence-backed portfolio`,
+          ]
+        : [];
+    });
+}
+
+export function compareCollectionGenerations(
+  primary: CollectionGeneration,
+  replay: CollectionGeneration,
+  minimumCoreRetention = 0.7
+): StabilityReport {
+  if (primary.corpusHash !== replay.corpusHash) {
+    throw new Error('Cannot compare collection generations from different corpus snapshots');
+  }
+  const replayById = new Map(replay.proposals.map((proposal) => [proposal.proposalId, proposal]));
+  const proposals = primary.proposals.map((proposal) => {
+    const replayProposal = replayById.get(proposal.proposalId);
+    if (!replayProposal) throw new Error(`Replay is missing proposal ${proposal.proposalId}`);
+    const primarySet = selectedSet(proposal);
+    const replaySet = selectedSet(replayProposal);
+    const intersectionItemIds = setIntersection(primarySet, replaySet);
+    const unionItemIds = setUnion(primarySet, replaySet);
+    const denominator = Math.max(1, Math.min(primarySet.size, replaySet.size));
+    const coreRetention = intersectionItemIds.length / denominator;
+    const jaccardSimilarity =
+      unionItemIds.length === 0 ? 1 : intersectionItemIds.length / unionItemIds.length;
+    return {
+      proposalId: proposal.proposalId,
+      primaryItemIds: [...primarySet].sort(),
+      replayItemIds: [...replaySet].sort(),
+      intersectionItemIds,
+      unionItemIds,
+      coreRetention,
+      jaccardSimilarity,
+      passes: coreRetention >= minimumCoreRetention,
+    };
+  });
+
+  return StabilityReportSchema.parse({
+    minimumCoreRetention,
+    proposals,
+    passes: proposals.every((proposal) => proposal.passes),
+  });
+}
+
+function displayEvidence(item: SemanticCollectionCorpusItem, ids: string[]): string[] {
+  const byId = new Map(item.signals.map((signal) => [signal.id, signal]));
+  return ids.flatMap((id) => {
+    const signal = byId.get(id);
+    if (!signal) return [];
+    return [`${signal.kind}: ${signal.text} [${signal.evidenceBlockIds.join(', ')}]`];
+  });
+}
+
+export function renderSemanticCollectionReview(input: {
+  corpus: SemanticCollectionCorpus;
+  primary: CollectionGeneration;
+  replay: CollectionGeneration;
+  stability: StabilityReport;
+  validationIssues: string[];
+}): string {
+  const itemById = new Map(input.corpus.items.map((item) => [item.itemId, item]));
+  const stabilityById = new Map(
+    input.stability.proposals.map((proposal) => [proposal.proposalId, proposal])
+  );
+  const lines = [
+    '# Semantic collection experiment review',
+    '',
+    `Generated: ${input.primary.generatedAt}`,
+    '',
+    `Corpus: ${input.corpus.items.length} deeply understood articles`,
+    '',
+    `Corpus hash: \`${input.corpus.corpusHash}\``,
+    '',
+    `Model: \`${input.primary.model}\` · prompt: \`${input.primary.promptVersion}\``,
+    '',
+    `Automated validation: ${input.validationIssues.length === 0 ? 'PASS' : 'FAIL'}`,
+    '',
+    `Replay stability: ${input.stability.passes ? 'PASS' : 'FAIL'} (minimum core retention ${(input.stability.minimumCoreRetention * 100).toFixed(0)}%)`,
+    '',
+  ];
+
+  if (input.validationIssues.length > 0) {
+    lines.push('## Validation issues', '');
+    for (const issue of input.validationIssues) lines.push(`- ${issue}`);
+    lines.push('');
+  }
+
+  for (const proposal of input.primary.proposals) {
+    const stability = stabilityById.get(proposal.proposalId);
+    lines.push(
+      `## ${proposal.title}`,
+      '',
+      `**Origin:** ${proposal.origin === 'USER_DIRECTED' ? 'User-directed' : 'AI-discovered'}`,
+      '',
+      `**Lens:** ${proposal.lens}`,
+      '',
+      proposal.description,
+      '',
+      proposal.collectionRationale,
+      '',
+      `**Replay:** ${stability?.passes ? 'PASS' : 'FAIL'} · core retention ${((stability?.coreRetention ?? 0) * 100).toFixed(0)}% · Jaccard ${((stability?.jaccardSimilarity ?? 0) * 100).toFixed(0)}%`,
+      '',
+      '- [ ] Keep this collection',
+      '- [ ] The collection is specific enough to be useful',
+      '- [ ] The ordering makes sense',
+      '- [ ] It reveals a useful non-obvious relationship',
+      '',
+      '### Selected articles',
+      ''
+    );
+
+    for (const selected of [...proposal.selectedItems].sort(
+      (left, right) => left.rank - right.rank
+    )) {
+      const item = itemById.get(selected.itemId);
+      if (!item) continue;
+      const candidate = proposal.candidateScores.find((entry) => entry.itemId === selected.itemId);
+      const membershipLabel =
+        proposal.origin === 'AI_DISCOVERED'
+          ? proposal.themeSeedItemIds.includes(selected.itemId)
+            ? ' · theme core'
+            : ' · additional'
+          : '';
+      lines.push(
+        `${selected.rank}. **[${item.title}](${item.canonicalUrl})**${item.creator || item.publisher ? ` — ${item.creator ?? item.publisher}` : ''}`,
+        '',
+        `   ${selected.reason}`,
+        '',
+        `   Score: ${candidate?.overallScore ?? '—'} (${candidate?.verdict ?? '—'})${membershipLabel}`,
+        '',
+        '   Evidence:',
+        ''
+      );
+      for (const evidence of displayEvidence(item, selected.signalIds)) {
+        lines.push(`   - ${evidence}`);
+      }
+      lines.push('', '   - [ ] This article belongs', '');
+    }
+
+    if (proposal.nearMisses.length > 0) {
+      lines.push('### Near misses', '');
+      for (const nearMiss of proposal.nearMisses) {
+        const item = itemById.get(nearMiss.itemId);
+        if (!item) continue;
+        lines.push(`- **${item.title}** — ${nearMiss.reason}`);
+      }
+      lines.push('');
+    }
+    lines.push('### Notes', '', 'Missing article or other feedback:', '', '---', '');
+  }
+
+  lines.push(
+    '## Final decision',
+    '',
+    '- [ ] Stop: semantic collections are not useful enough',
+    '- [ ] Tune: the idea is promising but generation needs another experiment',
+    '- [ ] Productize: add durable generated membership and collection snapshots',
+    ''
+  );
+  return lines.join('\n');
+}
+
+export function compactCorpusForModel(corpus: SemanticCollectionCorpus): unknown[] {
+  return corpus.items.map((item) => ({
+    itemId: item.itemId,
+    title: item.title,
+    creator: item.creator ?? item.publisher,
+    coverage: item.sourceCoverage,
+    qualityScore: item.sourceQualityScore,
+    warnings: item.sourceQualityWarnings,
+    signals: item.signals.map((signal) => [signal.id, signal.kind, signal.text]),
+  }));
+}

--- a/apps/worker/src/collections/semantic-experiment.ts
+++ b/apps/worker/src/collections/semantic-experiment.ts
@@ -227,6 +227,7 @@ export interface WorkersAIStructuredOptions<T> {
   repairAttempts?: number;
   transportRetries?: number;
   fetchImpl?: typeof fetch;
+  onDiagnostic?: (message: string) => void;
 }
 
 export interface SemanticCollectionCorpusRow {
@@ -362,7 +363,7 @@ export async function runWorkersAIStructured<T>(
       const retryable =
         response.status === 408 || response.status === 429 || response.status >= 500;
       if (response.ok || !retryable || transportAttempt >= transportRetries) break;
-      console.error(
+      options.onDiagnostic?.(
         `${options.operation} transport ${response.status}; retry ${transportAttempt + 1}/${transportRetries}`
       );
       await new Promise((resolve) => setTimeout(resolve, 500 * (transportAttempt + 1)));
@@ -383,7 +384,7 @@ export async function runWorkersAIStructured<T>(
     }
 
     if (attempt < repairAttempts) {
-      console.error(
+      options.onDiagnostic?.(
         `${options.operation} failed validation; repair ${attempt + 1}/${repairAttempts}: ${lastFailure.slice(0, 800)}`
       );
     }

--- a/docs/semantic-collections-experiment.md
+++ b/docs/semantic-collections-experiment.md
@@ -1,0 +1,114 @@
+# Semantic collection experiment
+
+This experiment tests whether evidence-backed article understanding can produce coherent,
+explainable collections before Zine adds generated membership, refresh behavior, or product UI.
+
+## Boundary
+
+The experiment is deliberately read-only:
+
+- it runs one fixed `SELECT` against the production D1 database;
+- the SQL guard rejects additional statements and write or administrative keywords;
+- it never calls a Zine mutation, queue, R2 write, D1 write, or Vectorize write;
+- it writes only gitignored local artifacts under `.local-data/semantic-collections/`;
+- it does not create or update a production collection.
+
+The input cohort contains only the user's bookmarked articles whose latest schema-v3 enrichment is
+`COMPLETE`, has non-null deep understanding, and still matches the recorded article-body source
+hash. Titles, creators, and publishers are included for presentation. Membership decisions must
+cite exact semantic signal IDs derived from evidence-backed summaries, topics, claims, answered
+questions, concepts, perspectives, audiences, or actionable takeaways.
+
+## Run
+
+Required environment variables:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN` with production D1 read and Workers AI inference access
+
+Optional environment variable:
+
+- `COLLECTION_GENERATION_MODEL` defaults to `@cf/meta/llama-3.3-70b-instruct-fp8-fast`. Article
+  understanding remains independently configured through `ARTICLE_UNDERSTANDING_MODEL`; changing
+  the collection experiment does not change saved semantic records.
+
+From the repository root:
+
+```bash
+bun run semantic-collections:experiment
+```
+
+Use a previously retained corpus snapshot without reading production again:
+
+```bash
+bun run semantic-collections:experiment -- \
+  --corpus .local-data/semantic-collections/<run-id>/corpus.json
+```
+
+Resume a failed replay from already-validated theme and primary artifacts:
+
+```bash
+bun run semantic-collections:experiment -- \
+  --corpus .local-data/semantic-collections/<run-id>/corpus.json \
+  --themes .local-data/semantic-collections/<run-id>/themes.json \
+  --primary .local-data/semantic-collections/<run-id>/proposals.json
+```
+
+Retained artifacts are accepted only when they pass the current schemas and semantic gates and
+match the exact corpus hash, collection model, and prompt version.
+
+Override the user-directed lens:
+
+```bash
+bun run semantic-collections:experiment -- \
+  --user-lens "How engineers create meaningful impact beyond writing code."
+```
+
+## Artifacts
+
+Each run writes:
+
+```text
+.local-data/semantic-collections/<run-id>/
+  corpus.json
+  themes.json
+  proposals.json
+  replay-proposals.json
+  validation.json
+  stability.json
+  review.md
+```
+
+The corpus is content-addressed independently of its generation timestamp. The first generation
+contains one user-directed proposal and three AI-discovered proposals. Discovered themes retain
+their evidence-backed seed item IDs so later proposal generation cannot silently collapse distinct
+themes back into the same broad portfolio. The replay uses the same corpus and fixed lenses with
+different seeds, isolating membership stability from theme-discovery variance.
+
+## Automated gates
+
+A run passes only when:
+
+- all four proposals pass schema and semantic validation;
+- every corpus item is scored exactly once in every proposal;
+- every selected item and near miss exists in the corpus;
+- every selected-item and near-miss explanation cites semantic signals belonging to that article,
+  inheriting validated source block IDs;
+- every proposal selects 3–6 unique articles with consecutive ranks;
+- AI-discovered portfolios do not exceed `0.60` pairwise Jaccard overlap;
+- each AI-discovered theme retains an exact three-item seed core and may add at most one article;
+- theme-discovery seed portfolios do not exceed `0.40` pairwise Jaccard overlap and collectively
+  cover at least `70%` of the corpus;
+- generated prose is complete and collection titles are not generic categories;
+- every fixed lens retains at least `0.70` of its smaller core portfolio on replay.
+
+The generated Markdown is the human review surface. It records collection-level and item-level
+checkboxes plus a final `Stop`, `Tune`, or `Productize` decision. No human decision is inferred from
+the automated score.
+
+## Non-goals
+
+This experiment does not add database tables, collection persistence, Home integration, native or
+web UI, refresh scheduling, notifications, historical article backfill, other content types,
+recommendation impressions, or learned personalization. A successful review authorizes none of
+those automatically; durable generated membership is a separate productization decision.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "data:prod:local": "bun run ./scripts/sync-prod-user-to-local.mjs",
     "data:people-names:prod": "bun run ./scripts/repair-prod-people-display-names.mjs",
     "article-body:review": "bun run ./scripts/review-article-body-corpus.ts",
+    "semantic-collections:experiment": "bun run ./scripts/semantic-collections-experiment.ts",
     "design-system:check": "node ./scripts/check-mobile-design-system.mjs",
     "storybook:mobile": "bun run --cwd apps/mobile storybook",
     "storybook:web": "bun run --cwd apps/web storybook",

--- a/scripts/semantic-collections-experiment.ts
+++ b/scripts/semantic-collections-experiment.ts
@@ -1,0 +1,509 @@
+#!/usr/bin/env bun
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+import { z } from 'zod';
+
+import {
+  CollectionGenerationSchema,
+  CollectionProposalModelOutputSchema,
+  CollectionProposalSchema,
+  SemanticCollectionCorpusSchema,
+  ThemeDiscoverySchema,
+  buildProductionCorpusQuery,
+  buildSemanticCollectionCorpus,
+  compactCorpusForModel,
+  compareCollectionGenerations,
+  renderSemanticCollectionReview,
+  runWorkersAIStructured,
+  validateCollectionProposal,
+  validateCollectionProposalSet,
+  validateDiscoveredThemes,
+  validateProposalNovelty,
+  type CollectionGeneration,
+  type CollectionProposal,
+  type CollectionProposalModelOutput,
+  type DiscoveredTheme,
+  type SemanticCollectionCorpus,
+} from '../apps/worker/src/collections/semantic-experiment';
+
+const DEFAULT_USER_ID = 'user_31ejjz59G6mTX1SIyErOi0fwu4A';
+const DEFAULT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+const DEFAULT_USER_LENS =
+  'How engineers create meaningful organizational impact beyond writing code or completing assigned tickets.';
+const DEFAULT_OUTPUT_ROOT = path.resolve('.local-data/semantic-collections');
+const PRODUCTION_DATABASE = 'zine-db-production';
+const PRODUCTION_ENVIRONMENT = 'production';
+const PROMPT_VERSION = 'semantic-collections-v1';
+const MAXIMUM_DISCOVERED_OVERLAP = 0.6;
+const MINIMUM_CORE_RETENTION = 0.7;
+
+interface ExperimentOptions {
+  userId: string;
+  userLens: string;
+  model: string;
+  outputRoot: string;
+  corpusPath: string | null;
+  themesPath: string | null;
+  primaryPath: string | null;
+}
+
+function argumentValue(argv: string[], name: string): string | null {
+  const index = argv.indexOf(name);
+  return index >= 0 ? (argv[index + 1] ?? null) : null;
+}
+
+export function parseSemanticExperimentOptions(argv: string[]): ExperimentOptions {
+  const supported = new Set([
+    '--user-id',
+    '--user-lens',
+    '--model',
+    '--output',
+    '--corpus',
+    '--themes',
+    '--primary',
+  ]);
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (!argument?.startsWith('--')) continue;
+    if (!supported.has(argument)) throw new Error(`Unknown argument: ${argument}`);
+    if (!argv[index + 1] || argv[index + 1]?.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+    index++;
+  }
+
+  return {
+    userId: argumentValue(argv, '--user-id') ?? DEFAULT_USER_ID,
+    userLens: argumentValue(argv, '--user-lens') ?? DEFAULT_USER_LENS,
+    model:
+      argumentValue(argv, '--model') ?? process.env.COLLECTION_GENERATION_MODEL ?? DEFAULT_MODEL,
+    outputRoot: path.resolve(argumentValue(argv, '--output') ?? DEFAULT_OUTPUT_ROOT),
+    corpusPath: argumentValue(argv, '--corpus')
+      ? path.resolve(argumentValue(argv, '--corpus')!)
+      : null,
+    themesPath: argumentValue(argv, '--themes')
+      ? path.resolve(argumentValue(argv, '--themes')!)
+      : null,
+    primaryPath: argumentValue(argv, '--primary')
+      ? path.resolve(argumentValue(argv, '--primary')!)
+      : null,
+  };
+}
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function timestampId(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function readProductionCorpusRows(userId: string): unknown[] {
+  const query = buildProductionCorpusQuery(userId);
+  const stdout = execFileSync(
+    'bun',
+    [
+      'x',
+      'wrangler',
+      'd1',
+      'execute',
+      PRODUCTION_DATABASE,
+      '--env',
+      PRODUCTION_ENVIRONMENT,
+      '--remote',
+      '--command',
+      query,
+      '--json',
+    ],
+    {
+      cwd: path.resolve('apps/worker'),
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 50,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    }
+  );
+  const batches = z
+    .array(z.object({ results: z.array(z.unknown()), success: z.literal(true) }))
+    .parse(JSON.parse(stdout));
+  if (batches.length !== 1) throw new Error('Production corpus query returned multiple batches');
+  return batches[0]?.results ?? [];
+}
+
+async function loadCorpus(options: ExperimentOptions): Promise<SemanticCollectionCorpus> {
+  if (options.corpusPath) {
+    return SemanticCollectionCorpusSchema.parse(await Bun.file(options.corpusPath).json());
+  }
+  return buildSemanticCollectionCorpus(options.userId, readProductionCorpusRows(options.userId));
+}
+
+function modelCorpusPayload(corpus: SemanticCollectionCorpus): string {
+  return JSON.stringify({ corpusHash: corpus.corpusHash, articles: compactCorpusForModel(corpus) });
+}
+
+async function discoverThemes(input: {
+  corpus: SemanticCollectionCorpus;
+  accountId: string;
+  apiToken: string;
+  model: string;
+}): Promise<DiscoveredTheme[]> {
+  const result = await runWorkersAIStructured({
+    accountId: input.accountId,
+    apiToken: input.apiToken,
+    model: input.model,
+    seed: 1001,
+    maxTokens: 2_400,
+    schema: ThemeDiscoverySchema,
+    operation: 'Collection theme discovery',
+    repairPrompt:
+      'Return exactly three distinct, narrow collection themes as valid JSON. Each theme must include exactly three exact seedItemIds. Keep rationales under 500 characters. Ensure seed portfolios have low pairwise overlap and collectively cover at least 70% of the corpus. Do not return generic subject categories or prose outside the object.',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are discovering durable semantic collection lenses for one reader. Use only the supplied evidence-backed semantic signals. A useful lens connects at least three articles through a specific tension, mechanism, argument, practice, or decision. Reject broad categories such as software development, AI, engineering, technology, career development, media studies, and entrepreneurship. Return only valid JSON. /no_think',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          task: 'Discover exactly three distinct collection lenses grounded in this corpus.',
+          constraints: [
+            'Each lens must plausibly support at least three supplied articles.',
+            'Prefer a recoverable thesis over a topical label.',
+            'The three lenses should not describe substantially the same portfolio.',
+            'Each theme must list exactly three exact seedItemIds that best demonstrate its lens.',
+            'Seed portfolios must have pairwise Jaccard overlap no greater than 0.40.',
+            'The union of all seed portfolios must cover at least 70% of supplied articles.',
+            'Do not invent articles, claims, or reader interests.',
+          ],
+          corpus: JSON.parse(modelCorpusPayload(input.corpus)),
+          outputContract: {
+            themes: [
+              {
+                lens: 'specific one-sentence collection lens',
+                rationale: 'why this lens emerges from several supplied articles',
+                seedItemIds: ['exact supplied itemId'],
+              },
+            ],
+          },
+        }),
+      },
+    ],
+    validate: (value) => validateDiscoveredThemes(value.themes, input.corpus),
+  });
+  return result.themes;
+}
+
+function proposalMessages(input: {
+  corpus: SemanticCollectionCorpus;
+  lens: string;
+  origin: 'USER_DIRECTED' | 'AI_DISCOVERED';
+  themeSeedItemIds: string[];
+  priorProposals: CollectionProposal[];
+}): Array<{ role: 'system' | 'user'; content: string }> {
+  return [
+    {
+      role: 'system',
+      content:
+        'You are assembling an explainable semantic collection from a personal article library. Judge article fit from the supplied evidence-backed signals, not from title, author, publisher, or broad category. Cite signal IDs exactly. Score every article, select only a coherent non-redundant portfolio, and return only valid JSON. /no_think',
+    },
+    {
+      role: 'user',
+      content: JSON.stringify({
+        task: 'Score the complete corpus and assemble one collection for the supplied lens.',
+        origin: input.origin,
+        lens: input.lens,
+        themeSeedItemIds: input.themeSeedItemIds,
+        constraints: [
+          'candidateScores must contain every supplied itemId exactly once.',
+          'Every selection and near miss must cite only signal IDs belonging to that same article.',
+          'For a user-directed collection, select 3 to 6 articles whose arguments make distinct contributions to one precise collection thesis.',
+          'For an AI-discovered collection, select exactly the three themeSeedItemIds plus at most one additional strongly fitting article.',
+          'Rank the selected articles from strongest to weakest fit with consecutive ranks starting at 1.',
+          'Return at most two near misses, and never also select a near miss.',
+          'Use a distinctive editorial title, never a broad category such as Software Development, AI, Engineering, Technology, Career Development, Media Studies, or Entrepreneurship.',
+          'Do not select an article merely because its title sounds related.',
+          'Retain caveats from PARTIAL_CONTENT or quality warnings in scoring.',
+          'All prose must be complete, concise, and untruncated.',
+          'Avoid reproducing prior AI-discovered portfolios when the evidence supports a distinct selection.',
+          'For an AI-discovered lens, treat themeSeedItemIds as the evidence-backed anchors discovered for this theme. Score every article independently, but do not replace the anchors with a prior collection merely because those articles are broadly about software.',
+        ],
+        priorAICollections: input.priorProposals
+          .filter((proposal) => proposal.origin === 'AI_DISCOVERED')
+          .map((proposal) => ({
+            lens: proposal.lens,
+            title: proposal.title,
+            selectedItemIds: proposal.selectedItems.map((item) => item.itemId),
+          })),
+        corpus: JSON.parse(modelCorpusPayload(input.corpus)),
+        outputContract: {
+          title: 'distinctive editorial collection title',
+          description: 'one-sentence reader-facing purpose',
+          collectionRationale:
+            'why these articles form a coherent collection rather than a topic bucket',
+          candidateScores: [
+            {
+              itemId: 'exact supplied itemId',
+              overallScore: 'number from 0 to 100',
+              verdict: 'STRONG | MODERATE | WEAK',
+            },
+          ],
+          selectedItems: [
+            {
+              itemId: 'exact supplied itemId',
+              rank: 'consecutive integer starting at 1',
+              reason: 'the distinct contribution this article makes to the collection',
+              signalIds: ['exact signal ID from this article'],
+            },
+          ],
+          nearMisses: [
+            {
+              itemId: 'exact supplied unselected itemId',
+              reason: 'why it is adjacent but excluded',
+              signalIds: ['exact signal ID from this article'],
+            },
+          ],
+        },
+      }),
+    },
+  ];
+}
+
+async function generateProposal(input: {
+  corpus: SemanticCollectionCorpus;
+  proposalId: string;
+  origin: 'USER_DIRECTED' | 'AI_DISCOVERED';
+  lens: string;
+  discoveryRationale: string | null;
+  themeSeedItemIds: string[];
+  priorProposals: CollectionProposal[];
+  accountId: string;
+  apiToken: string;
+  model: string;
+  seed: number;
+}): Promise<CollectionProposal> {
+  const parsed = await runWorkersAIStructured<CollectionProposalModelOutput>({
+    accountId: input.accountId,
+    apiToken: input.apiToken,
+    model: input.model,
+    seed: input.seed,
+    maxTokens: 6_000,
+    schema: CollectionProposalModelOutputSchema,
+    operation: `Collection proposal ${input.proposalId}`,
+    repairPrompt:
+      'Return the exact requested JSON object. Score every supplied article exactly once, cite only exact signal IDs belonging to every selected item and near miss, keep near misses unselected, and use complete non-truncated prose. For AI-discovered collections, retain all three exact themeSeedItemIds and select at most one additional article.',
+    repairAttempts: 4,
+    messages: proposalMessages({
+      corpus: input.corpus,
+      lens: input.lens,
+      origin: input.origin,
+      themeSeedItemIds: input.themeSeedItemIds,
+      priorProposals: input.priorProposals,
+    }),
+    validate: (value) => {
+      const candidate = CollectionProposalSchema.parse({
+        ...value,
+        proposalId: input.proposalId,
+        origin: input.origin,
+        lens: input.lens,
+        discoveryRationale: input.discoveryRationale,
+        themeSeedItemIds: input.themeSeedItemIds,
+        model: input.model,
+        promptVersion: PROMPT_VERSION,
+        seed: input.seed,
+      });
+      return validateCollectionProposal(candidate, input.corpus).concat(
+        validateProposalNovelty(candidate, input.priorProposals)
+      );
+    },
+  });
+
+  return CollectionProposalSchema.parse({
+    ...parsed,
+    proposalId: input.proposalId,
+    origin: input.origin,
+    lens: input.lens,
+    discoveryRationale: input.discoveryRationale,
+    themeSeedItemIds: input.themeSeedItemIds,
+    model: input.model,
+    promptVersion: PROMPT_VERSION,
+    seed: input.seed,
+  });
+}
+
+async function generateCollectionSet(input: {
+  corpus: SemanticCollectionCorpus;
+  userLens: string;
+  themes: DiscoveredTheme[];
+  accountId: string;
+  apiToken: string;
+  model: string;
+  seedBase: number;
+}): Promise<CollectionGeneration> {
+  const proposals: CollectionProposal[] = [];
+  proposals.push(
+    await generateProposal({
+      ...input,
+      proposalId: 'user-directed',
+      origin: 'USER_DIRECTED',
+      lens: input.userLens,
+      discoveryRationale: null,
+      themeSeedItemIds: [],
+      priorProposals: proposals,
+      seed: input.seedBase + 1,
+    })
+  );
+
+  for (let index = 0; index < input.themes.length; index++) {
+    const theme = input.themes[index];
+    if (!theme) continue;
+    proposals.push(
+      await generateProposal({
+        ...input,
+        proposalId: `ai-discovered-${index + 1}`,
+        origin: 'AI_DISCOVERED',
+        lens: theme.lens,
+        discoveryRationale: theme.rationale,
+        themeSeedItemIds: theme.seedItemIds,
+        priorProposals: proposals,
+        seed: input.seedBase + index + 2,
+      })
+    );
+  }
+
+  return CollectionGenerationSchema.parse({
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    corpusHash: input.corpus.corpusHash,
+    model: input.model,
+    promptVersion: PROMPT_VERSION,
+    proposals,
+  });
+}
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await Bun.write(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function loadRetainedThemes(
+  filePath: string | null,
+  corpus: SemanticCollectionCorpus
+): Promise<DiscoveredTheme[] | null> {
+  if (!filePath) return null;
+  const result = ThemeDiscoverySchema.parse(await Bun.file(filePath).json());
+  const issues = validateDiscoveredThemes(result.themes, corpus);
+  if (issues.length > 0) {
+    throw new Error(`Retained themes failed current validation: ${issues.join('; ')}`);
+  }
+  return result.themes;
+}
+
+async function loadRetainedPrimary(
+  filePath: string | null,
+  corpus: SemanticCollectionCorpus,
+  model: string
+): Promise<CollectionGeneration | null> {
+  if (!filePath) return null;
+  const generation = CollectionGenerationSchema.parse(await Bun.file(filePath).json());
+  if (generation.corpusHash !== corpus.corpusHash) {
+    throw new Error('Retained primary generation uses a different corpus hash');
+  }
+  if (generation.model !== model || generation.promptVersion !== PROMPT_VERSION) {
+    throw new Error('Retained primary generation uses a different model or prompt version');
+  }
+  const issues = validateCollectionProposalSet(generation, corpus, MAXIMUM_DISCOVERED_OVERLAP);
+  if (issues.length > 0) {
+    throw new Error(`Retained primary generation failed current validation: ${issues.join('; ')}`);
+  }
+  return generation;
+}
+
+export async function runSemanticCollectionExperiment(options: ExperimentOptions): Promise<{
+  outputDirectory: string;
+  corpus: SemanticCollectionCorpus;
+  primary: CollectionGeneration;
+  replay: CollectionGeneration;
+  validationIssues: string[];
+  stability: ReturnType<typeof compareCollectionGenerations>;
+}> {
+  const accountId = requireEnvironment('CLOUDFLARE_ACCOUNT_ID');
+  const apiToken = requireEnvironment('CLOUDFLARE_API_TOKEN');
+  const corpus = await loadCorpus(options);
+  const outputDirectory = path.join(options.outputRoot, timestampId());
+  await Bun.write(path.join(outputDirectory, '.keep'), '');
+  await writeJson(path.join(outputDirectory, 'corpus.json'), corpus);
+
+  console.error(`Corpus snapshot: ${corpus.items.length} articles · ${corpus.corpusHash}`);
+  const themes =
+    (await loadRetainedThemes(options.themesPath, corpus)) ??
+    (await discoverThemes({ corpus, accountId, apiToken, model: options.model }));
+  await writeJson(path.join(outputDirectory, 'themes.json'), { themes });
+
+  const primary =
+    (await loadRetainedPrimary(options.primaryPath, corpus, options.model)) ??
+    (await generateCollectionSet({
+      corpus,
+      userLens: options.userLens,
+      themes,
+      accountId,
+      apiToken,
+      model: options.model,
+      seedBase: 1_100,
+    }));
+  await writeJson(path.join(outputDirectory, 'proposals.json'), primary);
+
+  const replay = await generateCollectionSet({
+    corpus,
+    userLens: options.userLens,
+    themes,
+    accountId,
+    apiToken,
+    model: options.model,
+    seedBase: 2_100,
+  });
+  await writeJson(path.join(outputDirectory, 'replay-proposals.json'), replay);
+
+  const validationIssues = [
+    ...validateCollectionProposalSet(primary, corpus, MAXIMUM_DISCOVERED_OVERLAP),
+    ...validateCollectionProposalSet(replay, corpus, MAXIMUM_DISCOVERED_OVERLAP).map(
+      (issue) => `replay: ${issue}`
+    ),
+  ];
+  const stability = compareCollectionGenerations(primary, replay, MINIMUM_CORE_RETENTION);
+  await writeJson(path.join(outputDirectory, 'validation.json'), {
+    schemaVersion: 1,
+    corpusHash: corpus.corpusHash,
+    maximumDiscoveredOverlap: MAXIMUM_DISCOVERED_OVERLAP,
+    issues: validationIssues,
+    passes: validationIssues.length === 0,
+  });
+  await writeJson(path.join(outputDirectory, 'stability.json'), stability);
+  await Bun.write(
+    path.join(outputDirectory, 'review.md'),
+    renderSemanticCollectionReview({ corpus, primary, replay, stability, validationIssues })
+  );
+
+  const summary = {
+    outputDirectory,
+    corpusHash: corpus.corpusHash,
+    articleCount: corpus.items.length,
+    proposalCount: primary.proposals.length,
+    validationPasses: validationIssues.length === 0,
+    stabilityPasses: stability.passes,
+    proposals: primary.proposals.map((proposal) => ({
+      proposalId: proposal.proposalId,
+      origin: proposal.origin,
+      title: proposal.title,
+      selectedCount: proposal.selectedItems.length,
+    })),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (validationIssues.length > 0 || !stability.passes) process.exitCode = 1;
+  return { outputDirectory, corpus, primary, replay, validationIssues, stability };
+}
+
+if (import.meta.main) {
+  await runSemanticCollectionExperiment(parseSemanticExperimentOptions(process.argv.slice(2)));
+}

--- a/scripts/semantic-collections-experiment.ts
+++ b/scripts/semantic-collections-experiment.ts
@@ -36,6 +36,7 @@ const PRODUCTION_DATABASE = 'zine-db-production';
 const PRODUCTION_ENVIRONMENT = 'production';
 const PROMPT_VERSION = 'semantic-collections-v1';
 const MAXIMUM_DISCOVERED_OVERLAP = 0.6;
+const reportDiagnostic = (message: string): void => console.error(message);
 const MINIMUM_CORE_RETENTION = 0.7;
 
 interface ExperimentOptions {
@@ -157,6 +158,7 @@ async function discoverThemes(input: {
     maxTokens: 2_400,
     schema: ThemeDiscoverySchema,
     operation: 'Collection theme discovery',
+    onDiagnostic: reportDiagnostic,
     repairPrompt:
       'Return exactly three distinct, narrow collection themes as valid JSON. Each theme must include exactly three exact seedItemIds. Keep rationales under 500 characters. Ensure seed portfolios have low pairwise overlap and collectively cover at least 70% of the corpus. Do not return generic subject categories or prose outside the object.',
     messages: [
@@ -292,6 +294,7 @@ async function generateProposal(input: {
     maxTokens: 6_000,
     schema: CollectionProposalModelOutputSchema,
     operation: `Collection proposal ${input.proposalId}`,
+    onDiagnostic: reportDiagnostic,
     repairPrompt:
       'Return the exact requested JSON object. Score every supplied article exactly once, cite only exact signal IDs belonging to every selected item and near miss, keep near misses unselected, and use complete non-truncated prose. For AI-discovered collections, retain all three exact themeSeedItemIds and select at most one additional article.',
     repairAttempts: 4,


### PR DESCRIPTION
## Summary

- add a read-only production-corpus snapshot and semantic collection generator
- validate grounded evidence, portfolio distinctness, replay stability, and near misses
- add operator documentation and gitignored review artifacts

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run design-system:check`
- `bun run test`
- `bun run build`
- native iOS smoke: built, installed, launched, live streamed, and interacted with `app.zine.native` on `iPhone 17 — Zine`
- production experiment: 12 deeply understood articles, 4 proposals, all validation and replay-stability gates passed

## Experiment decision

Tune. Three of four proposals are worth keeping with edits; optional AI additions need a stronger marginal-fit threshold, and the user-directed lens must weight literal/direct alignment more strongly.