### PR TITLE
feat(ios): feature a recent article on Home

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -47,7 +47,6 @@ private struct AuthenticatedAppView: View {
     private let libraryCache: LibraryCache
 
     @State private var homeStore: HomeStore
-    @State private var peopleDailyStore: PeopleDailyStore
     @State private var search = ""
     @State private var selectedTab = AppTab.home
     @State private var homeTabReselection = 0
@@ -68,15 +67,10 @@ private struct AuthenticatedAppView: View {
             },
             articleBodyCache: ArticleBodyCache(userID: userID)
         )
-        let peopleDailyCache = PeopleDailyCache(userID: userID)
         let homeCache = HomeCache(userID: userID)
         self.client = client
         libraryCache = LibraryCache(userID: userID)
         _homeStore = State(initialValue: HomeStore(client: client, cache: homeCache))
-        _peopleDailyStore = State(initialValue: PeopleDailyStore(
-            client: client,
-            cache: peopleDailyCache
-        ))
     }
 
     var body: some View {
@@ -85,7 +79,6 @@ private struct AuthenticatedAppView: View {
                 HomeView(
                     client: client,
                     store: homeStore,
-                    peopleDailyStore: peopleDailyStore,
                     density: .compact,
                     onContentChanged: markBookmarkContentChanged,
                     onExternalOpen: handleExternalOpen,
@@ -127,9 +120,7 @@ private struct AuthenticatedAppView: View {
         }
         .zineTabShellChrome()
         .task(id: homeRevision) {
-            async let home: Void = homeStore.reload()
-            async let today: Void = peopleDailyStore.load()
-            _ = await (home, today)
+            await homeStore.reload()
         }
         .onChange(of: externalOpenEvent, initial: true) { _, event in
             guard let event else { return }

--- a/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
@@ -64,8 +64,13 @@ struct CondensedHomeDashboardSectionView: View {
                 sectionID: section.id,
                 transitionNamespace: transitionNamespace
             )
-        case .todayTopic(let topic):
-            CondensedTodayTopicSection(topic: topic)
+        case .featuredArticle(let item):
+            HomeFeaturedArticleSection(
+                item: item,
+                sectionID: section.id,
+                horizontalPadding: 16,
+                transitionNamespace: transitionNamespace
+            )
         }
     }
 }
@@ -334,77 +339,6 @@ private struct CondensedItemListSection: View {
             .background(ZineTheme.surface, in: .rect(cornerRadius: 13))
         }
         .padding(.horizontal, 16)
-    }
-}
-
-private struct CondensedTodayTopicSection: View {
-    let topic: HomeTodayTopic
-
-    var body: some View {
-        NavigationLink(value: PeopleDailyRoute.section(topic.section.id)) {
-            HStack(alignment: .top, spacing: 10) {
-                DailyParticipantFacepile(authors: topic.authors, size: 20, maximumVisible: 3)
-                    .frame(width: 54, alignment: .leading)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Text("TODAY")
-                            .font(.caption2.weight(.heavy))
-                            .tracking(0.8)
-                            .foregroundStyle(ZineTheme.brandAccent)
-
-                        if let statusText {
-                            Text(statusText)
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(ZineTheme.secondaryText)
-                        }
-                    }
-
-                    Text(topic.section.title)
-                        .font(.headline)
-                        .foregroundStyle(ZineTheme.primaryText)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(2)
-
-                    Text(topic.section.summary)
-                        .font(.caption)
-                        .foregroundStyle(ZineTheme.secondaryText)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(2)
-
-                    Text(conversationSummary)
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(ZineTheme.tertiaryText)
-                }
-
-                Spacer(minLength: 0)
-                Image(systemName: "chevron.right")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(ZineTheme.tertiaryText)
-                    .padding(.top, 2)
-            }
-            .padding(12)
-            .background(ZineTheme.brandAccent.opacity(0.07), in: .rect(cornerRadius: 14))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 16)
-        .accessibilityHint("Opens the conversations in this section")
-    }
-
-    private var statusText: String? {
-        if topic.isShowingCachedEdition { return "Saved edition" }
-        switch topic.freshnessStatus {
-        case .complete: return nil
-        case .partial: return nil
-        case .unavailable: return "Unavailable"
-        }
-    }
-
-    private var conversationSummary: String {
-        let favorites = "\(topic.section.favoriteConversationCount) conversation\(topic.section.favoriteConversationCount == 1 ? "" : "s")"
-        guard topic.section.supportingConversationCount > 0 else { return favorites }
-        return "\(favorites) · \(topic.section.supportingConversationCount) nearby"
     }
 }
 

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -148,73 +148,104 @@ struct HomeDashboardSectionView: View {
                 sectionID: section.id,
                 transitionNamespace: transitionNamespace
             )
