### PR TITLE
fix(ios): restore native tab navigation

### DIFF
--- a/apps/ios/DESIGN_SYSTEM.md
+++ b/apps/ios/DESIGN_SYSTEM.md
@@ -39,15 +39,16 @@ the surrounding theme changes.
   replace native scroll-edge behavior and shadows through UIKit appearance
   customization. Native floating controls may retain their system material;
   immersive destinations still own tab-bar visibility.
-- Show the shared bottom navigation only on the Home, Library, and Settings
-  roots. Hide it for Search and whenever one of those root navigation stacks
-  has a pushed destination, including bookmark details, source management, and
-  the article reader. Use automatic system visibility at an allowed root and
-  hidden visibility while its bound navigation path is nonempty. Destinations
-  reached with destination-form `NavigationLink` do not add their push to that
-  path, so bookmark details and the article reader also apply the shared
-  non-root hidden modifier locally. Never force a root visible, and do not use
-  delayed restoration after interactive pop.
+- Keep the shared bottom navigation inside the app-level `NavigationStack` root.
+  Home, Library, Settings, and Search are root tab content; pushed destinations
+  such as bookmark details, source management, creators, and the article reader
+  cover the complete tab shell. Do not issue explicit tab-bar visibility
+  preferences from the shell or destinations. Interactive pop must reveal the
+  intact tab shell underneath instead of hiding and reconstructing its bar.
+  Root-tab controls must route explicitly into the app-owned navigation path;
+  do not rely on value-based `NavigationLink` to discover and mutate a stack
+  across the lazy `TabView` boundary. Once a destination is pushed, deeper
+  links may use its normal stack-local navigation registration.
 - Do not scatter raw hex, RGB, `Color.primary`, or `Color.secondary` values
   through supported native views. If the product needs a new reusable role,
   add it to `ZineTheme.Role`, define both appearances, and update

--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -14,6 +14,24 @@ struct ExternalBookmarkOpenEvent: Equatable {
     let change: Change
 }
 
