### PR TITLE
feat(ios): open featured Home articles in reader

### DIFF
--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -4,6 +4,7 @@ struct HomeNavigationRoute: Hashable {
     enum Destination: Hashable {
         case item(HomeItem)
         case bookmark(Bookmark)
+        case articleReader(HomeItem)
     }
 
     let destination: Destination
@@ -20,6 +21,13 @@ struct HomeNavigationRoute: Hashable {
         HomeNavigationRoute(
             destination: .bookmark(bookmark),
             sourceID: "\(sectionID)-\(bookmark.id)"
+        )
+    }
+
+    static func articleReader(_ item: HomeItem, sectionID: String) -> HomeNavigationRoute {
+        HomeNavigationRoute(
+            destination: .articleReader(item),
+            sourceID: "\(sectionID)-\(item.id)"
         )
     }
 }
@@ -167,7 +175,7 @@ struct HomeFeaturedArticleSection: View {
 
     var body: some View {
         HomeNavigationLink(
-            route: .item(item, sectionID: sectionID),
+            route: .articleReader(item, sectionID: sectionID),
             transitionNamespace: transitionNamespace
         ) {
             VStack(alignment: .leading, spacing: 12) {

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -172,6 +172,26 @@ struct HomeView: View {
                 onBookmarkCommit: { _, _ in onContentChanged() },
                 onExternalOpen: onExternalOpen
             )
+        case .articleReader(let item):
+            ArticleReaderView(
+                metadata: ArticleReaderMetadata(
+                    bookmarkID: item.id,
+                    title: item.title,
+                    creator: item.creator,
+                    creatorImageURL: item.creatorImageUrl,
+                    canonicalURL: item.canonicalUrl,
+                    readingTimeMinutes: item.readingTimeMinutes,
+                    initialProgress: item.progress,
+                    isFinished: false,
+                    tags: []
+                ),
+                client: client,
+                onRead: { onHomeItemExternalOpen(item) },
+                onProgressSaved: { _ in onContentChanged() },
+                onFinishedChanged: { _, _ in onContentChanged() },
+                onFinishedCommit: { _ in onContentChanged() },
+                onTagsChanged: { _ in onContentChanged() }
+            )
         }
     }
 }

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -78,7 +78,57 @@ struct ScreenshotHomeView: View {
         case .bookmark(let bookmark):
             Text(bookmark.title)
                 .navigationTitle(bookmark.title)
+        case .articleReader(let item):
+            fixtureArticleReader(for: item)
         }
+    }
+
+    private func fixtureArticleReader(for item: HomeItem) -> some View {
+        let metadata = ArticleReaderMetadata(
+            bookmarkID: item.id,
+            title: item.title,
+            creator: item.creator,
+            creatorImageURL: item.creatorImageUrl,
+            canonicalURL: item.canonicalUrl,
+            readingTimeMinutes: item.readingTimeMinutes,
+            initialProgress: item.progress,
+            isFinished: false,
+            tags: []
+        )
+        let response = ArticleContentResponse(
+            content: """
+            <p>The next generation of tools will be shaped less by universal workflows and more by software that learns the context, taste, and intent of one person.</p>
+            <h2>Software that adapts to one person</h2>
+            <p>Personal agents change how interfaces should expose context, decisions, and useful next steps. The best tools will make that relationship understandable without making the machinery feel heavy.</p>
+            """,
+            articleBody: ArticleBodyStatus(
+                availability: .available,
+                pipelineStatus: .available,
+                schemaVersion: 1,
+                extractorVersion: 1,
+                sourceKind: "PUBLIC_WEB",
+                contentHash: "home-featured-article-fixture",
+                wordCount: 820,
+                readingTimeMinutes: item.readingTimeMinutes,
+                qualityScore: 0.98,
+                qualityWarnings: [],
+                lastErrorCode: nil,
+                updatedAt: "2026-08-14T12:00:00Z"
+            ),
+            request: nil,
+            requestId: "home-fixture-request",
+            traceId: "home-fixture-trace"
+        )
+
+        return ArticleReaderView(
+            metadata: metadata,
+            client: APIClient(
+                baseURL: URL(string: "https://api.myzine.app")!,
+                tokenProvider: { "fixture-token" }
+            ),
+            initialPhase: .ready(ArticleReaderDocument(metadata: metadata, response: response)),
+            loadsOnAppear: false
+        )
     }
 }
 

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -92,6 +92,7 @@ struct ArticleReaderView: View {
             }
         }
         .toolbarVisibility(.hidden, for: .navigationBar)
+        .toolbarVisibility(.hidden, for: .tabBar)
         .task(id: store.metadata.bookmarkID) {
             guard loadsOnAppear else { return }
             await store.load()

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -276,6 +276,14 @@ final class HomeTests: XCTestCase {
         )
     }
 
+    func testFeaturedArticleRouteOpensArticleReaderDirectly() {
+        let article = makeHomeItem(id: "featured", minutes: 8, summary: "Useful context.")
+        let route = HomeNavigationRoute.articleReader(article, sectionID: "featured-article")
+
+        XCTAssertEqual(route.destination, .articleReader(article))
+        XCTAssertEqual(route.sourceID, "featured-article-featured")
+    }
+
     func testContentSpecificHomeListsStartWithTheirMatchingFormatSelected() {
         XCTAssertEqual(HomeSectionRoute.podcasts.initialContentTypeFilter, .podcast)
         XCTAssertEqual(HomeSectionRoute.articles.initialContentTypeFilter, .article)


### PR DESCRIPTION
## Summary

- route the featured article card beneath the top Home card directly into the native article reader
- preserve article metadata, progress, completion, tags, and external-open callbacks in the direct reader path
- hide the tab bar while reading and add deterministic screenshot/test coverage for the new route

## Validation

- focused native Home and article-reader tests: 37 passed
- signed Release device build with xcodebuild: passed
- codesign --verify --deep --strict: passed
- physical iPhone install and launch with xcrun devicectl: passed
- bun run format:check: passed
- bun run design-system:check: passed
- bun run typecheck: passed
- bun run test:web: 86 tests passed plus 4 preview-target tests
- bun run test:worker:ci: 1,769 tests passed
- git diff --check: passed