### PR TITLE
feat(ios): redesign settings and keep tab bar visible

### DIFF
--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -39,12 +39,12 @@ the surrounding theme changes.
   replace native scroll-edge behavior and shadows through UIKit appearance
   customization. Native floating controls may retain their system material;
   immersive destinations still own tab-bar visibility.
-- Keep the root tab bar and ordinary screen navigation bars explicitly visible.
-  Visibility and semantic item tint are separate from the system-managed bar
-  material; hiding either bar must remain scoped to an immersive destination.
-  Each tab's root screen must reset tab-bar visibility to automatic so an
-  interactive pop cannot leave behind hidden state from the departing
-  destination while immersive detail views can still hide it locally.
+- Keep the root tab bar visibly overlaid above content across pushed bookmark
+  details and the article reader. Visibility and semantic item tint are
+  separate from the system-managed bar material. Do not hide the tab bar from a
+  pushed destination: an interactive pop can otherwise leave the tab shell in
+  the departing destination's hidden state. Root and pushed reading surfaces
+  use the shared persistent tab-bar visibility contract.
 - Do not scatter raw hex, RGB, `Color.primary`, or `Color.secondary` values
   through supported native views. If the product needs a new reusable role,
   add it to `ZineTheme.Role`, define both appearances, and update

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 import UIKit
 