-        case .todayTopic(let topic):
-            HomeTodayTopicSection(topic: topic)
+        case .featuredArticle(let item):
+            HomeFeaturedArticleSection(
+                item: item,
+                sectionID: section.id,
+                horizontalPadding: 20,
+                transitionNamespace: transitionNamespace
+            )
         }
     }
 }
 
-private struct HomeTodayTopicSection: View {
-    let topic: HomeTodayTopic
+struct HomeFeaturedArticleSection: View {
+    let item: HomeItem
+    let sectionID: String
+    let horizontalPadding: CGFloat
+    let transitionNamespace: Namespace.ID
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 8) {
-                Text("Today")
-                    .font(.caption.weight(.heavy))
-                    .tracking(1.1)
-                    .foregroundStyle(ZineTheme.brandAccent)
+        HomeNavigationLink(
+            route: .item(item, sectionID: sectionID),
+            transitionNamespace: transitionNamespace
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .center, spacing: 9) {
+                    CreatorAvatar(
+                        imageUrl: item.creatorImageUrl,
+                        creator: item.creator,
+                        contentType: item.contentType,
+                        size: 32
+                    )
 
-                Text(formattedDate)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(ZineTheme.secondaryText)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(item.creator)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(ZineTheme.primaryText)
+                            .lineLimit(1)
 
-                if topic.isShowingCachedEdition {
-                    statusLabel("Saved edition", color: ZineTheme.secondaryText)
-                } else {
-                    switch topic.freshnessStatus {
-                    case .complete:
-                        EmptyView()
-                    case .partial:
-                        statusLabel("Partial", color: .orange)
-                    case .unavailable:
-                        statusLabel("Unavailable", color: ZineTheme.secondaryText)
+                        Text("RECENTLY ADDED")
+                            .font(.caption2.weight(.heavy))
+                            .tracking(0.8)
+                            .foregroundStyle(ZineTheme.brandAccent)
                     }
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "chevron.right")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(ZineTheme.tertiaryText)
+                }
+
+                Text(item.title)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(3)
+
+                if let excerpt {
+                    Text(excerpt)
+                        .font(.subheadline)
+                        .foregroundStyle(ZineTheme.secondaryText)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(4)
+                }
+
+                if !footerLabels.isEmpty {
+                    Text(footerLabels.joined(separator: " · "))
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(ZineTheme.tertiaryText)
                 }
             }
-
-            NavigationLink(value: PeopleDailyRoute.section(topic.section.id)) {
-                DailyOverviewSectionRow(
-                    section: topic.section,
-                    authors: topic.authors
-                )
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(ZineTheme.border.opacity(0.45), lineWidth: 0.5)
             }
-            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .combine)
+            .accessibilityHint("Opens the article")
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, horizontalPadding)
     }
 
-    private func statusLabel(_ text: String, color: Color) -> some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(color)
-                .frame(width: 5, height: 5)
-            Text(text)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(ZineTheme.secondaryText)
-        }
+    private var excerpt: String? {
+        let value = item.summary?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
     }
 
-    private var formattedDate: String {
-        let components = topic.date.split(separator: "-").compactMap { Int($0) }
-        guard components.count == 3 else { return topic.date }
-        var value = DateComponents()
-        value.calendar = Calendar(identifier: .gregorian)
-        value.timeZone = TimeZone(identifier: topic.timezone)
-        value.year = components[0]
-        value.month = components[1]
-        value.day = components[2]
-        return value.date?.formatted(.dateTime.month(.abbreviated).day()) ?? topic.date
+    private var footerLabels: [String] {
+        [item.consumptionLabel, savedLabel].compactMap { $0 }
+    }
+
+    private var savedLabel: String? {
+        guard let bookmarkedAt = item.bookmarkedAt,
+              let date = try? Date(bookmarkedAt, strategy: .iso8601)
+        else { return nil }
+        return "Saved \(date.formatted(.relative(presentation: .named)))"
     }
 }
 

