### PR TITLE
fix(ios): restore collapsing root titles

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -70,6 +70,8 @@ private struct AuthenticatedAppView: View {
     @State private var navigationPath = NavigationPath()
     @State private var homeTabReselection = 0
     @State private var libraryTabReselection = 0
+    @State private var homeTitleCollapseProgress: CGFloat = 0
+    @State private var libraryTitleCollapseProgress: CGFloat = 0
     @State private var homeRevision = 0
     @State private var libraryRevision = 0
     @State private var externalOpenEvent: ExternalBookmarkOpenEvent?
@@ -105,6 +107,7 @@ private struct AuthenticatedAppView: View {
                         onExternalOpen: handleExternalOpen,
                         onHomeItemExternalOpen: handleHomeItemExternalOpen,
                         tabReselection: homeTabReselection,
+                        onTitleCollapseProgressChanged: { homeTitleCollapseProgress = $0 },
                         transitionNamespace: navigationTransition,
                         registersNavigationDestinations: false
                     )
@@ -119,6 +122,7 @@ private struct AuthenticatedAppView: View {
                         onContentChanged: markHomeChanged,
                         onExternalOpen: handleExternalOpen,
                         tabReselection: libraryTabReselection,
+                        onTitleCollapseProgressChanged: { libraryTitleCollapseProgress = $0 },
                         transitionNamespace: navigationTransition
                     )
                     .tint(ZineTheme.brandAccent)
@@ -144,6 +148,18 @@ private struct AuthenticatedAppView: View {
                 }
             }
             .zineTabShellChrome()
+            .navigationTitle(selectedRootTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if navigationPath.isEmpty, let compactTitle = selectedCompactRootTitle {
+                    ToolbarItem(placement: .principal) {
+                        CollapsedListTitle(
+                            title: compactTitle.title,
+                            progress: compactTitle.progress
+                        )
+                    }
+                }
+            }
             .environment(\.zineTabNavigationActions, tabNavigationActions)
             .navigationDestination(for: HomeNavigationRoute.self) { route in
                 homeDestination(for: route)
@@ -202,6 +218,28 @@ private struct AuthenticatedAppView: View {
                 }
             }
         )
+    }
+
+    private var selectedRootTitle: String {
+        switch selectedTab {
+        case .home, .library:
+            ""
+        case .settings:
+            "Settings"
+        case .search:
+            "Search"
+        }
+    }
+
+    private var selectedCompactRootTitle: (title: String, progress: CGFloat)? {
+        switch selectedTab {
+        case .home:
+            ("Home", homeTitleCollapseProgress)
+        case .library:
+            ("Library", libraryTitleCollapseProgress)
+        case .settings, .search:
+            nil
+        }
     }
 
     private var tabNavigationActions: ZineTabNavigationActions {

--- a/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
+++ b/apps/ios/ZineNative/Core/ContentTypeFilterBar.swift
@@ -39,6 +39,12 @@ struct CollapsedListTitle: View {
     }
 }
 
