### PR TITLE
fix(ios): align native screen backgrounds

### DIFF
--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -33,12 +33,12 @@ the surrounding theme changes.
   `ZineTheme.tertiaryText` for de-emphasized metadata.
 - Use `zineAppTheme()` at an app-level container and `zineScreenChrome()` for
   list-style screens when those modifiers fit the view structure.
-- Keep navigation bars and tab bars system-managed. Semantic colors may tint
-  controls and provide the content beneath them, but must not globally replace
-  native materials, scroll-edge behavior, or shadows with opaque palette
-  backgrounds. A collapsing filtered-list header may provide the canvas as its
-  toolbar background style, but must not force the material visible: forced
-  source chrome remains pinned over an interactive detail dismissal.
+- Keep navigation bars and tab bars system-managed. Shared screen and tab-shell
+  modifiers provide the canvas as their preferred toolbar background style so
+  the chrome matches the content, but must not force that background visible or
+  replace native scroll-edge behavior and shadows through UIKit appearance
+  customization. Native floating controls may retain their system material;
+  immersive destinations still own tab-bar visibility.
 - Keep the root tab bar and ordinary screen navigation bars explicitly visible.
   Visibility and semantic item tint are separate from the system-managed bar
   material; hiding either bar must remain scoped to an immersive destination.
@@ -54,6 +54,14 @@ the surrounding theme changes.
   long-form reading surfaces.
 - Keep the reading hierarchy neutral: body content uses surface and text roles,
   while links and narrow annotations may use the accent roles.
+- When a list intentionally uses surface-backed rows, extend `surface` through
+  its title, filters, empty space, navigation chrome, and tab-bar safe area so
+  the screen reads as one continuous background. Keep canvas-backed lists on
+  `canvas` throughout instead of mixing the two roles.
+- Full-screen loading views must fill their container with the destination's
+  semantic background. Loading, error, and empty rows inside a `List` must set
+  the same `listRowBackground` as the surrounding content instead of falling
+  back to a system background.
 - Check both light and dark appearances. Preserve Dynamic Type, system control
   behavior, sufficient contrast, and non-color indicators for meaningful
   state.