+enum ZineNavigationSurface: CaseIterable {
+    case root
+    case bookmarkDetail
+    case articleReader
+}
+
+enum ZineTabBarVisibilityContract {
+    static func keepsTabBarVisible(on surface: ZineNavigationSurface) -> Bool {
+        switch surface {
+        case .root, .bookmarkDetail, .articleReader:
+            true
+        }
+    }
+}
+
 enum ZineTheme {
     enum Role: CaseIterable, Hashable {
         case canvas
@@ -121,11 +136,20 @@ extension View {
             .tint(ZineTheme.brandAccent)
             .toolbarBackground(ZineTheme.canvas, for: .navigationBar)
             .toolbar(.visible, for: .navigationBar)
+            .zineTabBarVisibility(for: .root)
     }
 
     func zineTabShellChrome() -> some View {
         tint(ZineTheme.brandAccent)
             .background(ZineTheme.canvas)
             .toolbarBackground(ZineTheme.canvas, for: .tabBar)
+            .zineTabBarVisibility(for: .root)
+    }
+
+    func zineTabBarVisibility(for surface: ZineNavigationSurface) -> some View {
+        toolbarVisibility(
+            ZineTabBarVisibilityContract.keepsTabBarVisible(on: surface) ? .visible : .hidden,
+            for: .tabBar
+        )
     }
 }

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -225,7 +225,7 @@ struct BookmarkDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarVisibility(.hidden, for: .tabBar)
+        .zineTabBarVisibility(for: .bookmarkDetail)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task(id: content.id) {

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -92,7 +92,7 @@ struct ArticleReaderView: View {
             }
         }
         .toolbarVisibility(.hidden, for: .navigationBar)
-        .toolbarVisibility(.hidden, for: .tabBar)
+        .zineTabBarVisibility(for: .articleReader)
         .task(id: store.metadata.bookmarkID) {
             guard loadsOnAppear else { return }
             await store.load()

--- a/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
+++ b/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
@@ -1,49 +1,331 @@
 import ClerkKit
 import ClerkKitUI
+import Observation
 import SwiftUI
 
-private enum SettingsRoute: Hashable {
-    case subscriptions
+enum SettingsRoute: CaseIterable, Hashable {
+    case sources
     case appearance
+}
+
+@MainActor
+@Observable
+final class SettingsStore {
+    var isSignOutConfirmationPresented = false
+    private(set) var isSigningOut = false
+    private(set) var signOutError: String?
+
+    func requestSignOut() {
+        isSignOutConfirmationPresented = true
+    }
+
+    func cancelSignOut() {
+        isSignOutConfirmationPresented = false
+    }
+
+    func signOut(using action: () async throws -> Void) async {
+        isSignOutConfirmationPresented = false
+        isSigningOut = true
+        signOutError = nil
+        defer { isSigningOut = false }
+
+        do {
+            try await action()
+        } catch is CancellationError {
+            return
+        } catch {
+            signOutError = error.localizedDescription
+        }
+    }
+
+    func dismissSignOutError() {
+        signOutError = nil
+    }
 }
 
 struct AppSettingsView: View {
     let client: APIClient
 
     @Environment(Clerk.self) private var clerk
+    @State private var store = SettingsStore()
 
     var body: some View {
-        if clerk.session?.tasks?.isEmpty == false {
-            AuthView(isDismissible: false)
-        } else {
-            UserProfileView(isDismissible: false)
-                .userProfileRows([
-                    UserProfileCustomRow(
-                        route: SettingsRoute.subscriptions,
-                        title: "Subscriptions",
-                        icon: .system(name: "rectangle.stack.badge.person.crop"),
-                        placement: .before(.signOut)
-                    ),
-                    UserProfileCustomRow(
-                        route: SettingsRoute.appearance,
-                        title: "Appearance",
-                        icon: .system(name: "circle.lefthalf.filled"),
-                        placement: .before(.signOut)
-                    ),
-                ])
-                .userProfileDestination { route in
-                    switch route {
-                    case .subscriptions:
-                        SubscriptionsView(client: client)
-                    case .appearance:
-                        AppearanceSettingsView()
+        NavigationStack {
+            Group {
+                if clerk.session?.tasks?.isEmpty == false {
+                    AuthView(isDismissible: false)
+                } else {
+                    settingsContent
+                }
+            }
+            .navigationDestination(for: SettingsRoute.self) { route in
+                switch route {
+                case .sources:
+                    SubscriptionsView(client: client)
+                case .appearance:
+                    AppearanceSettingsView()
+                }
+            }
+        }
+        .zineScreenChrome()
+        .confirmationDialog(
+            "Sign out of Zine?",
+            isPresented: $store.isSignOutConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Sign Out", role: .destructive) {
+                Task {
+                    await store.signOut {
+                        try await clerk.auth.signOut()
                     }
                 }
+            }
+            Button("Cancel", role: .cancel) {
+                store.cancelSignOut()
+            }
+        } message: {
+            Text("You’ll need to sign in again to sync your library and sources on this device.")
         }
+        .alert("Couldn’t sign out", isPresented: signOutErrorBinding) {
+            Button("OK", role: .cancel) { store.dismissSignOutError() }
+        } message: {
+            Text(store.signOutError ?? "Please try again.")
+        }
+    }
+
+    private var settingsContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                settingsHeader
+                accountCard
+
+                VStack(alignment: .leading, spacing: 12) {
+                    settingsSectionTitle("Your Zine")
+                    sourcesCard
+                    appearanceCard
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    settingsSectionTitle("Account")
+                    signOutButton
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 18)
+            .padding(.bottom, 36)
+        }
+        .background(ZineTheme.canvas)
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .zineTabBarVisibility(for: .root)
+    }
+
+    private var settingsHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("MAKE IT YOURS")
+                .font(.system(.caption, design: .rounded, weight: .bold))
+                .tracking(1.4)
+                .foregroundStyle(ZineTheme.brandAccent)
+
+            Text("Your reading,\nyour sources.")
+                .font(.system(size: 38, weight: .bold, design: .rounded))
+                .foregroundStyle(ZineTheme.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Shape what arrives in Zine and how the app feels on this device.")
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(ZineTheme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var accountCard: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                Circle().fill(ZineTheme.raised)
+                Text(accountInitials)
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+            }
+            .frame(width: 52, height: 52)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(accountName)
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+                Text(accountDetail)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Image(systemName: "checkmark.seal.fill")
+                .font(.title3)
+                .foregroundStyle(ZineTheme.brandAccent)
+                .accessibilityLabel("Signed in")
+        }
+        .padding(18)
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 20))
+        .overlay {
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(ZineTheme.border.opacity(0.7), lineWidth: 1)
+        }
+    }
+
+    private var sourcesCard: some View {
+        NavigationLink(value: SettingsRoute.sources) {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack(alignment: .top) {
+                    SettingsIconTile(systemImage: "dot.radiowaves.up.forward", isPrimary: true)
+                    Spacer()
+                    Image(systemName: "arrow.up.right")
+                        .font(.system(.headline, design: .rounded, weight: .bold))
+                        .foregroundStyle(ZineTheme.brandAccent)
+                }
+
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("Sources")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(ZineTheme.primaryText)
+                    Text("Connect the places you follow and decide what flows into your Inbox and Library.")
+                        .font(.system(.subheadline, design: .rounded))
+                        .foregroundStyle(ZineTheme.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack(spacing: 8) {
+                    sourceChip("play.rectangle.fill")
+                    sourceChip("waveform.circle.fill")
+                    sourceChip("envelope.fill")
+                    sourceChip("bookmark.square.fill")
+                    sourceChip("dot.radiowaves.left.and.right")
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 22))
+            .overlay {
+                RoundedRectangle(cornerRadius: 22)
+                    .stroke(ZineTheme.border.opacity(0.75), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settings-sources")
+    }
+
+    private var appearanceCard: some View {
+        NavigationLink(value: SettingsRoute.appearance) {
+            HStack(spacing: 14) {
+                SettingsIconTile(systemImage: "circle.lefthalf.filled", isPrimary: false)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Appearance")
+                        .font(.system(.headline, design: .rounded, weight: .bold))
+                        .foregroundStyle(ZineTheme.primaryText)
+                    Text("System, light, or dark")
+                        .font(.system(.subheadline, design: .rounded))
+                        .foregroundStyle(ZineTheme.secondaryText)
+                }
+
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(ZineTheme.tertiaryText)
+            }
+            .padding(16)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(ZineTheme.border.opacity(0.65), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settings-appearance")
+    }
+
+    private var signOutButton: some View {
+        Button(role: .destructive) {
+            store.requestSignOut()
+        } label: {
+            HStack {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                Text(store.isSigningOut ? "Signing Out…" : "Sign Out")
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                Spacer()
+            }
+            .padding(17)
+            .frame(maxWidth: .infinity)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(Color.red.opacity(0.34), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(Color.red)
+        .disabled(store.isSigningOut)
+        .accessibilityIdentifier("settings-sign-out")
+    }
+
+    private func settingsSectionTitle(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(.caption2, design: .rounded, weight: .bold))
+            .tracking(1.2)
+            .foregroundStyle(ZineTheme.tertiaryText)
+            .padding(.leading, 3)
+    }
+
+    private func sourceChip(_ systemImage: String) -> some View {
+        Image(systemName: systemImage)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(ZineTheme.primaryText)
+            .frame(width: 34, height: 30)
+            .background(ZineTheme.raised, in: .rect(cornerRadius: 9))
+    }
+
+    private var accountName: String {
+        let components = [clerk.user?.firstName, clerk.user?.lastName]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return components.isEmpty ? "Zine Reader" : components.joined(separator: " ")
+    }
+
+    private var accountDetail: String {
+        clerk.user?.primaryEmailAddress?.emailAddress ?? "Signed in to Zine"
+    }
+
+    private var accountInitials: String {
+        let initials = accountName.split(separator: " ").prefix(2).compactMap(\.first)
+        return initials.isEmpty ? "Z" : String(initials)
+    }
+
+    private var signOutErrorBinding: Binding<Bool> {
+        Binding(
+            get: { store.signOutError != nil },
+            set: { if !$0 { store.dismissSignOutError() } }
+        )
     }
 }
 
-private struct AppearanceSettingsView: View {
+private struct SettingsIconTile: View {
+    let systemImage: String
+    let isPrimary: Bool
+
+    var body: some View {
+        Image(systemName: systemImage)
+            .font(.system(size: isPrimary ? 23 : 18, weight: .bold))
+            .foregroundStyle(isPrimary ? ZineTheme.onAccent : ZineTheme.primaryText)
+            .frame(width: isPrimary ? 48 : 42, height: isPrimary ? 48 : 42)
+            .background(
+                isPrimary ? ZineTheme.brandAccent : ZineTheme.raised,
+                in: .rect(cornerRadius: isPrimary ? 15 : 13)
+            )
+    }
+}
+
+struct AppearanceSettingsView: View {
     @AppStorage(AppAppearance.storageKey) private var storedAppearance = AppAppearance.system.rawValue
 
     private var selection: Binding<AppAppearance> {
@@ -54,31 +336,66 @@ private struct AppearanceSettingsView: View {
     }
 
     var body: some View {
-        List {
-            Section {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Choose how Zine looks on this device. System follows your iPhone’s appearance setting.")
+                    .font(.system(.body, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+                    .padding(.bottom, 8)
+
                 ForEach(AppAppearance.allCases) { appearance in
                     Button {
                         selection.wrappedValue = appearance
                     } label: {
-                        Label(appearance.title, systemImage: appearance.systemImage)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .contentShape(.rect)
-                            .overlay(alignment: .trailing) {
-                                if selection.wrappedValue == appearance {
-                                    Image(systemName: "checkmark")
-                                        .fontWeight(.semibold)
-                                }
-                            }
+                        HStack(spacing: 14) {
+                            Image(systemName: appearance.systemImage)
+                                .font(.title3.weight(.semibold))
+                                .foregroundStyle(
+                                    selection.wrappedValue == appearance
+                                        ? ZineTheme.brandAccent
+                                        : ZineTheme.primaryText
+                                )
+                                .frame(width: 42, height: 42)
+                                .background(ZineTheme.raised, in: .rect(cornerRadius: 13))
+
+                            Text(appearance.title)
+                                .font(.system(.headline, design: .rounded, weight: .bold))
+                                .foregroundStyle(ZineTheme.primaryText)
+
+                            Spacer()
+
+                            Image(
+                                systemName: selection.wrappedValue == appearance
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                            )
+                            .font(.title3)
+                            .foregroundStyle(
+                                selection.wrappedValue == appearance
+                                    ? ZineTheme.brandAccent
+                                    : ZineTheme.tertiaryText
+                            )
+                        }
+                        .padding(16)
+                        .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 18)
+                                .stroke(
+                                    selection.wrappedValue == appearance
+                                        ? ZineTheme.brandAccent
+                                        : ZineTheme.border.opacity(0.65),
+                                    lineWidth: selection.wrappedValue == appearance ? 1.5 : 1
+                                )
+                        }
                     }
                     .buttonStyle(.plain)
                 }
-            } footer: {
-                Text("System follows your iPhone’s appearance setting.")
             }
+            .padding(18)
         }
-        .scrollContentBackground(.hidden)
         .background(ZineTheme.canvas)
         .navigationTitle("Appearance")
         .navigationBarTitleDisplayMode(.inline)
+        .zineScreenChrome()
     }
 }

--- a/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/NewsletterSubscriptionsView.swift
@@ -187,6 +187,17 @@ struct NewsletterSubscriptionsView: View {
 
     private var newsletterList: some View {
         List {
+            Section {
+                SourceDetailHero(
+                    source: .gmail,
+                    title: "Newsletters",
+                    detail: SubscriptionSource.gmail.connectedDescription,
+                    status: connectionLabel,
+                    needsAttention: store.response?.connection?.needsAttention == true
+                )
+                .sourceHeroRow()
+            }
+
             connectionSection
 
             if store.response?.connection?.isActive != true {
@@ -197,6 +208,7 @@ struct NewsletterSubscriptionsView: View {
                         description: Text("Connect Gmail with read-only access to detect and manage newsletters.")
                     )
                 }
+                .sourceManagementRow()
             } else if filteredFeeds.isEmpty {
                 Section {
                     ContentUnavailableView(
@@ -209,14 +221,15 @@ struct NewsletterSubscriptionsView: View {
                         )
                     )
                 }
+                .sourceManagementRow()
             } else {
                 Section("Newsletters") {
                     ForEach(filteredFeeds) { feed in newsletterRow(feed) }
                 }
+                .sourceManagementRow()
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
+        .sourceManagementListStyle()
         .refreshable { await store.reload() }
     }
 
@@ -252,6 +265,7 @@ struct NewsletterSubscriptionsView: View {
                 }
             }
         }
+        .sourceManagementRow()
     }
 
     private var connectionLabel: String {
@@ -279,9 +293,11 @@ struct NewsletterSubscriptionsView: View {
             .clipShape(.circle)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(feed.displayName).lineLimit(2)
+                Text(feed.displayName)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .lineLimit(2)
                 Text(feed.fromAddress ?? feed.status.title)
-                    .font(.caption)
+                    .font(.system(.caption, design: .rounded))
                     .foregroundStyle(ZineTheme.secondaryText)
                     .lineLimit(1)
             }

--- a/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/ProviderSubscriptionsView.swift
@@ -102,6 +102,17 @@ struct ProviderSubscriptionsView: View {
 
     private var subscriptionList: some View {
         List {
+            Section {
+                SourceDetailHero(
+                    source: provider,
+                    title: provider.title,
+                    detail: provider.connectedDescription,
+                    status: connectionLabel,
+                    needsAttention: store.connection?.needsAttention == true
+                )
+                .sourceHeroRow()
+            }
+
             connectionSection
 
             if store.connectionRequired || store.connection?.isActive != true {
@@ -114,6 +125,7 @@ struct ProviderSubscriptionsView: View {
                         )
                     )
                 }
+                .sourceManagementRow()
             } else if filteredItems.isEmpty {
                 Section {
                     ContentUnavailableView(
@@ -126,14 +138,15 @@ struct ProviderSubscriptionsView: View {
                         )
                     )
                 }
+                .sourceManagementRow()
             } else {
                 Section(provider == .youtube ? "Channels" : "Shows") {
                     ForEach(filteredItems) { item in itemRow(item) }
                 }
+                .sourceManagementRow()
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
+        .sourceManagementListStyle()
         .refreshable { await store.reload() }
     }
 
@@ -169,6 +182,7 @@ struct ProviderSubscriptionsView: View {
                 }
             }
         }
+        .sourceManagementRow()
     }
 
     private var connectionLabel: String {
@@ -196,9 +210,11 @@ struct ProviderSubscriptionsView: View {
             .clipShape(.circle)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(item.name).lineLimit(2)
+                Text(item.name)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .lineLimit(2)
                 Text(item.status?.title ?? "Available to add")
-                    .font(.caption)
+                    .font(.system(.caption, design: .rounded))
                     .foregroundStyle(
                         item.status == .active || item.status == nil
                             ? ZineTheme.secondaryText

--- a/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/RssSubscriptionsView.swift
@@ -168,6 +168,16 @@ struct RssSubscriptionsView: View {
     private var feedList: some View {
         List {
             Section {
+                SourceDetailHero(
+                    source: .rss,
+                    title: "RSS Feeds",
+                    detail: SubscriptionSource.rss.connectedDescription,
+                    status: rssStatus
+                )
+                .sourceHeroRow()
+            }
+
+            Section {
                 HStack {
                     TextField("https://example.com/feed.xml", text: $feedURL)
                         .keyboardType(.URL)
@@ -190,6 +200,7 @@ struct RssSubscriptionsView: View {
             } footer: {
                 Text("RSS connects directly—no external account is required.")
             }
+            .sourceManagementRow()
 
             if filteredFeeds.isEmpty {
                 Section {
@@ -203,14 +214,15 @@ struct RssSubscriptionsView: View {
                         )
                     )
                 }
+                .sourceManagementRow()
             } else {
                 Section("Feeds") {
                     ForEach(filteredFeeds) { feed in feedRow(feed) }
                 }
+                .sourceManagementRow()
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
+        .sourceManagementListStyle()
         .refreshable { await store.reload() }
     }
 
@@ -227,9 +239,11 @@ struct RssSubscriptionsView: View {
             .clipShape(.circle)
 
             VStack(alignment: .leading, spacing: 3) {
-                Text(feed.title).lineLimit(2)
+                Text(feed.title)
+                    .font(.system(.body, design: .rounded, weight: .semibold))
+                    .lineLimit(2)
                 Text(feed.status.title)
-                    .font(.caption)
+                    .font(.system(.caption, design: .rounded))
                     .foregroundStyle(
                         feed.status == .active ? ZineTheme.secondaryText : ZineTheme.brandAccent
                     )
@@ -269,6 +283,11 @@ struct RssSubscriptionsView: View {
             }
         }
         .padding(.vertical, 3)
+    }
+
+    private var rssStatus: String {
+        let active = store.response?.stats.active ?? 0
+        return active == 1 ? "1 active feed" : "\(active) active feeds"
     }
 
     private var messageBinding: Binding<Bool> {

--- a/apps/ios/ZineNative/Features/Subscriptions/SourceManagementComponents.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SourceManagementComponents.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct SourceDetailHero: View {
+    let source: SubscriptionSource
+    let title: String
+    let detail: String
+    var status: String?
+    var needsAttention = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 15) {
+            Image(systemName: source.systemImage)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(ZineTheme.onAccent)
+                .frame(width: 50, height: 50)
+                .background(ZineTheme.brandAccent, in: .rect(cornerRadius: 15))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.system(.title3, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+                Text(detail)
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let status {
+                    SourceStatusPill(text: status, needsAttention: needsAttention)
+                        .padding(.top, 2)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(18)
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 20))
+        .overlay {
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(ZineTheme.border.opacity(0.7), lineWidth: 1)
+        }
+    }
+}
+
+struct SourceStatusPill: View {
+    let text: String
+    var needsAttention = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(needsAttention ? ZineTheme.brandAccent : statusColor)
+                .frame(width: 7, height: 7)
+            Text(text)
+                .font(.system(.caption2, design: .rounded, weight: .bold))
+        }
+        .foregroundStyle(needsAttention ? ZineTheme.brandAccent : ZineTheme.secondaryText)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(ZineTheme.raised, in: .capsule)
+    }
+
+    private var statusColor: Color {
+        text.localizedCaseInsensitiveContains("connected")
+            || text.localizedCaseInsensitiveContains("active")
+            ? .green
+            : ZineTheme.secondaryText
+    }
+}
+
+extension View {
+    func sourceManagementListStyle() -> some View {
+        listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .environment(\.defaultMinListRowHeight, 48)
+    }
+
+    func sourceManagementRow() -> some View {
+        listRowBackground(ZineTheme.surface)
+    }
+
+    func sourceHeroRow() -> some View {
+        listRowInsets(EdgeInsets(top: 8, leading: 18, bottom: 8, trailing: 18))
+            .listRowBackground(ZineTheme.canvas)
+            .listRowSeparator(.hidden)
+    }
+}

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionModels.swift
@@ -58,6 +58,22 @@ enum SubscriptionSource: String, CaseIterable, Decodable, Hashable, Identifiable
         case .rss: "RSS feeds sync directly without an external account."
         }
     }
+
+    var destination: SubscriptionDestination {
+        switch self {
+        case .youtube, .spotify: .providerSubscriptions
+        case .gmail: .newsletters
+        case .x: .xBookmarks
+        case .rss: .rssFeeds
+        }
+    }
+}
+
+enum SubscriptionDestination: Equatable {
+    case providerSubscriptions
+    case newsletters
+    case xBookmarks
+    case rssFeeds
 }
 
 enum ProviderSubscriptionStatus: String, Decodable {

--- a/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/SubscriptionsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @MainActor
 @Observable
-private final class SubscriptionsHubStore {
+final class SubscriptionsHubStore {
     private(set) var sources: [SubscriptionSourceSummary] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
@@ -48,33 +48,20 @@ struct SubscriptionsView: View {
     var body: some View {
         Group {
             if store.isLoading && store.sources.isEmpty {
-                ZineLoadingView(label: "Loading subscriptions…")
+                ZineLoadingView(label: "Loading sources…")
             } else if let error = store.errorMessage, store.sources.isEmpty {
                 ContentUnavailableView {
-                    Label("Subscriptions unavailable", systemImage: "exclamationmark.triangle")
+                    Label("Sources unavailable", systemImage: "exclamationmark.triangle")
                 } description: {
                     Text(error)
                 } actions: {
                     Button("Try again") { Task { await store.reload() } }
                 }
             } else {
-                List {
-                    Section {
-                        ForEach(orderedSources) { summary in
-                            NavigationLink(value: summary.provider) {
-                                subscriptionSourceRow(summary)
-                            }
-                        }
-                    } footer: {
-                        Text("Connect accounts and choose what Zine should sync from each source.")
-                    }
-                }
-                .scrollContentBackground(.hidden)
-                .background(ZineTheme.canvas)
-                .refreshable { await store.reload() }
+                dashboard
             }
         }
-        .navigationTitle("Subscriptions")
+        .navigationTitle("Sources")
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(for: SubscriptionSource.self) { source in
             destination(for: source)
@@ -83,42 +70,200 @@ struct SubscriptionsView: View {
         .zineScreenChrome()
     }
 
-    private var orderedSources: [SubscriptionSourceSummary] {
-        let byProvider = Dictionary(uniqueKeysWithValues: store.sources.map { ($0.provider, $0) })
-        return SubscriptionSource.allCases.compactMap { byProvider[$0] }
+    private var dashboard: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                dashboardHeader
+
+                if let error = store.errorMessage {
+                    refreshNotice(error)
+                }
+
+                Text("CONNECTED PLACES")
+                    .font(.system(.caption2, design: .rounded, weight: .bold))
+                    .tracking(1.2)
+                    .foregroundStyle(ZineTheme.tertiaryText)
+                    .padding(.leading, 3)
+                    .padding(.top, 4)
+
+                ForEach(orderedSources) { summary in
+                    sourceCard(summary)
+                }
+
+                Text("Pull to refresh source status. Each source keeps its own connection, sync, and delivery controls.")
+                    .font(.system(.footnote, design: .rounded))
+                    .foregroundStyle(ZineTheme.tertiaryText)
+                    .padding(.horizontal, 3)
+                    .padding(.top, 4)
+            }
+            .padding(.horizontal, 18)
+            .padding(.top, 16)
+            .padding(.bottom, 30)
+        }
+        .background(ZineTheme.canvas)
+        .refreshable { await store.reload() }
     }
 
-    private func subscriptionSourceRow(_ summary: SubscriptionSourceSummary) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: summary.provider.systemImage)
-                .font(.title3)
-                .foregroundStyle(summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.primaryText)
-                .frame(width: 28)
+    private var dashboardHeader: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("BUILD YOUR FEED")
+                .font(.system(.caption, design: .rounded, weight: .bold))
+                .tracking(1.4)
+                .foregroundStyle(ZineTheme.brandAccent)
 
-            VStack(alignment: .leading, spacing: 3) {
-                Text(summary.provider.title)
-                Text(summary.statusText)
-                    .font(.caption)
-                    .foregroundStyle(summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.secondaryText)
+            Text("Everything you follow,\nin one Zine.")
+                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .foregroundStyle(ZineTheme.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Connect the services you already use. Zine keeps each source’s real sync status and controls in one place.")
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(ZineTheme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 0) {
+                sourceMetric(value: "\(connectedCount)", label: "CONNECTED")
+                Divider()
+                    .overlay(ZineTheme.border)
+                    .padding(.vertical, 4)
+                sourceMetric(value: "\(activeItemCount)", label: "ACTIVE")
+                Divider()
+                    .overlay(ZineTheme.border)
+                    .padding(.vertical, 4)
+                sourceMetric(value: "\(SubscriptionSource.allCases.count)", label: "AVAILABLE")
+            }
+            .padding(.vertical, 14)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(ZineTheme.border.opacity(0.7), lineWidth: 1)
             }
         }
-        .padding(.vertical, 3)
+    }
+
+    private func sourceMetric(value: String, label: String) -> some View {
+        VStack(spacing: 3) {
+            Text(value)
+                .font(.system(.title2, design: .rounded, weight: .bold))
+                .foregroundStyle(ZineTheme.primaryText)
+            Text(label)
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .tracking(0.8)
+                .foregroundStyle(ZineTheme.tertiaryText)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func sourceCard(_ summary: SubscriptionSourceSummary) -> some View {
+        NavigationLink(value: summary.provider) {
+            HStack(spacing: 15) {
+                Image(systemName: summary.provider.systemImage)
+                    .font(.system(size: 21, weight: .bold))
+                    .foregroundStyle(
+                        summary.needsAttention ? ZineTheme.onAccent : ZineTheme.primaryText
+                    )
+                    .frame(width: 48, height: 48)
+                    .background(
+                        summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.raised,
+                        in: .rect(cornerRadius: 15)
+                    )
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(summary.provider.title)
+                        .font(.system(.headline, design: .rounded, weight: .bold))
+                        .foregroundStyle(ZineTheme.primaryText)
+                    Text(summary.provider.connectedDescription)
+                        .font(.system(.caption, design: .rounded))
+                        .foregroundStyle(ZineTheme.secondaryText)
+                        .lineLimit(2)
+                    SourceStatusPill(
+                        text: summary.statusText,
+                        needsAttention: summary.needsAttention
+                    )
+                }
+
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.right")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(
+                        summary.needsAttention ? ZineTheme.brandAccent : ZineTheme.tertiaryText
+                    )
+            }
+            .padding(16)
+            .background(ZineTheme.surface, in: .rect(cornerRadius: 20))
+            .overlay {
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(
+                        summary.needsAttention
+                            ? ZineTheme.brandAccent.opacity(0.8)
+                            : ZineTheme.border.opacity(0.65),
+                        lineWidth: 1
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("source-\(summary.provider.pathComponent)")
+    }
+
+    private func refreshNotice(_ error: String) -> some View {
+        HStack(alignment: .top, spacing: 11) {
+            Image(systemName: "wifi.exclamationmark")
+                .foregroundStyle(ZineTheme.brandAccent)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Showing your last source status")
+                    .font(.system(.subheadline, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+                Text(error)
+                    .font(.system(.caption, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+                    .lineLimit(2)
+            }
+            Spacer()
+            Button("Retry") { Task { await store.reload() } }
+                .font(.system(.caption, design: .rounded, weight: .bold))
+        }
+        .padding(14)
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(ZineTheme.brandAccent.opacity(0.5), lineWidth: 1)
+        }
+    }
+
+    private var orderedSources: [SubscriptionSourceSummary] {
+        let byProvider = Dictionary(uniqueKeysWithValues: store.sources.map { ($0.provider, $0) })
+        return SubscriptionSource.allCases.map { provider in
+            byProvider[provider]
+                ?? SubscriptionSourceSummary(
+                    provider: provider,
+                    connectionStatus: nil,
+                    activeCount: 0
+                )
+        }
+    }
+
+    private var connectedCount: Int {
+        orderedSources.filter { $0.isConnected }.count
+    }
+
+    private var activeItemCount: Int {
+        orderedSources.reduce(0) { $0 + $1.activeCount }
     }
 
     @ViewBuilder
     private func destination(for source: SubscriptionSource) -> some View {
-        switch source {
-        case .youtube, .spotify:
+        switch source.destination {
+        case .providerSubscriptions:
             ProviderSubscriptionsView(
                 provider: source,
                 client: client,
                 configuration: configuration
             )
-        case .gmail:
+        case .newsletters:
             NewsletterSubscriptionsView(client: client, configuration: configuration)
-        case .x:
+        case .xBookmarks:
             XSubscriptionsView(client: client, configuration: configuration)
-        case .rss:
+        case .rssFeeds:
             RssSubscriptionsView(client: client)
         }
     }

--- a/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
+++ b/apps/ios/ZineNative/Features/Subscriptions/XSubscriptionsView.swift
@@ -159,6 +159,17 @@ struct XSubscriptionsView: View {
 
     private var settingsList: some View {
         List {
+            Section {
+                SourceDetailHero(
+                    source: .x,
+                    title: "X Bookmarks",
+                    detail: SubscriptionSource.x.connectedDescription,
+                    status: connectionLabel,
+                    needsAttention: store.response?.connection?.needsAttention == true
+                )
+                .sourceHeroRow()
+            }
+
             Section("Account") {
                 LabeledContent("X") {
                     Text(connectionLabel).foregroundStyle(connectionColor)
@@ -181,6 +192,7 @@ struct XSubscriptionsView: View {
                     }
                 }
             }
+            .sourceManagementRow()
 
             if store.response?.connection?.isActive == true {
                 Section {
@@ -217,6 +229,7 @@ struct XSubscriptionsView: View {
                 } footer: {
                     Text("X applies API limits and Zine enforces a cooldown between manual syncs.")
                 }
+                .sourceManagementRow()
             } else {
                 Section {
                     ContentUnavailableView(
@@ -225,10 +238,10 @@ struct XSubscriptionsView: View {
                         description: Text("Connect X to import bookmarks into your Zine library.")
                     )
                 }
+                .sourceManagementRow()
             }
         }
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
+        .sourceManagementListStyle()
         .refreshable { await store.reload() }
     }
 

--- a/apps/ios/ZineNativeTests/SettingsTests.swift
+++ b/apps/ios/ZineNativeTests/SettingsTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import ZineNative
+
+struct SettingsTests {
+    @Test func exposesSourcesAsThePrimarySettingsDestination() {
+        #expect(SettingsRoute.allCases == [.sources, .appearance])
+    }
+
+    @MainActor
+    @Test func signOutRequiresConfirmationBeforeRunningTheAuthAction() async {
+        let store = SettingsStore()
+        var invocationCount = 0
+
+        store.requestSignOut()
+        #expect(store.isSignOutConfirmationPresented)
+        #expect(invocationCount == 0)
+
+        store.cancelSignOut()
+        #expect(!store.isSignOutConfirmationPresented)
+        #expect(invocationCount == 0)
+
+        store.requestSignOut()
+        await store.signOut {
+            invocationCount += 1
+        }
+
+        #expect(invocationCount == 1)
+        #expect(!store.isSignOutConfirmationPresented)
+        #expect(!store.isSigningOut)
+        #expect(store.signOutError == nil)
+    }
+
+    @MainActor
+    @Test func failedSignOutStaysInSettingsAndSurfacesTheError() async {
+        let store = SettingsStore()
+
+        store.requestSignOut()
+        await store.signOut {
+            throw SettingsTestError.rejected
+        }
+
+        #expect(!store.isSignOutConfirmationPresented)
+        #expect(!store.isSigningOut)
+        #expect(store.signOutError == SettingsTestError.rejected.localizedDescription)
+
+        store.dismissSignOutError()
+        #expect(store.signOutError == nil)
+    }
+}
+
+private enum SettingsTestError: Error, LocalizedError {
+    case rejected
+
+    var errorDescription: String? { "Session could not be ended" }
+}

--- a/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
+++ b/apps/ios/ZineNativeTests/SubscriptionSourcesTests.swift
@@ -3,6 +3,15 @@ import Testing
 @testable import ZineNative
 
 struct SubscriptionSourcesTests {
+    @Test func routesEverySupportedSourceToItsRealManagementScreen() {
+        #expect(SubscriptionSource.youtube.destination == .providerSubscriptions)
+        #expect(SubscriptionSource.spotify.destination == .providerSubscriptions)
+        #expect(SubscriptionSource.gmail.destination == .newsletters)
+        #expect(SubscriptionSource.x.destination == .xBookmarks)
+        #expect(SubscriptionSource.rss.destination == .rssFeeds)
+        #expect(SubscriptionSource.allCases.count == 5)
+    }
+
     @Test func buildsOAuthRequestsForEveryConnectedProvider() throws {
         let app = AppConfiguration(
             apiBaseURL: URL(string: "https://api.example.com")!,
@@ -141,6 +150,29 @@ struct SubscriptionSourcesTests {
         #expect(await recorder.addedIDs == [item.channelId])
     }
 
+    @MainActor
+    @Test func sourceDashboardKeepsKnownStatusWhenRefreshFails() async {
+        let connected = SubscriptionSourceSummary(
+            provider: .youtube,
+            connectionStatus: "ACTIVE",
+            activeCount: 2
+        )
+        let recorder = HubClientRecorder(
+            results: [
+                .success(SubscriptionsHubResponse(sources: [connected])),
+                .failure(HubTestError.offline),
+            ]
+        )
+        let store = SubscriptionsHubStore(loadSources: recorder.load)
+
+        await store.reload()
+        await store.reload()
+
+        #expect(store.sources == [connected])
+        #expect(store.errorMessage == HubTestError.offline.localizedDescription)
+        #expect(store.isLoading == false)
+    }
+
     private func response(items: [ProviderSubscriptionItem]) -> ProviderSubscriptionsResponse {
         ProviderSubscriptionsResponse(
             connection: ProviderConnection(
@@ -159,6 +191,28 @@ struct SubscriptionSourcesTests {
         return Dictionary(uniqueKeysWithValues: (query?.queryItems ?? []).compactMap {
             item in item.value.map { (item.name, $0) }
         })
+    }
+}
+
+private enum HubTestError: Error, LocalizedError {
+    case offline
+
+    var errorDescription: String? { "No connection" }
+}
+
+private actor HubClientRecorder {
+    private var results: [Result<SubscriptionsHubResponse, Error>]
+
+    init(results: [Result<SubscriptionsHubResponse, Error>]) {
+        self.results = results
+    }
+
+    nonisolated var load: () async throws -> SubscriptionsHubResponse {
+        { [self] in try await next() }
+    }
+
+    private func next() throws -> SubscriptionsHubResponse {
+        try results.removeFirst().get()
     }
 }
 

--- a/apps/ios/ZineNativeTests/ZineThemeTests.swift
+++ b/apps/ios/ZineNativeTests/ZineThemeTests.swift
@@ -45,6 +45,14 @@ final class ZineThemeTests: XCTestCase {
         }
     }
 
+    func testTabBarRemainsVisibleAcrossRootAndPushedReadingSurfaces() {
+        XCTAssertTrue(
+            ZineNavigationSurface.allCases.allSatisfy {
+                ZineTabBarVisibilityContract.keepsTabBarVisible(on: $0)
+            }
+        )
+    }
+
     @MainActor
     func testUIKitBarsKeepSystemManagedMaterialsAndScrollEdges() {
         ZineTheme.configureUIKitAppearance()


### PR DESCRIPTION
## Summary

- replace the vendor profile shell with a native Zine Settings experience, making Sources the primary destination and separating sign out behind confirmation
- redesign the existing five-provider Sources dashboard and management screens while preserving live API, auth, status, offline, and provider-specific behavior
- keep the shared tab bar explicitly visible across root, bookmark-detail, and article-reader navigation surfaces so interactive pop cannot leak a hidden destination state
- add focused tests for settings navigation, sign-out confirmation, provider routing, stale source state, and tab-bar visibility

## Validation

- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -parallel-testing-enabled NO test` — 84 tests passed
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` — 86 Vitest tests and 4 preview-target tests passed
- `cd apps/worker && bun run test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"` — 1,769 tests passed
- `git diff --check origin/main...HEAD`
- live native simulator build/install/launch/stream succeeded; authenticated Settings/Sources and Home swipe-back interaction was blocked at Clerk sign-in, and no stored credentials were used