--- a/apps/ios/ZineNative/Features/Home/HomeStore.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeStore.swift
@@ -1,17 +1,6 @@
 import Foundation
 import Observation
 
-struct HomeTodayTopic: Hashable, Identifiable {
-    let section: DailyOverviewSection
-    let authors: [DailyAuthor]
-    let date: String
-    let timezone: String
-    let freshnessStatus: DailyCoverageStatus
-    let isShowingCachedEdition: Bool
-
-    var id: String { section.id }
-}
-
 enum HomeDashboardSection: Identifiable {
     case jumpBackIn([HomeItem])
     case inbox([Bookmark])
@@ -21,7 +10,7 @@ enum HomeDashboardSection: Identifiable {
     case articles([HomeItem])
     case videos([HomeItem])
     case collection(HomeCollection)
-    case todayTopic(HomeTodayTopic)
+    case featuredArticle(HomeItem)
 
     var id: String {
         switch self {
@@ -33,7 +22,7 @@ enum HomeDashboardSection: Identifiable {
         case .articles: "articles"
         case .videos: "videos"
         case .collection(let collection): "collection-\(collection.id)"
-        case .todayTopic(let topic): "today-topic-\(topic.id)"
+        case .featuredArticle: "featured-article"
         }
     }
 }
@@ -171,16 +160,12 @@ final class HomeStore {
                 .filter { $0.isQuickWin && !jumpIDs.contains($0.id) }
                 .prefix(4)
         )
-        let quickWinIDs = Set(quickWins.map(\.id))
-        let recentlySavedWithoutRepeats = home.recentBookmarks.filter {
-            !jumpIDs.contains($0.id) && !quickWinIDs.contains($0.id)
+        let recentlySaved = Array(home.recentBookmarks.prefix(6))
+        let featuredArticle = home.recentBookmarks.first { item in
+            item.contentType == .article && !(item.summary ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty
         }
-        let recentlySaved = Array(
-            (recentlySavedWithoutRepeats.isEmpty
-                ? home.recentBookmarks.filter { !jumpIDs.contains($0.id) }
-                : recentlySavedWithoutRepeats)
-                .prefix(6)
-        )
         let collectionsByID = Dictionary(
             uniqueKeysWithValues: home.customCollections.map { ($0.id, $0) }
         )
@@ -219,77 +204,26 @@ final class HomeStore {
             result.insert(.quickWins(quickWins), at: insertionIndex)
         }
 
-        return result
+        return interleaveFeaturedArticle(featuredArticle, into: result)
     }
 
-    static func strongestTodayTopics(
-        sections: [DailyOverviewSection],
-        authors: [DailyAuthor],
-        date: String,
-        timezone: String,
-        freshnessStatus: DailyCoverageStatus,
-        isShowingCachedEdition: Bool
-    ) -> [HomeTodayTopic] {
-        let authorsByKey = Dictionary(uniqueKeysWithValues: authors.map { ($0.key, $0) })
-        return sections.prefix(2).map { section in
-            HomeTodayTopic(
-                section: section,
-                authors: section.authorKeys.compactMap { authorsByKey[$0] },
-                date: date,
-                timezone: timezone,
-                freshnessStatus: freshnessStatus,
-                isShowingCachedEdition: isShowingCachedEdition
-            )
-        }
-    }
-
-    static func interleaveTodayTopics(
-        _ topics: [HomeTodayTopic],
+    static func interleaveFeaturedArticle(
+        _ article: HomeItem?,
         into sections: [HomeDashboardSection]
     ) -> [HomeDashboardSection] {
-        guard let firstTopic = topics.first else { return sections }
+        guard let article else { return sections }
 
         var result = sections
-        let firstInsertionIndex: Int
+        let insertionIndex: Int
         if let jumpBackInIndex = result.firstIndex(where: { section in
             if case .jumpBackIn = section { return true }
             return false
         }) {
-            firstInsertionIndex = result.index(after: jumpBackInIndex)
+            insertionIndex = result.index(after: jumpBackInIndex)
         } else {
-            firstInsertionIndex = min(1, result.endIndex)
+            insertionIndex = min(1, result.endIndex)
         }
-        result.insert(.todayTopic(firstTopic), at: firstInsertionIndex)
-
-        guard topics.count > 1 else { return result }
-        let secondTopic = topics[1]
-        let searchStart = result.index(after: firstInsertionIndex)
-
-        if let collectionIndex = result[searchStart...].firstIndex(where: { section in
-            if case .collection = section { return true }
-            return false
-        }) {
-            result.insert(.todayTopic(secondTopic), at: result.index(after: collectionIndex))
-            return result
-        }
-
-        if let quickWinsIndex = result[searchStart...].firstIndex(where: { section in
-            if case .quickWins = section { return true }
-            return false
-        }) {
-            result.insert(.todayTopic(secondTopic), at: result.index(after: quickWinsIndex))
-            return result
-        }
-
-        if let inboxIndex = result[searchStart...].firstIndex(where: { section in
-            if case .inbox = section { return true }
-            return false
-        }) {
-            result.insert(.todayTopic(secondTopic), at: result.index(after: inboxIndex))
-            return result
-        }
-
-        result.append(.todayTopic(secondTopic))
+        result.insert(.featuredArticle(article), at: insertionIndex)
         return result
     }
 

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -39,7 +39,6 @@ enum HomeLayoutDensity: Equatable {
 struct HomeView: View {
     let client: APIClient
     let store: HomeStore
-    let peopleDailyStore: PeopleDailyStore
     var density: HomeLayoutDensity = .standard
     var title = "Home"
     let onContentChanged: () -> Void
@@ -52,7 +51,6 @@ struct HomeView: View {
     init(
         client: APIClient,
         store: HomeStore,
-        peopleDailyStore: PeopleDailyStore,
         density: HomeLayoutDensity = .standard,
         title: String = "Home",
         onContentChanged: @escaping () -> Void,
@@ -62,7 +60,6 @@ struct HomeView: View {
     ) {
         self.client = client
         self.store = store
-        self.peopleDailyStore = peopleDailyStore
         self.density = density
         self.title = title
         self.onContentChanged = onContentChanged
@@ -99,12 +96,6 @@ struct HomeView: View {
                             onExternalOpen: onExternalOpen,
                             tabReselection: tabReselection
                         )
-                    }
-                }
-                .navigationDestination(for: PeopleDailyRoute.self) { route in
-                    switch route {
-                    case let .section(id):
-                        PeopleDailySectionView(client: client, sectionID: id)
                     }
                 }
         }
@@ -147,28 +138,13 @@ struct HomeView: View {
             }
             .background(ZineTheme.canvas)
             .refreshable {
-                async let home: Void = store.reload()
-                async let today: Void = peopleDailyStore.load()
-                _ = await (home, today)
+                await store.reload()
             }
         }
     }
 
     private var dashboardSections: [HomeDashboardSection] {
-        guard let response = peopleDailyStore.response else {
-            return density.visibleSections(from: store.sections)
-        }
-        let topics = HomeStore.strongestTodayTopics(
-            sections: response.overviewSections,
-            authors: response.authors,
-            date: response.date,
-            timezone: response.timezone,
-            freshnessStatus: response.freshness.status,
-            isShowingCachedEdition: peopleDailyStore.isShowingCachedEdition
-        )
-        return density.visibleSections(
-            from: HomeStore.interleaveTodayTopics(topics, into: store.sections)
-        )
+        density.visibleSections(from: store.sections)
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -65,10 +65,6 @@ struct ScreenshotHomeView: View {
             .navigationDestination(for: HomeSectionRoute.self) { route in
                 ScreenshotHomeSectionListView(route: route)
             }
-            .navigationDestination(for: PeopleDailyRoute.self) { _ in
-                Text("Today topic")
-                    .navigationTitle("Conversations")
-            }
         }
         .zineScreenChrome()
     }
@@ -150,6 +146,16 @@ private enum ScreenshotHomeFixtures {
         bookmark(id: "opened-3", title: "A practical guide to product intuition", creator: "Every"),
     ]
 
+    static let featuredArticle = homeItem(
+        id: "featured-article",
+        title: "Designing software for a world of personal agents",
+        creator: "Maggie Appleton",
+        creatorImageUrl: URL(string: "https://i.pravatar.cc/96?img=47"),
+        summary: "The next generation of tools will be shaped less by universal workflows and more by software that learns the context, taste, and intent of one person.",
+        minutes: 8,
+        bookmarkedAt: Date.now.formatted(.iso8601)
+    )
+
     static let sections: [HomeDashboardSection] = [
         .jumpBackIn([
             homeItem(
@@ -197,14 +203,7 @@ private enum ScreenshotHomeFixtures {
                 progress: BookmarkProgress(position: 6, duration: 15, percent: 40)
             ),
         ]),
-        .todayTopic(todayTopic(
-            id: "agents",
-            title: "How people are reaching agents remotely",
-            summary: "Private networks and small custom apps are making agents available away from the desk.",
-            authors: ["Dan", "Ken", "Joel"],
-            favoriteCount: 4,
-            nearbyCount: 1
-        )),
+        .featuredArticle(featuredArticle),
         .inbox([
             bookmark(id: "inbox-1", title: "What comes after the app?", creator: "Stratechery"),
             bookmark(id: "inbox-2", title: "Designing tools for thought", creator: "Maggie Appleton"),
@@ -216,16 +215,18 @@ private enum ScreenshotHomeFixtures {
             homeItem(id: "quick-3", title: "A field guide to curiosity", creator: "Works in Progress"),
             homeItem(id: "quick-4", title: "Notes on taste", creator: "Every"),
         ]),
-        .todayTopic(todayTopic(
-            id: "open-weights",
-            title: "Open weights and access",
-            summary: "People compare who benefits when powerful models become easier to use.",
-            authors: ["Alice", "Bob", "Carol"],
-            favoriteCount: 3,
-            nearbyCount: 2
-        )),
         .recentlySaved([
-            homeItem(id: "saved-1", title: "The future of personal software", creator: "Ink & Switch"),
+            featuredArticle,
+            homeItem(
+                id: "resume",
+                title: "Building products that feel inevitable",
+                creator: "Lenny’s Podcast",
+                contentType: .podcast,
+                provider: .spotify,
+                duration: 3_420,
+                minutes: nil,
+                progress: BookmarkProgress(position: 1_368, duration: 3_420, percent: 40)
+            ),
             homeItem(id: "saved-2", title: "How great products compound", creator: "A Smart Bear"),
             homeItem(id: "saved-3", title: "Interfaces for invisible systems", creator: "Rachel Been"),
         ]),
@@ -255,10 +256,13 @@ private enum ScreenshotHomeFixtures {
         id: String,
         title: String,
         creator: String,
+        creatorImageUrl: URL? = nil,
+        summary: String? = nil,
         contentType: ContentType = .article,
         provider: Provider = .rss,
         duration: Int? = nil,
         minutes: Int? = 7,
+        bookmarkedAt: String = "2026-07-18T12:00:00Z",
         progress: BookmarkProgress? = nil
     ) -> HomeItem {
         HomeItem(
@@ -270,14 +274,14 @@ private enum ScreenshotHomeFixtures {
             contentType: contentType,
             provider: provider,
             creator: creator,
-            creatorImageUrl: nil,
+            creatorImageUrl: creatorImageUrl,
             creatorId: nil,
             publisher: nil,
-            summary: nil,
+            summary: summary,
             duration: duration,
             publishedAt: "2026-07-18T12:00:00Z",
             readingTimeMinutes: minutes,
-            bookmarkedAt: "2026-07-18T12:00:00Z",
+            bookmarkedAt: bookmarkedAt,
             lastOpenedAt: progress == nil ? nil : "2026-07-18T18:00:00Z",
             progress: progress
         )
@@ -312,45 +316,5 @@ private enum ScreenshotHomeFixtures {
         )
     }
 
-    private static func todayTopic(
-        id: String,
-        title: String,
-        summary: String,
-        authors: [String],
-        favoriteCount: Int,
-        nearbyCount: Int
-    ) -> HomeTodayTopic {
-        let dailyAuthors = authors.map { name in
-            DailyAuthor(
-                key: name.lowercased(),
-                username: name.lowercased(),
-                name: name,
-                profileUrl: nil,
-                profileImageUrl: nil,
-                verified: nil
-            )
-        }
-        return HomeTodayTopic(
-            section: DailyOverviewSection(
-                id: id,
-                title: title,
-                summary: summary,
-                source: "GENERATED",
-                representativePostIds: [],
-                favoriteThreadUnitIds: (0..<favoriteCount).map { "favorite-\(id)-\($0)" },
-                supportingThreadUnitIds: (0..<nearbyCount).map { "nearby-\(id)-\($0)" },
-                authorKeys: dailyAuthors.map(\.key),
-                favoriteConversationCount: favoriteCount,
-                supportingConversationCount: nearbyCount,
-                latestActivityAt: "2026-07-28T12:00:00Z",
-                coverageWarnings: []
-            ),
-            authors: dailyAuthors,
-            date: "2026-07-28",
-            timezone: "America/Chicago",
-            freshnessStatus: .complete,
-            isShowingCachedEdition: false
-        )
-    }
 }
 #endif

--- a/apps/ios/ZineNative/Features/Today/TodayView.swift
+++ b/apps/ios/ZineNative/Features/Today/TodayView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct TodayView: View {
     let client: APIClient
     let homeStore: HomeStore
-    let peopleDailyStore: PeopleDailyStore
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
     let onHomeItemExternalOpen: (HomeItem) -> Void
@@ -12,7 +11,6 @@ struct TodayView: View {
         HomeView(
             client: client,
             store: homeStore,
-            peopleDailyStore: peopleDailyStore,
             density: .compact,
             title: "Today",
             onContentChanged: onContentChanged,

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -88,6 +88,45 @@ final class HomeTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testRecentlySavedKeepsItemsThatAlsoAppearElsewhereOnHome() throws {
+        let shared = makeHomeItem(
+            id: "shared",
+            minutes: 5,
+            lastOpenedAt: "2026-08-12T10:00:00Z"
+        )
+        let recent = makeHomeItem(id: "recent", minutes: 20)
+        let home = HomeResponse(
+            recentBookmarks: [shared, recent],
+            jumpBackIn: [shared],
+            byContentType: HomeContentTypeSections(videos: [], podcasts: [], articles: []),
+            customCollections: [],
+            sectionOrder: [
+                HomeLayoutSection(kind: .builtIn, builtInSection: .jumpBackIn, collectionId: nil),
+                HomeLayoutSection(
+                    kind: .builtIn,
+                    builtInSection: .recentlyBookmarked,
+                    collectionId: nil
+                ),
+            ],
+            requestId: nil,
+            traceId: nil
+        )
+
+        let sections = HomeStore.makeSections(home: home, inboxItems: [])
+        let jumpBackIn = try XCTUnwrap(sections.first)
+        let recentlySaved = try XCTUnwrap(sections.last)
+
+        guard case .jumpBackIn(let jumpBackInItems) = jumpBackIn,
+              case .recentlySaved(let recentlySavedItems) = recentlySaved
+        else {
+            return XCTFail("Expected Jump Back In followed by Recently Saved")
+        }
+
+        XCTAssertEqual(jumpBackInItems.map(\.id), ["shared"])
+        XCTAssertEqual(recentlySavedItems.map(\.id), ["shared", "recent"])
+    }
+
     func testDecodesCompactHomeResponseWithProgress() throws {
         let response = try JSONDecoder().decode(
             HomeResponse.self,
@@ -317,100 +356,71 @@ final class HomeTests: XCTestCase {
     }
 
     @MainActor
-    func testSelectsOnlyTheTwoStrongestTodayTopicsInPublishedOrder() {
-        let authors = [
-            makeDailyAuthor(key: "alice"),
-            makeDailyAuthor(key: "bob"),
-            makeDailyAuthor(key: "carol"),
-        ]
-        let sections = [
-            makeDailySection(id: "strongest", authorKeys: ["alice", "bob"]),
-            makeDailySection(id: "second", authorKeys: ["carol"]),
-            makeDailySection(id: "third", authorKeys: ["alice"]),
-        ]
-
-        let topics = HomeStore.strongestTodayTopics(
-            sections: sections,
-            authors: authors,
-            date: "2026-07-28",
-            timezone: "America/Chicago",
-            freshnessStatus: .partial,
-            isShowingCachedEdition: true
-        )
-
-        XCTAssertEqual(topics.map(\.id), ["strongest", "second"])
-        XCTAssertEqual(topics[0].authors.map(\.key), ["alice", "bob"])
-        XCTAssertEqual(topics[1].authors.map(\.key), ["carol"])
-        XCTAssertEqual(topics[0].freshnessStatus, .partial)
-        XCTAssertTrue(topics[0].isShowingCachedEdition)
-    }
-
-    @MainActor
-    func testInterleavesTodayTopicsAfterJumpBackInAndFirstCollection() {
-        let topics = [makeTodayTopic(id: "one"), makeTodayTopic(id: "two")]
+    func testInterleavesOneFeaturedArticleAfterJumpBackIn() {
+        let article = makeHomeItem(id: "article", minutes: 8, summary: "Useful context.")
         let sections: [HomeDashboardSection] = [
             .jumpBackIn([makeHomeItem(id: "resume", minutes: 20)]),
             .inbox([makeBookmark(index: 0)]),
-            .collection(HomeCollection(
-                collectionId: "ideas",
-                title: "Ideas",
-                layout: .stackRail,
-                position: 0,
-                count: 1,
-                items: [makeHomeItem(id: "idea", minutes: 12)]
-            )),
             .recentlySaved([makeHomeItem(id: "recent", minutes: 10)]),
         ]
 
-        let result = HomeStore.interleaveTodayTopics(topics, into: sections)
+        let result = HomeStore.interleaveFeaturedArticle(article, into: sections)
 
         XCTAssertEqual(
             result.map(\.id),
             [
                 "jump-back-in",
-                "today-topic-one",
+                "featured-article",
                 "inbox",
-                "collection-ideas",
-                "today-topic-two",
                 "recently-saved",
             ]
         )
+
+        guard case .featuredArticle(let featured) = result[1] else {
+            return XCTFail("Expected the featured article after Jump Back In")
+        }
+        XCTAssertEqual(featured.id, article.id)
     }
 
     @MainActor
-    func testInterleavesSecondTodayTopicAfterQuickWinsWithoutACollection() {
-        let topics = [makeTodayTopic(id: "one"), makeTodayTopic(id: "two")]
-        let sections: [HomeDashboardSection] = [
-            .jumpBackIn([makeHomeItem(id: "resume", minutes: 20)]),
-            .inbox([makeBookmark(index: 0)]),
-            .quickWins([makeHomeItem(id: "quick", minutes: 5)]),
-            .recentlySaved([makeHomeItem(id: "recent", minutes: 10)]),
-        ]
-
-        let result = HomeStore.interleaveTodayTopics(topics, into: sections)
-
-        XCTAssertEqual(
-            result.map(\.id),
-            [
-                "jump-back-in",
-                "today-topic-one",
-                "inbox",
-                "quick-wins",
-                "today-topic-two",
-                "recently-saved",
-            ]
-        )
-    }
-
-    @MainActor
-    func testLeavesHomeUnchangedWithoutTodayTopics() {
+    func testLeavesHomeUnchangedWithoutAFeaturedArticle() {
         let sections: [HomeDashboardSection] = [
             .inbox([makeBookmark(index: 0)]),
         ]
 
-        let result = HomeStore.interleaveTodayTopics([], into: sections)
+        let result = HomeStore.interleaveFeaturedArticle(nil, into: sections)
 
         XCTAssertEqual(result.map(\.id), ["inbox"])
+    }
+
+    @MainActor
+    func testFeaturesNewestSavedArticleThatHasContent() throws {
+        let video = makeHomeItem(id: "video", minutes: 18, contentType: .video, summary: "Video")
+        let emptyArticle = makeHomeItem(id: "empty", minutes: 16, summary: "  ")
+        let featured = makeHomeItem(id: "featured", minutes: 19, summary: "Article excerpt")
+        let home = HomeResponse(
+            recentBookmarks: [video, emptyArticle, featured],
+            jumpBackIn: [],
+            byContentType: HomeContentTypeSections(videos: [video], podcasts: [], articles: [emptyArticle, featured]),
+            customCollections: [],
+            sectionOrder: [
+                HomeLayoutSection(
+                    kind: .builtIn,
+                    builtInSection: .recentlyBookmarked,
+                    collectionId: nil
+                ),
+            ],
+            requestId: nil,
+            traceId: nil
+        )
+
+        let sections = HomeStore.makeSections(home: home, inboxItems: [])
+
+        XCTAssertEqual(sections.map(\.id), ["recently-saved", "featured-article"])
+        guard case .featuredArticle(let article) = try XCTUnwrap(sections.last) else {
+            return XCTFail("Expected a featured article")
+        }
+        XCTAssertEqual(article.id, "featured")
     }
 
     func testHomeCacheKeepsOnlyFourInboxItems() async throws {
@@ -429,7 +439,9 @@ final class HomeTests: XCTestCase {
     private func makeHomeItem(
         id: String,
         minutes: Int,
-        lastOpenedAt: String? = nil
+        lastOpenedAt: String? = nil,
+        contentType: ContentType = .article,
+        summary: String? = nil
     ) -> HomeItem {
         HomeItem(
             id: id,
@@ -437,13 +449,13 @@ final class HomeTests: XCTestCase {
             title: "Item \(id)",
             thumbnailUrl: nil,
             canonicalUrl: URL(string: "https://example.com/\(id)")!,
-            contentType: .article,
+            contentType: contentType,
             provider: .rss,
             creator: "Creator",
             creatorImageUrl: nil,
             creatorId: "creator-1",
             publisher: nil,
-            summary: nil,
+            summary: summary,
             duration: nil,
             publishedAt: nil,
             readingTimeMinutes: minutes,
@@ -482,42 +494,4 @@ final class HomeTests: XCTestCase {
         )
     }
 
-    private func makeTodayTopic(id: String) -> HomeTodayTopic {
-        HomeTodayTopic(
-            section: makeDailySection(id: id, authorKeys: ["author-\(id)"]),
-            authors: [makeDailyAuthor(key: "author-\(id)")],
-            date: "2026-07-28",
-            timezone: "America/Chicago",
-            freshnessStatus: .complete,
-            isShowingCachedEdition: false
-        )
-    }
-
-    private func makeDailySection(id: String, authorKeys: [String]) -> DailyOverviewSection {
-        DailyOverviewSection(
-            id: id,
-            title: "Topic \(id)",
-            summary: "Summary for \(id).",
-            source: "GENERATED",
-            representativePostIds: [],
-            favoriteThreadUnitIds: ["conversation-\(id)"],
-            supportingThreadUnitIds: [],
-            authorKeys: authorKeys,
-            favoriteConversationCount: 1,
-            supportingConversationCount: 0,
-            latestActivityAt: "2026-07-28T12:00:00Z",
-            coverageWarnings: []
-        )
-    }
-
-    private func makeDailyAuthor(key: String) -> DailyAuthor {
-        DailyAuthor(
-            key: key,
-            username: key,
-            name: key.capitalized,
-            profileUrl: nil,
-            profileImageUrl: nil,
-            verified: nil
-        )
-    }
 }


### PR DESCRIPTION
## Summary

- replace the two Today editorial inserts on Home with one text-first recently added article card
- feature the newest saved article with usable content while keeping it visible in Recently Saved
- show the author avatar, author name, title, excerpt, reading time, and saved time with no thumbnail dependency
- remove the extra People Daily loading from Home and omit the feature gracefully when no eligible article exists

## Validation

- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -derivedDataPath .derived-featured-article -parallel-testing-enabled NO -only-testing:ZineNativeTests/HomeTests test` — 19 tests passed
- `bun run design-system:check` — passed
- `bun run format:check` — passed
- repository pre-push checks — passed, including typecheck, web tests, and 93 Worker test files / 1,767 tests
- streamed simulator interaction — verified dark/light rendering, article tap-through, and intentional duplication in Recently Saved
- physical iPhone — native build, install, and launch succeeded for `app.zine.native`