### PR TITLE
fix(ios): preserve title chrome during swipe back

### DIFF
--- a/apps/ios/ZineNative/App/AppRootView.swift
+++ b/apps/ios/ZineNative/App/AppRootView.swift
@@ -151,7 +151,9 @@ private struct AuthenticatedAppView: View {
             .navigationTitle(selectedRootTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if navigationPath.isEmpty, let compactTitle = selectedCompactRootTitle {
+                // Keep root chrome registered beneath pushed destinations so an interactive
+                // pop reveals the complete tab shell instead of reconstructing its title bar.
+                if let compactTitle = selectedCompactRootTitle {
                     ToolbarItem(placement: .principal) {
                         CollapsedListTitle(
                             title: compactTitle.title,

--- a/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
+++ b/apps/ios/ZineNative/Features/Home/ScreenshotHomeView.swift
@@ -2,6 +2,11 @@
 import SwiftUI
 
 struct ScreenshotHomeTabShell: View {
+    private let client = APIClient(
+        baseURL: URL(string: "https://example.invalid")!,
+        tokenProvider: { "screenshot-fixture" }
+    )
+
     @State private var selectedTab = 0
     @State private var navigationPath: NavigationPath
     @State private var homeTitleCollapseProgress: CGFloat = 0
@@ -10,7 +15,14 @@ struct ScreenshotHomeTabShell: View {
 
     init() {
         var initialPath = NavigationPath()
-        if ProcessInfo.processInfo.arguments.contains("-screenshot-home-pushed-fixture") {
+        if ProcessInfo.processInfo.arguments.contains("-screenshot-home-bookmark-pushed-fixture") {
+            initialPath.append(
+                HomeNavigationRoute.bookmark(
+                    ScreenshotHomeFixtures.openedBookmarks[0],
+                    sectionID: "jump-back-in"
+                )
+            )
+        } else if ProcessInfo.processInfo.arguments.contains("-screenshot-home-pushed-fixture") {
             initialPath.append(
                 HomeNavigationRoute.articleReader(
                     ScreenshotHomeFixtures.featuredArticle,
@@ -54,7 +66,9 @@ struct ScreenshotHomeTabShell: View {
             .navigationTitle(selectedRootTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if navigationPath.isEmpty, let compactTitle = selectedCompactRootTitle {
+                // Match the production shell's continuously registered root chrome so the
+                // interactive-pop fixture exercises the same navigation hierarchy.
+                if let compactTitle = selectedCompactRootTitle {
                     ToolbarItem(placement: .principal) {
                         CollapsedListTitle(
                             title: compactTitle.title,
@@ -109,11 +123,9 @@ struct ScreenshotHomeTabShell: View {
     private func fixtureDestination(for route: HomeNavigationRoute) -> some View {
         switch route.destination {
         case .item(let item):
-            Text(item.title)
-                .navigationTitle(item.title)
+            BookmarkDetailView(item: item, client: client) { _ in }
         case .bookmark(let bookmark):
-            Text(bookmark.title)
-                .navigationTitle(bookmark.title)
+            BookmarkDetailView(bookmark: bookmark, client: client) { _ in }
         case .articleReader(let item):
             fixtureArticleReader(for: item)
         }


### PR DESCRIPTION
## Summary

- keep the root compact-title toolbar structurally registered beneath pushed bookmark views
- prevent the title chrome from being reconstructed late during interactive swipe-back
- add a deterministic real bookmark-detail fixture matching the production navigation hierarchy

## Validation

- 84 native tests passed
- `git diff --check`
- `bun run format:check`
- `bun run design-system:check`
- `bun run typecheck`
- `bun run test:web` (86 tests + 4 preview-target tests)
- `bun run --cwd apps/worker test:run --exclude='**/user-do.test.ts' --exclude='**/scheduler.test.ts'` (1,769 tests)