### PR TITLE
fix(ios): make completion actions instantaneous

### DIFF
--- a/apps/ios/ZineNative/Core/Models/OptimisticFinishedState.swift
+++ b/apps/ios/ZineNative/Core/Models/OptimisticFinishedState.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct OptimisticFinishedState: Equatable {
+    struct Mutation: Equatable {
+        let previousIsFinished: Bool
+        let previousFinishedAt: String?
+        let requestedIsFinished: Bool
+    }
+
+    private(set) var isFinished: Bool
+    private(set) var finishedAt: String?
+    private(set) var isUpdating = false
+    private(set) var hasLocalChange = false
+
+    init(isFinished: Bool, finishedAt: String?) {
+        self.isFinished = isFinished
+        self.finishedAt = finishedAt
+    }
+
+    mutating func beginToggle(now: Date = Date()) -> Mutation? {
+        guard !isUpdating else { return nil }
+
+        let mutation = Mutation(
+            previousIsFinished: isFinished,
+            previousFinishedAt: finishedAt,
+            requestedIsFinished: !isFinished
+        )
+        hasLocalChange = true
+        isUpdating = true
+        isFinished = mutation.requestedIsFinished
+        finishedAt = mutation.requestedIsFinished ? now.formatted(.iso8601) : nil
+        return mutation
+    }
+
+    mutating func accept(isFinished: Bool, finishedAt: String?) {
+        self.isFinished = isFinished
+        self.finishedAt = finishedAt
+        isUpdating = false
+        hasLocalChange = true
+    }
+
+    mutating func rollback(_ mutation: Mutation) {
+        isFinished = mutation.previousIsFinished
+        finishedAt = mutation.previousFinishedAt
+        isUpdating = false
+        hasLocalChange = true
+    }
+
+    mutating func hydrate(isFinished: Bool, finishedAt: String?) {
+        guard !hasLocalChange else { return }
+        self.isFinished = isFinished
+        self.finishedAt = finishedAt
+    }
+
+    mutating func synchronize(
+        isFinished: Bool,
+        finishedAt: String?,
+        isUpdating: Bool
+    ) {
+        self.isFinished = isFinished
+        self.finishedAt = finishedAt
+        self.isUpdating = isUpdating
+        hasLocalChange = true
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -88,7 +88,7 @@ struct BookmarkDetailContent: Equatable {
         duration = nil
         readingTimeMinutes = nil
         progress = nil
-        isFinished = false
+        isFinished = presentation?.isFinished ?? false
         tags = []
     }
 
@@ -111,9 +111,7 @@ struct BookmarkDetailView: View {
     @State private var isBookmarked: Bool
     @State private var hasToggledBookmark = false
     @State private var isSavingBookmark = false
-    @State private var isSaving = false
-    @State private var isHydrating = false
-    @State private var hydrationFailed = false
+    @State private var finishedState: OptimisticFinishedState
     @State private var subscriptionSettings: BookmarkSubscriptionSettings?
     @State private var isSavingSubscriptionSettings = false
     @State private var errorMessage: String?
@@ -136,7 +134,10 @@ struct BookmarkDetailView: View {
         initialContent = BookmarkDetailContent(bookmark: bookmark)
         _bookmark = State(initialValue: .some(bookmark))
         _isBookmarked = State(initialValue: bookmark.state == "BOOKMARKED")
-        _isHydrating = State(initialValue: false)
+        _finishedState = State(initialValue: OptimisticFinishedState(
+            isFinished: bookmark.isFinished,
+            finishedAt: bookmark.finishedAt
+        ))
         self.client = client
         self.onUpdate = onUpdate
         self.onBookmarkChange = onBookmarkChange
@@ -157,7 +158,10 @@ struct BookmarkDetailView: View {
         initialContent = BookmarkDetailContent(item: item)
         _bookmark = State(initialValue: nil)
         _isBookmarked = State(initialValue: true)
-        _isHydrating = State(initialValue: true)
+        _finishedState = State(initialValue: OptimisticFinishedState(
+            isFinished: initialContent.isFinished,
+            finishedAt: nil
+        ))
         self.client = client
         self.onUpdate = onUpdate
         self.onBookmarkChange = onBookmarkChange
@@ -182,7 +186,10 @@ struct BookmarkDetailView: View {
         )
         _bookmark = State(initialValue: nil)
         _isBookmarked = State(initialValue: presentation?.isSaved ?? true)
-        _isHydrating = State(initialValue: true)
+        _finishedState = State(initialValue: OptimisticFinishedState(
+            isFinished: initialContent.isFinished,
+            finishedAt: nil
+        ))
         self.client = client
         self.onUpdate = onUpdate
         self.onBookmarkChange = onBookmarkChange
@@ -303,13 +310,14 @@ struct BookmarkDetailView: View {
                             canonicalURL: content.canonicalUrl,
                             readingTimeMinutes: content.readingTimeMinutes,
                             initialProgress: content.progress,
-                            isFinished: content.isFinished,
+                            isFinished: finishedState.isFinished,
                             tags: content.tags
                         ),
                         client: client,
                         onRead: { onExternalOpen(bookmark) },
                         onProgressSaved: updateReadingProgress,
                         onFinishedChanged: updateFinishedState,
+                        onFinishedCommit: commitFinishedState,
                         onTagsChanged: updateTags
                     )
                 } label: {
@@ -348,29 +356,21 @@ struct BookmarkDetailView: View {
     private var bookmarkActions: some View {
         if bookmark != nil {
             bookmarkButton
+        } else {
+            actionIcon(
+                systemName: isBookmarked ? "bookmark.fill" : "bookmark",
+                color: ZineTheme.secondaryText.opacity(0.55)
+            )
+                .accessibilityHidden(true)
+        }
 
-            if isBookmarked {
-                completionButton
-            }
+        if isBookmarked {
+            completionButton
+        }
+
+        if bookmark != nil {
             tagsMenu
         } else {
-            actionIcon(systemName: "bookmark.fill", color: .primary.opacity(0.55))
-                .accessibilityHidden(true)
-
-            if isHydrating {
-                ProgressView()
-                    .frame(width: 42, height: 44)
-                    .accessibilityLabel("Loading bookmark actions")
-            } else if hydrationFailed {
-                Button {
-                    Task { await hydrateBookmark() }
-                } label: {
-                    actionIcon(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Retry loading bookmark actions")
-            }
-
             actionIcon(systemName: "tag", color: ZineTheme.secondaryText.opacity(0.45))
                 .accessibilityHidden(true)
         }
@@ -393,21 +393,20 @@ struct BookmarkDetailView: View {
     }
 
     private var completionButton: some View {
-        let isFinished = bookmark?.isFinished ?? false
-
         return Button {
-            Task { await toggleFinished() }
+            toggleFinished()
         } label: {
             actionIcon(
-                systemName: isFinished
+                systemName: finishedState.isFinished
                     ? "checkmark.circle.fill"
                     : "checkmark.circle",
-                color: isFinished ? .green : ZineTheme.secondaryText
+                color: finishedState.isFinished ? .green : ZineTheme.secondaryText
             )
+            .contentTransition(.symbolEffect(.replace))
         }
         .buttonStyle(.plain)
-        .disabled(isSaving)
-        .accessibilityLabel(isFinished ? "Mark unfinished" : "Mark complete")
+        .allowsHitTesting(!finishedState.isUpdating)
+        .accessibilityLabel(finishedState.isFinished ? "Mark unfinished" : "Mark complete")
         .actionRowHaptic()
     }
 
@@ -607,27 +606,23 @@ struct BookmarkDetailView: View {
     }
 
     private func hydrateBookmark() async {
-        let needsInitialBookmark = bookmark == nil
-        if needsInitialBookmark {
-            isHydrating = true
-            hydrationFailed = false
-        }
-
         do {
-            let refreshed = try await client.getBookmark(id: content.id)
+            var refreshed = try await client.getBookmark(id: content.id)
             guard !Task.isCancelled else { return }
+            finishedState.hydrate(
+                isFinished: refreshed.isFinished,
+                finishedAt: refreshed.finishedAt
+            )
+            refreshed.isFinished = finishedState.isFinished
+            refreshed.finishedAt = finishedState.finishedAt
             bookmark = refreshed
-            isHydrating = false
-            hydrationFailed = false
             if !hasToggledBookmark {
                 isBookmarked = refreshed.state == "BOOKMARKED"
             }
         } catch is CancellationError {
             return
         } catch {
-            guard needsInitialBookmark else { return }
-            isHydrating = false
-            hydrationFailed = true
+            return
         }
     }
 
@@ -663,23 +658,29 @@ struct BookmarkDetailView: View {
         }
     }
 
-    private func toggleFinished() async {
-        guard var bookmark else { return }
+    private func toggleFinished() {
+        guard let mutation = finishedState.beginToggle() else { return }
+        updateBookmarkFromFinishedState(notify: false)
 
-        isSaving = true
-        defer { isSaving = false }
-
-        do {
-            let result = try await client.setFinished(
-                id: bookmark.id,
-                isFinished: !bookmark.isFinished
-            )
-            bookmark.isFinished = result.isFinished
-            bookmark.finishedAt = result.finishedAt
-            self.bookmark = bookmark
-            onUpdate(bookmark)
-        } catch {
-            errorMessage = error.localizedDescription
+        Task {
+            do {
+                let result = try await client.setFinished(
+                    id: content.id,
+                    isFinished: mutation.requestedIsFinished
+                )
+                finishedState.accept(
+                    isFinished: result.isFinished,
+                    finishedAt: result.finishedAt
+                )
+                updateBookmarkFromFinishedState(notify: true)
+            } catch is CancellationError {
+                finishedState.rollback(mutation)
+                updateBookmarkFromFinishedState(notify: false)
+            } catch {
+                finishedState.rollback(mutation)
+                updateBookmarkFromFinishedState(notify: false)
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -716,12 +717,31 @@ struct BookmarkDetailView: View {
         onUpdate(bookmark)
     }
 
-    private func updateFinishedState(_ isFinished: Bool) {
+    private func updateFinishedState(_ isFinished: Bool, phase: BookmarkChangePhase) {
+        finishedState.synchronize(
+            isFinished: isFinished,
+            finishedAt: isFinished ? Date().formatted(.iso8601) : nil,
+            isUpdating: phase == .optimistic
+        )
+        updateBookmarkFromFinishedState(notify: false)
+    }
+
+    private func commitFinishedState(_ isFinished: Bool) {
+        finishedState.accept(
+            isFinished: isFinished,
+            finishedAt: isFinished ? Date().formatted(.iso8601) : nil
+        )
+        updateBookmarkFromFinishedState(notify: true)
+    }
+
+    private func updateBookmarkFromFinishedState(notify: Bool) {
         guard var bookmark else { return }
-        bookmark.isFinished = isFinished
-        bookmark.finishedAt = isFinished ? Date().formatted(.iso8601) : nil
+        bookmark.isFinished = finishedState.isFinished
+        bookmark.finishedAt = finishedState.finishedAt
         self.bookmark = bookmark
-        onUpdate(bookmark)
+        if notify {
+            onUpdate(bookmark)
+        }
     }
 
     private func updateTags(_ tags: [BookmarkTag]) {

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderStore.swift
@@ -36,7 +36,7 @@ final class ArticleProgressWriteQueue {
 @Observable
 final class ArticleReaderStore {
     private(set) var phase: ArticleReaderPhase
-    private(set) var isFinished: Bool
+    private var finishedState: OptimisticFinishedState
 
     let metadata: ArticleReaderMetadata
     let initialProgressFraction: Double
@@ -70,8 +70,19 @@ final class ArticleReaderStore {
             }
         }
         phase = initialPhase
-        isFinished = metadata.isFinished
+        finishedState = OptimisticFinishedState(
+            isFinished: metadata.isFinished,
+            finishedAt: nil
+        )
         initialProgressFraction = metadata.initialProgress?.fraction ?? 0
+    }
+
+    var isFinished: Bool {
+        finishedState.isFinished
+    }
+
+    var isUpdatingFinished: Bool {
+        finishedState.isUpdating
     }
 
     var readyDocument: ArticleReaderDocument? {
@@ -127,16 +138,27 @@ final class ArticleReaderStore {
         )
     }
 
-    func toggleFinished() async -> Bool? {
+    func beginFinishedToggle() -> OptimisticFinishedState.Mutation? {
+        finishedState.beginToggle()
+    }
+
+    func persistFinishedToggle(_ mutation: OptimisticFinishedState.Mutation) async -> Bool {
         do {
             let result = try await client.setFinished(
                 id: metadata.bookmarkID,
-                isFinished: !isFinished
+                isFinished: mutation.requestedIsFinished
             )
-            isFinished = result.isFinished
-            return result.isFinished
+            finishedState.accept(
+                isFinished: result.isFinished,
+                finishedAt: result.finishedAt
+            )
+            return true
+        } catch is CancellationError {
+            finishedState.rollback(mutation)
+            return false
         } catch {
-            return nil
+            finishedState.rollback(mutation)
+            return false
         }
     }
 

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -26,7 +26,6 @@ struct ArticleReaderView: View {
     @State private var scrollProgress: Double
     @State private var lastPersistedProgress: Double
     @State private var hasRecordedOpen = false
-    @State private var isUpdatingFinished = false
     @State private var readerChromeOffset: CGFloat = 0
     @State private var showsEndActions: Bool
     @State private var presentedSheet: ArticleReaderSheet?
@@ -35,7 +34,8 @@ struct ArticleReaderView: View {
 
     private let onRead: () -> Void
     private let onProgressSaved: (BookmarkProgress) -> Void
-    private let onFinishedChanged: (Bool) -> Void
+    private let onFinishedChanged: (Bool, BookmarkChangePhase) -> Void
+    private let onFinishedCommit: (Bool) -> Void
     private let onTagsChanged: ([BookmarkTag]) -> Void
     private let client: APIClient
     private let loadsOnAppear: Bool
@@ -47,7 +47,8 @@ struct ArticleReaderView: View {
         loadsOnAppear: Bool = true,
         onRead: @escaping () -> Void = {},
         onProgressSaved: @escaping (BookmarkProgress) -> Void = { _ in },
-        onFinishedChanged: @escaping (Bool) -> Void = { _ in },
+        onFinishedChanged: @escaping (Bool, BookmarkChangePhase) -> Void = { _, _ in },
+        onFinishedCommit: @escaping (Bool) -> Void = { _ in },
         onTagsChanged: @escaping ([BookmarkTag]) -> Void = { _ in }
     ) {
         let initialProgress = metadata.initialProgress?.fraction ?? 0
@@ -67,6 +68,7 @@ struct ArticleReaderView: View {
         self.onRead = onRead
         self.onProgressSaved = onProgressSaved
         self.onFinishedChanged = onFinishedChanged
+        self.onFinishedCommit = onFinishedCommit
         self.onTagsChanged = onTagsChanged
         self.client = client
         self.loadsOnAppear = loadsOnAppear
@@ -290,16 +292,11 @@ struct ArticleReaderView: View {
 
                 Spacer()
 
-                if isUpdatingFinished {
-                    ProgressView()
-                        .controlSize(.small)
-                        .accessibilityLabel("Updating completion")
-                }
             }
 
             HStack(spacing: 10) {
                 Button {
-                    Task { await toggleFinished() }
+                    toggleFinished()
                 } label: {
                     Label(
                         store.isFinished ? "Mark unfinished" : "Mark complete",
@@ -312,7 +309,7 @@ struct ArticleReaderView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(ZineTheme.brandAccent)
                 .foregroundStyle(ZineTheme.onAccent)
-                .disabled(isUpdatingFinished)
+                .allowsHitTesting(!store.isUpdatingFinished)
                 .accessibilityIdentifier("article-reader-toggle-complete")
 
                 Button {
@@ -383,15 +380,18 @@ struct ArticleReaderView: View {
         Task { await persistProgress(progress) }
     }
 
-    private func toggleFinished() async {
-        guard !isUpdatingFinished else { return }
-        isUpdatingFinished = true
-        defer { isUpdatingFinished = false }
-        guard let value = await store.toggleFinished() else {
-            actionErrorMessage = "Zine couldn’t change the completion state. Check your connection and try again."
-            return
+    private func toggleFinished() {
+        guard let mutation = store.beginFinishedToggle() else { return }
+        onFinishedChanged(store.isFinished, .optimistic)
+
+        Task {
+            guard await store.persistFinishedToggle(mutation) else {
+                onFinishedChanged(store.isFinished, .rollback)
+                actionErrorMessage = "Zine couldn’t change the completion state. Check your connection and try again."
+                return
+            }
+            onFinishedCommit(store.isFinished)
         }
-        onFinishedChanged(value)
     }
 
     private func updateScrollProgress(_ progress: Double) {

--- a/apps/ios/ZineNativeTests/ArticleReaderTests.swift
+++ b/apps/ios/ZineNativeTests/ArticleReaderTests.swift
@@ -254,10 +254,34 @@ final class ArticleReaderTests: XCTestCase {
         }
         let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
 
-        let result = await store.toggleFinished()
+        let mutation = try XCTUnwrap(store.beginFinishedToggle())
+
+        XCTAssertTrue(store.isFinished)
+        XCTAssertTrue(store.isUpdatingFinished)
+
+        let result = await store.persistFinishedToggle(mutation)
 
         XCTAssertEqual(result, true)
         XCTAssertTrue(store.isFinished)
+        XCTAssertFalse(store.isUpdatingFinished)
+    }
+
+    @MainActor
+    func testStoreRollsBackOptimisticCompletionWhenTheRequestFails() async throws {
+        let client = Self.client { request in
+            XCTAssertEqual(request.httpMethod, "PATCH")
+            return (500, #"{"error":"unavailable"}"#)
+        }
+        let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
+
+        let mutation = try XCTUnwrap(store.beginFinishedToggle())
+
+        XCTAssertTrue(store.isFinished)
+        let result = await store.persistFinishedToggle(mutation)
+
+        XCTAssertFalse(result)
+        XCTAssertFalse(store.isFinished)
+        XCTAssertFalse(store.isUpdatingFinished)
     }
 
     func testTagEndpointsListAndReplaceArticleTags() async throws {

--- a/apps/ios/ZineNativeTests/BookmarkTests.swift
+++ b/apps/ios/ZineNativeTests/BookmarkTests.swift
@@ -64,6 +64,32 @@ final class BookmarkTests: XCTestCase {
         )
     }
 
+    func testFinishedStateTogglesImmediatelyAndRollsBack() throws {
+        var state = OptimisticFinishedState(isFinished: false, finishedAt: nil)
+
+        let mutation = try XCTUnwrap(state.beginToggle(now: Date(timeIntervalSince1970: 0)))
+
+        XCTAssertTrue(state.isFinished)
+        XCTAssertTrue(state.isUpdating)
+        XCTAssertNotNil(state.finishedAt)
+        XCTAssertNil(state.beginToggle())
+
+        state.rollback(mutation)
+
+        XCTAssertFalse(state.isFinished)
+        XCTAssertFalse(state.isUpdating)
+        XCTAssertNil(state.finishedAt)
+    }
+
+    func testFinishedStateDoesNotLetLateHydrationOverwriteTheUserAction() throws {
+        var state = OptimisticFinishedState(isFinished: false, finishedAt: nil)
+        _ = try XCTUnwrap(state.beginToggle())
+
+        state.hydrate(isFinished: false, finishedAt: nil)
+
+        XCTAssertTrue(state.isFinished)
+    }
+
     func testProviderTitlesUseProductCapitalization() {
         XCTAssertEqual(Provider.youtube.title, "YouTube")
         XCTAssertEqual(Provider.x.title, "X")

--- a/apps/ios/ZineNativeTests/EditorialTests.swift
+++ b/apps/ios/ZineNativeTests/EditorialTests.swift
@@ -337,7 +337,7 @@ final class EditorialTests: XCTestCase {
             zineUserItemId: "user-item-1",
             zineItemId: "item-1",
             isSaved: true,
-            isFinished: false
+            isFinished: true
         )
 
         let content = BookmarkDetailContent(
@@ -353,6 +353,7 @@ final class EditorialTests: XCTestCase {
         XCTAssertEqual(content.contentType, .article)
         XCTAssertEqual(content.summary, "Useful context.")
         XCTAssertEqual(content.thumbnailUrl, URL(string: "https://example.com/image.jpg"))
+        XCTAssertTrue(content.isFinished)
     }
 
     func testDecodesWhyTodayXVoicesAndZineConnections() throws {


### PR DESCRIPTION
## Summary

- update bookmark detail and article reader completion state optimistically so the checkmark changes immediately
- remove completion loading spinners while requests are pending and roll back on failure
- protect local completion changes from stale hydration and add focused regression coverage

## Validation

- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`
- `bun run typecheck` (pre-push hook)
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -derivedDataPath apps/ios/.derived-completion CODE_SIGNING_ALLOWED=NO test`
- signed Release build succeeded and was installed on Erik’s iPhone
- simulator live preview confirmed the stable completion control renders without a hydration spinner