+enum FilteredListScrollState {
+    static func collapseProgress(scrollOffset: CGFloat) -> CGFloat {
+        min(max(scrollOffset / 44, 0), 1)
+    }
+}
+
 struct ContentTypeFilterBar: View {
     @Binding var selection: ContentType?
     var background = ZineTheme.canvas

--- a/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeSectionListView.swift
@@ -31,19 +31,11 @@ struct HomeSectionListView: View {
 
     var body: some View {
         content
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(route.title)
+            .navigationBarTitleDisplayMode(.large)
             .contentTypeFilterChrome(background: ZineTheme.surface)
             .toolbarBackground(ZineTheme.surface, for: .tabBar)
             .toolbar(.visible, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    CollapsedListTitle(
-                        title: route.title,
-                        progress: titleCollapseProgress
-                    )
-                }
-            }
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -78,13 +70,6 @@ struct HomeSectionListView: View {
     private var content: some View {
         ScrollViewReader { proxy in
             List {
-                CollapsingListTitle(
-                    title: route.title,
-                    progress: titleCollapseProgress,
-                    background: ZineTheme.surface
-                )
-                .id(ScrollAnchor.top)
-
                 Section {
                     resultRows
                 } header: {
@@ -95,13 +80,14 @@ struct HomeSectionListView: View {
                         .textCase(nil)
                         .listRowInsets(EdgeInsets())
                 }
+                .id(ScrollAnchor.top)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .background(ZineTheme.surface)
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = geometry.contentOffset.y + geometry.contentInsets.top
-                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+                return FilteredListScrollState.collapseProgress(scrollOffset: offset)
             } action: { _, progress in
                 titleCollapseProgress = progress
             }

--- a/apps/ios/ZineNative/Features/Home/HomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/HomeView.swift
@@ -45,10 +45,12 @@ struct HomeView: View {
     let onExternalOpen: (Bookmark) -> Void
     let onHomeItemExternalOpen: (HomeItem) -> Void
     let tabReselection: Int
+    let onTitleCollapseProgressChanged: (CGFloat) -> Void
     let transitionNamespace: Namespace.ID?
     let registersNavigationDestinations: Bool
 
     @Namespace private var localTransitionNamespace
+    @State private var titleCollapseProgress: CGFloat = 0
 
     init(
         client: APIClient,
@@ -59,6 +61,7 @@ struct HomeView: View {
         onExternalOpen: @escaping (Bookmark) -> Void,
         onHomeItemExternalOpen: @escaping (HomeItem) -> Void,
         tabReselection: Int = 0,
+        onTitleCollapseProgressChanged: @escaping (CGFloat) -> Void = { _ in },
         transitionNamespace: Namespace.ID? = nil,
         registersNavigationDestinations: Bool = true
     ) {
@@ -70,6 +73,7 @@ struct HomeView: View {
         self.onExternalOpen = onExternalOpen
         self.onHomeItemExternalOpen = onHomeItemExternalOpen
         self.tabReselection = tabReselection
+        self.onTitleCollapseProgressChanged = onTitleCollapseProgressChanged
         self.transitionNamespace = transitionNamespace
         self.registersNavigationDestinations = registersNavigationDestinations
     }
@@ -110,8 +114,18 @@ struct HomeView: View {
 
     private var screen: some View {
         content
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if registersNavigationDestinations {
+                    ToolbarItem(placement: .principal) {
+                        CollapsedListTitle(
+                            title: title,
+                            progress: titleCollapseProgress
+                        )
+                    }
+                }
+            }
             .zineScreenChrome()
     }
 
@@ -142,6 +156,9 @@ struct HomeView: View {
         } else {
             ScrollView {
                 LazyVStack(spacing: density.sectionSpacing) {
+                    CollapsingListTitle(title: title, progress: titleCollapseProgress)
+                        .padding(.horizontal, 18)
+
                     ForEach(dashboardSections) { section in
                         HomeDashboardSectionView(
                             section: section,
@@ -154,6 +171,13 @@ struct HomeView: View {
                 .padding(.bottom, density == .compact ? 16 : 24)
             }
             .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
+                onTitleCollapseProgressChanged(progress)
+            }
             .refreshable {
                 await store.reload()
             }

--- a/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
+++ b/apps/ios/ZineNative/Features/Home/JumpBackInListView.swift
@@ -27,19 +27,11 @@ struct JumpBackInListView: View {
 
     var body: some View {
         content
-            .navigationTitle("")
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("Jump Back In")
+            .navigationBarTitleDisplayMode(.large)
             .contentTypeFilterChrome(background: ZineTheme.surface)
             .toolbarBackground(ZineTheme.surface, for: .tabBar)
             .toolbar(.visible, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    CollapsedListTitle(
-                        title: "Jump Back In",
-                        progress: titleCollapseProgress
-                    )
-                }
-            }
             .navigationDestination(for: Bookmark.self) { bookmark in
                 BookmarkDetailView(
                     bookmark: bookmark,
@@ -70,13 +62,6 @@ struct JumpBackInListView: View {
     private var content: some View {
         ScrollViewReader { proxy in
             List {
-                CollapsingListTitle(
-                    title: "Jump Back In",
-                    progress: titleCollapseProgress,
-                    background: ZineTheme.surface
-                )
-                .id(ScrollAnchor.top)
-
                 Section {
                     resultRows
                 } header: {
@@ -87,13 +72,14 @@ struct JumpBackInListView: View {
                         .textCase(nil)
                         .listRowInsets(EdgeInsets())
                 }
+                .id(ScrollAnchor.top)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
             .background(ZineTheme.surface)
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = geometry.contentOffset.y + geometry.contentInsets.top
-                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+                return FilteredListScrollState.collapseProgress(scrollOffset: offset)
             } action: { _, progress in
                 titleCollapseProgress = progress
             }

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct ScreenshotHomeTabShell: View {
     @State private var selectedTab = 0
     @State private var navigationPath: NavigationPath
+    @State private var homeTitleCollapseProgress: CGFloat = 0
+    @State private var libraryTitleCollapseProgress: CGFloat = 0
     @Namespace private var navigationTransition
 
     init() {
@@ -25,12 +27,15 @@ struct ScreenshotHomeTabShell: View {
                 Tab("Home", systemImage: "house", value: 0) {
                     ScreenshotHomeView(
                         density: .compact,
-                        bookmarkTransition: navigationTransition
+                        bookmarkTransition: navigationTransition,
+                        onTitleCollapseProgressChanged: { homeTitleCollapseProgress = $0 }
                     )
                 }
 
                 Tab("Library", systemImage: "books.vertical", value: 1) {
-                    ScreenshotLibraryContentView()
+                    ScreenshotLibraryContentView(
+                        onTitleCollapseProgressChanged: { libraryTitleCollapseProgress = $0 }
+                    )
                 }
 
                 Tab("Settings", systemImage: "gearshape", value: 2) {
@@ -46,6 +51,18 @@ struct ScreenshotHomeTabShell: View {
                 }
             }
             .zineTabShellChrome()
+            .navigationTitle(selectedRootTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if navigationPath.isEmpty, let compactTitle = selectedCompactRootTitle {
+                    ToolbarItem(placement: .principal) {
+                        CollapsedListTitle(
+                            title: compactTitle.title,
+                            progress: compactTitle.progress
+                        )
+                    }
+                }
+            }
             .environment(\.zineTabNavigationActions, navigationActions)
             .navigationDestination(for: HomeNavigationRoute.self) { route in
                 fixtureDestination(for: route)
@@ -56,6 +73,28 @@ struct ScreenshotHomeTabShell: View {
             .navigationDestination(for: HomeSectionRoute.self) { route in
                 ScreenshotHomeSectionListView(route: route)
             }
+        }
+    }
+
+    private var selectedRootTitle: String {
+        switch selectedTab {
+        case 0, 1:
+            ""
+        case 2:
+            "Settings"
+        default:
+            "Search"
+        }
+    }
+
+    private var selectedCompactRootTitle: (title: String, progress: CGFloat)? {
+        switch selectedTab {
+        case 0:
+            ("Home", homeTitleCollapseProgress)
+        case 1:
+            ("Library", libraryTitleCollapseProgress)
+        default:
+            nil
         }
     }
 
@@ -132,23 +171,45 @@ struct ScreenshotHomeTabShell: View {
 struct ScreenshotHomeView: View {
     var density: HomeLayoutDensity = .standard
     let bookmarkTransition: Namespace.ID
+    var onTitleCollapseProgressChanged: (CGFloat) -> Void = { _ in }
+
+    @State private var titleCollapseProgress: CGFloat = 0
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: density.sectionSpacing) {
-                ForEach(density.visibleSections(from: ScreenshotHomeFixtures.sections)) { section in
-                    HomeDashboardSectionView(
-                        section: section,
-                        density: density,
-                        transitionNamespace: bookmarkTransition
-                    )
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: density.sectionSpacing) {
+                    CollapsingListTitle(title: "Home", progress: titleCollapseProgress)
+                        .padding(.horizontal, 18)
+
+                    ForEach(density.visibleSections(from: ScreenshotHomeFixtures.sections)) { section in
+                        HomeDashboardSectionView(
+                            section: section,
+                            density: density,
+                            transitionNamespace: bookmarkTransition
+                        )
+                        .id(section.id)
+                    }
+                }
+                .padding(.vertical, density == .compact ? 6 : 10)
+                .padding(.bottom, density == .compact ? 16 : 24)
+            }
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
+                onTitleCollapseProgressChanged(progress)
+            }
+            .task {
+                if ProcessInfo.processInfo.arguments.contains("-screenshot-scrolled-fixture") {
+                    try? await Task.sleep(for: .milliseconds(300))
+                    proxy.scrollTo("inbox", anchor: .top)
                 }
             }
-            .padding(.vertical, density == .compact ? 6 : 10)
-            .padding(.bottom, density == .compact ? 16 : 24)
         }
-        .navigationTitle("Home")
-        .navigationBarTitleDisplayMode(density == .compact ? .inline : .automatic)
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
         .zineScreenChrome()
     }
 }
@@ -157,7 +218,6 @@ private struct ScreenshotHomeSectionListView: View {
     let route: HomeSectionRoute
 
     @State private var contentType: ContentType?
-    @State private var titleCollapseProgress: CGFloat = 0
 
     init(route: HomeSectionRoute) {
         self.route = route
@@ -175,12 +235,6 @@ private struct ScreenshotHomeSectionListView: View {
 
     var body: some View {
         List {
-            CollapsingListTitle(
-                title: route.title,
-                progress: titleCollapseProgress,
-                background: ZineTheme.surface
-            )
-
             Section {
                 if showsLoadingState {
                     FilteredListLoadingRow(
@@ -205,25 +259,11 @@ private struct ScreenshotHomeSectionListView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(ZineTheme.surface)
-        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-        } action: { _, progress in
-            titleCollapseProgress = progress
-        }
-        .navigationTitle("")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle(route.title)
+        .navigationBarTitleDisplayMode(.large)
         .contentTypeFilterChrome(background: ZineTheme.surface)
         .toolbarBackground(ZineTheme.surface, for: .tabBar)
         .toolbar(.visible, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                CollapsedListTitle(
-                    title: route.title,
-                    progress: titleCollapseProgress
-                )
-            }
-        }
     }
 }
 

--- a/apps/ios/ZineNative/Features/Library/LibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/LibraryView.swift
@@ -7,6 +7,7 @@ struct LibraryView: View {
     let onContentChanged: () -> Void
     let onExternalOpen: (Bookmark) -> Void
     let tabReselection: Int
+    let onTitleCollapseProgressChanged: (CGFloat) -> Void
     let transitionNamespace: Namespace.ID
 
     @State private var store: LibraryStore
@@ -25,6 +26,7 @@ struct LibraryView: View {
         onContentChanged: @escaping () -> Void = {},
         onExternalOpen: @escaping (Bookmark) -> Void = { _ in },
         tabReselection: Int = 0,
+        onTitleCollapseProgressChanged: @escaping (CGFloat) -> Void = { _ in },
         transitionNamespace: Namespace.ID
     ) {
         self.client = client
@@ -33,6 +35,7 @@ struct LibraryView: View {
         self.onContentChanged = onContentChanged
         self.onExternalOpen = onExternalOpen
         self.tabReselection = tabReselection
+        self.onTitleCollapseProgressChanged = onTitleCollapseProgressChanged
         self.transitionNamespace = transitionNamespace
         _store = State(initialValue: LibraryStore(
             client: client,
@@ -60,7 +63,7 @@ struct LibraryView: View {
 
     var body: some View {
         content
-            .navigationTitle(isSearchMode ? "Search" : "Library")
+            .navigationTitle(isSearchMode ? "Search" : "")
             .navigationBarTitleDisplayMode(.inline)
             .contentTypeFilterChrome()
             .toolbar(.visible, for: .navigationBar)
@@ -68,13 +71,6 @@ struct LibraryView: View {
                 if isSearchMode {
                     ToolbarItem(placement: .topBarLeading) {
                         filterMenu
-                    }
-                } else {
-                    ToolbarItem(placement: .principal) {
-                        CollapsedListTitle(
-                            title: "Library",
-                            progress: titleCollapseProgress
-                        )
                     }
                 }
             }
@@ -130,9 +126,10 @@ struct LibraryView: View {
             .background(ZineTheme.canvas)
             .onScrollGeometryChange(for: CGFloat.self) { geometry in
                 let offset = geometry.contentOffset.y + geometry.contentInsets.top
-                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+                return FilteredListScrollState.collapseProgress(scrollOffset: offset)
             } action: { _, progress in
                 titleCollapseProgress = progress
+                onTitleCollapseProgressChanged(progress)
             }
             .onChange(of: tabReselection) {
                 handleTabReselection(using: proxy)

--- a/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
+++ b/apps/ios/ZineNative/Features/Library/ScreenshotLibraryView.swift
@@ -2,9 +2,21 @@
 import SwiftUI
 
 struct ScreenshotLibraryView: View {
+    @State private var titleCollapseProgress: CGFloat = 0
+
     var body: some View {
         NavigationStack {
-            ScreenshotLibraryContentView()
+            ScreenshotLibraryContentView(
+                onTitleCollapseProgressChanged: { titleCollapseProgress = $0 }
+            )
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    CollapsedListTitle(
+                        title: "Library",
+                        progress: titleCollapseProgress
+                    )
+                }
+            }
         }
     }
 }
@@ -18,13 +30,16 @@ struct ScreenshotLibraryContentView: View {
     @State private var titleCollapseProgress: CGFloat = 0
     @Namespace private var bookmarkTransition
 
+    var onTitleCollapseProgressChanged: (CGFloat) -> Void = { _ in }
+
     private var bookmarks: [Bookmark] {
         guard let contentType else { return ScreenshotFixtures.bookmarks }
         return ScreenshotFixtures.bookmarks.filter { $0.contentType == contentType }
     }
 
     var body: some View {
-        List {
+        ScrollViewReader { proxy in
+            List {
             CollapsingListTitle(
                 title: "Library",
                 progress: titleCollapseProgress
@@ -37,6 +52,7 @@ struct ScreenshotLibraryContentView: View {
                     NavigationLink(value: route) {
                         BookmarkRow(bookmark: bookmark)
                     }
+                    .id(index)
                     .listRowInsets(EdgeInsets(top: 6, leading: 18, bottom: 6, trailing: 14))
                     .listRowBackground(ZineTheme.canvas)
                     .listRowSeparator(.hidden)
@@ -47,28 +63,28 @@ struct ScreenshotLibraryContentView: View {
                     .textCase(nil)
                     .listRowInsets(EdgeInsets())
             }
-        }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(ZineTheme.canvas)
-        .onScrollGeometryChange(for: CGFloat.self) { geometry in
-            let offset = geometry.contentOffset.y + geometry.contentInsets.top
-            return CollapsingListTitle.collapseProgress(scrollOffset: offset)
-        } action: { _, progress in
-            titleCollapseProgress = progress
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(ZineTheme.canvas)
+            .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                let offset = geometry.contentOffset.y + geometry.contentInsets.top
+                return CollapsingListTitle.collapseProgress(scrollOffset: offset)
+            } action: { _, progress in
+                titleCollapseProgress = progress
+                onTitleCollapseProgressChanged(progress)
+            }
+            .task {
+                if ProcessInfo.processInfo.arguments.contains("-screenshot-scrolled-fixture") {
+                    try? await Task.sleep(for: .milliseconds(300))
+                    proxy.scrollTo(5, anchor: .top)
+                }
+            }
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .contentTypeFilterChrome()
         .toolbar(.visible, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                CollapsedListTitle(
-                    title: "Library",
-                    progress: titleCollapseProgress
-                )
-            }
-        }
         .navigationDestination(for: ScreenshotLibraryRoute.self) { route in
             BookmarkDetailView(bookmark: route.bookmark, client: client) { _ in }
                 .navigationTransition(

--- a/apps/ios/ZineNativeTests/HomeTests.swift
+++ b/apps/ios/ZineNativeTests/HomeTests.swift
@@ -306,7 +306,13 @@ final class HomeTests: XCTestCase {
         )
     }
 
-    func testContentTypeTitleCollapseProgressClampsScrollOffset() {
+    func testFilteredListCollapseProgressClampsScrollOffset() {
+        XCTAssertEqual(FilteredListScrollState.collapseProgress(scrollOffset: -20), 0)
+        XCTAssertEqual(FilteredListScrollState.collapseProgress(scrollOffset: 22), 0.5)
+        XCTAssertEqual(FilteredListScrollState.collapseProgress(scrollOffset: 80), 1)
+    }
+
+    func testRootTitleCollapseProgressClampsScrollOffset() {
         XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: -20), 0)
         XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: 22), 0.5)
         XCTAssertEqual(CollapsingListTitle.collapseProgress(scrollOffset: 80), 1)


### PR DESCRIPTION
## Summary

- restore the large Home and Library headings at the top of their root tabs
- surface compact centered titles from the root navigation shell as those screens scroll
- keep Home collection-list destinations on their working system large-title behavior
- extend deterministic screenshot fixtures and collapse-progress coverage

## Validation

- `xcodebuild -project apps/ios/ZineNative.xcodeproj -scheme ZineNative -destination "platform=iOS Simulator,id=1E80FF6E-D2D0-4617-9203-31EA60ABD908" -only-testing:ZineNativeTests/HomeTests test`
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` (90 tests)
- `bun run --cwd apps/worker test:run --exclude="**/user-do.test.ts" --exclude="**/scheduler.test.ts"` (1,769 tests)
- `git diff --check`
- live simulator verification of Home and Library large/compact title states in light and dark appearances