--- a/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
+++ b/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CollapsingListTitle: View {
     let title: String
     let progress: CGFloat
+    var background = ZineTheme.canvas
 
     var body: some View {
         Text(title)
@@ -14,7 +15,7 @@ struct CollapsingListTitle: View {
             .padding(.top, 8)
             .padding(.bottom, 2)
             .listRowInsets(EdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 18))
-            .listRowBackground(ZineTheme.canvas)
+            .listRowBackground(background)
             .listRowSeparator(.hidden)
             .accessibilityAddTraits(.isHeader)
             .accessibilityHidden(progress >= 0.5)
@@ -40,6 +41,7 @@ struct CollapsedListTitle: View {
 
 struct ContentTypeFilterBar: View {
     @Binding var selection: ContentType?
+    var background = ZineTheme.canvas
 
     private let options: [ContentType?] = [nil, .article, .podcast, .video, .post]
 
@@ -49,7 +51,7 @@ struct ContentTypeFilterBar: View {
         }
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(ZineTheme.canvas)
+        .background(background)
         .sensoryFeedback(.selection, trigger: selection)
         .accessibilityLabel("Content format filters")
     }
@@ -78,6 +80,18 @@ struct ContentTypeFilterBar: View {
         option: ContentType?
     ) -> ContentType? {
         current == option ? nil : option
+    }
+}
+
+struct FilteredListLoadingRow: View {
+    let label: String
+    var background = ZineTheme.canvas
+
+    var body: some View {
+        ProgressView(label)
+            .frame(maxWidth: .infinity, minHeight: 260)
+            .listRowBackground(background)
+            .listRowSeparator(.hidden)
     }
 }
 
@@ -124,7 +138,7 @@ private struct ContentTypeFilterChip: View {
 }
 
 extension View {
-    func contentTypeFilterChrome() -> some View {
-        toolbarBackground(ZineTheme.canvas, for: .navigationBar)
+    func contentTypeFilterChrome(background: Color = ZineTheme.canvas) -> some View {
+        toolbarBackground(background, for: .navigationBar)
     }
 }

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -82,6 +82,19 @@ enum ZineTheme {
     }
 }
 
+struct ZineLoadingView: View {
+    let label: String
+    var background = ZineTheme.canvas
+
+    var body: some View {
+        ProgressView(label)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .foregroundStyle(ZineTheme.primaryText)
+            .tint(ZineTheme.brandAccent)
+            .background(background)
+    }
+}
+
 private extension UIColor {
     convenience init(zineHex hex: String) {
         let value = UInt64(hex, radix: 16) ?? 0
@@ -106,11 +119,13 @@ extension View {
             .background(ZineTheme.canvas)
             .foregroundStyle(ZineTheme.primaryText)
             .tint(ZineTheme.brandAccent)
+            .toolbarBackground(ZineTheme.canvas, for: .navigationBar)
             .toolbar(.visible, for: .navigationBar)
     }
 
     func zineTabShellChrome() -> some View {
         tint(ZineTheme.brandAccent)
             .background(ZineTheme.canvas)
+            .toolbarBackground(ZineTheme.canvas, for: .tabBar)
     }
 }

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -33,7 +33,8 @@ struct HomeSectionListView: View {
         content
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
-            .contentTypeFilterChrome()
+            .contentTypeFilterChrome(background: ZineTheme.surface)
+            .toolbarBackground(ZineTheme.surface, for: .tabBar)
             .toolbar(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -79,21 +80,25 @@ struct HomeSectionListView: View {
             List {
                 CollapsingListTitle(
                     title: route.title,
-                    progress: titleCollapseProgress
+                    progress: titleCollapseProgress,
+                    background: ZineTheme.surface
                 )
                 .id(ScrollAnchor.top)
 
                 Section {
                     resultRows
                 } header: {
-                    ContentTypeFilterBar(selection: $contentType)
+                    ContentTypeFilterBar(
+                        selection: $contentType,
+                        background: ZineTheme.surface
+                    )
                         .textCase(nil)
                         .listRowInsets(EdgeInsets())
                 }
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
+            .background(ZineTheme.surface)
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = geometry.contentOffset.y + geometry.contentInsets.top
                 return CollapsingListTitle.collapseProgress(scrollOffset: offset)
@@ -136,9 +141,10 @@ struct HomeSectionListView: View {
     @ViewBuilder
     private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
-            ProgressView("Loading \(route.title.lowercased())…")
-                .frame(maxWidth: .infinity, minHeight: 260)
-                .listRowSeparator(.hidden)
+            FilteredListLoadingRow(
+                label: "Loading \(route.title.lowercased())…",
+                background: ZineTheme.surface
+            )
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("Section unavailable", systemImage: "exclamationmark.triangle")
@@ -150,6 +156,7 @@ struct HomeSectionListView: View {
                 }
             }
             .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowBackground(ZineTheme.surface)
             .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
             ContentUnavailableView(
@@ -162,6 +169,7 @@ struct HomeSectionListView: View {
                 )
             )
             .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowBackground(ZineTheme.surface)
             .listRowSeparator(.hidden)
         } else {
             ForEach(store.items) { bookmark in
@@ -169,6 +177,7 @@ struct HomeSectionListView: View {
                     BookmarkRow(bookmark: bookmark)
                 }
                 .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowBackground(ZineTheme.surface)
                 .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .swipeActions(edge: .leading, allowsFullSwipe: true) {

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -105,7 +105,7 @@ struct HomeView: View {
     @ViewBuilder
     private var content: some View {
         if store.isLoading && dashboardSections.isEmpty {
-            ProgressView("Loading \(title)…")
+            ZineLoadingView(label: "Loading \(title)…")
         } else if let error = store.errorMessage, dashboardSections.isEmpty {
             ContentUnavailableView {
                 Label("\(title) unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -29,7 +29,8 @@ struct JumpBackInListView: View {
         content
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
-            .contentTypeFilterChrome()
+            .contentTypeFilterChrome(background: ZineTheme.surface)
+            .toolbarBackground(ZineTheme.surface, for: .tabBar)
             .toolbar(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {
@@ -71,21 +72,25 @@ struct JumpBackInListView: View {
             List {
                 CollapsingListTitle(
                     title: "Jump Back In",
-                    progress: titleCollapseProgress
+                    progress: titleCollapseProgress,
+                    background: ZineTheme.surface
                 )
                 .id(ScrollAnchor.top)
 
                 Section {
                     resultRows
                 } header: {
-                    ContentTypeFilterBar(selection: $contentType)
+                    ContentTypeFilterBar(
+                        selection: $contentType,
+                        background: ZineTheme.surface
+                    )
                         .textCase(nil)
                         .listRowInsets(EdgeInsets())
                 }
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
+            .background(ZineTheme.surface)
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = geometry.contentOffset.y + geometry.contentInsets.top
                 return CollapsingListTitle.collapseProgress(scrollOffset: offset)
@@ -128,9 +133,10 @@ struct JumpBackInListView: View {
     @ViewBuilder
     private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
-            ProgressView("Loading history…")
-                .frame(maxWidth: .infinity, minHeight: 260)
-                .listRowSeparator(.hidden)
+            FilteredListLoadingRow(
+                label: "Loading history…",
+                background: ZineTheme.surface
+            )
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("History unavailable", systemImage: "exclamationmark.triangle")
@@ -142,6 +148,7 @@ struct JumpBackInListView: View {
                 }
             }
             .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowBackground(ZineTheme.surface)
             .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
             ContentUnavailableView(
@@ -154,6 +161,7 @@ struct JumpBackInListView: View {
                 )
             )
             .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowBackground(ZineTheme.surface)
             .listRowSeparator(.hidden)
         } else {
             ForEach(store.items) { bookmark in
@@ -161,6 +169,7 @@ struct JumpBackInListView: View {
                     BookmarkRow(bookmark: bookmark)
                 }
                 .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                .listRowBackground(ZineTheme.surface)
                 .listRowSeparator(.hidden)
                 .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
                 .task {

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -98,26 +98,42 @@ private struct ScreenshotHomeSectionListView: View {
         return ScreenshotHomeFixtures.openedBookmarks.filter { $0.contentType == contentType }
     }
 
+    private var showsLoadingState: Bool {
+        ProcessInfo.processInfo.arguments.contains("-screenshot-filtered-list-loading-fixture")
+    }
+
     var body: some View {
         List {
             CollapsingListTitle(
                 title: route.title,
-                progress: titleCollapseProgress
+                progress: titleCollapseProgress,
+                background: ZineTheme.surface
             )
 
             Section {
-                ForEach(bookmarks) { bookmark in
-                    BookmarkRow(bookmark: bookmark)
+                if showsLoadingState {
+                    FilteredListLoadingRow(
+                        label: "Loading \(route.title.lowercased())…",
+                        background: ZineTheme.surface
+                    )
+                } else {
+                    ForEach(bookmarks) { bookmark in
+                        BookmarkRow(bookmark: bookmark)
+                            .listRowBackground(ZineTheme.surface)
+                    }
                 }
             } header: {
-                ContentTypeFilterBar(selection: $contentType)
+                ContentTypeFilterBar(
+                    selection: $contentType,
+                    background: ZineTheme.surface
+                )
                     .textCase(nil)
                     .listRowInsets(EdgeInsets())
             }
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
+        .background(ZineTheme.surface)
         .onScrollGeometryChange(for: CGFloat.self) { geometry in
             let offset = geometry.contentOffset.y + geometry.contentInsets.top
             return CollapsingListTitle.collapseProgress(scrollOffset: offset)
@@ -126,7 +142,8 @@ private struct ScreenshotHomeSectionListView: View {
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
-        .contentTypeFilterChrome()
+        .contentTypeFilterChrome(background: ZineTheme.surface)
+        .toolbarBackground(ZineTheme.surface, for: .tabBar)
         .toolbar(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .principal) {

--- a/apps/ios/ZineNative/Features/Inbox/InboxView.swift
+++ b/apps/ios/ZineNative/Features/Inbox/InboxView.swift
@@ -77,7 +77,7 @@ struct InboxView: View {
     @ViewBuilder
     private var content: some View {
         if store.isLoading && store.items.isEmpty {
-            ProgressView("Loading inbox…")
+            ZineLoadingView(label: "Loading inbox…")
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("Inbox unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -182,9 +182,7 @@ struct LibraryView: View {
     @ViewBuilder
     private var resultRows: some View {
         if store.isLoading && store.items.isEmpty {
-            ProgressView("Loading library…")
-                .frame(maxWidth: .infinity, minHeight: 260)
-                .listRowSeparator(.hidden)
+            FilteredListLoadingRow(label: "Loading library…")
         } else if let error = store.errorMessage, store.items.isEmpty {
             ContentUnavailableView {
                 Label("Library unavailable", systemImage: "exclamationmark.triangle")
@@ -196,10 +194,12 @@ struct LibraryView: View {
                 }
             }
             .frame(maxWidth: .infinity, minHeight: 320)
+            .listRowBackground(ZineTheme.canvas)
             .listRowSeparator(.hidden)
         } else if store.items.isEmpty {
             emptyState
                 .frame(maxWidth: .infinity, minHeight: 320)
+                .listRowBackground(ZineTheme.canvas)
                 .listRowSeparator(.hidden)
         } else {
             ForEach(store.items) { bookmark in

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -76,7 +76,7 @@ struct ArticleReaderView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            ZineTheme.canvas
+            ZineTheme.surface
                 .ignoresSafeArea()
 
             phaseContent

--- a/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
@@ -138,7 +138,7 @@ struct NewsletterSubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.response == nil {
-                ProgressView("Loading newsletters…")
+                ZineLoadingView(label: "Loading newsletters…")
             } else if let error = store.errorMessage, store.response == nil {
                 ContentUnavailableView {
                     Label("Newsletters unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
@@ -42,7 +42,7 @@ struct ProviderSubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.items.isEmpty {
-                ProgressView("Loading \(provider.title)…")
+                ZineLoadingView(label: "Loading \(provider.title)…")
             } else if let error = store.errorMessage, store.items.isEmpty {
                 ContentUnavailableView {
                     Label("\(provider.title) unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
@@ -130,7 +130,7 @@ struct RssSubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.response == nil {
-                ProgressView("Loading RSS feeds…")
+                ZineLoadingView(label: "Loading RSS feeds…")
             } else if let error = store.errorMessage, store.response == nil {
                 ContentUnavailableView {
                     Label("RSS unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
@@ -48,7 +48,7 @@ struct SubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.sources.isEmpty {
-                ProgressView("Loading subscriptions…")
+                ZineLoadingView(label: "Loading subscriptions…")
             } else if let error = store.errorMessage, store.sources.isEmpty {
                 ContentUnavailableView {
                     Label("Subscriptions unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
@@ -124,7 +124,7 @@ struct XSubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.response == nil {
-                ProgressView("Loading X bookmarks…")
+                ZineLoadingView(label: "Loading X bookmarks…")
             } else if let error = store.errorMessage, store.response == nil {
                 ContentUnavailableView {
                     Label("X bookmarks unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyAuthorActivityView.swift
@@ -27,8 +27,7 @@ struct DailyAuthorActivityView: View {
     @ViewBuilder
     private var content: some View {
         if store.isLoading, store.response == nil {
-            ProgressView("Loading @\(author.username)…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            ZineLoadingView(label: "Loading @\(author.username)…")
         } else if let error = store.errorMessage, store.response == nil {
             ContentUnavailableView {
                 Label("Activity unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
+++ b/apps/ios/ZineNative/Features/Today/DailyFeedReviewView.swift
@@ -40,8 +40,7 @@ struct PeopleDailyTodayView: View {
     @ViewBuilder
     private var content: some View {
         if store.isLoading, store.response == nil {
-            ProgressView("Loading Today…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            ZineLoadingView(label: "Loading Today…")
         } else if let error = store.errorMessage, store.response == nil {
             ContentUnavailableView {
                 Label("Today unavailable", systemImage: "exclamationmark.triangle")
@@ -236,8 +235,7 @@ struct PeopleDailySectionView: View {
     var body: some View {
         Group {
             if store.isLoading, store.response == nil {
-                ProgressView("Loading conversations…")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                ZineLoadingView(label: "Loading conversations…")
             } else if let error = store.errorMessage, store.response == nil {
                 ContentUnavailableView {
                     Label("Conversations unavailable", systemImage: "exclamationmark.triangle")
@@ -407,8 +405,7 @@ struct DailyFeedReviewView: View {
     @ViewBuilder
     private var content: some View {
         if store.isLoading, store.response == nil {
-            ProgressView("Loading frozen X posts…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            ZineLoadingView(label: "Loading frozen X posts…")
         } else if let error = store.errorMessage, store.response == nil {
             ContentUnavailableView {
                 Label("Daily View unavailable", systemImage: "exclamationmark.triangle")

--- a/apps/ios/ZineNative/Features/Today/EditorialComponents.swift
+++ b/apps/ios/ZineNative/Features/Today/EditorialComponents.swift
@@ -649,6 +649,7 @@ struct TodayLoadingView: View {
             .padding(20)
             .redacted(reason: .placeholder)
         }
+        .background(ZineTheme.canvas)
         .accessibilityLabel("Loading today’s issue")
     }
 }

--- a/apps/ios/ZineNative/Features/Today/EditorialLabView.swift
+++ b/apps/ios/ZineNative/Features/Today/EditorialLabView.swift
@@ -10,7 +10,7 @@ struct EditorialLabView: View {
         NavigationStack {
             Group {
                 if store.isLoading && store.experiments.isEmpty {
-                    ProgressView("Loading experiments…")
+                    ZineLoadingView(label: "Loading experiments…")
                 } else if let experiment = store.selectedExperiment {
                     experimentContent(experiment)
                 } else {


### PR DESCRIPTION
## Summary

- align navigation, tab, list, and reader safe-area backgrounds with each destination content surface
- give full-screen and list-row loading states explicit semantic backgrounds
- add a deterministic Fresh in Your Inbox loading fixture and document the background contract

## Validation

- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` (86 Vitest tests and 4 preview-target tests)
- `bun run --cwd apps/worker test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"` (1,767 tests)
- focused Xcode tests: 23 passed (`HomeTests` and `ZineThemeTests`)
- signed arm64 device build, install, and launch on Erik’s iPhone
- live simulator UI verification of Fresh in Your Inbox loading state in light and dark mode
- `git diff --check`