### PR TITLE
perf(ios): warm article reader content

### DIFF
--- a/apps/ios/ZineNative/Core/API/APIClient.swift
+++ b/apps/ios/ZineNative/Core/API/APIClient.swift
@@ -35,6 +35,7 @@ struct APIClient {
     let tokenProvider: TokenProvider
     var session: URLSession
     private let articleBodyCache: ArticleBodyCache?
+    private let articleContentRequests: ArticleContentRequestCoordinator
 
     init(
         baseURL: URL,
@@ -46,6 +47,7 @@ struct APIClient {
         self.tokenProvider = tokenProvider
         self.session = session
         self.articleBodyCache = articleBodyCache
+        articleContentRequests = ArticleContentRequestCoordinator()
     }
 
     func getHome() async throws -> HomeResponse {
@@ -391,9 +393,31 @@ struct APIClient {
     }
 
     func getArticleContent(id: String) async throws -> ArticleContentResponse {
-        try await request(
-            url: baseURL.appending(path: "/api/v1/bookmarks/\(id)/article-content")
-        )
+        let url = baseURL.appending(path: "/api/v1/bookmarks/\(id)/article-content")
+        return try await articleContentRequests.response(
+            bookmarkID: id,
+            purpose: .reader
+        ) {
+            try await request(url: url)
+        }
+    }
+
+    func warmArticleContent(id: String) async throws {
+        if let cached = await cachedArticleContent(id: id),
+           cached.readableContent != nil
+        {
+            return
+        }
+
+        let url = baseURL.appending(path: "/api/v1/bookmarks/\(id)/article-content")
+        let response = try await articleContentRequests.response(
+            bookmarkID: id,
+            purpose: .warmup
+        ) {
+            try await request(url: url)
+        }
+        try Task.checkCancellation()
+        await cacheArticleContent(response, id: id)
     }
 
     func requestArticleContent(id: String) async throws -> ArticleContentResponse {

--- a/apps/ios/ZineNative/Core/Persistence/ArticleBodyCache.swift
+++ b/apps/ios/ZineNative/Core/Persistence/ArticleBodyCache.swift
@@ -72,3 +72,153 @@ actor ArticleBodyCache {
         }
     }
 }
+
+actor ArticleContentRequestCoordinator {
+    enum Purpose {
+        case warmup
+        case reader
+    }
+
+    private struct InFlightRequest {
+        let id: UUID
+        let task: Task<ArticleContentResponse, Error>
+        var waiterIDs: Set<UUID>
+        let startedByWarmup: Bool
+        var hasReader: Bool
+    }
+
+    private struct WarmedResponse {
+        let response: ArticleContentResponse
+        let storedAt: Date
+    }
+
+    private static let maximumWarmedResponses = 8
+
+    private var inFlightRequests: [String: InFlightRequest] = [:]
+    private var warmedResponses: [String: WarmedResponse] = [:]
+
+    func response(
+        bookmarkID: String,
+        purpose: Purpose,
+        fetch: @escaping () async throws -> ArticleContentResponse
+    ) async throws -> ArticleContentResponse {
+        if purpose == .reader,
+           let warmed = warmedResponses.removeValue(forKey: bookmarkID)
+        {
+            return warmed.response
+        }
+
+        let waiterID = UUID()
+        let requestID: UUID
+        let task: Task<ArticleContentResponse, Error>
+
+        if var inFlight = inFlightRequests[bookmarkID] {
+            inFlight.waiterIDs.insert(waiterID)
+            if purpose == .reader {
+                inFlight.hasReader = true
+            }
+            inFlightRequests[bookmarkID] = inFlight
+            requestID = inFlight.id
+            task = inFlight.task
+        } else {
+            requestID = UUID()
+            task = Task {
+                try await fetch()
+            }
+            inFlightRequests[bookmarkID] = InFlightRequest(
+                id: requestID,
+                task: task,
+                waiterIDs: [waiterID],
+                startedByWarmup: purpose == .warmup,
+                hasReader: purpose == .reader
+            )
+        }
+
+        return try await withTaskCancellationHandler {
+            do {
+                let response = try await task.value
+                try Task.checkCancellation()
+                completeWaiter(
+                    waiterID,
+                    requestID: requestID,
+                    bookmarkID: bookmarkID,
+                    response: response
+                )
+                return response
+            } catch {
+                completeWaiter(
+                    waiterID,
+                    requestID: requestID,
+                    bookmarkID: bookmarkID,
+                    response: nil
+                )
+                throw error
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(
+                    waiterID,
+                    requestID: requestID,
+                    bookmarkID: bookmarkID
+                )
+            }
+        }
+    }
+
+    private func completeWaiter(
+        _ waiterID: UUID,
+        requestID: UUID,
+        bookmarkID: String,
+        response: ArticleContentResponse?
+    ) {
+        guard var inFlight = inFlightRequests[bookmarkID],
+              inFlight.id == requestID,
+              inFlight.waiterIDs.remove(waiterID) != nil
+        else { return }
+
+        if let response,
+           response.readableContent != nil,
+           inFlight.startedByWarmup,
+           !inFlight.hasReader
+        {
+            warmedResponses[bookmarkID] = WarmedResponse(
+                response: response,
+                storedAt: Date()
+            )
+            pruneWarmedResponses()
+        }
+
+        if inFlight.waiterIDs.isEmpty {
+            inFlightRequests.removeValue(forKey: bookmarkID)
+        } else {
+            inFlightRequests[bookmarkID] = inFlight
+        }
+    }
+
+    private func cancelWaiter(
+        _ waiterID: UUID,
+        requestID: UUID,
+        bookmarkID: String
+    ) {
+        guard var inFlight = inFlightRequests[bookmarkID],
+              inFlight.id == requestID,
+              inFlight.waiterIDs.remove(waiterID) != nil
+        else { return }
+
+        if inFlight.waiterIDs.isEmpty {
+            inFlight.task.cancel()
+            inFlightRequests.removeValue(forKey: bookmarkID)
+        } else {
+            inFlightRequests[bookmarkID] = inFlight
+        }
+    }
+
+    private func pruneWarmedResponses() {
+        guard warmedResponses.count > Self.maximumWarmedResponses else { return }
+        let retainedKeys = warmedResponses
+            .sorted { $0.value.storedAt > $1.value.storedAt }
+            .prefix(Self.maximumWarmedResponses)
+            .map(\.key)
+        warmedResponses = warmedResponses.filter { retainedKeys.contains($0.key) }
+    }
+}

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -234,6 +234,10 @@ struct BookmarkDetailView: View {
         .task(id: content.id) {
             await hydrateSubscriptionSettings()
         }
+        .task(id: articleWarmupID) {
+            guard let articleWarmupID else { return }
+            try? await client.warmArticleContent(id: articleWarmupID)
+        }
         .alert("Couldn’t update", isPresented: Binding(
             get: { errorMessage != nil },
             set: { if !$0 { errorMessage = nil } }
@@ -350,6 +354,13 @@ struct BookmarkDetailView: View {
                     .padding(.trailing, 8)
             }
         }
+    }
+
+    private var articleWarmupID: String? {
+        guard content.provider.opensInZineReader(contentType: content.contentType) else {
+            return nil
+        }
+        return content.id
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNativeTests/ArticleReaderTests.swift
+++ b/apps/ios/ZineNativeTests/ArticleReaderTests.swift
@@ -197,6 +197,91 @@ final class ArticleReaderTests: XCTestCase {
     }
 
     @MainActor
+    func testWarmupMakesReaderReadyWithoutASecondArticleContentRequest() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "article-warmup-\(UUID().uuidString)", directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let client = Self.client(
+            articleBodyCache: ArticleBodyCache(userID: "warm-user", baseDirectory: directory)
+        ) { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/v1/bookmarks/bookmark-1/article-content")
+            return (200, Self.availableJSON)
+        }
+
+        try await client.warmArticleContent(id: "bookmark-1")
+        let store = ArticleReaderStore(metadata: Self.metadata(), client: client)
+        await store.load()
+
+        guard case let .ready(document) = store.phase else {
+            return XCTFail("Expected a ready reader, got \(store.phase)")
+        }
+        XCTAssertEqual(document.response.articleBody.contentHash, "hash-1")
+        XCTAssertEqual(ArticleReaderURLProtocol.requests.count, 1)
+    }
+
+    func testReaderJoinsAnInFlightWarmupRequest() async throws {
+        let response = try JSONDecoder().decode(
+            ArticleContentResponse.self,
+            from: Data(Self.availableJSON.utf8)
+        )
+        let coordinator = ArticleContentRequestCoordinator()
+        let gate = ArticleRequestGate()
+        let fetchStarted = expectation(description: "article content fetch started")
+        fetchStarted.assertForOverFulfill = true
+        let fetch = {
+            fetchStarted.fulfill()
+            await gate.wait()
+            return response
+        }
+
+        let warmup = Task {
+            try await coordinator.response(
+                bookmarkID: "bookmark-1",
+                purpose: .warmup,
+                fetch: fetch
+            )
+        }
+        await fulfillment(of: [fetchStarted], timeout: 1)
+        let reader = Task {
+            try await coordinator.response(
+                bookmarkID: "bookmark-1",
+                purpose: .reader,
+                fetch: fetch
+            )
+        }
+        await Task.yield()
+        await gate.open()
+
+        let warmedResponse = try await warmup.value
+        let readerResponse = try await reader.value
+        XCTAssertEqual(warmedResponse.articleBody.contentHash, "hash-1")
+        XCTAssertEqual(readerResponse.articleBody.contentHash, "hash-1")
+    }
+
+    func testWarmupOnlyGetsStoredContentAndDoesNotCacheAnUnreadableResponse() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "article-warmup-\(UUID().uuidString)", directoryHint: .isDirectory)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cache = ArticleBodyCache(userID: "warm-user", baseDirectory: directory)
+        let client = Self.client(articleBodyCache: cache) { request in
+            return (200, Self.unavailableJSON)
+        }
+
+        try await client.warmArticleContent(id: "bookmark-1")
+
+        XCTAssertEqual(ArticleReaderURLProtocol.requests.count, 1)
+        XCTAssertEqual(ArticleReaderURLProtocol.requests.first?.httpMethod, "GET")
+        XCTAssertEqual(
+            ArticleReaderURLProtocol.requests.first?.url?.path,
+            "/api/v1/bookmarks/bookmark-1/article-content"
+        )
+        let cached = await cache.load(bookmarkID: "bookmark-1")
+        XCTAssertNil(cached)
+    }
+
+    @MainActor
     func testStoreLoadsAnAvailableArticleWithoutRequestingAgain() async throws {
         let client = Self.client { request in
             XCTAssertEqual(request.httpMethod, "GET")
@@ -342,6 +427,7 @@ final class ArticleReaderTests: XCTestCase {
     }
 
     private static func client(
+        articleBodyCache: ArticleBodyCache? = nil,
         handler: @escaping (URLRequest) throws -> (Int, String)
     ) -> APIClient {
         ArticleReaderURLProtocol.handler = handler
@@ -351,7 +437,8 @@ final class ArticleReaderTests: XCTestCase {
         return APIClient(
             baseURL: URL(string: "https://api.myzine.app")!,
             tokenProvider: { "test-token" },
-            session: URLSession(configuration: configuration)
+            session: URLSession(configuration: configuration),
+            articleBodyCache: articleBodyCache
         )
     }
 
@@ -441,4 +528,23 @@ private final class ArticleReaderURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+}
+
+private actor ArticleRequestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        pending.forEach { $0.resume() }
+    }
 }


### PR DESCRIPTION
## Summary

- warm eligible stored article bodies while bookmark detail is open
- share completed and in-flight GET results with the reader while preserving cancellation
- keep extraction, polling, opened events, and progress writes exclusive to explicit reader opens
- cache only readable bodies within existing bounded storage conventions

## Validation

- ArticleReaderTests: 20 passed
- git diff check: passed
- pre-push format check: passed
- pre-push design-system check: passed
- pre-push typecheck: 14 tasks passed
- pre-push web tests: 90 passed
- pre-push worker tests: 1,769 passed