### PR TITLE
fix(ios): hide tab bar outside root screens

### DIFF
--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -39,12 +39,15 @@ the surrounding theme changes.
   replace native scroll-edge behavior and shadows through UIKit appearance
   customization. Native floating controls may retain their system material;
   immersive destinations still own tab-bar visibility.
-- Keep the root tab bar visibly overlaid above content across pushed bookmark
-  details and the article reader. Visibility and semantic item tint are
-  separate from the system-managed bar material. Do not hide the tab bar from a
-  pushed destination: an interactive pop can otherwise leave the tab shell in
-  the departing destination's hidden state. Root and pushed reading surfaces
-  use the shared persistent tab-bar visibility contract.
+- Show the shared bottom navigation only on the Home, Library, and Settings
+  roots. Hide it for Search and whenever one of those root navigation stacks
+  has a pushed destination, including bookmark details, source management, and
+  the article reader. Use automatic system visibility at an allowed root and
+  hidden visibility while its bound navigation path is nonempty. Destinations
+  reached with destination-form `NavigationLink` do not add their push to that
+  path, so bookmark details and the article reader also apply the shared
+  non-root hidden modifier locally. Never force a root visible, and do not use
+  delayed restoration after interactive pop.
 - Do not scatter raw hex, RGB, `Color.primary`, or `Color.secondary` values
   through supported native views. If the product needs a new reusable role,
   add it to `ZineTheme.Role`, define both appearances, and update

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -49,6 +49,10 @@ private struct AuthenticatedAppView: View {
     @State private var homeStore: HomeStore
     @State private var search = ""
     @State private var selectedTab = AppTab.home
+    @State private var homeNavigationPath = NavigationPath()
+    @State private var libraryNavigationPath = NavigationPath()
+    @State private var settingsNavigationPath = NavigationPath()
+    @State private var searchNavigationPath = NavigationPath()
     @State private var homeTabReselection = 0
     @State private var libraryTabReselection = 0
     @State private var homeRevision = 0
@@ -83,7 +87,8 @@ private struct AuthenticatedAppView: View {
                     onContentChanged: markBookmarkContentChanged,
                     onExternalOpen: handleExternalOpen,
                     onHomeItemExternalOpen: handleHomeItemExternalOpen,
-                    tabReselection: homeTabReselection
+                    tabReselection: homeTabReselection,
+                    navigationPath: $homeNavigationPath
                 )
                 .tint(ZineTheme.brandAccent)
             }
@@ -95,13 +100,17 @@ private struct AuthenticatedAppView: View {
                     refreshRevision: libraryRevision,
                     onContentChanged: markHomeChanged,
                     onExternalOpen: handleExternalOpen,
-                    tabReselection: libraryTabReselection
+                    tabReselection: libraryTabReselection,
+                    navigationPath: $libraryNavigationPath
                 )
                 .tint(ZineTheme.brandAccent)
             }
 
             Tab("Settings", systemImage: "gearshape", value: AppTab.settings) {
-                AppSettingsView(client: client)
+                AppSettingsView(
+                    client: client,
+                    navigationPath: $settingsNavigationPath
+                )
                     .tint(ZineTheme.brandAccent)
             }
 
@@ -112,13 +121,18 @@ private struct AuthenticatedAppView: View {
                     searchText: $search,
                     refreshRevision: libraryRevision,
                     onContentChanged: markHomeChanged,
-                    onExternalOpen: handleExternalOpen
+                    onExternalOpen: handleExternalOpen,
+                    navigationPath: $searchNavigationPath
                 )
                 .searchable(text: $search, prompt: "Search your library")
                 .tint(ZineTheme.brandAccent)
             }
         }
         .zineTabShellChrome()
+        .zineNavigationTabBar(
+            for: selectedRootSurface,
+            navigationDepth: selectedNavigationDepth
+        )
         .task(id: homeRevision) {
             await homeStore.reload()
         }
@@ -157,6 +171,28 @@ private struct AuthenticatedAppView: View {
                 }
             }
         )