+struct ZineTabNavigationActions {
+    var home: ((HomeNavigationRoute) -> Void)?
+    var homeSection: ((HomeSectionRoute) -> Void)?
+    var bookmark: ((Bookmark) -> Void)?
+    var settings: ((SettingsRoute) -> Void)?
+}
+
+private struct ZineTabNavigationActionsKey: EnvironmentKey {
+    static let defaultValue = ZineTabNavigationActions()
+}
+
+extension EnvironmentValues {
+    var zineTabNavigationActions: ZineTabNavigationActions {
+        get { self[ZineTabNavigationActionsKey.self] }
+        set { self[ZineTabNavigationActionsKey.self] = newValue }
+    }
+}
+
 struct AppRootView: View {
     let configuration: AppConfiguration
 
@@ -49,16 +67,14 @@ private struct AuthenticatedAppView: View {
     @State private var homeStore: HomeStore
     @State private var search = ""
     @State private var selectedTab = AppTab.home
-    @State private var homeNavigationPath = NavigationPath()
-    @State private var libraryNavigationPath = NavigationPath()
-    @State private var settingsNavigationPath = NavigationPath()
-    @State private var searchNavigationPath = NavigationPath()
+    @State private var navigationPath = NavigationPath()
     @State private var homeTabReselection = 0
     @State private var libraryTabReselection = 0
     @State private var homeRevision = 0
     @State private var libraryRevision = 0
     @State private var externalOpenEvent: ExternalBookmarkOpenEvent?
     @State private var externalOpenError: String?
+    @Namespace private var navigationTransition
 
     init(configuration: AppConfiguration, userID: String) {
         let client = APIClient(
@@ -78,61 +94,76 @@ private struct AuthenticatedAppView: View {
     }
 
     var body: some View {
-        TabView(selection: tabSelection) {
-            Tab("Home", systemImage: "house", value: AppTab.home) {
-                HomeView(
-                    client: client,
-                    store: homeStore,
-                    density: .compact,
-                    onContentChanged: markBookmarkContentChanged,
-                    onExternalOpen: handleExternalOpen,
-                    onHomeItemExternalOpen: handleHomeItemExternalOpen,
-                    tabReselection: homeTabReselection,
-                    navigationPath: $homeNavigationPath
-                )
-                .tint(ZineTheme.brandAccent)
-            }
-
-            Tab("Library", systemImage: "books.vertical", value: AppTab.library) {
-                LibraryView(
-                    client: client,
-                    cache: libraryCache,
-                    refreshRevision: libraryRevision,
-                    onContentChanged: markHomeChanged,
-                    onExternalOpen: handleExternalOpen,
-                    tabReselection: libraryTabReselection,
-                    navigationPath: $libraryNavigationPath
-                )
-                .tint(ZineTheme.brandAccent)
-            }
-
-            Tab("Settings", systemImage: "gearshape", value: AppTab.settings) {
-                AppSettingsView(
-                    client: client,
-                    navigationPath: $settingsNavigationPath
-                )
+        NavigationStack(path: $navigationPath) {
+            TabView(selection: tabSelection) {
+                Tab("Home", systemImage: "house", value: AppTab.home) {
+                    HomeView(
+                        client: client,
+                        store: homeStore,
+                        density: .compact,
+                        onContentChanged: markBookmarkContentChanged,
+                        onExternalOpen: handleExternalOpen,
+                        onHomeItemExternalOpen: handleHomeItemExternalOpen,
+                        tabReselection: homeTabReselection,
+                        transitionNamespace: navigationTransition,
+                        registersNavigationDestinations: false
+                    )
                     .tint(ZineTheme.brandAccent)
-            }
+                }
 
-            Tab(value: AppTab.search, role: .search) {
-                LibraryView(
-                    client: client,
-                    cache: libraryCache,
-                    searchText: $search,
-                    refreshRevision: libraryRevision,
-                    onContentChanged: markHomeChanged,
-                    onExternalOpen: handleExternalOpen,
-                    navigationPath: $searchNavigationPath
-                )
-                .searchable(text: $search, prompt: "Search your library")
-                .tint(ZineTheme.brandAccent)
+                Tab("Library", systemImage: "books.vertical", value: AppTab.library) {
+                    LibraryView(
+                        client: client,
+                        cache: libraryCache,
+                        refreshRevision: libraryRevision,
+                        onContentChanged: markHomeChanged,
+                        onExternalOpen: handleExternalOpen,
+                        tabReselection: libraryTabReselection,
+                        transitionNamespace: navigationTransition
+                    )
+                    .tint(ZineTheme.brandAccent)
+                }
+
+                Tab("Settings", systemImage: "gearshape", value: AppTab.settings) {
+                    AppSettingsView(client: client)
+                    .tint(ZineTheme.brandAccent)
+                }
+
+                Tab(value: AppTab.search, role: .search) {
+                    LibraryView(
+                        client: client,
+                        cache: libraryCache,
+                        searchText: $search,
+                        refreshRevision: libraryRevision,
+                        onContentChanged: markHomeChanged,
+                        onExternalOpen: handleExternalOpen,
+                        transitionNamespace: navigationTransition
+                    )
+                    .searchable(text: $search, prompt: "Search your library")
+                    .tint(ZineTheme.brandAccent)
+                }
+            }
+            .zineTabShellChrome()
+            .environment(\.zineTabNavigationActions, tabNavigationActions)
+            .navigationDestination(for: HomeNavigationRoute.self) { route in
+                homeDestination(for: route)
+                    .navigationTransition(
+                        .zoom(sourceID: route.sourceID, in: navigationTransition)
+                    )
+            }
+            .navigationDestination(for: HomeSectionRoute.self) { route in
+                homeSectionDestination(for: route)
+            }
+            .navigationDestination(for: Bookmark.self) { bookmark in
+                bookmarkDestination(for: bookmark)
+                    .navigationTransition(
+                        .zoom(sourceID: bookmark.id, in: navigationTransition)
+                    )
+            }
+            .navigationDestination(for: SettingsRoute.self) { route in
+                settingsDestination(for: route)
             }
         }
-        .zineTabShellChrome()
-        .zineNavigationTabBar(
-            for: selectedRootSurface,
-            navigationDepth: selectedNavigationDepth
-        )
         .task(id: homeRevision) {
             await homeStore.reload()
         }
@@ -173,26 +204,13 @@ private struct AuthenticatedAppView: View {
         )
     }
 
-    private var selectedNavigationDepth: Int {
-        switch selectedTab {
-        case .home:
-            homeNavigationPath.count
-        case .library:
-            libraryNavigationPath.count
-        case .settings:
-            settingsNavigationPath.count
-        case .search:
-            searchNavigationPath.count
-        }
-    }
-
-    private var selectedRootSurface: ZineTabRootSurface {
-        switch selectedTab {
-        case .home: .home
-        case .library: .library
-        case .settings: .settings
-        case .search: .search
-        }
+    private var tabNavigationActions: ZineTabNavigationActions {
+        ZineTabNavigationActions(
+            home: { navigationPath.append($0) },
+            homeSection: { navigationPath.append($0) },
+            bookmark: { navigationPath.append($0) },
+            settings: { navigationPath.append($0) }
+        )
     }
 
     private func handleTabReselection(_ tab: AppTab) {
@@ -213,6 +231,95 @@ private struct AuthenticatedAppView: View {
     private func markBookmarkContentChanged() {
         homeRevision += 1
         libraryRevision += 1
+    }
+
+    @ViewBuilder
+    private func homeDestination(for route: HomeNavigationRoute) -> some View {
+        switch route.destination {
+        case .item(let item):
+            BookmarkDetailView(
+                item: item,
+                client: client,
+                onUpdate: { _ in markBookmarkContentChanged() },
+                onBookmarkCommit: { _, _ in markBookmarkContentChanged() },
+                onExternalOpen: { bookmark, item in
+                    if let bookmark {
+                        handleExternalOpen(bookmark)
+                    } else {
+                        handleHomeItemExternalOpen(item)
+                    }
+                }
+            )
+        case .bookmark(let bookmark):
+            BookmarkDetailView(
+                bookmark: bookmark,
+                client: client,
+                onUpdate: { _ in markBookmarkContentChanged() },
+                onBookmarkCommit: { _, _ in markBookmarkContentChanged() },
+                onExternalOpen: handleExternalOpen
+            )
+        case .articleReader(let item):
+            ArticleReaderView(
+                metadata: ArticleReaderMetadata(
+                    bookmarkID: item.id,
+                    title: item.title,
+                    creator: item.creator,
+                    creatorImageURL: item.creatorImageUrl,
+                    canonicalURL: item.canonicalUrl,
+                    readingTimeMinutes: item.readingTimeMinutes,
+                    initialProgress: item.progress,
+                    isFinished: false,
+                    tags: []
+                ),
+                client: client,
+                onRead: { handleHomeItemExternalOpen(item) },
+                onProgressSaved: { _ in markBookmarkContentChanged() },
+                onFinishedChanged: { _, _ in markBookmarkContentChanged() },
+                onFinishedCommit: { _ in markBookmarkContentChanged() },
+                onTagsChanged: { _ in markBookmarkContentChanged() }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func homeSectionDestination(for route: HomeSectionRoute) -> some View {
+        switch route {
+        case .jumpBackIn:
+            JumpBackInListView(
+                client: client,
+                onContentChanged: markBookmarkContentChanged,
+                onExternalOpen: handleExternalOpen,
+                tabReselection: homeTabReselection
+            )
+        default:
+            HomeSectionListView(
+                route: route,
+                client: client,
+                onContentChanged: markBookmarkContentChanged,
+                onExternalOpen: handleExternalOpen,
+                tabReselection: homeTabReselection
+            )
+        }
+    }
+
+    private func bookmarkDestination(for bookmark: Bookmark) -> some View {
+        BookmarkDetailView(
+            bookmark: bookmark,
+            client: client,
+            onUpdate: { _ in markBookmarkContentChanged() },
+            onBookmarkChange: { _, _, _ in markBookmarkContentChanged() },
+            onExternalOpen: handleExternalOpen
+        )
+    }
+
+    @ViewBuilder
+    private func settingsDestination(for route: SettingsRoute) -> some View {
+        switch route {
+        case .sources:
+            SubscriptionsView(client: client)
+        case .appearance:
+            AppearanceSettingsView()
+        }
     }
 
     private func handleExternalOpen(_ bookmark: Bookmark) {

--- a/apps/ios/ZineNative/Core/ZineTheme.swift
+++ b/apps/ios/ZineNative/Core/ZineTheme.swift
@@ -1,41 +1,6 @@
 import SwiftUI
 import UIKit
 
-enum ZineTabRootSurface: CaseIterable, Hashable {
-    case home
-    case library
-    case settings
-    case search
-}
-
-enum ZineTabBarSurface: Hashable {
-    case tabRoot(ZineTabRootSurface)
-    case bookmarkDetail
-    case articleReader
-}
-
-enum ZineTabBarVisibilityContract {
-    private static let visibleRoots: Set<ZineTabRootSurface> = [
-        .home,
-        .library,
-        .settings,
-    ]
-
-    static func showsTabBar(
-        on surface: ZineTabBarSurface,
-        navigationDepth: Int
-    ) -> Bool {
-        guard navigationDepth == 0 else { return false }
-
-        return switch surface {
-        case .tabRoot(let root):
-            visibleRoots.contains(root)
-        case .bookmarkDetail, .articleReader:
-            false
-        }
-    }
-}
-
 enum ZineTheme {
     enum Role: CaseIterable, Hashable {
         case canvas
@@ -162,28 +127,5 @@ extension View {
         tint(ZineTheme.brandAccent)
             .background(ZineTheme.canvas)
             .toolbarBackground(ZineTheme.canvas, for: .tabBar)
-    }
-
-    func zineNavigationTabBar(
-        for surface: ZineTabRootSurface,
-        navigationDepth: Int
-    ) -> some View {
-        toolbarVisibility(
-            ZineTabBarVisibilityContract.showsTabBar(
-                on: .tabRoot(surface),
-                navigationDepth: navigationDepth
-            ) ? .automatic : .hidden,
-            for: .tabBar
-        )
-    }
-
-    func zineNonRootTabBar(for surface: ZineTabBarSurface) -> some View {
-        toolbarVisibility(
-            ZineTabBarVisibilityContract.showsTabBar(
-                on: surface,
-                navigationDepth: 0
-            ) ? .automatic : .hidden,
-            for: .tabBar
-        )
     }
 }

--- a/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/CondensedHomeSections.swift
@@ -79,20 +79,36 @@ private struct CondensedSectionHeader: View {
     let title: String
     let route: HomeSectionRoute
 
+    @Environment(\.zineTabNavigationActions) private var navigation
+
     var body: some View {
-        NavigationLink(value: route) {
-            HStack(spacing: 5) {
-                Text(title)
-                    .font(.headline)
-                Image(systemName: "chevron.right")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(ZineTheme.tertiaryText)
+        Group {
+            if let navigate = navigation.homeSection {
+                Button {
+                    navigate(route)
+                } label: {
+                    headerLabel
+                }
+            } else {
+                NavigationLink(value: route) {
+                    headerLabel
+                }
             }
-            .foregroundStyle(ZineTheme.primaryText)
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("View all \(title)")
+    }
+
+    private var headerLabel: some View {
+        HStack(spacing: 5) {
+            Text(title)
+                .font(.headline)
+            Image(systemName: "chevron.right")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(ZineTheme.tertiaryText)
+        }
+        .foregroundStyle(ZineTheme.primaryText)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/apps/ios/ZineNative/Features/Home/HomeSections.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSections.swift
@@ -70,10 +70,18 @@ struct HomeNavigationLink<Label: View>: View {
     let transitionNamespace: Namespace.ID
     @ViewBuilder let label: () -> Label
 
+    @Environment(\.zineTabNavigationActions) private var navigation
+
     var body: some View {
-        NavigationLink(value: route, label: label)
-            .buttonStyle(.plain)
-            .matchedTransitionSource(id: route.sourceID, in: transitionNamespace)
+        Group {
+            if let navigate = navigation.home {
+                Button(action: { navigate(route) }, label: label)
+            } else {
+                NavigationLink(value: route, label: label)
+            }
+        }
+        .buttonStyle(.plain)
+        .matchedTransitionSource(id: route.sourceID, in: transitionNamespace)
     }
 }
 
@@ -262,17 +270,22 @@ private struct HomeSectionHeader: View {
     var subtitle: String?
     let route: HomeSectionRoute
 
+    @Environment(\.zineTabNavigationActions) private var navigation
+
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
-            NavigationLink(value: route) {
-                HStack(spacing: 6) {
-                    Text(title)
-                        .font(.title3.bold())
-                    Image(systemName: "chevron.right")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(ZineTheme.secondaryText)
+            Group {
+                if let navigate = navigation.homeSection {
+                    Button {
+                        navigate(route)
+                    } label: {
+                        headerLabel
+                    }
+                } else {
+                    NavigationLink(value: route) {
+                        headerLabel
+                    }
                 }
-                .foregroundStyle(ZineTheme.primaryText)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("View all \(title)")
@@ -284,6 +297,17 @@ private struct HomeSectionHeader: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var headerLabel: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .font(.title3.bold())
+            Image(systemName: "chevron.right")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(ZineTheme.secondaryText)
+        }
+        .foregroundStyle(ZineTheme.primaryText)
     }
 }
 
@@ -328,6 +352,7 @@ private struct HomeJumpBackInSection: View {
             }
         }
     }
+
 }
 
 struct HomeCompactHorizontalCard: View {

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -45,9 +45,10 @@ struct HomeView: View {
     let onExternalOpen: (Bookmark) -> Void
     let onHomeItemExternalOpen: (HomeItem) -> Void
     let tabReselection: Int
+    let transitionNamespace: Namespace.ID?
+    let registersNavigationDestinations: Bool
 
-    @Binding private var navigationPath: NavigationPath
-    @Namespace private var bookmarkTransition
+    @Namespace private var localTransitionNamespace
 
     init(
         client: APIClient,
@@ -58,7 +59,8 @@ struct HomeView: View {
         onExternalOpen: @escaping (Bookmark) -> Void,
         onHomeItemExternalOpen: @escaping (HomeItem) -> Void,
         tabReselection: Int = 0,
-        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
+        transitionNamespace: Namespace.ID? = nil,
+        registersNavigationDestinations: Bool = true
     ) {
         self.client = client
         self.store = store
@@ -68,14 +70,14 @@ struct HomeView: View {
         self.onExternalOpen = onExternalOpen
         self.onHomeItemExternalOpen = onHomeItemExternalOpen
         self.tabReselection = tabReselection
-        _navigationPath = navigationPath
+        self.transitionNamespace = transitionNamespace
+        self.registersNavigationDestinations = registersNavigationDestinations
     }
 
+    @ViewBuilder
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            content
-                .navigationTitle(title)
-                .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+        if registersNavigationDestinations {
+            screen
                 .navigationDestination(for: HomeNavigationRoute.self) { route in
                     destination(for: route)
                         .navigationTransition(
@@ -101,8 +103,20 @@ struct HomeView: View {
                         )
                     }
                 }
+        } else {
+            screen
         }
-        .zineScreenChrome()
+    }
+
+    private var screen: some View {
+        content
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+            .zineScreenChrome()
+    }
+
+    private var bookmarkTransition: Namespace.ID {
+        transitionNamespace ?? localTransitionNamespace
     }
 
     @ViewBuilder

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -3,70 +3,67 @@ import SwiftUI
 
 struct ScreenshotHomeTabShell: View {
     @State private var selectedTab = 0
+    @State private var navigationPath: NavigationPath
+    @Namespace private var navigationTransition
+
+    init() {
+        var initialPath = NavigationPath()
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-home-pushed-fixture") {
+            initialPath.append(
+                HomeNavigationRoute.articleReader(
+                    ScreenshotHomeFixtures.featuredArticle,
+                    sectionID: "featured"
+                )
+            )
+        }
+        _navigationPath = State(initialValue: initialPath)
+    }
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            Tab("Home", systemImage: "house", value: 0) {
-                ScreenshotHomeView(density: .compact)
-            }
+        NavigationStack(path: $navigationPath) {
+            TabView(selection: $selectedTab) {
+                Tab("Home", systemImage: "house", value: 0) {
+                    ScreenshotHomeView(
+                        density: .compact,
+                        bookmarkTransition: navigationTransition
+                    )
+                }
 
-            Tab("Library", systemImage: "books.vertical", value: 1) {
-                ScreenshotLibraryView()
-            }
+                Tab("Library", systemImage: "books.vertical", value: 1) {
+                    ScreenshotLibraryContentView()
+                }
 
-            Tab("Settings", systemImage: "gearshape", value: 2) {
-                NavigationStack {
+                Tab("Settings", systemImage: "gearshape", value: 2) {
                     Text("Settings")
                         .navigationTitle("Settings")
+                        .zineScreenChrome()
                 }
-                .zineScreenChrome()
-            }
 
-            Tab("Search", systemImage: "magnifyingglass", value: 3) {
-                NavigationStack {
+                Tab("Search", systemImage: "magnifyingglass", value: 3) {
                     Text("Search")
                         .navigationTitle("Search")
+                        .zineScreenChrome()
                 }
-                .zineScreenChrome()
             }
-        }
-        .zineTabShellChrome()
-    }
-}
-
-struct ScreenshotHomeView: View {
-    var density: HomeLayoutDensity = .standard
-
-    @Namespace private var bookmarkTransition
-
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                LazyVStack(spacing: density.sectionSpacing) {
-                    ForEach(density.visibleSections(from: ScreenshotHomeFixtures.sections)) { section in
-                        HomeDashboardSectionView(
-                            section: section,
-                            density: density,
-                            transitionNamespace: bookmarkTransition
-                        )
-                    }
-                }
-                .padding(.vertical, density == .compact ? 6 : 10)
-                .padding(.bottom, density == .compact ? 16 : 24)
-            }
-            .navigationTitle("Home")
-            .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+            .zineTabShellChrome()
+            .environment(\.zineTabNavigationActions, navigationActions)
             .navigationDestination(for: HomeNavigationRoute.self) { route in
                 fixtureDestination(for: route)
                     .navigationTransition(
-                        .zoom(sourceID: route.sourceID, in: bookmarkTransition)
+                        .zoom(sourceID: route.sourceID, in: navigationTransition)
                     )
             }
             .navigationDestination(for: HomeSectionRoute.self) { route in
                 ScreenshotHomeSectionListView(route: route)
             }
         }
-        .zineScreenChrome()
+    }
+
+    private var navigationActions: ZineTabNavigationActions {
+        ZineTabNavigationActions(
+            home: { navigationPath.append($0) },
+            homeSection: { navigationPath.append($0) }
+        )
     }
 
     @ViewBuilder
@@ -129,6 +126,30 @@ struct ScreenshotHomeView: View {
             initialPhase: .ready(ArticleReaderDocument(metadata: metadata, response: response)),
             loadsOnAppear: false
         )
+    }
+}
+
+struct ScreenshotHomeView: View {
+    var density: HomeLayoutDensity = .standard
+    let bookmarkTransition: Namespace.ID
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: density.sectionSpacing) {
+                ForEach(density.visibleSections(from: ScreenshotHomeFixtures.sections)) { section in
+                    HomeDashboardSectionView(
+                        section: section,
+                        density: density,
+                        transitionNamespace: bookmarkTransition
+                    )
+                }
+            }
+            .padding(.vertical, density == .compact ? 6 : 10)
+            .padding(.bottom, density == .compact ? 16 : 24)
+        }
+        .navigationTitle("Home")
+        .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+        .zineScreenChrome()
     }
 }
 

--- a/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
+++ b/apps/ios/ZineNative/Features/Library/BookmarkDetailView.swift
@@ -225,7 +225,6 @@ struct BookmarkDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .zineNonRootTabBar(for: .bookmarkDetail)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task(id: content.id) {

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -7,15 +7,15 @@ struct LibraryView: View {
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
     let tabReselection: Int
+    let transitionNamespace: Namespace.ID
 
     @State private var store: LibraryStore
-    @Binding private var navigationPath: NavigationPath
     @State private var showsFinished = false
     @State private var provider: Provider?
     @State private var contentType: ContentType?
     @State private var titleCollapseProgress: CGFloat = 0
     @State private var isVisible = false
-    @Namespace private var bookmarkTransition
+    @Environment(\.zineTabNavigationActions) private var navigation
 
     init(
         client: APIClient,
@@ -25,7 +25,7 @@ struct LibraryView: View {
         onContentChanged: @escaping () -> Void = {},
         onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
         tabReselection: Int = 0,
-        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
+        transitionNamespace: Namespace.ID
     ) {
         self.client = client
         self.searchText = searchText
@@ -33,7 +33,7 @@ struct LibraryView: View {
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         self.tabReselection = tabReselection
-        _navigationPath = navigationPath
+        self.transitionNamespace = transitionNamespace
         _store = State(initialValue: LibraryStore(
             client: client,
             cache: cache,
@@ -59,60 +59,44 @@ struct LibraryView: View {
     }
 
     var body: some View {
-        NavigationStack(path: $navigationPath) {
-            content
-                .navigationTitle(isSearchMode ? "Search" : "Library")
-                .navigationBarTitleDisplayMode(.inline)
-                .contentTypeFilterChrome()
-                .toolbar(.visible, for: .navigationBar)
-                .toolbar {
-                    if isSearchMode {
-                        ToolbarItem(placement: .topBarLeading) {
-                            filterMenu
-                        }
-                    } else {
-                        ToolbarItem(placement: .principal) {
-                            CollapsedListTitle(
-                                title: "Library",
-                                progress: titleCollapseProgress
-                            )
-                        }
+        content
+            .navigationTitle(isSearchMode ? "Search" : "Library")
+            .navigationBarTitleDisplayMode(.inline)
+            .contentTypeFilterChrome()
+            .toolbar(.visible, for: .navigationBar)
+            .toolbar {
+                if isSearchMode {
+                    ToolbarItem(placement: .topBarLeading) {
+                        filterMenu
+                    }
+                } else {
+                    ToolbarItem(placement: .principal) {
+                        CollapsedListTitle(
+                            title: "Library",
+                            progress: titleCollapseProgress
+                        )
                     }
                 }
-                .navigationDestination(for: Bookmark.self) { bookmark in
-                    BookmarkDetailView(
-                        bookmark: bookmark,
-                        client: client,
-                        onUpdate: { updated in store.update(updated) },
-                        onBookmarkChange: { changed, isBookmarked, _ in
-                            store.setBookmarked(changed, isBookmarked: isBookmarked)
-                        },
-                        onExternalOpen: onExternalOpen
-                    )
-                    .navigationTransition(
-                        .zoom(sourceID: bookmark.id, in: bookmarkTransition)
-                    )
+            }
+            .zineScreenChrome()
+            .task(id: LibraryReloadKey(query: query, revision: refreshRevision)) {
+                if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    store.reset()
+                    return
                 }
-        }
-        .zineScreenChrome()
-        .task(id: LibraryReloadKey(query: query, revision: refreshRevision)) {
-            if isSearchMode && search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                store.reset()
-                return
+                if !search.isEmpty {
+                    try? await Task.sleep(for: .milliseconds(250))
+                }
+                guard !Task.isCancelled else { return }
+                await store.reload(query: query)
             }
-            if !search.isEmpty {
-                try? await Task.sleep(for: .milliseconds(250))
+            .alert("Couldn’t update bookmark", isPresented: actionErrorBinding) {
+                Button("OK", role: .cancel) {
+                    store.dismissActionError()
+                }
+            } message: {
+                Text(store.actionErrorMessage ?? "Please try again.")
             }
-            guard !Task.isCancelled else { return }
-            await store.reload(query: query)
-        }
-        .alert("Couldn’t update bookmark", isPresented: actionErrorBinding) {
-            Button("OK", role: .cancel) {
-                store.dismissActionError()
-            }
-        } message: {
-            Text(store.actionErrorMessage ?? "Please try again.")
-        }
     }
 
     @ViewBuilder
@@ -237,13 +221,24 @@ struct LibraryView: View {
     }
 
     private func bookmarkRow(_ bookmark: Bookmark) -> some View {
-        NavigationLink(value: bookmark) {
-            BookmarkRow(bookmark: bookmark)
+        Group {
+            if let navigate = navigation.bookmark {
+                Button {
+                    navigate(bookmark)
+                } label: {
+                    BookmarkRow(bookmark: bookmark)
+                }
+            } else {
+                NavigationLink(value: bookmark) {
+                    BookmarkRow(bookmark: bookmark)
+                }
+            }
         }
+        .buttonStyle(.plain)
         .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
         .listRowBackground(ZineTheme.canvas)
         .listRowSeparator(.hidden)
-        .matchedTransitionSource(id: bookmark.id, in: bookmarkTransition)
+        .matchedTransitionSource(id: bookmark.id, in: transitionNamespace)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             if !bookmark.isFinished {
                 Button {

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -2,6 +2,14 @@
 import SwiftUI
 
 struct ScreenshotLibraryView: View {
+    var body: some View {
+        NavigationStack {
+            ScreenshotLibraryContentView()
+        }
+    }
+}
+
+struct ScreenshotLibraryContentView: View {
     private let client = APIClient(
         baseURL: URL(string: "https://example.invalid")!,
         tokenProvider: { "screenshot-fixture" }
@@ -16,58 +24,56 @@ struct ScreenshotLibraryView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            List {
-                CollapsingListTitle(
+        List {
+            CollapsingListTitle(
+                title: "Library",
+                progress: titleCollapseProgress
+            )
+
+            Section {
+                ForEach(0..<(bookmarks.count * 3), id: \.self) { index in
+                    let bookmark = bookmarks[index % bookmarks.count]
+                    let route = ScreenshotLibraryRoute(bookmark: bookmark, sourceID: index)
+                    NavigationLink(value: route) {
+                        BookmarkRow(bookmark: bookmark)
+                    }
+                    .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
+                    .listRowBackground(ZineTheme.canvas)
+                    .listRowSeparator(.hidden)
+                    .matchedTransitionSource(id: route.sourceID, in: bookmarkTransition)
+                }
+            } header: {
+                ContentTypeFilterBar(selection: $contentType)
+                    .textCase(nil)
+                    .listRowInsets(EdgeInsets())
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(ZineTheme.canvas)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            let offset = geometry.contentOffset.y + geometry.contentInsets.top
+            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+        } action: { _, progress in
+            titleCollapseProgress = progress
+        }
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .contentTypeFilterChrome()
+        .toolbar(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                CollapsedListTitle(
                     title: "Library",
                     progress: titleCollapseProgress
                 )
-
-                Section {
-                    ForEach(0..<(bookmarks.count * 3), id: \.self) { index in
-                        let bookmark = bookmarks[index % bookmarks.count]
-                        let route = ScreenshotLibraryRoute(bookmark: bookmark, sourceID: index)
-                        NavigationLink(value: route) {
-                            BookmarkRow(bookmark: bookmark)
-                        }
-                        .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
-                        .listRowBackground(ZineTheme.canvas)
-                        .listRowSeparator(.hidden)
-                        .matchedTransitionSource(id: route.sourceID, in: bookmarkTransition)
-                    }
-                } header: {
-                    ContentTypeFilterBar(selection: $contentType)
-                        .textCase(nil)
-                        .listRowInsets(EdgeInsets())
-                }
             }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            .background(ZineTheme.canvas)
-            .onScrollGeometryChange(for: CGFloat.self) { geometry in
-                let offset = geometry.contentOffset.y + geometry.contentInsets.top
-                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-            } action: { _, progress in
-                titleCollapseProgress = progress
-            }
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
-            .contentTypeFilterChrome()
-            .toolbar(.visible, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    CollapsedListTitle(
-                        title: "Library",
-                        progress: titleCollapseProgress
-                    )
-                }
-            }
-            .navigationDestination(for: ScreenshotLibraryRoute.self) { route in
-                BookmarkDetailView(bookmark: route.bookmark, client: client) { _ in }
-                    .navigationTransition(
-                        .zoom(sourceID: route.sourceID, in: bookmarkTransition)
-                    )
-            }
+        }
+        .navigationDestination(for: ScreenshotLibraryRoute.self) { route in
+            BookmarkDetailView(bookmark: route.bookmark, client: client) { _ in }
+                .navigationTransition(
+                    .zoom(sourceID: route.sourceID, in: bookmarkTransition)
+                )
         }
         .zineScreenChrome()
     }

--- a/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
+++ b/apps/ios/ZineNative/Features/Reader/ArticleReaderView.swift
@@ -92,7 +92,6 @@ struct ArticleReaderView: View {
             }
         }
         .toolbarVisibility(.hidden, for: .navigationBar)
-        .zineNonRootTabBar(for: .articleReader)
         .task(id: store.metadata.bookmarkID) {
             guard loadsOnAppear else { return }
             await store.load()

--- a/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
+++ b/apps/ios/ZineNative/Features/Settings/AppSettingsView.swift
@@ -45,35 +45,17 @@ final class SettingsStore {
 
 struct AppSettingsView: View {
     let client: APIClient
-    let navigationPath: Binding<NavigationPath>
 
     @Environment(Clerk.self) private var clerk
+    @Environment(\.zineTabNavigationActions) private var navigation
     @State private var store = SettingsStore()
 
-    init(
-        client: APIClient,
-        navigationPath: Binding<NavigationPath> = .constant(NavigationPath())
-    ) {
-        self.client = client
-        self.navigationPath = navigationPath
-    }
-
     var body: some View {
-        NavigationStack(path: navigationPath) {
-            Group {
-                if clerk.session?.tasks?.isEmpty == false {
-                    AuthView(isDismissible: false)
-                } else {
-                    settingsContent
-                }
-            }
-            .navigationDestination(for: SettingsRoute.self) { route in
-                switch route {
-                case .sources:
-                    SubscriptionsView(client: client)
-                case .appearance:
-                    AppearanceSettingsView()
-                }
+        Group {
+            if clerk.session?.tasks?.isEmpty == false {
+                AuthView(isDismissible: false)
+            } else {
+                settingsContent
             }
         }
         .zineScreenChrome()
@@ -183,74 +165,102 @@ struct AppSettingsView: View {
     }
 
     private var sourcesCard: some View {
-        NavigationLink(value: SettingsRoute.sources) {
-            VStack(alignment: .leading, spacing: 18) {
-                HStack(alignment: .top) {
-                    SettingsIconTile(systemImage: "dot.radiowaves.up.forward", isPrimary: true)
-                    Spacer()
-                    Image(systemName: "arrow.up.right")
-                        .font(.system(.headline, design: .rounded, weight: .bold))
-                        .foregroundStyle(ZineTheme.brandAccent)
+        Group {
+            if let navigate = navigation.settings {
+                Button {
+                    navigate(.sources)
+                } label: {
+                    sourcesCardLabel
                 }
-
-                VStack(alignment: .leading, spacing: 7) {
-                    Text("Sources")
-                        .font(.system(size: 28, weight: .bold, design: .rounded))
-                        .foregroundStyle(ZineTheme.primaryText)
-                    Text("Connect the places you follow and decide what flows into your Inbox and Library.")
-                        .font(.system(.subheadline, design: .rounded))
-                        .foregroundStyle(ZineTheme.secondaryText)
-                        .fixedSize(horizontal: false, vertical: true)
+            } else {
+                NavigationLink(value: SettingsRoute.sources) {
+                    sourcesCardLabel
                 }
-
-                HStack(spacing: 8) {
-                    sourceChip("play.rectangle.fill")
-                    sourceChip("waveform.circle.fill")
-                    sourceChip("envelope.fill")
-                    sourceChip("bookmark.square.fill")
-                    sourceChip("dot.radiowaves.left.and.right")
-                }
-            }
-            .padding(20)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(ZineTheme.surface, in: .rect(cornerRadius: 22))
-            .overlay {
-                RoundedRectangle(cornerRadius: 22)
-                    .stroke(ZineTheme.border.opacity(0.75), lineWidth: 1)
             }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("settings-sources")
     }
 
-    private var appearanceCard: some View {
-        NavigationLink(value: SettingsRoute.appearance) {
-            HStack(spacing: 14) {
-                SettingsIconTile(systemImage: "circle.lefthalf.filled", isPrimary: false)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Appearance")
-                        .font(.system(.headline, design: .rounded, weight: .bold))
-                        .foregroundStyle(ZineTheme.primaryText)
-                    Text("System, light, or dark")
-                        .font(.system(.subheadline, design: .rounded))
-                        .foregroundStyle(ZineTheme.secondaryText)
-                }
-
+    private var sourcesCardLabel: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                SettingsIconTile(systemImage: "dot.radiowaves.up.forward", isPrimary: true)
                 Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(ZineTheme.tertiaryText)
+                Image(systemName: "arrow.up.right")
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.brandAccent)
             }
-            .padding(16)
-            .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
-            .overlay {
-                RoundedRectangle(cornerRadius: 18)
-                    .stroke(ZineTheme.border.opacity(0.65), lineWidth: 1)
+
+            VStack(alignment: .leading, spacing: 7) {
+                Text("Sources")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundStyle(ZineTheme.primaryText)
+                Text("Connect the places you follow and decide what flows into your Inbox and Library.")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                sourceChip("play.rectangle.fill")
+                sourceChip("waveform.circle.fill")
+                sourceChip("envelope.fill")
+                sourceChip("bookmark.square.fill")
+                sourceChip("dot.radiowaves.left.and.right")
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 22))
+        .overlay {
+            RoundedRectangle(cornerRadius: 22)
+                .stroke(ZineTheme.border.opacity(0.75), lineWidth: 1)
+        }
+    }
+
+    private var appearanceCard: some View {
+        Group {
+            if let navigate = navigation.settings {
+                Button {
+                    navigate(.appearance)
+                } label: {
+                    appearanceCardLabel
+                }
+            } else {
+                NavigationLink(value: SettingsRoute.appearance) {
+                    appearanceCardLabel
+                }
             }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("settings-appearance")
+    }
+
+    private var appearanceCardLabel: some View {
+        HStack(spacing: 14) {
+            SettingsIconTile(systemImage: "circle.lefthalf.filled", isPrimary: false)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Appearance")
+                    .font(.system(.headline, design: .rounded, weight: .bold))
+                    .foregroundStyle(ZineTheme.primaryText)
+                Text("System, light, or dark")
+                    .font(.system(.subheadline, design: .rounded))
+                    .foregroundStyle(ZineTheme.secondaryText)
+            }
+
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(ZineTheme.tertiaryText)
+        }
+        .padding(16)
+        .background(ZineTheme.surface, in: .rect(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(ZineTheme.border.opacity(0.65), lineWidth: 1)
+        }
     }
 
     private var signOutButton: some View {

--- a/apps/ios/ZineNativeTests/ZineThemeTests.swift
+++ b/apps/ios/ZineNativeTests/ZineThemeTests.swift
@@ -45,55 +45,6 @@ final class ZineThemeTests: XCTestCase {
         }
     }
 
-    func testTabBarIsVisibleOnlyOnPrimaryRootScreens() {
-        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.home), navigationDepth: 0))
-        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.library), navigationDepth: 0))
-        XCTAssertTrue(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.settings), navigationDepth: 0))
-        XCTAssertFalse(ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(.search), navigationDepth: 0))
-    }
-
-    func testTabBarIsHiddenForEveryPushedDestination() {
-        for surface in ZineTabRootSurface.allCases {
-            XCTAssertFalse(
-                ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(surface), navigationDepth: 1),
-                "Expected the tab bar to be hidden after pushing from \(surface)"
-            )
-            XCTAssertFalse(
-                ZineTabBarVisibilityContract.showsTabBar(on: .tabRoot(surface), navigationDepth: 2),
-                "Expected the tab bar to remain hidden deeper in \(surface)"
-            )
-        }
-    }
-
-    func testDestinationFormReaderPushHidesTabBarWithoutAPathEntry() {
-        XCTAssertFalse(
-            ZineTabBarVisibilityContract.showsTabBar(
-                on: .articleReader,
-                navigationDepth: 0
-            )
-        )
-        XCTAssertFalse(
-            ZineTabBarVisibilityContract.showsTabBar(
-                on: .bookmarkDetail,
-                navigationDepth: 0
-            )
-        )
-    }
-
-    func testInteractivePopReturnPathRestoresTabBarAtPrimaryRoot() {
-        let navigationDepths = [0, 1, 2, 1, 0]
-
-        XCTAssertEqual(
-            navigationDepths.map {
-                ZineTabBarVisibilityContract.showsTabBar(
-                    on: .tabRoot(.home),
-                    navigationDepth: $0
-                )
-            },
-            [true, false, false, false, true]
-        )
-    }
-
     @MainActor
     func testUIKitBarsKeepSystemManagedMaterialsAndScrollEdges() {
         ZineTheme.configureUIKitAppearance()


### PR DESCRIPTION
## Summary

- keep the shared tab shell intact beneath one app-owned navigation stack so pushed content covers it without tab-bar hide/show races
- route Home, Library, Search, and Settings root actions explicitly across the lazy TabView boundary
- remove the old visibility-contract workaround and align screenshot fixtures and native navigation guidance

## Validation

- xcodebuild test -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908
- bun run format:check
- bun run design-system:check
- bun run typecheck
- bun run test:web
- bun run --cwd apps/worker test:run --exclude=**/user-do.test.ts --exclude=**/scheduler.test.ts
- physical iPhone smoke test: bookmark links open and interactive back restores the tab bar immediately (user-confirmed before merge)