+    }
+
+    private var selectedNavigationDepth: Int {
+        switch selectedTab {
+        case .home:
+            homeNavigationPath.count
+        case .library:
+            libraryNavigationPath.count
+        case .settings:
+            settingsNavigationPath.count
+        case .search:
+            searchNavigationPath.count
+        }
+    }
+
+    private var selectedRootSurface: ZineTabRootSurface {
+        switch selectedTab {
+        case .home: .home
+        case .library: .library
+        case .settings: .settings
+        case .search: .search
+        }
     }
 
     private func handleTabReselection(_ tab: AppTab) {

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -1,17 +1,37 @@
 import SwiftUI
 import UIKit
 
-enum ZineNavigationSurface: CaseIterable {
-    case root
+enum ZineTabRootSurface: CaseIterable, Hashable {
+    case home
+    case library
+    case settings
+    case search
+}
+
+enum ZineTabBarSurface: Hashable {
+    case tabRoot(ZineTabRootSurface)
     case bookmarkDetail
     case articleReader
 }
 
 enum ZineTabBarVisibilityContract {
-    static func keepsTabBarVisible(on surface: ZineNavigationSurface) -> Bool {
-        switch surface {
-        case .root, .bookmarkDetail, .articleReader:
-            true
+    private static let visibleRoots: Set<ZineTabRootSurface> = [
+        .home,
+        .library,
+        .settings,
+    ]
+
+    static func showsTabBar(
+        on surface: ZineTabBarSurface,
+        navigationDepth: Int
+    ) -> Bool {
+        guard navigationDepth == 0 else { return false }
+
+        return switch surface {
+        case .tabRoot(let root):
+            visibleRoots.contains(root)
+        case .bookmarkDetail, .articleReader:
+            false
         }
     }
 }
@@ -136,19 +156,33 @@ extension View {
             .tint(ZineTheme.brandAccent)
             .toolbarBackground(ZineTheme.canvas, for: .navigationBar)
             .toolbar(.visible, for: .navigationBar)
-            .zineTabBarVisibility(for: .root)
     }
 
     func zineTabShellChrome() -> some View {
         tint(ZineTheme.brandAccent)
             .background(ZineTheme.canvas)
             .toolbarBackground(ZineTheme.canvas, for: .tabBar)
-            .zineTabBarVisibility(for: .root)
     }
 
-    func zineTabBarVisibility(for surface: ZineNavigationSurface) -> some View {
+    func zineNavigationTabBar(
+        for surface: ZineTabRootSurface,
+        navigationDepth: Int
+    ) -> some View {
         toolbarVisibility(
-            ZineTabBarVisibilityContract.keepsTabBarVisible(on: surface) ? .visible : .hidden,
+            ZineTabBarVisibilityContract.showsTabBar(
+                on: .tabRoot(surface),
+                navigationDepth: navigationDepth
+            ) ? .automatic : .hidden,
+            for: .tabBar
+        )
+    }
+
+    func zineNonRootTabBar(for surface: ZineTabBarSurface) -> some View {
+        toolbarVisibility(
+            ZineTabBarVisibilityContract.showsTabBar(
+                on: surface,
+                navigationDepth: 0
+            ) ? .automatic : .hidden,
             for: .tabBar
         )
     }

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -46,6 +46,7 @@ struct HomeView: View {
     let onHomeItemExternalOpen: (HomeItem) -> Void
     let tabReselection: Int
 
+    @Binding private var navigationPath: NavigationPath
     @Namespace private var bookmarkTransition
 
     init(
@@ -56,7 +57,8 @@ struct HomeView: View {
         onContentChanged: @escaping () -> Void,
         onExternalOpen: @escaping (Bookmark) -> Void,
         onHomeItemExternalOpen: @escaping (HomeItem) -> Void,
-        tabReselection: Int = 0
+        tabReselection: Int = 0,
+        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
     ) {
         self.client = client
         self.store = store
@@ -66,10 +68,11 @@ struct HomeView: View {
         self.onExternalOpen = onExternalOpen
         self.onHomeItemExternalOpen = onHomeItemExternalOpen
         self.tabReselection = tabReselection
+        _navigationPath = navigationPath
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             content
                 .navigationTitle(title)
                 .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -225,7 +225,7 @@ struct BookmarkDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .zineTabBarVisibility(for: .bookmarkDetail)
+        .zineNonRootTabBar(for: .bookmarkDetail)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task(id: content.id) {

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -9,6 +9,7 @@ struct LibraryView: View {
     let tabReselection: Int
 
     @State private var store: LibraryStore
+    @Binding private var navigationPath: NavigationPath
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
@@ -23,7 +24,8 @@ struct LibraryView: View {
         refreshRevision: Int = 0,
         onContentChanged: @escaping () -> Void = {},
         onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
-        tabReselection: Int = 0
+        tabReselection: Int = 0,
+        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
     ) {
         self.client = client
         self.searchText = searchText
@@ -31,6 +33,7 @@ struct LibraryView: View {
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         self.tabReselection = tabReselection
+        _navigationPath = navigationPath
         _store = State(initialValue: LibraryStore(
             client: client,
             cache: cache,
@@ -56,7 +59,7 @@ struct LibraryView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             content
                 .navigationTitle(isSearchMode ? "Search" : "Library")
                 .navigationBarTitleDisplayMode(.inline)

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -92,7 +92,7 @@ struct ArticleReaderView: View {
             }
         }
         .toolbarVisibility(.hidden, for: .navigationBar)
-        .zineTabBarVisibility(for: .articleReader)
+        .zineNonRootTabBar(for: .articleReader)
         .task(id: store.metadata.bookmarkID) {
             guard loadsOnAppear else { return }
             await store.load()

--- a/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
+++ b/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
@@ -45,12 +45,21 @@ final class SettingsStore {
 
 struct AppSettingsView: View {
     let client: APIClient
+    let navigationPath: Binding<NavigationPath>
 
     @Environment(Clerk.self) private var clerk
     @State private var store = SettingsStore()
 
+    init(
+        client: APIClient,
+        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
+    ) {
+        self.client = client
+        self.navigationPath = navigationPath
+    }
+
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: navigationPath) {
             Group {
                 if clerk.session?.tasks?.isEmpty == false {
                     AuthView(isDismissible: false)
@@ -117,7 +126,6 @@ struct AppSettingsView: View {
         .background(ZineTheme.canvas)
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
-        .zineTabBarVisibility(for: .root)
     }
 
     private var settingsHeader: some View {

--- a/apps/ios/ZineNativeTests/ZineThemeTests.swift
+++ b/apps/ios/ZineNativeTests/ZineThemeTests.swift
@@ -45,11 +45,52 @@ final class ZineThemeTests: XCTestCase {
         }
     }
 
-    func testTabBarRemainsVisibleAcrossRootAndPushedReadingSurfaces() {
-        XCTAssertTrue(
-            ZineNavigationSurface.allCases.allSatisfy {
-                ZineTabBarVisibilityContract.keepsTabBarVisible(on: $0)
-            }
+    func testTabBarIsVisibleOnlyOnPrimaryRootScreens() {
+        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.home), navigationDepth: 0))
+        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.library), navigationDepth: 0))
+        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.settings), navigationDepth: 0))
+        XCTAssertFalse(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.search), navigationDepth: 0))
+    }
+
+    func testTabBarIsHiddenForEveryPushedDestination() {
+        for surface in ZineTabRootSurface.allCases {
+            XCTAssertFalse(
+                ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(surface), navigationDepth: 1),
+                "Expected the tab bar to be hidden after pushing from \(surface)"
+            )
+            XCTAssertFalse(
+                ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(surface), navigationDepth: 2),
+                "Expected the tab bar to remain hidden deeper in \(surface)"
+            )
+        }
+    }
+
+    func testDestinationFormReaderPushHidesTabBarWithoutAPathEntry() {
+        XCTAssertFalse(
+            ZineTabBarVisibilityContract.showsTabBar(
+                on: .articleReader,
+                navigationDepth: 0
+            )
+        )
+        XCTAssertFalse(
+            ZineTabBarVisibilityContract.showsTabBar(
+                on: .bookmarkDetail,
+                navigationDepth: 0
+            )
+        )
+    }
+
+    func testInteractivePopReturnPathRestoresTabBarAtPrimaryRoot() {
+        let navigationDepths = [0, 1, 2, 1, 0]
+
+        XCTAssertEqual(
+            navigationDepths.map {
+                ZineTabBarVisibilityContract.showsTabBar(
+                    on: .tabRoot(.home),
+                    navigationDepth: $0
+                )
+            },
+            [true, false, false, false, true]
         )
     }
 


### PR DESCRIPTION
## Summary
- make the shared tab bar visible only at Home, Library, and Settings roots
- hide it for path-backed pushes and destination-form bookmark/reader navigation
- cover root, push, reader, and interactive-return visibility contracts

## Validation
- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS\ Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908 -parallel-testing-enabled NO test` (87 tests)
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` (90 checks)
- `bun run --cwd apps/worker test:run --exclude=...` (1,769 tests)
- `git diff --check`